### PR TITLE
fix: support single-maintainer release governance

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -468,11 +468,16 @@ those optional rules are active.
 
 Repository governance is proved from GitHub's effective rules for `main`, not
 from the legacy branch-protection administration endpoint. The effective rule
-set must enforce strict results from the exact seven GitHub Actions CI jobs, at
-least one approving review, stale-review dismissal, last-push approval,
-conversation resolution, no force pushes, and no deletion. Active tag rules
-must prevent `v*` update and deletion. Detailed ruleset responses must report
-that the current workflow token can never bypass each contributing ruleset.
+set must enforce strict results from the exact seven GitHub Actions CI jobs,
+pull-request-only changes, stale-review dismissal, conversation resolution, no
+force pushes, and no deletion. For 1.0, the receipt records the explicit
+`single-maintainer` review policy: the repository has no second eligible
+collaborator, so the ruleset must require exactly zero approvals and must not
+require an impossible last-pusher approval. Enabling independent review later
+requires a reviewed policy change rather than silently changing the live rule.
+Active tag rules must prevent `v*` update and deletion. Detailed ruleset
+responses must report that the current workflow token can never bypass each
+contributing ruleset.
 GitHub may omit the global `bypass_actors` list for the workflow token; receipts
 record whether that list was visible and never convert an omitted list into a
 false empty-list claim. Global actor policy therefore remains an administrator

--- a/src/clio_relay/ci_validation.py
+++ b/src/clio_relay/ci_validation.py
@@ -33,6 +33,9 @@ REQUIRED_CI_JOBS: tuple[str, ...] = (
     "windows-latest / python 3.14",
 )
 GITHUB_ACTIONS_APP_ID = 15368
+MAIN_REVIEW_POLICY = "single-maintainer"
+REQUIRED_APPROVING_REVIEW_COUNT = 0
+REQUIRE_LAST_PUSH_APPROVAL = False
 REQUIRED_ENVIRONMENTS: tuple[str, ...] = (
     "live-validation",
     "pypi",
@@ -2091,6 +2094,7 @@ def _main_ruleset_protection_receipt(
         "rulesets": [normalized_rulesets[item] for item in sorted(effective_ruleset_ids)],
         "strict_status_checks": status.get("strict_required_status_checks_policy") is True,
         "required_status_checks": status_checks,
+        "review_policy": MAIN_REVIEW_POLICY,
         "required_approving_review_count": _integer(
             reviews.get("required_approving_review_count"), "required approval count"
         ),
@@ -2131,6 +2135,8 @@ def _protected_branch_names(document: object) -> list[str]:
 
 def _verify_main_protection(branch: Mapping[str, object]) -> None:
     checks = branch.get("required_status_checks")
+    approval_count = branch.get("required_approving_review_count")
+    last_push_approval = branch.get("require_last_push_approval")
     expected_checks = [
         {"context": context, "app_id": GITHUB_ACTIONS_APP_ID}
         for context in sorted(REQUIRED_CI_JOBS)
@@ -2141,12 +2147,12 @@ def _verify_main_protection(branch: Mapping[str, object]) -> None:
         and bool(branch.get("ruleset_ids")),
         "strict_status_checks": branch.get("strict_status_checks") is True,
         "required_status_checks": checks == expected_checks,
-        "required_approving_review_count": isinstance(
-            branch.get("required_approving_review_count"), int
-        )
-        and cast(int, branch["required_approving_review_count"]) >= 1,
+        "review_policy": branch.get("review_policy") == MAIN_REVIEW_POLICY,
+        "required_approving_review_count": type(approval_count) is int
+        and approval_count == REQUIRED_APPROVING_REVIEW_COUNT,
         "dismiss_stale_reviews": branch.get("dismiss_stale_reviews") is True,
-        "require_last_push_approval": branch.get("require_last_push_approval") is True,
+        "require_last_push_approval": type(last_push_approval) is bool
+        and last_push_approval == REQUIRE_LAST_PUSH_APPROVAL,
         "required_conversation_resolution": branch.get("required_conversation_resolution") is True,
         "prevents_force_pushes": branch.get("prevents_force_pushes") is True,
         "prevents_deletions": branch.get("prevents_deletions") is True,

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -18,6 +18,7 @@ import pytest
 from clio_relay import ci_validation
 from clio_relay.ci_validation import (
     GITHUB_ACTIONS_APP_ID,
+    MAIN_REVIEW_POLICY,
     MAX_ACTIONS_ARTIFACT_ARCHIVE_BYTES,
     MAX_DISTRIBUTION_BYTES,
     MAX_DISTRIBUTION_MEMBERS,
@@ -30,6 +31,8 @@ from clio_relay.ci_validation import (
     MAX_VALIDATION_REPORT_AGGREGATE_BYTES,
     MAX_VALIDATION_REPORT_ASSETS,
     MAX_VALIDATION_REPORT_BYTES,
+    REQUIRE_LAST_PUSH_APPROVAL,
+    REQUIRED_APPROVING_REVIEW_COUNT,
     REQUIRED_CI_JOBS,
     REQUIRED_ENVIRONMENTS,
     ProvenanceError,
@@ -111,8 +114,8 @@ def _main_effective_rules() -> list[dict[str, object]]:
             "ruleset_id": MAIN_RULESET_ID,
             "parameters": {
                 "dismiss_stale_reviews_on_push": True,
-                "require_last_push_approval": True,
-                "required_approving_review_count": 1,
+                "require_last_push_approval": REQUIRE_LAST_PUSH_APPROVAL,
+                "required_approving_review_count": REQUIRED_APPROVING_REVIEW_COUNT,
                 "required_review_thread_resolution": True,
             },
         },
@@ -835,6 +838,9 @@ def test_repository_governance_receipt_requires_effective_current_token_controls
     assert main["source"] == "effective_rulesets"
     assert main["ruleset_ids"] == [MAIN_RULESET_ID]
     assert main["current_workflow_token_can_bypass"] is False
+    assert main["review_policy"] == MAIN_REVIEW_POLICY
+    assert main["required_approving_review_count"] == REQUIRED_APPROVING_REVIEW_COUNT
+    assert main["require_last_push_approval"] is REQUIRE_LAST_PUSH_APPROVAL
     main_ruleset = cast(list[dict[str, object]], main["rulesets"])[0]
     assert main_ruleset["global_bypass_actors_visible"] is True
     assert main_ruleset["configured_bypass_actor_count"] == 1
@@ -887,6 +893,8 @@ def test_live_governance_requery_must_equal_the_carried_receipt() -> None:
         ("status_app", "integration id"),
         ("main_bypass", "current workflow token can bypass"),
         ("missing_main_rule", "effective main branch rules are incomplete"),
+        ("review_count", "required_approving_review_count"),
+        ("last_push_approval", "require_last_push_approval"),
         ("tag_bypass", "current_workflow_token_cannot_bypass"),
         ("tag_update", "no active workflow-token-protected tag ruleset"),
         ("environment", "protected-branch deployment policy"),
@@ -909,6 +917,12 @@ def test_repository_governance_rejects_weakened_controls(
         branch_rulesets[0]["current_user_can_bypass"] = "always"
     elif surface == "missing_main_rule":
         effective.pop(0)
+    elif surface == "review_count":
+        reviews = cast(dict[str, object], effective[2]["parameters"])
+        reviews["required_approving_review_count"] = 1
+    elif surface == "last_push_approval":
+        reviews = cast(dict[str, object], effective[2]["parameters"])
+        reviews["require_last_push_approval"] = True
     elif surface == "tag_bypass":
         tag_rulesets[0]["current_user_can_bypass"] = "always"
     elif surface == "tag_update":


### PR DESCRIPTION
## What changed

- declare the release governance model as `single-maintainer`
- require exactly zero approvals and disable impossible last-pusher approval
- retain pull-request enforcement, discussion resolution, seven strict CI checks, and branch/tag mutation protections
- add negative tests that reject any live review configuration that differs from the declared policy

## Why

The existing release verifier required an independent approval even though the repository has no second eligible collaborator. GitHub therefore enforced a condition the project could never satisfy, and the promotion workflow would reject the live repository after merge.

## Validation

- `ruff check --fix` and `ruff format`
- strict `pyright`: 0 errors
- 133 governance and release-workflow tests passed
- live GitHub governance receipt verified the exact singleton policy and all retained protections