### PR TITLE
fix: prepare corrected 1.0.1 release gate

### DIFF
--- a/.github/scripts/release-api.sh
+++ b/.github/scripts/release-api.sh
@@ -14,6 +14,21 @@ relay_release_resolve() {
     "$@"
 }
 
+relay_release_resolve_eventually() {
+  local tag_name="$1" draft_state="$2" output_path="$3" attempt
+  for attempt in $(seq 1 10); do
+    relay_release_resolve "$tag_name" "$draft_state" "$output_path" --allow-absent
+    if jq -e '. != null' "$output_path" >/dev/null; then
+      return 0
+    fi
+    if [ "$attempt" -eq 10 ]; then
+      echo "draft release did not become visible after bounded retries" >&2
+      return 1
+    fi
+    sleep 3
+  done
+}
+
 relay_release_complete_assets() {
   local release_json="$1" output_path="$2"
   local release_id page_one page_two refreshed

--- a/.github/workflows/live-validation-attest.yml
+++ b/.github/workflows/live-validation-attest.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing immutable-candidate draft tag, such as v1.0.0
+        description: Existing immutable-candidate draft tag, such as v1.0.1
         required: true
         type: string
 

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing draft release tag, such as v1.0.0
+        description: Existing draft release tag, such as v1.0.1
         required: true
         type: string
       reviewed_main_sha:

--- a/.github/workflows/stage-candidate.yml
+++ b/.github/workflows/stage-candidate.yml
@@ -307,8 +307,9 @@ jobs:
               --title "$TAG_NAME" \
               --notes "Immutable candidate wheel SHA-256: $wheel_sha. Live validation and PyPI promotion are pending."
           fi
+          relay_release_resolve_eventually "$TAG_NAME" true \
+            "$RUNNER_TEMP/release-after-create.json"
           "${authority[@]}" --release-state present --draft true
-          relay_release_resolve "$TAG_NAME" true "$RUNNER_TEMP/release-after-create.json"
 
       - name: revalidate protected main immediately before candidate attestation
         env:

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> The current development candidate is `1.0.0`. The latest released live
-> evidence is `0.9.22`; 1.0.0 is not release-complete until its immutable-candidate
+> The current development candidate is `1.0.1`; the immutable `v1.0.0` candidate
+> was abandoned before publication after its acceptance runbook rejected the
+> staged GNU checksum format. The latest released live evidence is `0.9.22`;
+> 1.0.1 is not release-complete until its immutable-candidate
 > reports pass, its exact candidate is published, and the released-artifact
 > runs pass again. The policy currently selects the `ares` and `homelab`
 > evidence labels; those labels are release configuration, not hardcoded

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.0.0"
+$Version = "1.0.1"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }
@@ -212,10 +212,10 @@ if ($Stage -eq "candidate") {
   $WheelName = $Wheels[0].Name
   $ManifestLines = @(
     Get-Content -LiteralPath $Manifests[0].FullName |
-      Where-Object { $_ -match "^[0-9A-Fa-f]{64}[ *]$([Regex]::Escape($WheelName))$" }
+      Where-Object { $_ -match "^[0-9A-Fa-f]{64} [ *]$([Regex]::Escape($WheelName))$" }
   )
   if ($ManifestLines.Count -ne 1) { throw "candidate manifest entry is missing or ambiguous" }
-  if ($ManifestLines[0] -notmatch '^([0-9A-Fa-f]{64})[ *](.+)$' -or $Matches[2] -ne $WheelName) {
+  if ($ManifestLines[0] -notmatch '^([0-9A-Fa-f]{64}) [ *](.+)$' -or $Matches[2] -ne $WheelName) {
     throw "candidate manifest entry is malformed"
   }
   $ExpectedWheelSha256 = $Matches[1].ToLowerInvariant()

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.0.0"
+release_version: "1.0.1"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: b62a51a57d55fd2928c928d2a6b7892b006c627e5e64bd06cb03874d28602fe2
+acceptance_matrix_sha256: ad15a5d03b7bec8d15343b6931fc4ba7abcc7d2fe466154becb6bb1ec3eeab4c
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -70,7 +70,7 @@ Commit the release change with a conventional commit, then create and push an
 exact matching tag:
 
 ```powershell
-$Tag = "v1.0.0"
+$Tag = "v1.0.1"
 git fetch origin main
 $ReviewedMainSha = (git rev-parse refs/remotes/origin/main).Trim()
 if ((git rev-parse HEAD).Trim() -ne $ReviewedMainSha) {
@@ -123,6 +123,11 @@ manifest, attests the bytes, and creates the draft with an explicit target of
 the reviewed commit. Tag-supplied workflow code never receives release-write or
 OIDC authority.
 
+GitHub's release list can lag immediately after draft creation. Staging retries
+only a conclusively absent draft through the same numeric-ID resolver, ten times
+at three-second intervals. API errors, duplicate tag matches, numeric drift, or
+an unexpected draft state remain immediate failures.
+
 An existing draft is reusable only when every staged asset is byte-for-byte
 identical and its complete asset-name set equals the six staged candidate
 assets. The workflow never replaces a candidate distribution.
@@ -150,7 +155,7 @@ Download the draft wheel and manifest, verify both the digest and the signed
 tag-build provenance, and compute the digest locally:
 
 ```powershell
-$Tag = "v1.0.0"
+$Tag = "v1.0.1"
 New-Item -ItemType Directory -Force .clio-relay\candidate | Out-Null
 gh release download $Tag --pattern "*.whl" --pattern "SHA256SUMS" `
   --dir .clio-relay\candidate
@@ -158,7 +163,7 @@ $Wheel = (Get-ChildItem .clio-relay\candidate\*.whl).FullName
 $Expected = ((Get-FileHash -Algorithm SHA256 $Wheel).Hash).ToLowerInvariant()
 $WheelName = Split-Path $Wheel -Leaf
 $ManifestLine = Get-Content .clio-relay\candidate\SHA256SUMS |
-  Where-Object { $_ -match "[ *]$([Regex]::Escape($WheelName))$" }
+  Where-Object { $_ -match " [ *]$([Regex]::Escape($WheelName))$" }
 if ($ManifestLine -notmatch "^$Expected [ *]") { throw "candidate digest mismatch" }
 $Commit = gh api "repos/iowarp/clio-relay/commits/$Tag" --jq .sha
 gh attestation verify $Wheel `

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.0.0",
-  "matrix_sha256": "b62a51a57d55fd2928c928d2a6b7892b006c627e5e64bd06cb03874d28602fe2",
+  "release_version": "1.0.1",
+  "matrix_sha256": "ad15a5d03b7bec8d15343b6931fc4ba7abcc7d2fe466154becb6bb1ec3eeab4c",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.0.0"
+version = "1.0.1"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1330,7 +1330,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "b62a51a57d55fd2928c928d2a6b7892b006c627e5e64bd06cb03874d28602fe2"
+        "ad15a5d03b7bec8d15343b6931fc4ba7abcc7d2fe466154becb6bb1ec3eeab4c"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import re
+import tomllib
 from pathlib import Path
 from typing import cast
 
@@ -29,6 +31,36 @@ def _matrix_reports() -> list[dict[str, object]]:
     )
     assert document["report_count_per_stage"] == 17
     return cast(list[dict[str, object]], document["reports"])
+
+
+def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook() -> None:
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    policy = cast(dict[str, object], yaml.safe_load(POLICY.read_text(encoding="utf-8")))
+    matrix = cast(
+        dict[str, object],
+        json.loads((FIXTURES / "report-matrix-1.0.json").read_text(encoding="utf-8")),
+    )
+    version = cast(dict[str, object], project["project"])["version"]
+
+    assert policy["release_version"] == version
+    assert matrix["release_version"] == version
+    assert f'$Version = "{version}"' in RUNBOOK.read_text(encoding="utf-8")
+
+
+def test_candidate_manifest_parser_accepts_the_exact_gnu_checksum_separator() -> None:
+    digest = "a" * 64
+    wheel_name = "clio_relay-1.0.1-py3-none-any.whl"
+    selector = re.compile(rf"^[0-9A-Fa-f]{{64}} [ *]{re.escape(wheel_name)}$")
+    parser = re.compile(r"^([0-9A-Fa-f]{64}) [ *](.+)$")
+
+    for mode in ("*", " "):
+        line = f"{digest} {mode}{wheel_name}"
+        assert selector.fullmatch(line) is not None
+        match = parser.fullmatch(line)
+        assert match is not None
+        assert match.groups() == (digest, wheel_name)
+
+    assert selector.fullmatch(f"{digest}*{wheel_name}") is None
 
 
 def test_release_helper_scripts_bind_direct_gray_scott_and_private_spack_state() -> None:
@@ -314,6 +346,8 @@ def test_release_acceptance_runbook_binds_production_specifics_without_secrets()
     assert "gh release download $Tag --repo $GitHubRepo" in text
     assert "gh api --hostname github.com user" in text
     assert "$ManifestLines.Count -ne 1" in text
+    assert "^[0-9A-Fa-f]{64} [ *]$([Regex]::Escape($WheelName))$" in text
+    assert "^([0-9A-Fa-f]{64}) [ *](.+)$" in text
     assert "$Observed -ne $ExpectedWheelSha256" in text
     assert "gh attestation verify $Wheel --hostname github.com --repo iowarp/clio-relay" in text
     assert "$CheckoutCommit -ne $TagCommit" in text

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -73,6 +73,12 @@ def test_protected_main_staging_attests_and_creates_the_explicit_target_draft() 
     assert "actions/attest@" in text
     assert "gh release create" in text
     assert '--target "$SOURCE_COMMIT"' in text
+    assert 'relay_release_resolve_eventually "$TAG_NAME" true' in text
+    assert text.index("gh release create") < text.index("relay_release_resolve_eventually")
+    eventual_index = text.index("relay_release_resolve_eventually")
+    assert eventual_index < text.index(
+        '"${authority[@]}" --release-state present --draft true', eventual_index
+    )
     assert '--signer-workflow "$REPOSITORY/.github/workflows/stage-candidate.yml"' in text
     assert '--source-ref "refs/heads/main"' in text
     assert "ci_validation.py mutation-authority" in text
@@ -486,6 +492,14 @@ def test_draft_release_io_resolves_a_bounded_numeric_id() -> None:
         assert "source .github/scripts/release-api.sh" in text, workflow_name
 
     helper = (ROOT / ".github" / "scripts" / "release-api.sh").read_text(encoding="utf-8")
+    assert "relay_release_resolve_eventually()" in helper
+    assert "for attempt in $(seq 1 10)" in helper
+    assert (
+        'relay_release_resolve "$tag_name" "$draft_state" "$output_path" --allow-absent' in helper
+    )
+    assert "if jq -e '. != null'" in helper
+    assert 'if [ "$attempt" -eq 10 ]' in helper
+    assert "sleep 3" in helper
     assert "releases/$release_id/assets?per_page=100&page=1" in helper
     assert "releases/$release_id/assets?per_page=100&page=2" in helper
     assert "releases/assets/$asset_id" in helper

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -407,6 +407,7 @@ def _report(
     launcher: str = "uv-tool",
     released_artifact: bool = True,
     artifact_identity_verified: bool = True,
+    version: str = "1.0.0",
 ) -> LiveValidationReport:
     now = _timestamp()
     absolute_root = Path(Path.cwd().anchor) / "clio-relay-test"
@@ -423,18 +424,18 @@ def _report(
             invocation_id="run-20260710-0001",
         ),
         software=SoftwareIdentity(
-            version="1.0.0",
+            version=version,
             commit="a" * 40,
-            tag="v1.0.0",
+            tag=f"v{version}",
             dirty=False,
         ),
         install_source=InstallSource(
             kind=kind,
             detected_kind=kind,
-            reference="clio-relay==1.0.0",
+            reference=f"clio-relay=={version}",
             launcher=launcher,
             package_path="/tmp/uv/archive/clio_relay",
-            distribution_version="1.0.0",
+            distribution_version=version,
             artifact_sha256="b" * 64,
             artifact_identity_verified=artifact_identity_verified,
             released_artifact=released_artifact,
@@ -1410,7 +1411,7 @@ def test_actual_release_policy_combines_bootstrap_with_worker_by_physical_target
             )
         )
 
-    bootstrap = _report()
+    bootstrap = _report(version=policy.release_version)
     bootstrap.report_id = "validation_bootstrap"
     bootstrap.scenario = "cluster-bootstrap"
     bootstrap.cluster = "ares"
@@ -1437,7 +1438,7 @@ def test_actual_release_policy_combines_bootstrap_with_worker_by_physical_target
     ]
     attach_target(bootstrap)
 
-    worker = _report()
+    worker = _report(version=policy.release_version)
     worker.report_id = "validation_worker"
     worker.scenario = "cluster-bootstrap"
     worker.cluster = "ares"
@@ -1611,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.0.0"
+    assert policy.release_version == "1.0.1"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256
@@ -1857,7 +1858,7 @@ def test_explicit_cancel_release_gate_requires_preserved_unowned_scheduler_senti
 
 def test_repository_policy_target_digests_match_canonical_live_pins() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
-    ares = _report()
+    ares = _report(version=policy.release_version)
     ares.cluster = "ares"
     _attach_verified_target_identity(
         ares,
@@ -1877,7 +1878,7 @@ def test_repository_policy_target_digests_match_canonical_live_pins() -> None:
         }
     )
 
-    homelab = _report()
+    homelab = _report(version=policy.release_version)
     homelab.report_id = "validation_homelab"
     homelab.cluster = "homelab"
     _attach_verified_target_identity(
@@ -1930,7 +1931,7 @@ def test_native_application_progress_gate_rejects_legacy_adapter_only_evidence()
             }
         )
     )
-    report = _report()
+    report = _report(version=policy.release_version)
     report.scenario = "remote-mcp"
     report.cluster = "ares"
     now = _timestamp()
@@ -2359,7 +2360,7 @@ def test_spack_producer_evidence_satisfies_real_policy_and_rejects_mutations() -
         item for item in requirement.required_resources if item.kind == "relay_worker"
     )
     reports: list[LiveValidationReport] = []
-    trusted = _report()
+    trusted = _report(version=policy.release_version)
     for index, (tool, arguments, expectation_fields, structured) in enumerate(cases, start=1):
         expectation = RemoteMcpStructuredResultExpectation.model_validate(
             {
@@ -2475,6 +2476,8 @@ def test_spack_producer_evidence_satisfies_real_policy_and_rejects_mutations() -
 
 def _fresh_spack_transition_report(
     requirement: ReleaseGateRequirement,
+    *,
+    release_version: str,
 ) -> LiveValidationReport:
     """Build representative canonical evidence for the typed fresh-install gate."""
     requested_spec = "libsigsegv@2.14"
@@ -2637,7 +2640,7 @@ def _fresh_spack_transition_report(
             "phases_match": True,
         },
     }
-    report = _report()
+    report = _report(version=release_version)
     report.report_id = "validation_ares_spack_fresh_install"
     report.cluster = "ares"
     report.checks = [
@@ -2917,7 +2920,10 @@ def test_fresh_spack_transition_policy_cross_binds_dynamic_evidence(case: str) -
             "targets": {},
         }
     )
-    report = _fresh_spack_transition_report(requirement)
+    report = _fresh_spack_transition_report(
+        requirement,
+        release_version=policy.release_version,
+    )
 
     accepted = _evaluate(policy, [report])
     assert accepted.passed is True
@@ -3165,7 +3171,7 @@ def test_gateway_start_and_stop_reports_combine_for_release_gate() -> None:
         invocation_id: str,
         include_worker: bool,
     ) -> LiveValidationReport:
-        evidence = _report()
+        evidence = _report(version=policy.release_version)
         evidence.report_id = report_id
         evidence.scenario = canonical.scenario
         evidence.cluster = canonical.cluster

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- correct the PowerShell candidate-manifest parser for GNU `sha256sum` text and binary separators
- add a bounded, null-only retry for GitHub draft-release list visibility after creation
- bind package, policy, matrix, and runbook to release candidate 1.0.1
- add regression tests for checksum parsing, release identity consistency, and retry ordering
- document that immutable v1.0.0 was abandoned before publication

## Why

The first v1.0.0 candidate acceptance run stopped before cluster bootstrap because the tagged runbook treated GNU's two-character checksum separator as one character. Staging also exposed GitHub release-list eventual consistency immediately after draft creation. The v1.0.0 tag is immutable, so 1.0.1 is the corrected release candidate.

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright` (0 errors)
- `uv run pytest -q tests/test_release_acceptance_runbook.py tests/test_release_workflows.py tests/test_ci_validation.py tests/test_validation_report.py` (220 passed)
- LF-normalized `bash -n .github/scripts/release-api.sh`
- `git diff --check`