### PR TITLE
fix: retry Windows durable record deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> The current development candidate is `1.0.1`; the immutable `v1.0.0` candidate
+> The current development candidate is `1.0.2`. The immutable `v1.0.0` candidate
 > was abandoned before publication after its acceptance runbook rejected the
-> staged GNU checksum format. The latest released live evidence is `0.9.22`;
-> 1.0.1 is not release-complete until its immutable-candidate
+> staged GNU checksum format; `v1.0.1` was also abandoned before publication
+> after protected-main validation exposed a Windows lease-deletion race. The
+> latest released live evidence is `0.9.22`;
+> 1.0.2 is not release-complete until its immutable-candidate
 > reports pass, its exact candidate is published, and the released-artifact
 > runs pass again. The policy currently selects the `ares` and `homelab`
 > evidence labels; those labels are release configuration, not hardcoded

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.0.1"
+$Version = "1.0.2"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.0.1"
+release_version: "1.0.2"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: ad15a5d03b7bec8d15343b6931fc4ba7abcc7d2fe466154becb6bb1ec3eeab4c
+acceptance_matrix_sha256: 4adf6567e504c1a2ea9879358466ad0751f9b4bec6a496888267964a10b0de91
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -70,7 +70,7 @@ Commit the release change with a conventional commit, then create and push an
 exact matching tag:
 
 ```powershell
-$Tag = "v1.0.1"
+$Tag = "v1.0.2"
 git fetch origin main
 $ReviewedMainSha = (git rev-parse refs/remotes/origin/main).Trim()
 if ((git rev-parse HEAD).Trim() -ne $ReviewedMainSha) {
@@ -155,7 +155,7 @@ Download the draft wheel and manifest, verify both the digest and the signed
 tag-build provenance, and compute the digest locally:
 
 ```powershell
-$Tag = "v1.0.1"
+$Tag = "v1.0.2"
 New-Item -ItemType Directory -Force .clio-relay\candidate | Out-Null
 gh release download $Tag --pattern "*.whl" --pattern "SHA256SUMS" `
   --dir .clio-relay\candidate

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.0.1",
-  "matrix_sha256": "ad15a5d03b7bec8d15343b6931fc4ba7abcc7d2fe466154becb6bb1ec3eeab4c",
+  "release_version": "1.0.2",
+  "matrix_sha256": "4adf6567e504c1a2ea9879358466ad0751f9b4bec6a496888267964a10b0de91",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.0.1"
+version = "1.0.2"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -1086,13 +1086,6 @@ def endpoint_target_info(
     """Report physical host and scheduler identity from the cluster process context."""
 
     def action() -> None:
-        machine_id_path = Path("/etc/machine-id")
-        try:
-            machine_id = machine_id_path.read_text(encoding="utf-8").strip()
-        except OSError as exc:
-            raise ConfigurationError(f"could not read physical site marker: {exc}") from exc
-        if not machine_id:
-            raise ConfigurationError("physical site marker is empty")
         provider = provider_for_scheduler(scheduler_provider)
         scheduler_cluster_name = provider.scheduler_cluster_name()
         typer.echo(
@@ -1101,7 +1094,7 @@ def endpoint_target_info(
                     "schema_version": "clio-relay.cluster-target-info.v1",
                     "hostname": socket.gethostname(),
                     "fqdn": socket.getfqdn(),
-                    "site_marker_sha256": hashlib.sha256(machine_id.encode()).hexdigest(),
+                    "site_marker_sha256": _physical_site_marker_sha256(Path("/etc/machine-id")),
                     "scheduler_provider": provider.name,
                     "scheduler_cluster_name": scheduler_cluster_name,
                 },
@@ -1110,6 +1103,17 @@ def endpoint_target_info(
         )
 
     _run_or_exit(action)
+
+
+def _physical_site_marker_sha256(path: Path) -> str:
+    """Hash the exact physical-site marker bytes used by operator pinning tools."""
+    try:
+        marker = path.read_bytes()
+    except OSError as exc:
+        raise ConfigurationError(f"could not read physical site marker: {exc}") from exc
+    if not marker.strip():
+        raise ConfigurationError("physical site marker is empty")
+    return hashlib.sha256(marker).hexdigest()
 
 
 @cluster_app.command("list")

--- a/src/clio_relay/core_queue.py
+++ b/src/clio_relay/core_queue.py
@@ -1135,7 +1135,7 @@ class ClioCoreQueue:
         self._clear_lease_operational_indexes_unlocked()
         for lease, job, _identity in indexed:
             self._sync_lease_operational_indexes_unlocked(lease, job=job)
-        intent_path.unlink(missing_ok=True)
+        _unlink_durable_path(intent_path, missing_ok=True)
         return len(indexed)
 
     def _clear_lease_operational_indexes_unlocked(self) -> None:
@@ -1191,7 +1191,7 @@ class ClioCoreQueue:
         for root in roots:
             inspect(root, depth=0)
         for path in files:
-            path.unlink()
+            _unlink_durable_path(path)
         for path in sorted(directories, key=lambda item: len(item.parts), reverse=True):
             path.rmdir()
 
@@ -2260,7 +2260,7 @@ class ClioCoreQueue:
                         stale_path.parent,
                         create=False,
                     )
-                    stale_path.unlink(missing_ok=True)
+                    _unlink_durable_path(stale_path, missing_ok=True)
         self._write_lease_index_identity_unlocked(identity)
         for path in (
             self._lease_identity_ref_path(identity),
@@ -2300,7 +2300,7 @@ class ClioCoreQueue:
             self._lease_identity_ref_path(identity),
         ):
             self._require_safe_lease_index_directory(path.parent, create=False)
-            path.unlink(missing_ok=True)
+            _unlink_durable_path(path, missing_ok=True)
         endpoint_directory = self._lease_endpoint_directory(identity.endpoint_id)
         if endpoint_directory.exists():
             with os.scandir(endpoint_directory) as entries:
@@ -2308,7 +2308,7 @@ class ClioCoreQueue:
             if endpoint_empty:
                 endpoint_directory.rmdir()
         if owns_manifest and os.path.lexists(index_path):
-            index_path.unlink()
+            _unlink_durable_path(index_path)
 
     def _require_safe_lease_index_directory(
         self,
@@ -2811,11 +2811,14 @@ class ClioCoreQueue:
                         raise QueueConflictError(
                             f"scheduler cancellation disposition is not terminal: {completed_path}"
                         )
-                    self._scheduler_cancel_record_path(
-                        "scheduler_cancel_pending",
-                        record.cluster,
-                        record.job_id,
-                    ).unlink(missing_ok=True)
+                    _unlink_durable_path(
+                        self._scheduler_cancel_record_path(
+                            "scheduler_cancel_pending",
+                            record.cluster,
+                            record.job_id,
+                        ),
+                        missing_ok=True,
+                    )
                     continue
                 active_records.append(record)
             records = active_records
@@ -3282,7 +3285,7 @@ class ClioCoreQueue:
         self._write(self._job_record_path("leases_by_job", job.job_id, lease.lease_id), lease)
         self._sync_lease_operational_indexes_unlocked(lease, job=leased_job)
         self._after_lease_operational_index_write(lease)
-        intent_path.unlink(missing_ok=True)
+        _unlink_durable_path(intent_path, missing_ok=True)
         self.append_event(
             job.job_id,
             "job.leased",
@@ -3423,7 +3426,7 @@ class ClioCoreQueue:
                 job=job,
                 previous_lease=lease,
             )
-            intent_path.unlink(missing_ok=True)
+            _unlink_durable_path(intent_path, missing_ok=True)
             return renewed
 
     def recover_stale_jobs(self, *, cluster: str, max_attempts: int = 3) -> list[RelayJob]:
@@ -3678,7 +3681,7 @@ class ClioCoreQueue:
                 identity=identity,
                 finalize_intent=False,
             )
-        intent_path.unlink(missing_ok=True)
+        _unlink_durable_path(intent_path, missing_ok=True)
         return target
 
     def _write_recovery_event_unlocked(self, event: RelayEvent) -> None:
@@ -3769,13 +3772,19 @@ class ClioCoreQueue:
                     "index": _lease_index_document(identity),
                 },
             )
-        (self._storage_root / "leases" / f"{lease.lease_id}.json").unlink(missing_ok=True)
+        _unlink_durable_path(
+            self._storage_root / "leases" / f"{lease.lease_id}.json",
+            missing_ok=True,
+        )
         self._after_lease_canonical_delete(lease)
-        self._job_record_path("leases_by_job", lease.job_id, lease.lease_id).unlink(missing_ok=True)
+        _unlink_durable_path(
+            self._job_record_path("leases_by_job", lease.job_id, lease.lease_id),
+            missing_ok=True,
+        )
         self._delete_lease_operational_indexes_unlocked(identity)
         self._after_lease_index_delete(lease)
         if finalize_intent:
-            owned_intent.unlink(missing_ok=True)
+            _unlink_durable_path(owned_intent, missing_ok=True)
 
     def _after_lease_canonical_delete(self, _lease: Lease) -> None:
         """Fault-injection seam after the canonical lease record is removed."""
@@ -4114,7 +4123,7 @@ class ClioCoreQueue:
             self._sync_task_retention_indexes_unlocked(updated)
             self._after_execution_cleanup_canonical_ack(updated)
             pending_path = self._execution_cleanup_path(cluster, job_id, task_id)
-            pending_path.unlink(missing_ok=True)
+            _unlink_durable_path(pending_path, missing_ok=True)
             self._fsync_execution_cleanup_directory(pending_path.parent)
             try:
                 pending_path.parent.rmdir()
@@ -4460,7 +4469,7 @@ class ClioCoreQueue:
                     raise QueueConflictError(
                         f"execution cleanup migration target conflicts: {target}"
                     )
-                legacy_path.unlink()
+                _unlink_durable_path(legacy_path)
             else:
                 legacy_path.replace(target)
             self._fsync_execution_cleanup_directory(target.parent)
@@ -5253,7 +5262,7 @@ class ClioCoreQueue:
                         f"{owner_session_id}"
                     )
                 previous_generation_id = closing_generation
-                closing_path.unlink(missing_ok=True)
+                _unlink_durable_path(closing_path, missing_ok=True)
                 closing_generation = None
             if (
                 self.get_owner_session_closed(
@@ -5405,7 +5414,7 @@ class ClioCoreQueue:
                             f"owner session has an unfinished generation transition: "
                             f"{owner_session_id}"
                         )
-                    closing_path.unlink(missing_ok=True)
+                    _unlink_durable_path(closing_path, missing_ok=True)
                     return active_generation
                 if recorded_generation_id not in {None, active_generation}:
                     previous_generation = (
@@ -5468,7 +5477,7 @@ class ClioCoreQueue:
                 },
             )
             if closing_generation is not None:
-                closing_path.unlink(missing_ok=True)
+                _unlink_durable_path(closing_path, missing_ok=True)
             return selected_generation
 
     def clear_owner_session_closing(
@@ -5625,7 +5634,10 @@ class ClioCoreQueue:
                     self._owner_session_closed_path(owner_session_id),
                     legacy_closure,
                 )
-            self._owner_session_active_path(owner_session_id).unlink(missing_ok=True)
+            _unlink_durable_path(
+                self._owner_session_active_path(owner_session_id),
+                missing_ok=True,
+            )
             if not closing_path.is_file():
                 raise QueueConflictError(
                     f"owner session closing proof disappeared: {owner_session_id}"
@@ -6069,7 +6081,7 @@ class ClioCoreQueue:
             task.task_id,
         )
         if task.state in TERMINAL_STATES:
-            active_path.unlink(missing_ok=True)
+            _unlink_durable_path(active_path, missing_ok=True)
         else:
             self._write(active_path, task)
         self._sync_scheduler_source_unlocked(
@@ -6093,7 +6105,7 @@ class ClioCoreQueue:
         if rule.enabled and rule.triggered_at is None:
             self._write(active_path, rule)
         else:
-            active_path.unlink(missing_ok=True)
+            _unlink_durable_path(active_path, missing_ok=True)
 
     def _sync_scheduler_source_unlocked(
         self,
@@ -6130,8 +6142,9 @@ class ClioCoreQueue:
                 raise QueueConflictError(f"scheduler reference is invalid: {manifest_path}")
             old_ids = set(cast(list[str], raw_old_ids))
         for scheduler_id in old_ids - scheduler_ids:
-            self._scheduler_reverse_ref_path(scheduler_id, job_id, source_id).unlink(
-                missing_ok=True
+            _unlink_durable_path(
+                self._scheduler_reverse_ref_path(scheduler_id, job_id, source_id),
+                missing_ok=True,
             )
             gateway_paths = self._bounded_json_record_paths(
                 self._gateway_reverse_directory("scheduler", scheduler_id),
@@ -6158,14 +6171,14 @@ class ClioCoreQueue:
                 },
             )
         else:
-            manifest_path.unlink(missing_ok=True)
+            _unlink_durable_path(manifest_path, missing_ok=True)
         if ambiguous:
             self._write_json(
                 protection_path,
                 {"job_id": job_id, "source_id": source_id, "ambiguous": True},
             )
         else:
-            protection_path.unlink(missing_ok=True)
+            _unlink_durable_path(protection_path, missing_ok=True)
         for scheduler_id in scheduler_ids:
             self._write_json(
                 self._scheduler_reverse_ref_path(scheduler_id, job_id, source_id),
@@ -6291,13 +6304,14 @@ class ClioCoreQueue:
             record_name = job_ref.get("record_name")
             if not isinstance(job_id, str) or not isinstance(record_name, str):
                 raise QueueConflictError(f"gateway job reference is invalid: {path}")
-            (
+            _unlink_durable_path(
                 self._storage_root
                 / "active_gateway_refs_by_job"
                 / self._durable_key(job_id)
-                / record_name
-            ).unlink(missing_ok=True)
-            path.unlink(missing_ok=True)
+                / record_name,
+                missing_ok=True,
+            )
+            _unlink_durable_path(path, missing_ok=True)
         reverse_backlinks = (
             self._storage_root / "gateway_reverse_refs_by_session" / self._durable_key(session_id)
         )
@@ -6322,10 +6336,11 @@ class ClioCoreQueue:
                 or not isinstance(record_name, str)
             ):
                 raise QueueConflictError(f"gateway reverse reference is invalid: {path}")
-            (self._gateway_reverse_directory(cast(str, family), key) / record_name).unlink(
-                missing_ok=True
+            _unlink_durable_path(
+                self._gateway_reverse_directory(cast(str, family), key) / record_name,
+                missing_ok=True,
             )
-            path.unlink(missing_ok=True)
+            _unlink_durable_path(path, missing_ok=True)
 
     def _write_gateway_reverse_ref_unlocked(
         self,
@@ -6420,18 +6435,20 @@ class ClioCoreQueue:
         record_name = (
             f"{_stable_ref_token(session_id, relation_kind, relation_key, source_id or '')}.json"
         )
-        (
+        _unlink_durable_path(
             self._storage_root
             / "active_gateway_refs_by_job"
             / self._durable_key(job_id)
-            / record_name
-        ).unlink(missing_ok=True)
-        (
+            / record_name,
+            missing_ok=True,
+        )
+        _unlink_durable_path(
             self._storage_root
             / "active_gateway_refs_by_session"
             / self._durable_key(session_id)
-            / f"{_stable_ref_token(job_id, record_name)}.json"
-        ).unlink(missing_ok=True)
+            / f"{_stable_ref_token(job_id, record_name)}.json",
+            missing_ok=True,
+        )
 
     def _gateway_reverse_directory(self, relation_kind: str, relation_key: str) -> Path:
         if relation_kind not in {"artifact", "scheduler"}:
@@ -6883,7 +6900,7 @@ class ClioCoreQueue:
             record.job_id,
         )
         self._write(completed_path, record)
-        pending_path.unlink(missing_ok=True)
+        _unlink_durable_path(pending_path, missing_ok=True)
         return record
 
     def _ensure_active_job_capacity_unlocked(self, job: RelayJob) -> None:
@@ -6974,7 +6991,7 @@ class ClioCoreQueue:
                 / f"{endpoint.endpoint_id}.json"
             )
             if previous_target != target:
-                previous_target.unlink(missing_ok=True)
+                _unlink_durable_path(previous_target, missing_ok=True)
         self._write(target, endpoint)
         self._write_json(
             mapping_path,
@@ -7004,7 +7021,7 @@ class ClioCoreQueue:
         )
         self._write(self._storage_root / "jobs" / f"{job.job_id}.json", job)
         self._sync_job_derived_unlocked(job)
-        intent_path.unlink(missing_ok=True)
+        _unlink_durable_path(intent_path, missing_ok=True)
 
     def _sync_job_derived_unlocked(self, job: RelayJob) -> None:
         """Converge every mutable job index from one canonical job record."""
@@ -7017,14 +7034,14 @@ class ClioCoreQueue:
         active_path = self._storage_root / "jobs_active" / f"{job.job_id}.json"
         queued_path = self._storage_root / "jobs_queued" / f"{job.job_id}.json"
         if job.state in TERMINAL_STATES:
-            active_path.unlink(missing_ok=True)
-            queued_path.unlink(missing_ok=True)
+            _unlink_durable_path(active_path, missing_ok=True)
+            _unlink_durable_path(queued_path, missing_ok=True)
             return
         self._write(active_path, job)
         if job.state is JobState.QUEUED:
             self._write(queued_path, job)
         else:
-            queued_path.unlink(missing_ok=True)
+            _unlink_durable_path(queued_path, missing_ok=True)
 
     def _write_task_unlocked(self, task: RelayTask) -> None:
         """Write one task and make its per-job and scheduler indexes replayable."""
@@ -7035,7 +7052,7 @@ class ClioCoreQueue:
         )
         self._write(self._storage_root / "tasks" / f"{task.task_id}.json", task)
         self._sync_task_derived_unlocked(task)
-        intent_path.unlink(missing_ok=True)
+        _unlink_durable_path(intent_path, missing_ok=True)
 
     def _sync_task_derived_unlocked(self, task: RelayTask) -> None:
         """Converge task indexes and scheduler references from the canonical task."""
@@ -7064,7 +7081,7 @@ class ClioCoreQueue:
         )
         self._after_gateway_canonical_write(session)
         self._sync_gateway_session_derived_unlocked(session.session_id)
-        intent_path.unlink(missing_ok=True)
+        _unlink_durable_path(intent_path, missing_ok=True)
 
     def _after_gateway_canonical_write(self, _session: GatewaySession) -> None:
         """Fault-injection seam after a canonical gateway transition."""
@@ -7159,7 +7176,7 @@ class ClioCoreQueue:
                     job=job,
                     previous_lease=previous,
                 )
-                path.unlink(missing_ok=True)
+                _unlink_durable_path(path, missing_ok=True)
                 continue
             if kind == "lease_delete":
                 lease_id = payload.get("lease_id")
@@ -7182,11 +7199,17 @@ class ClioCoreQueue:
                     self._validate_lease_index_identity(lease, identity)
                     if lease_id != lease.lease_id or job_id != lease.job_id:
                         raise QueueConflictError(f"lease deletion intent identity mismatch: {path}")
-                (self._storage_root / "leases" / f"{lease_id}.json").unlink(missing_ok=True)
-                self._job_record_path("leases_by_job", job_id, lease_id).unlink(missing_ok=True)
+                _unlink_durable_path(
+                    self._storage_root / "leases" / f"{lease_id}.json",
+                    missing_ok=True,
+                )
+                _unlink_durable_path(
+                    self._job_record_path("leases_by_job", job_id, lease_id),
+                    missing_ok=True,
+                )
                 if identity is not None:
                     self._delete_lease_operational_indexes_unlocked(identity)
-                path.unlink(missing_ok=True)
+                _unlink_durable_path(path, missing_ok=True)
                 continue
             if kind == "stale_lease_recovery":
                 recovered_stale_jobs.append(
@@ -7200,7 +7223,7 @@ class ClioCoreQueue:
                 job = self._read_optional(self._storage_root / "jobs" / f"{job_id}.json", RelayJob)
                 if job is not None:
                     self._sync_job_derived_unlocked(job)
-                path.unlink(missing_ok=True)
+                _unlink_durable_path(path, missing_ok=True)
                 continue
             if kind == "task_sync":
                 task_id = payload.get("task_id")
@@ -7211,14 +7234,14 @@ class ClioCoreQueue:
                 )
                 if task is not None:
                     self._sync_task_derived_unlocked(task)
-                path.unlink(missing_ok=True)
+                _unlink_durable_path(path, missing_ok=True)
                 continue
             if kind == "gateway_sync":
                 session_id = payload.get("session_id")
                 if not isinstance(session_id, str) or not session_id:
                     raise QueueConflictError(f"invalid gateway transition intent: {path}")
                 self._sync_gateway_session_derived_unlocked(session_id)
-                path.unlink(missing_ok=True)
+                _unlink_durable_path(path, missing_ok=True)
                 continue
             raise QueueConflictError(f"unsupported queue transition intent kind {kind!r}: {path}")
         return recovered_stale_jobs
@@ -7272,13 +7295,13 @@ class ClioCoreQueue:
             self._write(indexed_path, lease)
             self._sync_lease_operational_indexes_unlocked(lease, job=current)
         else:
-            lease_path.unlink(missing_ok=True)
-            indexed_path.unlink(missing_ok=True)
+            _unlink_durable_path(lease_path, missing_ok=True)
+            _unlink_durable_path(indexed_path, missing_ok=True)
             self._delete_lease_operational_indexes_unlocked(
                 identity,
                 allow_foreign_manifest=True,
             )
-        path.unlink(missing_ok=True)
+        _unlink_durable_path(path, missing_ok=True)
 
     def _repair_active_job_index_unlocked(self) -> None:
         """Remove stale capacity entries and refresh every indexed active job."""
@@ -7294,9 +7317,10 @@ class ClioCoreQueue:
                 RelayJob,
             )
             if canonical is None or canonical.state in TERMINAL_STATES:
-                path.unlink(missing_ok=True)
-                (self._storage_root / "jobs_queued" / f"{indexed.job_id}.json").unlink(
-                    missing_ok=True
+                _unlink_durable_path(path, missing_ok=True)
+                _unlink_durable_path(
+                    self._storage_root / "jobs_queued" / f"{indexed.job_id}.json",
+                    missing_ok=True,
                 )
                 continue
             self._write(path, canonical)
@@ -7304,7 +7328,7 @@ class ClioCoreQueue:
             if canonical.state is JobState.QUEUED:
                 self._write(queued_path, canonical)
             else:
-                queued_path.unlink(missing_ok=True)
+                _unlink_durable_path(queued_path, missing_ok=True)
 
     def _terminal_job_gc_protections(self, job: RelayJob) -> list[str]:
         protections: list[str] = []
@@ -7651,11 +7675,14 @@ class ClioCoreQueue:
             for scheduler_id in cast(list[object], raw_ids):
                 if not isinstance(scheduler_id, str):
                     raise QueueConflictError(f"scheduler reference is invalid: {path}")
-                self._scheduler_reverse_ref_path(
-                    scheduler_id,
-                    tombstone.job_id,
-                    source_id,
-                ).unlink(missing_ok=True)
+                _unlink_durable_path(
+                    self._scheduler_reverse_ref_path(
+                        scheduler_id,
+                        tombstone.job_id,
+                        source_id,
+                    ),
+                    missing_ok=True,
+                )
             _move_gc_path(path, trash / "processed" / "scheduler_refs_by_job" / path.name)
             actions += 1
         references_empty = all(
@@ -8517,7 +8544,7 @@ class ClioCoreQueue:
         except OSError as error:
             raise QueueConflictError(f"cannot scan queue write staging: {staging}") from error
         for path in leftovers:
-            path.unlink()
+            _unlink_durable_path(path)
         if leftovers:
             self._fsync_write_directory(staging)
 
@@ -8573,7 +8600,7 @@ class ClioCoreQueue:
                         raise
                     time.sleep(ATOMIC_REPLACE_RETRY_SECONDS)
         finally:
-            temporary.unlink(missing_ok=True)
+            _unlink_durable_path(temporary, missing_ok=True)
         self._fsync_write_directory(staging)
         self._fsync_write_directory(internal_path.parent)
 
@@ -9434,7 +9461,7 @@ def _remove_gc_candidate(
         if stat.S_ISDIR(candidate_stat.st_mode):
             os.rmdir(candidate)
         else:
-            candidate.unlink()
+            _unlink_durable_path(candidate)
     except OSError as exc:
         raise QueueConflictError(
             f"GC could not remove quarantined path {candidate}: {exc}"
@@ -9666,6 +9693,21 @@ def _transient_record_access_conflict(error: QueueConflictError) -> bool:
         or cause.errno in {errno.EACCES, errno.EPERM}
         or getattr(cause, "winerror", None) in {5, 32, 33}
     )
+
+
+def _unlink_durable_path(path: Path, *, missing_ok: bool = False) -> None:
+    """Delete one durable path after bounded Windows sharing-violation retries."""
+    for attempt in range(ATOMIC_REPLACE_ATTEMPTS):
+        try:
+            path.unlink(missing_ok=missing_ok)
+            return
+        except OSError as error:
+            if (
+                getattr(error, "winerror", None) not in {5, 32, 33}
+                or attempt + 1 >= ATOMIC_REPLACE_ATTEMPTS
+            ):
+                raise
+            time.sleep(ATOMIC_REPLACE_RETRY_SECONDS)
 
 
 def _job_idempotency_digest(job: RelayJob) -> str:

--- a/src/clio_relay/core_queue.py
+++ b/src/clio_relay/core_queue.py
@@ -9461,7 +9461,7 @@ def _remove_gc_candidate(
         if stat.S_ISDIR(candidate_stat.st_mode):
             os.rmdir(candidate)
         else:
-            _unlink_durable_path(candidate)
+            candidate.unlink()
     except OSError as exc:
         raise QueueConflictError(
             f"GC could not remove quarantined path {candidate}: {exc}"

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -451,7 +451,7 @@ def test_actions_artifact_manifest_rejects_replay_or_unbounded_metadata(
     elif mutation == "head":
         run["head_sha"] = "b" * 40
     elif mutation == "name":
-        artifact["name"] = "release-candidate-v1.0.1"
+        artifact["name"] = "release-candidate-v1.0.2"
     elif mutation == "count":
         artifacts["total_count"] = 2
     elif mutation == "expired":
@@ -1009,7 +1009,7 @@ def test_release_identity_rejects_mutable_or_mismatched_identity(mutation: str) 
     tag_commit = COMMIT
     target_commit = COMMIT
     if mutation == "tag_name":
-        release["tag_name"] = "v1.0.1"
+        release["tag_name"] = "v1.0.2"
     elif mutation == "tag_resolution":
         tag_commit = "b" * 40
     elif mutation == "target_resolution":
@@ -1330,7 +1330,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "ad15a5d03b7bec8d15343b6931fc4ba7abcc7d2fe466154becb6bb1ec3eeab4c"
+        "4adf6567e504c1a2ea9879358466ad0751f9b4bec6a496888267964a10b0de91"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4825,6 +4825,27 @@ def test_ssh_host_key_fingerprint_parser_rejects_revoked_and_malformed_records()
     assert fingerprints == {f"SHA256:{expected}"}
 
 
+def test_endpoint_target_info_hashes_raw_machine_id_bytes(
+    tmp_path: Path,
+) -> None:
+    machine_id = tmp_path / "machine-id"
+    marker = b"production-site-id\n"
+    machine_id.write_bytes(marker)
+
+    observed = cli._physical_site_marker_sha256(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        machine_id
+    )
+
+    assert observed == hashlib.sha256(marker).hexdigest()
+    assert observed != hashlib.sha256(marker.strip()).hexdigest()
+
+    machine_id.write_bytes(b"\n")
+    with pytest.raises(ConfigurationError, match="physical site marker is empty"):
+        cli._physical_site_marker_sha256(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            machine_id
+        )
+
+
 def test_remote_worker_info_binds_worker_to_operator_pinned_physical_target(
     monkeypatch: MonkeyPatch,
 ) -> None:

--- a/tests/test_core_retention.py
+++ b/tests/test_core_retention.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 
 import pytest
 
+import clio_relay.core_queue as core_queue_module
 from clio_relay.core_queue import (
     RECORD_FAMILY_MAX_BYTES,
     ClioCoreQueue,
@@ -28,6 +29,12 @@ from clio_relay.models import (
     RelayTask,
     StorageReservationEstimate,
 )
+
+
+class _SimulatedWindowsSharingViolation(PermissionError):
+    """Portable WinError 32 fixture for fail-closed GC deletion tests."""
+
+    winerror = 32
 
 
 def _intent(key: str, *, metadata: dict[str, object] | None = None) -> RelayJob:
@@ -711,6 +718,50 @@ def test_gc_purge_is_iterative_and_detects_directory_swap_races(
     with pytest.raises(QueueConflictError, match="changed during traversal"):
         _purge_tree_batch(race_root, limit=1)
     assert (moved_root / "record.json").is_file()
+
+
+def test_gc_windows_delete_does_not_retry_a_replaced_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "trash"
+    root.mkdir()
+    candidate = root / "record.json"
+    candidate.write_text("original", encoding="utf-8")
+    displaced = tmp_path / "original-record.json"
+    root_stat = os.lstat(root)
+    candidate_stat = os.lstat(candidate)
+    original_unlink = Path.unlink
+    attempts = 0
+
+    def swap_then_unlink(path: Path, missing_ok: bool = False) -> None:
+        nonlocal attempts
+        if path == candidate:
+            attempts += 1
+            if attempts == 1:
+                candidate.replace(displaced)
+                candidate.write_text("replacement", encoding="utf-8")
+                raise _SimulatedWindowsSharingViolation(
+                    13,
+                    "simulated Windows sharing violation",
+                    str(path),
+                )
+        original_unlink(path, missing_ok=missing_ok)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(core_queue_module.os, "name", "nt")
+        patch.setattr(Path, "unlink", swap_then_unlink)
+        with pytest.raises(QueueConflictError, match="could not remove quarantined path"):
+            core_queue_module._remove_gc_candidate(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+                root,
+                candidate,
+                root_stat=root_stat,
+                candidate_stat=candidate_stat,
+            )
+
+    assert attempts == 1
+    assert displaced.read_text(encoding="utf-8") == "original"
+    assert candidate.read_text(encoding="utf-8") == "replacement"
 
 
 def test_terminal_gc_refuses_symlink_or_reparse_roots_without_following_them(

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -201,6 +201,97 @@ def test_durable_record_read_retries_wrapped_windows_sharing_denial(
     assert attempts == 2
 
 
+def test_release_lease_retries_windows_sharing_violation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue = ClioCoreQueue(tmp_path / "core")
+    job = queue.submit_job(
+        RelayJob(
+            cluster="ares",
+            kind=JobKind.JARVIS,
+            spec=JarvisRunSpec(command=["true"]),
+            idempotency_key="lease-delete-sharing-race",
+        )
+    )
+    lease = queue.acquire_next_job("sharing-race-worker", cluster="ares")
+    assert lease is not None
+    indexed_path = queue.root / "leases_by_job" / job.job_id / f"{lease.lease_id}.json"
+    original_unlink = Path.unlink
+    attempts = 0
+
+    def transient_unlink(path: Path, missing_ok: bool = False) -> None:
+        nonlocal attempts
+        if logical_filesystem_path(path) == indexed_path and attempts < 2:
+            attempts += 1
+            error = PermissionError(13, "simulated Windows sharing violation", str(path))
+            error.winerror = 32
+            raise error
+        original_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", transient_unlink)
+
+    queue.release_lease(lease.lease_id)
+
+    assert attempts == 2
+    assert queue.list_leases(cluster="ares") == []
+    assert queue.scan_job_leases(job.job_id, limit=10) == ([], False)
+    assert not queue._lease_index_path(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        lease.lease_id
+    ).exists()
+    assert list((queue.root / "transition_intents").glob("*.json")) == []
+
+
+def test_release_lease_sharing_violation_exhaustion_replays_on_restart(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "core"
+    queue = ClioCoreQueue(root)
+    job = queue.submit_job(
+        RelayJob(
+            cluster="ares",
+            kind=JobKind.JARVIS,
+            spec=JarvisRunSpec(command=["true"]),
+            idempotency_key="lease-delete-sharing-replay",
+        )
+    )
+    lease = queue.acquire_next_job("sharing-replay-worker", cluster="ares")
+    assert lease is not None
+    indexed_path = queue.root / "leases_by_job" / job.job_id / f"{lease.lease_id}.json"
+    original_unlink = Path.unlink
+    attempts = 0
+
+    def blocked_unlink(path: Path, missing_ok: bool = False) -> None:
+        nonlocal attempts
+        if logical_filesystem_path(path) == indexed_path:
+            attempts += 1
+            error = PermissionError(13, "simulated persistent sharing violation", str(path))
+            error.winerror = 32
+            raise error
+        original_unlink(path, missing_ok=missing_ok)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(Path, "unlink", blocked_unlink)
+        patch.setattr(core_queue_module, "ATOMIC_REPLACE_RETRY_SECONDS", 0.0)
+        with pytest.raises(PermissionError, match="persistent sharing violation"):
+            queue.release_lease(lease.lease_id)
+
+    assert attempts == core_queue_module.ATOMIC_REPLACE_ATTEMPTS
+    assert indexed_path.is_file()
+    assert len(list((queue.root / "transition_intents").glob("*.json"))) == 1
+
+    reopened = ClioCoreQueue(root)
+    reopened.initialize()
+
+    assert reopened.list_leases(cluster="ares") == []
+    assert reopened.scan_job_leases(job.job_id, limit=10) == ([], False)
+    assert not reopened._lease_index_path(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        lease.lease_id
+    ).exists()
+    assert list((reopened.root / "transition_intents").glob("*.json")) == []
+
+
 def test_durable_record_read_retries_identity_replacement_before_open(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -36,6 +36,12 @@ from clio_relay.models import (
 from clio_relay.relay_ops import evaluate_monitor_rules
 
 
+class _SimulatedWindowsSharingViolation(PermissionError):
+    """Portable WinError 32 fixture for cross-platform queue tests."""
+
+    winerror = 32
+
+
 def _stat_with_link_count(value: os.stat_result, link_count: int) -> os.stat_result:
     fields = list(value)
     fields[3] = link_count
@@ -224,9 +230,11 @@ def test_release_lease_retries_windows_sharing_violation(
         nonlocal attempts
         if logical_filesystem_path(path) == indexed_path and attempts < 2:
             attempts += 1
-            error = PermissionError(13, "simulated Windows sharing violation", str(path))
-            error.winerror = 32
-            raise error
+            raise _SimulatedWindowsSharingViolation(
+                13,
+                "simulated Windows sharing violation",
+                str(path),
+            )
         original_unlink(path, missing_ok=missing_ok)
 
     monkeypatch.setattr(Path, "unlink", transient_unlink)
@@ -266,9 +274,11 @@ def test_release_lease_sharing_violation_exhaustion_replays_on_restart(
         nonlocal attempts
         if logical_filesystem_path(path) == indexed_path:
             attempts += 1
-            error = PermissionError(13, "simulated persistent sharing violation", str(path))
-            error.winerror = 32
-            raise error
+            raise _SimulatedWindowsSharingViolation(
+                13,
+                "simulated persistent sharing violation",
+                str(path),
+            )
         original_unlink(path, missing_ok=missing_ok)
 
     with monkeypatch.context() as patch:

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -49,7 +49,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
 
 def test_candidate_manifest_parser_accepts_the_exact_gnu_checksum_separator() -> None:
     digest = "a" * 64
-    wheel_name = "clio_relay-1.0.1-py3-none-any.whl"
+    wheel_name = "clio_relay-1.0.2-py3-none-any.whl"
     selector = re.compile(rf"^[0-9A-Fa-f]{{64}} [ *]{re.escape(wheel_name)}$")
     parser = re.compile(r"^([0-9A-Fa-f]{64}) [ *](.+)$")
 

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1612,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.0.1"
+    assert policy.release_version == "1.0.2"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- retry durable queue-record deletion only for bounded Win32 sharing/access violations (errors 5, 32, and 33)
- apply the retry consistently to lease records, operational indexes, transition replay, and other durable queue indexes
- preserve bounded failure propagation and replayable transition intents
- add deterministic success and exhaustion/restart regression tests
- advance the immutable release candidate identity to 1.0.2 and refresh its acceptance-matrix digest

## Root cause

Lock-free queue readers can briefly hold a durable JSON record while a writer removes that generation. POSIX permits unlinking an open file, but Windows can return `WinError 32`. The direct unlink escaped the worker loop, so the transition remained recoverable on disk but the live worker stopped. The retry now covers only the transient Windows sharing boundary; permanent failures still surface.

## Validation

- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run pyright`
- `uv lock --check`
- 302 focused queue, operational-index, validation, and release-contract tests
- deterministic real-Windows held-handle reproduction verified before and after the fix