### PR TITLE
fix: handle Spack JSON arrays in release runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> The current development candidate is `1.0.2`. The immutable `v1.0.0` candidate
+> The current development candidate is `1.0.3`. The immutable `v1.0.0` candidate
 > was abandoned before publication after its acceptance runbook rejected the
 > staged GNU checksum format; `v1.0.1` was also abandoned before publication
-> after protected-main validation exposed a Windows lease-deletion race. The
+> after protected-main validation exposed a Windows lease-deletion race;
+> `v1.0.2` was abandoned before publication when candidate acceptance found a
+> strict-mode Spack JSON-array parsing defect in the reviewed runbook. The
 > latest released live evidence is `0.9.22`;
-> 1.0.2 is not release-complete until its immutable-candidate
+> 1.0.3 is not release-complete until its immutable-candidate
 > reports pass, its exact candidate is published, and the released-artifact
 > runs pass again. The policy currently selects the `ares` and `homelab`
 > evidence labels; those labels are release configuration, not hardcoded

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -848,7 +848,7 @@ valid substitute.
 function Start-OwnedSession {
   param([string] $Cluster, [string] $SessionId, [int] $RemotePort)
   & $Relay session start --cluster $Cluster --session-id $SessionId `
-    --remote-api-port $RemotePort --require-token
+    --remote-api-port $RemotePort --require-token | Out-Host
   if ($LASTEXITCODE -ne 0) { throw "session start failed: $SessionId" }
   $Status = (& $Relay session status --cluster $Cluster --session-id $SessionId | Out-String) | ConvertFrom-Json
   if (-not $Status.session_generation_id) { throw "session generation is absent" }

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.0.2"
+$Version = "1.0.3"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }
@@ -378,7 +378,9 @@ if ($ExpectedAdiosHash -cnotmatch '^[a-z0-9]{32}$') {
 function Get-SpackRecordHash {
   param([Parameter(Mandatory)] $Record)
   foreach ($Property in @("hash", "full_hash", "dag_hash")) {
-    $Value = [string]$Record.$Property
+    $Candidate = $Record.PSObject.Properties[$Property]
+    if ($null -eq $Candidate) { continue }
+    $Value = [string]$Candidate.Value
     if (-not [string]::IsNullOrWhiteSpace($Value)) { return $Value }
   }
   throw "Spack package record omitted its DAG hash"
@@ -389,11 +391,10 @@ $AdiosJson = (
 )
 if ($LASTEXITCODE -ne 0) { throw "selected plain ADIOS2 lookup failed" }
 $AdiosDecoded = $AdiosJson | ConvertFrom-Json
-$AdiosRecords = if ($null -ne $AdiosDecoded.specs) {
-  @($AdiosDecoded.specs)
-} else {
-  @($AdiosDecoded)
-}
+$AdiosSpecs = $AdiosDecoded.PSObject.Properties["specs"]
+$AdiosRecords = @(
+  if ($null -ne $AdiosSpecs) { $AdiosSpecs.Value } else { $AdiosDecoded }
+)
 $PlainAdios = @($AdiosRecords | Where-Object { [string]$_.name -ceq "adios2" })
 if ($PlainAdios.Count -ne 1 -or
     (Get-SpackRecordHash $PlainAdios[0]) -cne $ExpectedAdiosHash) {

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.0.2"
+release_version: "1.0.3"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 4adf6567e504c1a2ea9879358466ad0751f9b4bec6a496888267964a10b0de91
+acceptance_matrix_sha256: b23a4d0b6f355f697dac4eedf386ee6b64980453858a991b5ba24d2857e2be18
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -70,7 +70,7 @@ Commit the release change with a conventional commit, then create and push an
 exact matching tag:
 
 ```powershell
-$Tag = "v1.0.2"
+$Tag = "v1.0.3"
 git fetch origin main
 $ReviewedMainSha = (git rev-parse refs/remotes/origin/main).Trim()
 if ((git rev-parse HEAD).Trim() -ne $ReviewedMainSha) {
@@ -155,7 +155,7 @@ Download the draft wheel and manifest, verify both the digest and the signed
 tag-build provenance, and compute the digest locally:
 
 ```powershell
-$Tag = "v1.0.2"
+$Tag = "v1.0.3"
 New-Item -ItemType Directory -Force .clio-relay\candidate | Out-Null
 gh release download $Tag --pattern "*.whl" --pattern "SHA256SUMS" `
   --dir .clio-relay\candidate

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.0.2",
-  "matrix_sha256": "4adf6567e504c1a2ea9879358466ad0751f9b4bec6a496888267964a10b0de91",
+  "release_version": "1.0.3",
+  "matrix_sha256": "b23a4d0b6f355f697dac4eedf386ee6b64980453858a991b5ba24d2857e2be18",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.0.2"
+version = "1.0.3"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -451,7 +451,7 @@ def test_actions_artifact_manifest_rejects_replay_or_unbounded_metadata(
     elif mutation == "head":
         run["head_sha"] = "b" * 40
     elif mutation == "name":
-        artifact["name"] = "release-candidate-v1.0.2"
+        artifact["name"] = "release-candidate-v1.0.3"
     elif mutation == "count":
         artifacts["total_count"] = 2
     elif mutation == "expired":
@@ -1009,7 +1009,7 @@ def test_release_identity_rejects_mutable_or_mismatched_identity(mutation: str) 
     tag_commit = COMMIT
     target_commit = COMMIT
     if mutation == "tag_name":
-        release["tag_name"] = "v1.0.2"
+        release["tag_name"] = "v1.0.3"
     elif mutation == "tag_resolution":
         tag_commit = "b" * 40
     elif mutation == "target_resolution":
@@ -1330,7 +1330,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "4adf6567e504c1a2ea9879358466ad0751f9b4bec6a496888267964a10b0de91"
+        "b23a4d0b6f355f697dac4eedf386ee6b64980453858a991b5ba24d2857e2be18"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
+import subprocess
 import tomllib
 from pathlib import Path
 from typing import cast
@@ -73,6 +75,86 @@ def test_spack_json_array_fallback_is_safe_under_powershell_strict_mode() -> Non
     assert "$Record.$Property" not in runbook
     assert "$Candidate = $Record.PSObject.Properties[$Property]" in runbook
     assert "$Value = [string]$Candidate.Value" in runbook
+
+
+def test_owned_session_helper_isolates_command_output_from_its_return_value(
+    tmp_path: Path,
+) -> None:
+    runbook = RUNBOOK.read_text(encoding="utf-8")
+    function_match = re.search(
+        r"^function Start-OwnedSession \{.*?^\}",
+        runbook,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    assert function_match is not None
+    function_source = function_match.group(0)
+    assert "--remote-api-port $RemotePort --require-token | Out-Host" in function_source
+
+    powershell = next(
+        (
+            executable
+            for name in ("pwsh", "powershell.exe", "powershell")
+            if (executable := shutil.which(name)) is not None
+        ),
+        None,
+    )
+    assert powershell is not None, "PowerShell is required to validate the release runbook"
+    script_path = tmp_path / "owned-session-output.ps1"
+    script_path.write_text(
+        "\n".join(
+            (
+                "Set-StrictMode -Version Latest",
+                "$global:LASTEXITCODE = 0",
+                "$Relay = {",
+                "  param([Parameter(ValueFromRemainingArguments=$true)] [object[]] $Command)",
+                "  $global:LASTEXITCODE = 0",
+                "  if (($Command -join ' ') -like 'session start *') {",
+                "    'session_started=owned-session'",
+                "    'api_pid=123'",
+                "    'remote_api_port=9001'",
+                "    return",
+                "  }",
+                "  if (($Command -join ' ') -like 'session status *') {",
+                '    \'{"session_generation_id":"generation-123"}\'',
+                "    return",
+                "  }",
+                '  throw "unexpected relay command: $Command"',
+                "}",
+                function_source,
+                "$Generation = @(Start-OwnedSession 'ares' 'owned-session' 9001)",
+                "[pscustomobject]@{",
+                "  count = $Generation.Count",
+                "  value = [string]$Generation[0]",
+                "} | ConvertTo-Json -Compress",
+            )
+        ),
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [
+            powershell,
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(script_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    output_lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert output_lines[:3] == [
+        "session_started=owned-session",
+        "api_pid=123",
+        "remote_api_port=9001",
+    ]
+    assert json.loads(output_lines[-1]) == {"count": 1, "value": "generation-123"}
 
 
 def test_release_helper_scripts_bind_direct_gray_scott_and_private_spack_state() -> None:

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -49,7 +49,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
 
 def test_candidate_manifest_parser_accepts_the_exact_gnu_checksum_separator() -> None:
     digest = "a" * 64
-    wheel_name = "clio_relay-1.0.2-py3-none-any.whl"
+    wheel_name = "clio_relay-1.0.3-py3-none-any.whl"
     selector = re.compile(rf"^[0-9A-Fa-f]{{64}} [ *]{re.escape(wheel_name)}$")
     parser = re.compile(r"^([0-9A-Fa-f]{64}) [ *](.+)$")
 
@@ -61,6 +61,18 @@ def test_candidate_manifest_parser_accepts_the_exact_gnu_checksum_separator() ->
         assert match.groups() == (digest, wheel_name)
 
     assert selector.fullmatch(f"{digest}*{wheel_name}") is None
+
+
+def test_spack_json_array_fallback_is_safe_under_powershell_strict_mode() -> None:
+    runbook = RUNBOOK.read_text(encoding="utf-8")
+
+    assert "$AdiosDecoded.specs" not in runbook
+    assert '$AdiosSpecs = $AdiosDecoded.PSObject.Properties["specs"]' in runbook
+    assert "$AdiosRecords = @(" in runbook
+    assert "if ($null -ne $AdiosSpecs) { $AdiosSpecs.Value } else { $AdiosDecoded }" in runbook
+    assert "$Record.$Property" not in runbook
+    assert "$Candidate = $Record.PSObject.Properties[$Property]" in runbook
+    assert "$Value = [string]$Candidate.Value" in runbook
 
 
 def test_release_helper_scripts_bind_direct_gray_scott_and_private_spack_state() -> None:

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1612,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.0.2"
+    assert policy.release_version == "1.0.3"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- handle both top-level Spack JSON arrays and optional `{ specs: [...] }` wrappers under PowerShell strict mode
- resolve optional `hash`, `full_hash`, and `dag_hash` properties without strict-mode member failures
- add a regression that rejects direct optional-property access in the reviewed runbook
- advance the immutable release identity to 1.0.3 and refresh its acceptance-matrix digest
- record v1.0.2 as abandoned before publication

## Root cause

Ares returns `spack find --json` as a top-level JSON array. The reviewed v1.0.2 acceptance runbook directly accessed `$AdiosDecoded.specs`; strict mode rejects that missing member before the intended array fallback can run. Acceptance failed before creating a run ID, report, remote root, or cluster job.

## Validation

- exercised both top-level-array and wrapped-object shapes under PowerShell strict mode
- exercised hash fallback when only `full_hash` exists
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run pyright`
- `uv lock --check`
- 221 release-policy/workflow/runbook tests plus the focused runbook regression