### PR TITLE
fix: normalize remote release fixtures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.sh text eol=lf
+examples/release-gate/**/*.py text eol=lf
+examples/release-gate/**/*.in text eol=lf
+examples/release-gate/**/*.tmpl text eol=lf

--- a/README.md
+++ b/README.md
@@ -8,14 +8,16 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> The current development candidate is `1.0.3`. The immutable `v1.0.0` candidate
+> The current development candidate is `1.0.4`. The immutable `v1.0.0` candidate
 > was abandoned before publication after its acceptance runbook rejected the
 > staged GNU checksum format; `v1.0.1` was also abandoned before publication
 > after protected-main validation exposed a Windows lease-deletion race;
 > `v1.0.2` was abandoned before publication when candidate acceptance found a
-> strict-mode Spack JSON-array parsing defect in the reviewed runbook. The
-> latest released live evidence is `0.9.22`;
-> 1.0.3 is not release-complete until its immutable-candidate
+> strict-mode Spack JSON-array parsing defect in the reviewed runbook;
+> `v1.0.3` was abandoned before any reports were produced when candidate
+> acceptance found that Windows checkout CRLF bytes had been copied directly
+> into a remote shell fixture. The latest released live evidence is `0.9.22`;
+> 1.0.4 is not release-complete until its immutable-candidate
 > reports pass, its exact candidate is published, and the released-artifact
 > runs pass again. The policy currently selects the `ares` and `homelab`
 > evidence labels; those labels are release configuration, not hardcoded

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.0.3"
+$Version = "1.0.4"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }
@@ -293,18 +293,96 @@ function Invoke-RelayReport {
   [pscustomobject]@{ Path = (Resolve-Path $Path).Path; Output = ($Output -join "`n"); Report = $Report }
 }
 
+function ConvertTo-LfText {
+  param(
+    [Parameter(Mandatory)] [AllowEmptyString()] [string] $Text,
+    [Parameter(Mandatory)] [string] $Description
+  )
+  if ($Text.Length -gt 0 -and [int]$Text[0] -eq 0xFEFF) {
+    $Text = $Text.Substring(1)
+  }
+  if ($Text.IndexOf([char]0) -ge 0) {
+    throw "$Description contains a NUL byte"
+  }
+  $Text = $Text.Replace("`r`n", "`n").Replace("`r", "`n")
+  if (-not $Text.EndsWith("`n", [StringComparison]::Ordinal)) {
+    $Text += "`n"
+  }
+  $Text
+}
+
+function Read-LfUtf8TextFile {
+  param([Parameter(Mandatory)] [string] $Source)
+  $ResolvedSource = (Resolve-Path -LiteralPath $Source -ErrorAction Stop).Path
+  if (-not (Test-Path -LiteralPath $ResolvedSource -PathType Leaf)) {
+    throw "text staging source is not a file: $Source"
+  }
+  $StrictUtf8 = [Text.UTF8Encoding]::new($false, $true)
+  try {
+    $Text = $StrictUtf8.GetString([IO.File]::ReadAllBytes($ResolvedSource))
+  } catch {
+    throw "text staging source is not valid UTF-8: $Source"
+  }
+  ConvertTo-LfText $Text "text staging source $Source"
+}
+
 function Render-Template {
   param(
     [Parameter(Mandatory)] [string] $Source,
     [Parameter(Mandatory)] [string] $Destination,
     [Parameter(Mandatory)] [hashtable] $Values
   )
-  $Text = Get-Content -Raw $Source
+  $Text = Read-LfUtf8TextFile $Source
   foreach ($Key in $Values.Keys) { $Text = $Text.Replace("__${Key}__", [string]$Values[$Key]) }
   if ($Text -match '__[A-Z_]+__') { throw "unresolved template token in $Destination" }
+  $Text = ConvertTo-LfText $Text "rendered template $Destination"
   $Parent = Split-Path -Parent $Destination
   New-Item -ItemType Directory -Force $Parent | Out-Null
   [IO.File]::WriteAllText((Join-Path (Resolve-Path $Parent) (Split-Path -Leaf $Destination)), $Text, [Text.UTF8Encoding]::new($false))
+}
+
+function New-LfTextStagingCopy {
+  param(
+    [Parameter(Mandatory)] [string] $Source,
+    [Parameter(Mandatory)] [string] $StagingName
+  )
+  if ($StagingName -cnotmatch '^[A-Za-z0-9._-]+$') {
+    throw "text staging name is unsafe: $StagingName"
+  }
+  $Text = Read-LfUtf8TextFile $Source
+  $StagingDirectory = Join-Path $RenderedRoot "remote-text"
+  New-Item -ItemType Directory -Force $StagingDirectory | Out-Null
+  $StagingPath = Join-Path $StagingDirectory $StagingName
+  if (Test-Path -LiteralPath $StagingPath) {
+    throw "refusing to replace normalized text staging copy: $StagingPath"
+  }
+  [IO.File]::WriteAllText($StagingPath, $Text, [Text.UTF8Encoding]::new($false))
+  $StagedBytes = [IO.File]::ReadAllBytes($StagingPath)
+  $HasUtf8Bom = (
+    $StagedBytes.Length -ge 3 -and
+    $StagedBytes[0] -eq 0xEF -and
+    $StagedBytes[1] -eq 0xBB -and
+    $StagedBytes[2] -eq 0xBF
+  )
+  if ($HasUtf8Bom -or
+      $StagedBytes -contains [byte]0x0D -or
+      $StagedBytes -contains [byte]0x00) {
+    throw "normalized text staging copy is not LF-only, NUL-free UTF-8: $StagingPath"
+  }
+  $StagingPath
+}
+
+function Copy-RemoteTextFile {
+  param(
+    [Parameter(Mandatory)] [string] $Source,
+    [Parameter(Mandatory)] [string] $StagingName,
+    [Parameter(Mandatory)] [string] $SshHost,
+    [Parameter(Mandatory)] [string] $RemotePath,
+    [Parameter(Mandatory)] [string] $Description
+  )
+  $StagingPath = New-LfTextStagingCopy $Source $StagingName
+  & $OpenScp $StagingPath "${SshHost}:$RemotePath" | Out-Host
+  if ($LASTEXITCODE -ne 0) { throw "$Description staging failed" }
 }
 ```
 
@@ -407,9 +485,12 @@ if ($LASTEXITCODE -ne 0 -or $AdiosPrefix -notmatch '^/[A-Za-z0-9._+/-]+$') {
   throw "selected plain ADIOS2 prefix is unavailable"
 }
 
-& $OpenScp examples/release-gate/gray-scott-direct-build.sh `
-  "${AresSshHost}:$AresRemoteRoot/gray-scott-direct-build.sh"
-if ($LASTEXITCODE -ne 0) { throw "Gray-Scott build-script staging failed" }
+Copy-RemoteTextFile `
+  -Source "examples/release-gate/gray-scott-direct-build.sh" `
+  -StagingName "gray-scott-direct-build.sh" `
+  -SshHost $AresSshHost `
+  -RemotePath "$AresRemoteRoot/gray-scott-direct-build.sh" `
+  -Description "Gray-Scott build script"
 & $OpenSsh $AresSshHost "chmod 700 '$AresRemoteRoot/gray-scott-direct-build.sh' && '$AresRemoteRoot/gray-scott-direct-build.sh' '$AresSpack' '$AresCoreRoot' '$GrayBuildRoot' '$GrayInstallRoot' '$ExpectedCoreCommit' '$ExpectedGrayTree' '$ExpectedAdiosHash'"
 if ($LASTEXITCODE -ne 0) { throw "direct IOWarp Gray-Scott build failed" }
 if ((& $OpenSsh $AresSshHost "git -C '$AresCoreRoot' rev-parse HEAD").Trim() -ne $ExpectedCoreCommit) {
@@ -557,22 +638,42 @@ foreach ($Port in @(
 }
 
 foreach ($Target in @(
-  @{ Host = $AresSshHost; Root = $AresFixtureRoot; State = $AresStateRoot },
-  @{ Host = $HomelabSshHost; Root = $HomelabFixtureRoot; State = $HomelabStateRoot }
+  @{ Name = $AresCluster; Host = $AresSshHost; Root = $AresFixtureRoot; State = $AresStateRoot },
+  @{ Name = $HomelabCluster; Host = $HomelabSshHost; Root = $HomelabFixtureRoot; State = $HomelabStateRoot }
 )) {
   & $OpenSsh $Target.Host "install -d -m 700 '$($Target.Root)/gateway' '$($Target.State)'"
   if ($LASTEXITCODE -ne 0) { throw "remote fixture directory creation failed" }
-  $Destination = "$($Target.Host):$($Target.Root)/gateway/"
-  & $OpenScp examples/release-gate/gateway/http_service.py `
-    examples/release-gate/gateway/external_runtime.py `
-    $Destination
-  if ($LASTEXITCODE -ne 0) { throw "gateway fixture staging failed" }
+  Copy-RemoteTextFile `
+    -Source "examples/release-gate/gateway/http_service.py" `
+    -StagingName "$($Target.Name)-gateway-http-service.py" `
+    -SshHost $Target.Host `
+    -RemotePath "$($Target.Root)/gateway/http_service.py" `
+    -Description "gateway HTTP fixture"
+  Copy-RemoteTextFile `
+    -Source "examples/release-gate/gateway/external_runtime.py" `
+    -StagingName "$($Target.Name)-gateway-external-runtime.py" `
+    -SshHost $Target.Host `
+    -RemotePath "$($Target.Root)/gateway/external_runtime.py" `
+    -Description "gateway external-runtime fixture"
 }
-& $OpenScp examples/release-gate/gateway/slurm_submit.sh `
-  examples/release-gate/gateway/slurm_status.py `
-  examples/release-gate/gateway/slurm_cancel.py `
-  "${AresSshHost}:$AresFixtureRoot/gateway/"
-if ($LASTEXITCODE -ne 0) { throw "SLURM gateway fixture staging failed" }
+Copy-RemoteTextFile `
+  -Source "examples/release-gate/gateway/slurm_status.py" `
+  -StagingName "gateway-slurm-status.py" `
+  -SshHost $AresSshHost `
+  -RemotePath "$AresFixtureRoot/gateway/slurm_status.py" `
+  -Description "SLURM gateway status fixture"
+Copy-RemoteTextFile `
+  -Source "examples/release-gate/gateway/slurm_cancel.py" `
+  -StagingName "gateway-slurm-cancel.py" `
+  -SshHost $AresSshHost `
+  -RemotePath "$AresFixtureRoot/gateway/slurm_cancel.py" `
+  -Description "SLURM gateway cancel fixture"
+Copy-RemoteTextFile `
+  -Source "examples/release-gate/gateway/slurm_submit.sh" `
+  -StagingName "gateway-slurm-submit.sh" `
+  -SshHost $AresSshHost `
+  -RemotePath "$AresFixtureRoot/gateway/slurm_submit.sh" `
+  -Description "SLURM gateway shell fixture"
 
 $AresRuntime = Join-Path $RenderedRoot "ares-runtime.json"
 Render-Template "examples/release-gate/gateway/ares-runtime.json.tmpl" $AresRuntime @{
@@ -667,8 +768,12 @@ Invoke-RelayReport -Id "ares-jarvis-gray-scott" -ReportOption "--report" -Comman
 
 $RemoteLammpsInput = "$AresRemoteRoot/lammps/in.lj"
 & $OpenSsh $AresSshHost "install -d -m 700 '$AresRemoteRoot/lammps'"
-& $OpenScp examples/release-gate/lammps-bounded.in "${AresSshHost}:$RemoteLammpsInput"
-if ($LASTEXITCODE -ne 0) { throw "LAMMPS input staging failed" }
+Copy-RemoteTextFile `
+  -Source "examples/release-gate/lammps-bounded.in" `
+  -StagingName "lammps-bounded.in" `
+  -SshHost $AresSshHost `
+  -RemotePath $RemoteLammpsInput `
+  -Description "LAMMPS input"
 $LammpsPipeline = "$RunId-lammps"
 Invoke-JarvisSetupTool "jarvis_create_pipeline" "lammps-create" @{
   pipeline_id = $LammpsPipeline
@@ -759,9 +864,12 @@ $FreshSpackStore = "$FreshSpackRoot/store"
 $FreshSpackWrapper = "$FreshSpackRoot/bin/spack"
 $FreshSpackConfigurationManifest = "$FreshSpackRoot/acceptance-manifest.sha256"
 $FreshSpackSpec = "libsigsegv@2.14"
-& $OpenScp examples/release-gate/spack-fresh-store.sh `
-  "${AresSshHost}:$AresRemoteRoot/spack-fresh-store.sh"
-if ($LASTEXITCODE -ne 0) { throw "fresh Spack setup-script staging failed" }
+Copy-RemoteTextFile `
+  -Source "examples/release-gate/spack-fresh-store.sh" `
+  -StagingName "spack-fresh-store.sh" `
+  -SshHost $AresSshHost `
+  -RemotePath "$AresRemoteRoot/spack-fresh-store.sh" `
+  -Description "fresh Spack setup script"
 & $OpenSsh $AresSshHost "chmod 700 '$AresRemoteRoot/spack-fresh-store.sh' && '$AresRemoteRoot/spack-fresh-store.sh' '$FreshSpackRoot' '$AresFreshBaseSpack'"
 if ($LASTEXITCODE -ne 0) { throw "disposable Spack store setup failed" }
 $ExpectedFreshSpackConfigurationSha256 = (

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.0.3"
+release_version: "1.0.4"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: b23a4d0b6f355f697dac4eedf386ee6b64980453858a991b5ba24d2857e2be18
+acceptance_matrix_sha256: d496a031e59bf9414e99aee50285d842504f90c9c16ec6c31218394bdcb41965
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -70,7 +70,7 @@ Commit the release change with a conventional commit, then create and push an
 exact matching tag:
 
 ```powershell
-$Tag = "v1.0.3"
+$Tag = "v1.0.4"
 git fetch origin main
 $ReviewedMainSha = (git rev-parse refs/remotes/origin/main).Trim()
 if ((git rev-parse HEAD).Trim() -ne $ReviewedMainSha) {
@@ -155,7 +155,7 @@ Download the draft wheel and manifest, verify both the digest and the signed
 tag-build provenance, and compute the digest locally:
 
 ```powershell
-$Tag = "v1.0.3"
+$Tag = "v1.0.4"
 New-Item -ItemType Directory -Force .clio-relay\candidate | Out-Null
 gh release download $Tag --pattern "*.whl" --pattern "SHA256SUMS" `
   --dir .clio-relay\candidate

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.0.3",
-  "matrix_sha256": "b23a4d0b6f355f697dac4eedf386ee6b64980453858a991b5ba24d2857e2be18",
+  "release_version": "1.0.4",
+  "matrix_sha256": "d496a031e59bf9414e99aee50285d842504f90c9c16ec6c31218394bdcb41965",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.0.3"
+version = "1.0.4"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1330,7 +1330,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "b23a4d0b6f355f697dac4eedf386ee6b64980453858a991b5ba24d2857e2be18"
+        "d496a031e59bf9414e99aee50285d842504f90c9c16ec6c31218394bdcb41965"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -51,7 +51,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
 
 def test_candidate_manifest_parser_accepts_the_exact_gnu_checksum_separator() -> None:
     digest = "a" * 64
-    wheel_name = "clio_relay-1.0.3-py3-none-any.whl"
+    wheel_name = "clio_relay-1.0.4-py3-none-any.whl"
     selector = re.compile(rf"^[0-9A-Fa-f]{{64}} [ *]{re.escape(wheel_name)}$")
     parser = re.compile(r"^([0-9A-Fa-f]{64}) [ *](.+)$")
 
@@ -75,6 +75,214 @@ def test_spack_json_array_fallback_is_safe_under_powershell_strict_mode() -> Non
     assert "$Record.$Property" not in runbook
     assert "$Candidate = $Record.PSObject.Properties[$Property]" in runbook
     assert "$Value = [string]$Candidate.Value" in runbook
+
+
+def test_remote_release_text_fixtures_are_lf_attributed_and_normalized_before_scp() -> None:
+    runbook = RUNBOOK.read_text(encoding="utf-8")
+    attributes = (ROOT / ".gitattributes").read_text(encoding="utf-8").splitlines()
+    remote_text_fixtures = {
+        "examples/release-gate/gray-scott-direct-build.sh",
+        "examples/release-gate/spack-fresh-store.sh",
+        "examples/release-gate/gateway/slurm_submit.sh",
+        "examples/release-gate/gateway/http_service.py",
+        "examples/release-gate/gateway/external_runtime.py",
+        "examples/release-gate/gateway/slurm_status.py",
+        "examples/release-gate/gateway/slurm_cancel.py",
+        "examples/release-gate/lammps-bounded.in",
+    }
+    staged_sources = set(
+        re.findall(
+            r'^\s*-Source "(examples/release-gate/[^"]+)"',
+            runbook,
+            flags=re.MULTILINE,
+        )
+    )
+
+    assert "*.sh text eol=lf" in attributes
+    assert "examples/release-gate/**/*.py text eol=lf" in attributes
+    assert "examples/release-gate/**/*.in text eol=lf" in attributes
+    assert "examples/release-gate/**/*.tmpl text eol=lf" in attributes
+    assert staged_sources == remote_text_fixtures
+    assert runbook.count("& $OpenScp") == 1
+    assert "function New-LfTextStagingCopy" in runbook
+    assert "function Copy-RemoteTextFile" in runbook
+    assert '& $OpenScp $StagingPath "${SshHost}:$RemotePath" | Out-Host' in runbook
+    assert '$Text.Replace("`r`n", "`n").Replace("`r", "`n")' in runbook
+    assert "$StagedBytes -contains [byte]0x0D" in runbook
+    assert "$StagedBytes -contains [byte]0x00" in runbook
+    assert "$Text = Read-LfUtf8TextFile $Source" in runbook
+    assert '$Text = ConvertTo-LfText $Text "rendered template $Destination"' in runbook
+
+
+def test_lf_text_staging_and_rendering_normalize_windows_bytes_under_powershell(
+    tmp_path: Path,
+) -> None:
+    runbook = RUNBOOK.read_text(encoding="utf-8")
+    function_sources: list[str] = []
+    for name in (
+        "ConvertTo-LfText",
+        "Read-LfUtf8TextFile",
+        "Render-Template",
+        "New-LfTextStagingCopy",
+    ):
+        function_match = re.search(
+            rf"^function {re.escape(name)} \{{.*?^\}}",
+            runbook,
+            flags=re.DOTALL | re.MULTILINE,
+        )
+        assert function_match is not None
+        function_sources.append(function_match.group(0))
+    template = tmp_path / "windows-template.yaml.tmpl"
+    template.write_bytes(b"\xef\xbb\xbfvalue: __VALUE__\r\n")
+    rendered_root = tmp_path / "rendered"
+    powershell = next(
+        (
+            executable
+            for name in ("powershell.exe", "pwsh", "powershell")
+            if (executable := shutil.which(name)) is not None
+        ),
+        None,
+    )
+    assert powershell is not None, "PowerShell is required to validate the release runbook"
+    script_path = tmp_path / "normalize-shell-script.ps1"
+    script_path.write_text(
+        "\n".join(
+            (
+                (
+                    "param([string] $Source, [string] $OutputRoot, "
+                    "[string] $Template, [string] $StagingName)"
+                ),
+                "Set-StrictMode -Version Latest",
+                "$ErrorActionPreference = 'Stop'",
+                "$RenderedRoot = $OutputRoot",
+                *function_sources,
+                "$Staged = New-LfTextStagingCopy $Source $StagingName",
+                "$Rendered = Join-Path $RenderedRoot 'rendered.yaml'",
+                "Render-Template $Template $Rendered @{ VALUE = 'ready' }",
+                "$StagedBytes = [IO.File]::ReadAllBytes($Staged)",
+                "$RenderedBytes = [IO.File]::ReadAllBytes($Rendered)",
+                "$StrictUtf8 = [Text.UTF8Encoding]::new($false, $true)",
+                "[pscustomobject]@{",
+                "  staged_hex = [BitConverter]::ToString($StagedBytes)",
+                "  staged_text = $StrictUtf8.GetString($StagedBytes)",
+                "  rendered_hex = [BitConverter]::ToString($RenderedBytes)",
+                "  rendered_text = $StrictUtf8.GetString($RenderedBytes)",
+                "} | ConvertTo-Json -Compress",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    def invoke(source: Path, staging_name: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                powershell,
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(script_path),
+                str(source),
+                str(rendered_root),
+                str(template),
+                staging_name,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    cases = (
+        (
+            "fixture.sh",
+            b"\xef\xbb\xbf#!/usr/bin/env bash\r\nprintf '%s\\n' ready\r\n",
+            "#!/usr/bin/env bash\nprintf '%s\\n' ready\n",
+        ),
+        ("fixture.py", b"print('ready')\r", "print('ready')\n"),
+        ("fixture.in", b"\xef\xbb\xbfunits lj\r\nrun 1", "units lj\nrun 1\n"),
+    )
+    for name, original, expected in cases:
+        source = tmp_path / name
+        source.write_bytes(original)
+        result = invoke(source, f"normalized-{name}")
+
+        assert result.returncode == 0, result.stderr
+        document = json.loads(result.stdout)
+        assert "EF-BB-BF" not in document["staged_hex"]
+        assert "-0D-" not in f"-{document['staged_hex']}-"
+        assert "-00-" not in f"-{document['staged_hex']}-"
+        assert document["staged_text"] == expected
+        assert document["rendered_hex"].startswith("76-61-")
+        assert "EF-BB-BF" not in document["rendered_hex"]
+        assert "-0D-" not in f"-{document['rendered_hex']}-"
+        assert document["rendered_text"] == "value: ready\n"
+        assert source.read_bytes() == original
+        if name.endswith(".py"):
+            compile(document["staged_text"], name, "exec")
+
+    bash = shutil.which("bash")
+    if bash is not None:
+        syntax = subprocess.run(
+            [bash, "-n"],
+            check=False,
+            capture_output=True,
+            input=(rendered_root / "remote-text" / "normalized-fixture.sh").read_bytes(),
+            timeout=30,
+        )
+        assert syntax.returncode == 0, syntax.stderr.decode(errors="replace")
+    assert template.read_bytes() == b"\xef\xbb\xbfvalue: __VALUE__\r\n"
+
+    collision = invoke(tmp_path / "fixture.sh", "normalized-fixture.sh")
+    assert collision.returncode != 0
+    assert "refusing to replace normalized text staging copy" in collision.stderr
+
+    nul_source = tmp_path / "contains-nul.py"
+    nul_source.write_bytes(b"print('before')\r\n\x00print('after')\r\n")
+    nul_rejected = invoke(nul_source, "contains-nul.py")
+    assert nul_rejected.returncode != 0
+    assert "contains a NUL byte" in nul_rejected.stderr
+
+    invalid_source = tmp_path / "invalid-utf8.in"
+    invalid_source.write_bytes(b"valid\r\n\xffinvalid")
+    utf8_rejected = invoke(invalid_source, "invalid-utf8.in")
+    assert utf8_rejected.returncode != 0
+    assert "is not valid UTF-8" in utf8_rejected.stderr
+
+
+def test_remote_release_programs_parse_after_lf_normalization() -> None:
+    python_programs = sorted((FIXTURES / "gateway").glob("*.py"))
+    assert [path.name for path in python_programs] == [
+        "external_runtime.py",
+        "http_service.py",
+        "slurm_cancel.py",
+        "slurm_status.py",
+    ]
+    for path in python_programs:
+        normalized = path.read_bytes().decode("utf-8-sig").replace("\r\n", "\n").replace("\r", "\n")
+        compile(normalized, str(path), "exec")
+
+    bash = shutil.which("bash")
+    if bash is None:
+        return
+    shell_programs = sorted(FIXTURES.rglob("*.sh"))
+    assert [path.relative_to(FIXTURES).as_posix() for path in shell_programs] == [
+        "gateway/slurm_submit.sh",
+        "gray-scott-direct-build.sh",
+        "spack-fresh-store.sh",
+    ]
+    for path in shell_programs:
+        normalized = path.read_bytes().decode("utf-8-sig").replace("\r\n", "\n").replace("\r", "\n")
+        result = subprocess.run(
+            [bash, "-n"],
+            input=normalized.encode("utf-8"),
+            check=False,
+            capture_output=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, f"{path}: {result.stderr.decode(errors='replace')}"
 
 
 def test_owned_session_helper_isolates_command_output_from_its_return_value(

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1612,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.0.3"
+    assert policy.release_version == "1.0.4"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.0.3"
+version = "1.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- advance the corrected immutable candidate to v1.0.4 and record v1.0.3 as abandoned before reports
- normalize every Linux-interpreted release fixture and rendered template to strict UTF-8, BOM/NUL-free LF before remote staging
- enforce LF checkout attributes and cover the exact eight-fixture boundary with real PowerShell and parser regressions

## Validation
- 225 focused release tests passed
- runbook tests: 19 passed on Windows PowerShell 5.1
- Ruff and formatting clean
- Pyright: 0 errors
- `uv lock --check` and `git diff --check` clean
- all 18 extracted PowerShell blocks parse