### PR TITLE
fix: bind Gray-Scott build to selected ADIOS2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> The current development candidate is `1.0.4`. The immutable `v1.0.0` candidate
+> The current development candidate is `1.0.5`. The immutable `v1.0.0` candidate
 > was abandoned before publication after its acceptance runbook rejected the
 > staged GNU checksum format; `v1.0.1` was also abandoned before publication
 > after protected-main validation exposed a Windows lease-deletion race;
@@ -16,8 +16,11 @@ It is a piece of the federation layer for [`clio-agent`](https://github.com/iowa
 > strict-mode Spack JSON-array parsing defect in the reviewed runbook;
 > `v1.0.3` was abandoned before any reports were produced when candidate
 > acceptance found that Windows checkout CRLF bytes had been copied directly
-> into a remote shell fixture. The latest released live evidence is `0.9.22`;
-> 1.0.4 is not release-complete until its immutable-candidate
+> into a remote shell fixture; `v1.0.4` was abandoned before any reports were
+> produced when the corrected fixture reached CMake and exposed that the direct
+> Gray-Scott helper did not bind the selected Spack ADIOS2 package's own CMake
+> configuration. The latest released live evidence is `0.9.22`; 1.0.5 is not
+> release-complete until its immutable-candidate
 > reports pass, its exact candidate is published, and the released-artifact
 > runs pass again. The policy currently selects the `ares` and `homelab`
 > evidence labels; those labels are release configuration, not hardcoded

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.0.4"
+$Version = "1.0.5"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }
@@ -432,7 +432,11 @@ latest reviewed `clio-core` development commit that contains the direct
 `external/iowarp-gray-scott` application. It is not the Coeus adapter and it
 must not resolve Hermes or `adios2-coeus`. The source commit, embedded
 Gray-Scott tree, exact plain-ADIOS2 DAG hash, build directory, and install
-directory are all bound below:
+directory are all bound below. The build helper resolves the selected hash's
+own install prefix, requires exactly one ADIOS2 CMake package configuration
+under that prefix, and passes its directory explicitly as `ADIOS2_DIR`;
+`spack build-env` alone exposes dependencies but not the selected package's own
+installation prefix.
 
 Before invoking this block, set `CLIO_RELAY_ACCEPTANCE_ADIOS_HASH` to the
 reviewed 32-character DAG hash of the plain `adios2` installation selected for

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.0.4"
+release_version: "1.0.5"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: d496a031e59bf9414e99aee50285d842504f90c9c16ec6c31218394bdcb41965
+acceptance_matrix_sha256: d0b87b7f9a0adc8cc723f0c3d95b7f907145d3ccfd909591d8066d7583a14d06
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -70,7 +70,7 @@ Commit the release change with a conventional commit, then create and push an
 exact matching tag:
 
 ```powershell
-$Tag = "v1.0.4"
+$Tag = "v1.0.5"
 git fetch origin main
 $ReviewedMainSha = (git rev-parse refs/remotes/origin/main).Trim()
 if ((git rev-parse HEAD).Trim() -ne $ReviewedMainSha) {
@@ -155,7 +155,7 @@ Download the draft wheel and manifest, verify both the digest and the signed
 tag-build provenance, and compute the digest locally:
 
 ```powershell
-$Tag = "v1.0.4"
+$Tag = "v1.0.5"
 New-Item -ItemType Directory -Force .clio-relay\candidate | Out-Null
 gh release download $Tag --pattern "*.whl" --pattern "SHA256SUMS" `
   --dir .clio-relay\candidate

--- a/examples/release-gate/gray-scott-direct-build.sh
+++ b/examples/release-gate/gray-scott-direct-build.sh
@@ -48,6 +48,40 @@ if [ ! -x "$spack" ]; then
   echo "Spack executable is absent: $spack" >&2
   exit 66
 fi
+
+adios_prefix=""
+if ! adios_prefix="$("$spack" location -i "/$adios_hash")"; then
+  echo "selected ADIOS2 prefix lookup failed" >&2
+  exit 66
+fi
+readonly adios_prefix
+require_absolute_path "ADIOS2 prefix" "$adios_prefix"
+if [ ! -d "$adios_prefix" ]; then
+  echo "ADIOS2 prefix is absent: $adios_prefix" >&2
+  exit 66
+fi
+
+declare -a adios_configs=()
+mapfile -d '' -t adios_configs < <(
+  find "$adios_prefix" -type f \
+    \( -name ADIOS2Config.cmake -o -name adios2-config.cmake \) -print0
+)
+readonly find_pid="$!"
+if ! wait "$find_pid"; then
+  echo "ADIOS2 CMake package discovery failed" >&2
+  exit 74
+fi
+if [ "${#adios_configs[@]}" -ne 1 ]; then
+  echo "selected ADIOS2 prefix must contain exactly one CMake package config" >&2
+  exit 65
+fi
+readonly adios2_dir="$(dirname -- "${adios_configs[0]}")"
+require_absolute_path "ADIOS2 CMake package directory" "$adios2_dir"
+if [[ "$adios2_dir/" != "$adios_prefix/"* ]]; then
+  echo "ADIOS2 CMake package directory escaped the selected prefix" >&2
+  exit 65
+fi
+
 for path in "$source_root" "$build_root" "$install_root"; do
   if [ -e "$path" ]; then
     echo "refusing to reuse acceptance path: $path" >&2
@@ -68,6 +102,7 @@ test "$(git -C "$source_root" rev-parse HEAD:external/iowarp-gray-scott)" = \
   cmake -S "$source_root/external/iowarp-gray-scott" -B "$build_root" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX="$install_root" \
+    -DADIOS2_DIR="$adios2_dir" \
     -DENABLE_RPATH=ON \
     -DENABLE_VTK=OFF
 "$spack" build-env "/$adios_hash" -- cmake --build "$build_root" --parallel 4

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.0.4",
-  "matrix_sha256": "d496a031e59bf9414e99aee50285d842504f90c9c16ec6c31218394bdcb41965",
+  "release_version": "1.0.5",
+  "matrix_sha256": "d0b87b7f9a0adc8cc723f0c3d95b7f907145d3ccfd909591d8066d7583a14d06",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.0.4"
+version = "1.0.5"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1330,7 +1330,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "d496a031e59bf9414e99aee50285d842504f90c9c16ec6c31218394bdcb41965"
+        "d0b87b7f9a0adc8cc723f0c3d95b7f907145d3ccfd909591d8066d7583a14d06"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -2046,7 +2046,10 @@ def test_concurrent_jobs_receive_isolated_sidecar_environments(
                 for worker, lease in zip(workers, resolved_leases, strict=True)
             ]
             for future in futures:
-                future.result(timeout=10)
+                # The provider's five-second barrier is the semantic overlap proof.
+                # This outer bound only detects a hung durable setup/cleanup path and
+                # must accommodate the queue's bounded Windows filesystem latency.
+                future.result(timeout=60)
     finally:
         for lease in resolved_leases:
             queue.release_lease(lease.lease_id)

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -51,7 +51,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
 
 def test_candidate_manifest_parser_accepts_the_exact_gnu_checksum_separator() -> None:
     digest = "a" * 64
-    wheel_name = "clio_relay-1.0.4-py3-none-any.whl"
+    wheel_name = "clio_relay-1.0.5-py3-none-any.whl"
     selector = re.compile(rf"^[0-9A-Fa-f]{{64}} [ *]{re.escape(wheel_name)}$")
     parser = re.compile(r"^([0-9A-Fa-f]{64}) [ *](.+)$")
 
@@ -372,6 +372,11 @@ def test_release_helper_scripts_bind_direct_gray_scott_and_private_spack_state()
     assert "https://github.com/iowarp/clio-core.git" in gray
     assert "rev-parse HEAD:external/iowarp-gray-scott" in gray
     assert 'build-env "/$adios_hash"' in gray
+    assert 'location -i "/$adios_hash"' in gray
+    assert 'if ! adios_prefix="$("$spack" location -i "/$adios_hash")"; then' in gray
+    assert 'if ! wait "$find_pid"; then' in gray
+    assert "selected ADIOS2 prefix must contain exactly one CMake package config" in gray
+    assert '-DADIOS2_DIR="$adios2_dir"' in gray
     assert '[[ "$value" == *//* ]]' in gray
     assert '[[ "$value" == *"/./"* ]]' in gray
     assert "coeus" not in gray.lower()
@@ -385,6 +390,94 @@ def test_release_helper_scripts_bind_direct_gray_scott_and_private_spack_state()
     assert "sha256sum --check --strict" in fresh_spack
     assert '[[ "$value" == *//* ]]' in fresh_spack
     assert '[[ "$value" == *"/./"* ]]' in fresh_spack
+
+
+def test_gray_scott_helper_fails_closed_on_spack_and_config_discovery_errors(
+    tmp_path: Path,
+) -> None:
+    bash = shutil.which("bash")
+    assert bash is not None, "Bash is required to validate the remote release helper"
+    helper = (FIXTURES / "gray-scott-direct-build.sh").read_bytes()
+    helper = helper.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+    commit = "e2fedd8847f8deb71f041f692e405023a712ca44"
+    tree = "072d6eab3df3bde92e48ae2f4823305af831535e"
+    adios_hash = "wqc5dwbj7vx4i3oekrembw6irpo5h7g6"
+
+    def invoke(
+        name: str,
+        *,
+        location_exit: int = 0,
+        find_program: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        root = tmp_path / name
+        config = root / "adios" / "lib" / "cmake" / "adios2" / "adios2-config.cmake"
+        config.parent.mkdir(parents=True)
+        config.write_bytes(b"# test config\n")
+        (root / "helper.sh").write_bytes(helper)
+        (root / "spack").write_bytes(
+            (
+                "#!/usr/bin/env bash\n"
+                'if [ "$1" = location ]; then\n'
+                "  printf '%s\\n' \"$PWD/adios\"\n"
+                f"  exit {location_exit}\n"
+                "fi\n"
+                "exit 64\n"
+            ).encode()
+        )
+        fake_bin = root / "fake-bin"
+        fake_bin.mkdir()
+        if find_program is not None:
+            (fake_bin / "find").write_bytes(find_program.encode("utf-8"))
+        command = (
+            'chmod 700 "$PWD/helper.sh" "$PWD/spack"; '
+            'if [ -f "$PWD/fake-bin/find" ]; then '
+            'chmod 700 "$PWD/fake-bin/find"; fi; '
+            'export PATH="$PWD/fake-bin:$PATH"; '
+            '"$PWD/helper.sh" "$PWD/spack" "$PWD/source" "$PWD/build" '
+            f'"$PWD/install" "{commit}" "{tree}" "{adios_hash}"'
+        )
+        return subprocess.run(
+            [bash, "-c", command],
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    location_failure = invoke("location-failure", location_exit=23)
+    assert location_failure.returncode == 66
+    assert "selected ADIOS2 prefix lookup failed" in location_failure.stderr
+
+    partial_find_failure = invoke(
+        "find-failure",
+        find_program=(
+            "#!/usr/bin/env bash\n"
+            "printf '%s\\0' \"$PWD/adios/lib/cmake/adios2/adios2-config.cmake\"\n"
+            "exit 19\n"
+        ),
+    )
+    assert partial_find_failure.returncode == 74
+    assert "ADIOS2 CMake package discovery failed" in partial_find_failure.stderr
+
+    empty_find = invoke(
+        "find-empty",
+        find_program="#!/usr/bin/env bash\nexit 0\n",
+    )
+    assert empty_find.returncode == 65
+    assert "must contain exactly one CMake package config" in empty_find.stderr
+
+    ambiguous_find = invoke(
+        "find-ambiguous",
+        find_program=(
+            "#!/usr/bin/env bash\n"
+            "printf '%s\\0%s\\0' "
+            '"$PWD/adios/lib/cmake/adios2/adios2-config.cmake" '
+            '"$PWD/adios/lib/cmake/adios2/ADIOS2Config.cmake"\n'
+        ),
+    )
+    assert ambiguous_find.returncode == 65
+    assert "must contain exactly one CMake package config" in ambiguous_find.stderr
 
 
 def test_release_acceptance_matrix_is_complete_ordered_and_unique() -> None:
@@ -608,6 +701,7 @@ def test_release_acceptance_runbook_binds_production_specifics_without_secrets()
     assert "$ExpectedAdiosHash = [string]$env:CLIO_RELAY_ACCEPTANCE_ADIOS_HASH" in text
     assert "find --json '/$ExpectedAdiosHash'" in text
     assert "find --json adios2" not in text
+    assert "ADIOS2_DIR" in text
     assert 'spack_specs = @("/$ExpectedAdiosHash")' in text
     assert 'spack_specs = @("/$ExpectedLammpsHash")' in text
     assert 'spack_specs = @("adios2-coeus")' not in text

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1612,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.0.4"
+    assert policy.release_version == "1.0.5"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.0.4"
+version = "1.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- record v1.0.4 as an abandoned pre-report candidate after its live Gray-Scott configure exposed the missing ADIOS2 package-prefix binding
- resolve the exact pinned Spack ADIOS2 prefix and require exactly one CMake package config beneath it
- pass that exact config directory as `ADIOS2_DIR` while retaining `spack build-env` for dependency materialization
- fail closed when `spack location` returns nonzero, config discovery returns partial output then fails, or the config set is empty/ambiguous
- advance the candidate identity to 1.0.5 and rebind the acceptance-matrix digest

## Validation

- focused release-runbook, CI-validation, and validation-report tests passed
- behavioral Bash regressions cover nonzero Spack lookup, failed/partial discovery, empty discovery, and ambiguity
- Ruff check/format, Pyright, `uv lock --check`, and `git diff --check` passed
- two isolated full Ares Gray-Scott builds passed; the final reviewed helper was LF-clean with SHA-256 `230a5a2e6af4f5bc0848668350594c79e6a07a6da3a41796a930820d6ff8dcfc`
- the final Ares build installed Gray-Scott, had no missing `ldd` dependencies, and resolved all nine ADIOS2 libraries under the exact pinned `wqc5dwbj7vx4i3oekrembw6irpo5h7g6` prefix

The v1.0.4 live attempt produced no acceptance reports and left no scheduler jobs or owned processes.
