### PR TITLE
fix: canonicalize JARVIS wheel provenance

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -144,33 +144,7 @@ jobs:
             --matrix examples/release-gate/report-matrix-1.0.json \
             --output finalization/evidence/released-report-assets-before.json
 
-      - name: prove immutable releases are enabled before publication
-        env:
-          IMMUTABLE_RELEASES_READ_TOKEN: ${{ secrets.IMMUTABLE_RELEASES_READ_TOKEN }}
-          REPOSITORY: ${{ github.repository }}
-        shell: bash
-        run: |
-          test -n "$IMMUTABLE_RELEASES_READ_TOKEN"
-          GH_TOKEN="$IMMUTABLE_RELEASES_READ_TOKEN" \
-            gh api "repos/$REPOSITORY/immutable-releases" \
-            > "$RUNNER_TEMP/immutable-releases-api.json"
-          jq -e '
-            type == "object"
-            and .enabled == true
-            and (.enforced_by_owner | type == "boolean")
-          ' "$RUNNER_TEMP/immutable-releases-api.json" >/dev/null
-          jq -n \
-            --arg repository "$REPOSITORY" \
-            --slurpfile settings "$RUNNER_TEMP/immutable-releases-api.json" \
-            '{
-              schema_version: "clio-relay.immutable-releases-receipt.v1",
-              repository: $repository,
-              endpoint: ("repos/" + $repository + "/immutable-releases"),
-              enabled: $settings[0].enabled,
-              enforced_by_owner: $settings[0].enforced_by_owner
-            }' > finalization/evidence/IMMUTABLE-RELEASES.json
-
-      - name: download the complete immutable release evidence chain
+      - name: download the complete release evidence chain
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
@@ -326,7 +300,6 @@ jobs:
           released_gate_path = root / "evidence" / "released-release-gate-1.0.json"
           ci_status_path = root / "evidence" / "CI-STATUS.json"
           governance_path = root / "evidence" / "REPOSITORY-GOVERNANCE.json"
-          immutable_releases_path = root / "evidence" / "IMMUTABLE-RELEASES.json"
           candidate_report_manifest = json.loads(
               (root / "evidence" / "candidate-report-assets-after.json").read_text(
                   encoding="utf-8"
@@ -742,19 +715,6 @@ jobs:
               raise SystemExit("final decision does not separate local and released gates")
           ci_status = json.loads(ci_status_path.read_text(encoding="utf-8"))
           governance = json.loads(governance_path.read_text(encoding="utf-8"))
-          immutable_releases = json.loads(
-              immutable_releases_path.read_text(encoding="utf-8")
-          )
-          if immutable_releases != {
-              "schema_version": "clio-relay.immutable-releases-receipt.v1",
-              "repository": os.environ["GITHUB_REPOSITORY"],
-              "endpoint": (
-                  "repos/" + os.environ["GITHUB_REPOSITORY"] + "/immutable-releases"
-              ),
-              "enabled": True,
-              "enforced_by_owner": immutable_releases.get("enforced_by_owner"),
-          } or not isinstance(immutable_releases.get("enforced_by_owner"), bool):
-              raise SystemExit("immutable releases receipt is invalid or disabled")
           claims = {
               "schema_version": "1.0",
               "artifact_stage": "published",
@@ -793,7 +753,10 @@ jobs:
                   ),
                   "environments": governance.get("environments"),
               },
-              "immutable_releases": immutable_releases,
+              "release_publication": {
+                  "github_release_immutable": False,
+                  "immutability_deferred_to_version": "1.1",
+              },
               "local_quality_requirements": local_requirements,
               "released_artifact_requirements": released_requirements,
               "released_reports": used_reports,
@@ -917,10 +880,9 @@ jobs:
           --source-digest "$SOURCE_COMMIT"
           --deny-self-hosted-runners
 
-      - name: bind exact final assets, publish once, and verify immutable equality
+      - name: bind exact final assets, publish once, and verify published equality
         env:
           GH_TOKEN: ${{ github.token }}
-          IMMUTABLE_RELEASES_READ_TOKEN: ${{ secrets.IMMUTABLE_RELEASES_READ_TOKEN }}
           REPOSITORY: ${{ github.repository }}
           REVIEWED_MAIN_SHA: ${{ inputs.reviewed_main_sha }}
           SOURCE_COMMIT: ${{ steps.release.outputs.source_commit }}
@@ -985,27 +947,6 @@ jobs:
             --page-size 100 \
             "${asset_args[@]}" \
             --output "$RUNNER_TEMP/EXACT-FINAL-ASSETS.json"
-          test -n "$IMMUTABLE_RELEASES_READ_TOKEN"
-          GH_TOKEN="$IMMUTABLE_RELEASES_READ_TOKEN" \
-            gh api "repos/$REPOSITORY/immutable-releases" \
-            > "$RUNNER_TEMP/immutable-releases-before-publish-api.json"
-          jq -e '
-            type == "object"
-            and .enabled == true
-            and (.enforced_by_owner | type == "boolean")
-          ' "$RUNNER_TEMP/immutable-releases-before-publish-api.json" >/dev/null
-          jq -n \
-            --arg repository "$REPOSITORY" \
-            --slurpfile settings "$RUNNER_TEMP/immutable-releases-before-publish-api.json" \
-            '{
-              schema_version: "clio-relay.immutable-releases-receipt.v1",
-              repository: $repository,
-              endpoint: ("repos/" + $repository + "/immutable-releases"),
-              enabled: $settings[0].enabled,
-              enforced_by_owner: $settings[0].enforced_by_owner
-            }' > "$RUNNER_TEMP/IMMUTABLE-RELEASES-before-publish.json"
-          cmp --silent finalization/evidence/IMMUTABLE-RELEASES.json \
-            "$RUNNER_TEMP/IMMUTABLE-RELEASES-before-publish.json"
           if test "$is_draft" = "true"; then
             jq -n --rawfile body "$notes" \
               '{body: $body, draft: false, prerelease: false}' \
@@ -1017,13 +958,13 @@ jobs:
             expected="$(cat "$notes")"
             test "$actual" = "$expected"
           fi
-          capture_release_assets immutable
+          capture_release_assets published
           python src/clio_relay/ci_validation.py exact-release-assets \
-            --release "$RUNNER_TEMP/final-release-assets-immutable.json" \
-            --next-assets-page "$RUNNER_TEMP/final-assets-immutable-page-2.json" \
+            --release "$RUNNER_TEMP/final-release-assets-published.json" \
+            --next-assets-page "$RUNNER_TEMP/final-assets-published-page-2.json" \
             --page-size 100 \
             "${asset_args[@]}" \
             --verify-existing "$RUNNER_TEMP/EXACT-FINAL-ASSETS.json"
-          test "$(jq -r .draft "$RUNNER_TEMP/final-release-immutable.json")" = "false"
-          test "$(jq -r .immutable "$RUNNER_TEMP/final-release-immutable.json")" = "true"
-          gh release verify "$TAG_NAME" --repo "$REPOSITORY"
+          test "$(jq -r .draft "$RUNNER_TEMP/final-release-published.json")" = "false"
+          test "$(jq -r .prerelease "$RUNNER_TEMP/final-release-published.json")" = "false"
+          test "$(jq -r .immutable "$RUNNER_TEMP/final-release-published.json")" = "false"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> The current development candidate is `1.0.5`. The immutable `v1.0.0` candidate
+> The current development candidate is `1.0.6`. The immutable `v1.0.0` candidate
 > was abandoned before publication after its acceptance runbook rejected the
 > staged GNU checksum format; `v1.0.1` was also abandoned before publication
 > after protected-main validation exposed a Windows lease-deletion race;
@@ -19,8 +19,10 @@ It is a piece of the federation layer for [`clio-agent`](https://github.com/iowa
 > into a remote shell fixture; `v1.0.4` was abandoned before any reports were
 > produced when the corrected fixture reached CMake and exposed that the direct
 > Gray-Scott helper did not bind the selected Spack ADIOS2 package's own CMake
-> configuration. The latest released live evidence is `0.9.22`; 1.0.5 is not
-> release-complete until its immutable-candidate
+> configuration; `v1.0.5` was abandoned after one failed bootstrap report when
+> Ares exposed a lexical-versus-canonical home-path mismatch in the JARVIS-CD
+> wheel provenance check. The latest released live evidence is `0.9.22`;
+> 1.0.6 is not release-complete until its immutable-candidate
 > reports pass, its exact candidate is published, and the released-artifact
 > runs pass again. The policy currently selects the `ares` and `homelab`
 > evidence labels; those labels are release configuration, not hardcoded

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ It is a piece of the federation layer for [`clio-agent`](https://github.com/iowa
 > wheel provenance check. The latest released live evidence is `0.9.22`;
 > 1.0.6 is not release-complete until its immutable-candidate
 > reports pass, its exact candidate is published, and the released-artifact
-> runs pass again. The policy currently selects the `ares` and `homelab`
+> runs pass again. The published 1.0 GitHub release is intentionally mutable;
+> GitHub release immutability is deferred to 1.1. The policy currently selects the `ares` and `homelab`
 > evidence labels; those labels are release configuration, not hardcoded
 > product targets, and operators can select additional or different clusters.
 > The coordinated JARVIS-CD 1.2.2 and clio-kit 2.3.2 artifacts are exact pins;

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.0.5"
+$Version = "1.0.6"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.0.5"
+release_version: "1.0.6"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: d0b87b7f9a0adc8cc723f0c3d95b7f907145d3ccfd909591d8066d7583a14d06
+acceptance_matrix_sha256: 99e58203a62ed58f6fcf5b9a7d7abb8954932ffc03d707a082e12918ba5ae226
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -132,15 +132,13 @@ An existing draft is reusable only when every staged asset is byte-for-byte
 identical and its complete asset-name set equals the six staged candidate
 assets. The workflow never replaces a candidate distribution.
 
-Enable GitHub immutable releases for the repository before the 1.0 release.
-The default workflow token cannot read the repository administration endpoint,
-so configure an `IMMUTABLE_RELEASES_READ_TOKEN` secret on the protected
-`release-finalization` environment. Use a fine-grained token restricted to this
-repository with repository Administration read permission. Finalization calls
-`GET /repos/{owner}/{repo}/immutable-releases`, requires `enabled: true`, and
-records the deterministic result in `RELEASE-CLAIMS.json`. It repeats the same
-admin-read check immediately before changing the draft to public and refuses
-publication if the endpoint is unavailable, disabled, or has changed.
+The 1.0 release line intentionally publishes a normal, mutable GitHub release.
+Finalization still binds the tag to reviewed `main`, verifies the complete
+asset inventory immediately before and after publication, and requires the
+published release to remain non-prerelease and mutable. GitHub immutable
+releases are deferred to the 1.1 release line, where the additional repository
+setting and administration-read preflight can be introduced independently of
+the production 1.0 acceptance path.
 
 ## Live validation of the candidate
 
@@ -442,8 +440,8 @@ promotion record, manifest, and claims file by exact asset id, name, size, and
 SHA-256 digest, with no additional payloads. Both reads request a 100-record
 first page and an explicit second page; the configured 96-asset ceiling and an
 empty second page are recorded in the inventory, so pagination cannot silently
-truncate the comparison. After publication it requires the
-immutable inventory to remain byte-for-byte and id-for-id identical before the
+truncate the comparison. After publication it requires the captured inventory
+to remain byte-for-byte and id-for-id identical before the
 workflow can succeed. The claims file separates the local quality gate from
 only those live requirements and reports selected through the released-artifact
 path. The workflow attaches and attests

--- a/docs/release.md
+++ b/docs/release.md
@@ -70,7 +70,7 @@ Commit the release change with a conventional commit, then create and push an
 exact matching tag:
 
 ```powershell
-$Tag = "v1.0.5"
+$Tag = "v1.0.6"
 git fetch origin main
 $ReviewedMainSha = (git rev-parse refs/remotes/origin/main).Trim()
 if ((git rev-parse HEAD).Trim() -ne $ReviewedMainSha) {
@@ -155,7 +155,7 @@ Download the draft wheel and manifest, verify both the digest and the signed
 tag-build provenance, and compute the digest locally:
 
 ```powershell
-$Tag = "v1.0.5"
+$Tag = "v1.0.6"
 New-Item -ItemType Directory -Force .clio-relay\candidate | Out-Null
 gh release download $Tag --pattern "*.whl" --pattern "SHA256SUMS" `
   --dir .clio-relay\candidate

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.0.5",
-  "matrix_sha256": "d0b87b7f9a0adc8cc723f0c3d95b7f907145d3ccfd909591d8066d7583a14d06",
+  "release_version": "1.0.6",
+  "matrix_sha256": "99e58203a62ed58f6fcf5b9a7d7abb8954932ffc03d707a082e12918ba5ae226",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.0.5"
+version = "1.0.6"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.0.5"
+__version__ = "1.0.6"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -584,10 +584,12 @@ verify_jarvis_cd_distribution() {{
     "$JARVIS_CD_VERSION" \\
     <<'__CLIO_RELAY_NATIVE_JARVIS_PROBE__'
 import hashlib
-import json
 import sys
 from importlib.metadata import distribution
 from pathlib import Path
+
+from clio_relay.errors import ConfigurationError
+from clio_relay.installation import verify_distribution_file_source
 
 wheel = Path(sys.argv[1]).resolve()
 expected_sha256 = sys.argv[2]
@@ -597,9 +599,15 @@ if hashlib.sha256(wheel.read_bytes()).hexdigest() != expected_sha256:
 installed = distribution("jarvis_cd")
 if installed.version != expected_version:
     raise SystemExit("JARVIS-CD installed version does not match the release pin")
-direct_url = json.loads(installed.read_text("direct_url.json") or "{{}}")
-if direct_url.get("url") != wheel.as_uri():
-    raise SystemExit("JARVIS-CD was not installed from the verified release wheel")
+try:
+    verify_distribution_file_source(
+        direct_url_text=installed.read_text("direct_url.json"),
+        expected_artifact=wheel,
+    )
+except ConfigurationError as exc:
+    raise SystemExit(
+        f"JARVIS-CD was not installed from the verified release wheel: {{exc}}"
+    ) from exc
 print(f"jarvis_cd_distribution={{installed.name}}=={{installed.version}}")
 __CLIO_RELAY_NATIVE_JARVIS_PROBE__
 }}

--- a/src/clio_relay/ci_validation.py
+++ b/src/clio_relay/ci_validation.py
@@ -667,7 +667,7 @@ def verify_exact_release_asset_inventory(
     )
     if current != expected_receipt:
         raise ProvenanceError(
-            "current immutable release asset inventory differs from the prepublication receipt"
+            "current release asset inventory differs from the prepublication receipt"
         )
 
 

--- a/src/clio_relay/installation.py
+++ b/src/clio_relay/installation.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime
 from importlib import metadata
 from pathlib import Path
 from typing import Any, Literal, cast
+from urllib.parse import unquote, urlsplit
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
@@ -210,6 +211,58 @@ def default_install_receipt_path() -> Path:
     if configured is not None and configured.strip():
         return Path(configured).expanduser()
     return Path.home() / ".local" / "share" / "clio-relay" / "install-receipt.json"
+
+
+def verify_distribution_file_source(
+    *,
+    direct_url_text: str | None,
+    expected_artifact: Path,
+) -> Path:
+    """Verify that installed distribution metadata names one exact local artifact.
+
+    Package installers preserve the lexical path supplied by the operator in
+    ``direct_url.json``. Cluster home directories can be mounted through a
+    different canonical path, so provenance identity must compare resolved
+    filesystem paths instead of raw file-URL strings.
+    """
+    try:
+        loaded = cast(object, json.loads(direct_url_text or "{}"))
+    except json.JSONDecodeError as exc:
+        raise ConfigurationError("distribution direct_url.json is not valid JSON") from exc
+    if not isinstance(loaded, dict):
+        raise ConfigurationError("distribution direct_url.json must contain an object")
+    payload = cast(dict[str, object], loaded)
+    source_url = payload.get("url")
+    if not isinstance(source_url, str) or not source_url:
+        raise ConfigurationError("distribution direct_url.json does not name a source URL")
+    try:
+        parsed = urlsplit(source_url)
+    except ValueError as exc:
+        raise ConfigurationError("distribution source URL is not valid") from exc
+    if parsed.scheme.lower() != "file":
+        raise ConfigurationError("distribution source URL is not a local file URL")
+    if parsed.netloc:
+        raise ConfigurationError("distribution source file URL must not contain an authority")
+    if parsed.query or parsed.fragment:
+        raise ConfigurationError("distribution source file URL must not contain query or fragment")
+    source_path_text = unquote(parsed.path)
+    if os.name == "nt" and re.fullmatch(r"/[A-Za-z]:/.*", source_path_text):
+        source_path_text = source_path_text[1:]
+    if not source_path_text:
+        raise ConfigurationError("distribution source file URL has no path")
+    source_artifact = Path(source_path_text)
+    if not source_artifact.is_absolute():
+        raise ConfigurationError("distribution source file URL path must be absolute")
+    try:
+        expected = expected_artifact.resolve(strict=True)
+        source = source_artifact.resolve(strict=True)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ConfigurationError("distribution source artifact cannot be resolved") from exc
+    if not expected.is_file() or not source.is_file():
+        raise ConfigurationError("distribution source artifact is not a regular file")
+    if source != expected:
+        raise ConfigurationError("distribution source artifact does not match the verified wheel")
+    return source
 
 
 def write_install_receipt(

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -139,6 +139,9 @@ def test_linux_user_bootstrap_script_installs_required_components() -> None:
         'python -m pip install --isolated --index-url https://pypi.org/simple "$JARVIS_CD_WHEEL"'
     ) in script
     assert "JARVIS-CD was not installed from the verified release wheel" in script
+    assert "from clio_relay.installation import verify_distribution_file_source" in script
+    assert "verify_distribution_file_source(" in script
+    assert 'direct_url.get("url") != wheel.as_uri()' not in script
     assert 'verify_jarvis_cd_distribution "$RELAY_PROVIDER_PYTHON"' in script
     assert 'verify_jarvis_cd_distribution "$JARVIS_VENV/bin/python"' in script
     assert 'entry_point.group == "clio_relay.package_progress_adapters"' not in script

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1330,7 +1330,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "d0b87b7f9a0adc8cc723f0c3d95b7f907145d3ccfd909591d8066d7583a14d06"
+        "99e58203a62ed58f6fcf5b9a7d7abb8954932ffc03d707a082e12918ba5ae226"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -19,6 +19,7 @@ from clio_relay.installation import (
     installation_info,
     load_install_receipt,
     probe_clio_kit_native_execution_contract,
+    verify_distribution_file_source,
     verify_remote_clio_kit_native_execution_component,
     verify_remote_native_jarvis_component,
     verify_remote_worker_info,
@@ -31,6 +32,100 @@ from clio_relay.jarvis_mcp import (
     jarvis_user_contract,
 )
 from clio_relay.validation_report import SoftwareIdentity
+
+
+def test_distribution_file_source_accepts_a_canonical_filesystem_alias(
+    tmp_path: Path,
+) -> None:
+    canonical_home = tmp_path / "mnt" / "common" / "operator"
+    canonical_home.mkdir(parents=True)
+    wheel = canonical_home / "jarvis_cd-1.2.2-py3-none-any.whl"
+    wheel.write_bytes(b"verified-wheel")
+    lexical_home = tmp_path / "home" / "operator"
+    lexical_home.parent.mkdir()
+    try:
+        lexical_home.symlink_to(canonical_home, target_is_directory=True)
+        source = lexical_home / wheel.name
+    except OSError:
+        source = canonical_home / ".." / canonical_home.name / wheel.name
+
+    resolved = verify_distribution_file_source(
+        direct_url_text=json.dumps({"url": source.as_uri(), "archive_info": {}}),
+        expected_artifact=wheel,
+    )
+
+    assert resolved == wheel.resolve()
+
+
+@pytest.mark.parametrize(
+    ("direct_url_text", "message"),
+    [
+        ("not-json", "not valid JSON"),
+        ("[]", "must contain an object"),
+        ("{}", "does not name a source URL"),
+        (json.dumps({"url": "https://example.invalid/wheel.whl"}), "not a local file URL"),
+        (json.dumps({"url": "file://remote.example/wheel.whl"}), "must not contain an authority"),
+        (json.dumps({"url": "file:relative.whl"}), "path must be absolute"),
+        (json.dumps({"url": "file:///wheel.whl?source=other"}), "query or fragment"),
+        (json.dumps({"url": "file:///wheel.whl#other"}), "query or fragment"),
+        (json.dumps({"url": "file://[invalid/wheel.whl"}), "source URL is not valid"),
+    ],
+)
+def test_distribution_file_source_rejects_ambiguous_metadata(
+    tmp_path: Path,
+    direct_url_text: str,
+    message: str,
+) -> None:
+    wheel = tmp_path / "jarvis_cd-1.2.2-py3-none-any.whl"
+    wheel.write_bytes(b"verified-wheel")
+
+    with pytest.raises(ConfigurationError, match=message):
+        verify_distribution_file_source(
+            direct_url_text=direct_url_text,
+            expected_artifact=wheel,
+        )
+
+
+def test_distribution_file_source_rejects_a_different_existing_artifact(
+    tmp_path: Path,
+) -> None:
+    expected = tmp_path / "expected.whl"
+    other = tmp_path / "other.whl"
+    expected.write_bytes(b"same-bytes")
+    other.write_bytes(b"same-bytes")
+
+    with pytest.raises(ConfigurationError, match="does not match the verified wheel"):
+        verify_distribution_file_source(
+            direct_url_text=json.dumps({"url": other.as_uri()}),
+            expected_artifact=expected,
+        )
+
+
+def test_distribution_file_source_rejects_a_decoded_nul_path(tmp_path: Path) -> None:
+    wheel = tmp_path / "jarvis_cd-1.2.2-py3-none-any.whl"
+    wheel.write_bytes(b"verified-wheel")
+
+    with pytest.raises(ConfigurationError, match="cannot be resolved"):
+        verify_distribution_file_source(
+            direct_url_text=json.dumps({"url": f"{wheel.as_uri()}%00"}),
+            expected_artifact=wheel,
+        )
+
+
+def test_distribution_file_source_decodes_file_url_percent_escapes_once(
+    tmp_path: Path,
+) -> None:
+    wheel = tmp_path / "jarvis%20cd.whl"
+    wheel.write_bytes(b"verified-wheel")
+    source_url = wheel.as_uri()
+    assert "%2520" in source_url
+
+    resolved = verify_distribution_file_source(
+        direct_url_text=json.dumps({"url": source_url}),
+        expected_artifact=wheel,
+    )
+
+    assert resolved == wheel.resolve()
 
 
 def test_install_receipt_binds_running_package_to_wheel_bytes(tmp_path: Path) -> None:

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -51,7 +51,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
 
 def test_candidate_manifest_parser_accepts_the_exact_gnu_checksum_separator() -> None:
     digest = "a" * 64
-    wheel_name = "clio_relay-1.0.5-py3-none-any.whl"
+    wheel_name = "clio_relay-1.0.6-py3-none-any.whl"
     selector = re.compile(rf"^[0-9A-Fa-f]{{64}} [ *]{re.escape(wheel_name)}$")
     parser = re.compile(r"^([0-9A-Fa-f]{64}) [ *](.+)$")
 

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -947,7 +947,7 @@ def test_every_release_mutation_rechecks_live_identity_immediately_before_write(
     assert "mutation-authority" in str(publish_steps[publish_index - 1].get("run"))
 
 
-def test_final_publication_rechecks_exact_assets_before_and_after_immutability() -> None:
+def test_final_publication_rechecks_exact_assets_before_and_after_publication() -> None:
     workflow = _workflow("finalize-release.yml")
     jobs = cast(dict[str, dict[str, Any]], workflow["jobs"])
     steps = cast(list[dict[str, Any]], jobs["finalize"]["steps"])
@@ -959,16 +959,19 @@ def test_final_publication_rechecks_exact_assets_before_and_after_immutability()
     receipt = script.index('--output "$RUNNER_TEMP/EXACT-FINAL-ASSETS.json"', preflight)
     publish = script.index("relay_release_patch", receipt)
     postflight = script.index("ci_validation.py exact-release-assets", publish)
-    immutable_receipt = script.index(
+    published_receipt = script.index(
         '--verify-existing "$RUNNER_TEMP/EXACT-FINAL-ASSETS.json"',
         postflight,
     )
-    immutable_check = script.index(
-        '.immutable "$RUNNER_TEMP/final-release-immutable.json"', immutable_receipt
+    mutable_check = script.index(
+        '.immutable "$RUNNER_TEMP/final-release-published.json"', published_receipt
     )
 
     assert authority < preflight < receipt < publish
-    assert publish < postflight < immutable_receipt < immutable_check
+    assert publish < postflight < published_receipt < mutable_check
+    assert (
+        'test "$(jq -r .immutable "$RUNNER_TEMP/final-release-published.json")" = "false"' in script
+    )
     assert '"${asset_args[@]}"' in script
     assert script.count("relay_release_complete_assets") == 1
     assert script.count("--next-assets-page") == 2
@@ -1035,17 +1038,18 @@ def test_privileged_release_jobs_never_execute_candidate_or_pypi_code() -> None:
                     assert "uv run --no-sync clio-relay release gate" in script
 
 
-def test_finalization_proves_immutable_mode_before_publishing() -> None:
+def test_finalization_intentionally_publishes_a_normal_mutable_release() -> None:
     text = (WORKFLOWS / "finalize-release.yml").read_text(encoding="utf-8")
 
-    endpoint = 'gh api "repos/$REPOSITORY/immutable-releases"'
-    publish = "relay_release_patch"
-    assert text.count(endpoint) == 2
-    assert "secrets.IMMUTABLE_RELEASES_READ_TOKEN" in text
-    assert 'test -n "$IMMUTABLE_RELEASES_READ_TOKEN"' in text
-    assert ".enabled == true" in text
-    assert "clio-relay.immutable-releases-receipt.v1" in text
-    assert text.rindex(endpoint) < text.rindex(publish)
+    assert 'gh api "repos/$REPOSITORY/immutable-releases"' not in text
+    assert "IMMUTABLE_RELEASES_READ_TOKEN" not in text
+    assert '"github_release_immutable": False' in text
+    assert '"immutability_deferred_to_version": "1.1"' in text
+    assert '.immutable "$RUNNER_TEMP/final-release-published.json"' in text
+    assert (
+        'test "$(jq -r .immutable "$RUNNER_TEMP/final-release-published.json")" = "false"' in text
+    )
+    assert "gh release verify" not in text
 
 
 def test_final_claims_resolve_all_decision_reports_and_bind_target_policy() -> None:

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1612,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.0.5"
+    assert policy.release_version == "1.0.6"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.0.5"
+version = "1.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- compare JARVIS-CD PEP 610 file provenance by canonical filesystem identity instead of raw lexical URI text
- retain fail-closed version, SHA-256, local-file URL, regular-file, and exact-artifact checks
- publish the 1.0 line as a normal mutable GitHub release; defer GitHub immutable releases to 1.1
- record the abandoned v1.0.5 bootstrap report and advance the reviewed release identity to v1.0.6

## Why
Ares exposes the same home directory through `/home/jcernudagarcia` and canonical `/mnt/common/jcernudagarcia`. Both pip and uv correctly recorded the lexical `/home/...` wheel URL, while the verifier canonicalized the expected wheel to `/mnt/common/...` and falsely rejected the same file.

The first production release should work end to end before adding GitHub release immutability. Finalization still binds reviewed main/tag identity, verifies candidate and released attestations, and requires exact asset ID/name/size/digest equality before and after publication. It explicitly verifies the published 1.0 release is mutable; immutability is a separate 1.1 change.

## Validation
- focused installation/bootstrap/release-policy and publication-workflow tests
- `uv run pyright`
- `uv run ruff check`
- `uv run ruff format --check`
- isolated Ares wheel probe passed for both persistent `uv tool --with` and pip-seeded environments against the real `/home` -> `/mnt/common` mapping

The v1.0.5 draft remains unpublished and contains no successful live-validation claim.