### PR TITLE
fix: canonicalize persistent tool provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> The current development candidate is `1.0.6`. The immutable `v1.0.0` candidate
+> The current development candidate is `1.0.7`. The `v1.0.0` candidate
 > was abandoned before publication after its acceptance runbook rejected the
 > staged GNU checksum format; `v1.0.1` was also abandoned before publication
 > after protected-main validation exposed a Windows lease-deletion race;
@@ -21,9 +21,11 @@ It is a piece of the federation layer for [`clio-agent`](https://github.com/iowa
 > Gray-Scott helper did not bind the selected Spack ADIOS2 package's own CMake
 > configuration; `v1.0.5` was abandoned after one failed bootstrap report when
 > Ares exposed a lexical-versus-canonical home-path mismatch in the JARVIS-CD
-> wheel provenance check. The latest released live evidence is `0.9.22`;
-> 1.0.6 is not release-complete until its immutable-candidate
-> reports pass, its exact candidate is published, and the released-artifact
+> wheel provenance check; `v1.0.6` was abandoned after one failed bootstrap
+> report exposed the same mount-alias boundary in persistent uv-tool provider,
+> distribution-source, and receipt verification. The latest released live
+> evidence is `0.9.22`; `1.0.7` is not release-complete until its digest-bound
+> candidate reports pass, its exact candidate is published, and the released-artifact
 > runs pass again. The published 1.0 GitHub release is intentionally mutable;
 > GitHub release immutability is deferred to 1.1. The policy currently selects the `ares` and `homelab`
 > evidence labels; those labels are release configuration, not hardcoded

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.0.6"
+$Version = "1.0.7"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.0.6"
+release_version: "1.0.7"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 99e58203a62ed58f6fcf5b9a7d7abb8954932ffc03d707a082e12918ba5ae226
+acceptance_matrix_sha256: 5d44747f9632e818b3c52acde9e832ad46bb941d8aedfa20e590e872a23600e4
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -70,7 +70,7 @@ Commit the release change with a conventional commit, then create and push an
 exact matching tag:
 
 ```powershell
-$Tag = "v1.0.6"
+$Tag = "v1.0.7"
 git fetch origin main
 $ReviewedMainSha = (git rev-parse refs/remotes/origin/main).Trim()
 if ((git rev-parse HEAD).Trim() -ne $ReviewedMainSha) {
@@ -153,7 +153,7 @@ Download the draft wheel and manifest, verify both the digest and the signed
 tag-build provenance, and compute the digest locally:
 
 ```powershell
-$Tag = "v1.0.6"
+$Tag = "v1.0.7"
 New-Item -ItemType Directory -Force .clio-relay\candidate | Out-Null
 gh release download $Tag --pattern "*.whl" --pattern "SHA256SUMS" `
   --dir .clio-relay\candidate

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.0.6",
-  "matrix_sha256": "99e58203a62ed58f6fcf5b9a7d7abb8954932ffc03d707a082e12918ba5ae226",
+  "release_version": "1.0.7",
+  "matrix_sha256": "5d44747f9632e818b3c52acde9e832ad46bb941d8aedfa20e590e872a23600e4",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.0.6"
+version = "1.0.7"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.0.6"
+__version__ = "1.0.7"

--- a/src/clio_relay/installation.py
+++ b/src/clio_relay/installation.py
@@ -331,6 +331,10 @@ def probe_persistent_uv_tool_identity(
         provider_location,
         label="tool provider interpreter",
     )
+    provider_environment_location = _resolved_parent_location(
+        provider_location,
+        label="tool provider interpreter",
+    )
     source_path = _required_regular_file(source_artifact, label="tool source artifact")
     uv_version_output = _bounded_identity_command([str(uv_path), "--version"])
     version_match = re.fullmatch(
@@ -505,7 +509,7 @@ print(json.dumps({
         or observed_provider_target != provider_path
     ):
         raise ConfigurationError("persistent uv tool probe used the wrong interpreter")
-    if not _path_within(provider_location, environment_prefix):
+    if not _path_within(provider_environment_location, environment_prefix):
         raise ConfigurationError("persistent uv tool provider is outside its environment")
     if not _path_within(environment_prefix, tool_directory):
         raise ConfigurationError("persistent tool environment is outside uv's tool directory")
@@ -529,9 +533,19 @@ print(json.dumps({
             "persistent uv tool launcher does not match its RECORD-owned entry point"
         )
     direct_url = evidence.get("direct_url")
-    direct_url_mapping = cast(dict[str, object], direct_url) if isinstance(direct_url, dict) else {}
-    if direct_url_mapping.get("url") != source_path.as_uri():
-        raise ConfigurationError("persistent tool was not installed from the receipt wheel")
+    try:
+        direct_url_text = json.dumps(direct_url, sort_keys=True)
+    except (TypeError, ValueError) as exc:
+        raise ConfigurationError("persistent tool source metadata is invalid") from exc
+    try:
+        verify_distribution_file_source(
+            direct_url_text=direct_url_text,
+            expected_artifact=source_path,
+        )
+    except ConfigurationError as exc:
+        raise ConfigurationError(
+            "persistent tool was not installed from the receipt wheel"
+        ) from exc
     observed_distribution = str(evidence.get("distribution", "")).lower().replace("_", "-")
     expected_distribution = distribution.lower().replace("_", "-")
     if (
@@ -614,7 +628,7 @@ def _required_regular_file(value: str | Path, *, label: str) -> Path:
     """Resolve one required regular identity file."""
     try:
         path = Path(value).expanduser().resolve(strict=True)
-    except OSError as exc:
+    except (OSError, RuntimeError, TypeError, ValueError) as exc:
         raise ConfigurationError(f"{label} is unavailable") from exc
     if not path.is_file():
         raise ConfigurationError(f"{label} is not a regular file")
@@ -631,6 +645,14 @@ def _absolute_path(value: str | Path, *, label: str) -> Path:
     if not absolute.is_absolute():
         raise ConfigurationError(f"{label} path is not absolute")
     return absolute
+
+
+def _resolved_parent_location(path: Path, *, label: str) -> Path:
+    """Resolve a path's parent while preserving its final symlink location."""
+    try:
+        return path.parent.resolve(strict=True) / path.name
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ConfigurationError(f"{label} parent is unavailable") from exc
 
 
 def _verify_uv_tool_receipt(
@@ -700,9 +722,21 @@ def _verify_uv_tool_receipt(
     if len(requirement_matches) != 1:
         raise ConfigurationError("persistent uv tool receipt source requirement is ambiguous")
     requirement_path = requirement_matches[0].get("path")
-    if not isinstance(requirement_path, str) or _lexical_path_key(
-        _absolute_path(requirement_path, label="uv receipt source path")
-    ) != _lexical_path_key(source_path):
+    if not isinstance(requirement_path, str):
+        raise ConfigurationError("persistent uv tool receipt does not bind the source wheel")
+    try:
+        requirement_location = Path(requirement_path).expanduser()
+        if not requirement_location.is_absolute():
+            raise ConfigurationError("persistent uv tool receipt does not bind the source wheel")
+        receipt_source_path = _required_regular_file(
+            requirement_location,
+            label="uv receipt source artifact",
+        )
+    except (ConfigurationError, OSError, RuntimeError, ValueError) as exc:
+        raise ConfigurationError(
+            "persistent uv tool receipt does not bind the source wheel"
+        ) from exc
+    if receipt_source_path != source_path:
         raise ConfigurationError("persistent uv tool receipt does not bind the source wheel")
     return receipt.resolve(strict=True), hashlib.sha256(payload).hexdigest()
 
@@ -1711,12 +1745,15 @@ def _native_jarvis_component_runtime_identity(
     )
     entry_points_visible = set(expected_entry_points).issubset(installed_entry_points)
     provider_python = component.runtime_interpreters.get("provider")
+    provider_source_verified = runtime_path is not None and _direct_url_source_matches(
+        provider_direct_url,
+        expected_artifact=runtime_path,
+    )
     provider_interpreter_verified = (
         provider_python is not None
         and Path(provider_python).expanduser().resolve() == Path(sys.executable).resolve()
         and provider_distribution_identity_verified
-        and runtime_path is not None
-        and provider_direct_url.get("url") == runtime_path.as_uri()
+        and provider_source_verified
     )
     execution_python = component.runtime_interpreters.get("execution")
     execution = _probe_python_distribution(execution_python, component.distribution)
@@ -1730,8 +1767,9 @@ def _native_jarvis_component_runtime_identity(
     execution_entry_points_visible = isinstance(execution_entry_points, list) and set(
         expected_entry_points
     ).issubset({str(value) for value in cast(list[object], execution_entry_points)})
-    execution_source_verified = (
-        runtime_path is not None and execution.get("direct_url") == runtime_path.as_uri()
+    execution_source_verified = runtime_path is not None and _direct_url_source_matches(
+        execution.get("direct_url"),
+        expected_artifact=runtime_path,
     )
     runtime_artifact_path_verified = (
         runtime_path is not None
@@ -1853,6 +1891,20 @@ def _distribution_direct_url(distribution: metadata.Distribution) -> dict[str, o
     return {str(key): value for key, value in cast(dict[object, object], loaded).items()}
 
 
+def _direct_url_source_matches(value: object, *, expected_artifact: Path) -> bool:
+    """Return whether direct-url evidence resolves to one exact local artifact."""
+    document: object = {"url": value} if isinstance(value, str) else value
+    try:
+        direct_url_text = json.dumps(document, sort_keys=True)
+        verify_distribution_file_source(
+            direct_url_text=direct_url_text,
+            expected_artifact=expected_artifact,
+        )
+    except (ConfigurationError, TypeError, ValueError):
+        return False
+    return True
+
+
 def _probe_python_distribution(python: str | None, distribution_name: str) -> dict[str, object]:
     """Inspect a second interpreter without importing provider application code."""
     if python is None:
@@ -1913,13 +1965,15 @@ def _jarvis_executable_matches_interpreter(
     executable_path = Path(executable).expanduser()
     python_path = Path(python).expanduser()
     try:
+        execution_bin_directory = python_path.parent.resolve(strict=True)
         return (
             executable_path.is_file()
             and os.access(executable_path, os.X_OK)
-            and executable_path.resolve().parent == python_path.resolve().parent
-            and Path(runtime_command[0]).expanduser().resolve() == executable_path.resolve()
+            and executable_path.resolve(strict=True).parent == execution_bin_directory
+            and Path(runtime_command[0]).expanduser().resolve(strict=True)
+            == executable_path.resolve(strict=True)
         )
-    except OSError:
+    except (OSError, RuntimeError, ValueError):
         return False
 
 

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1330,7 +1330,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "99e58203a62ed58f6fcf5b9a7d7abb8954932ffc03d707a082e12918ba5ae226"
+        "5d44747f9632e818b3c52acde9e832ad46bb941d8aedfa20e590e872a23600e4"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_clio_kit_mcp_contracts.py
+++ b/tests/test_clio_kit_mcp_contracts.py
@@ -349,6 +349,44 @@ def test_real_uv_tool_install_binds_external_launcher_to_receipt_and_record(
         )
     receipt_path.write_bytes(receipt_payload)
 
+    recorded_source = probe_wheel.as_posix()
+    assert receipt_text.count(recorded_source) == 1
+    other_wheel = tmp_path / "other" / probe_wheel.name
+    other_wheel.parent.mkdir()
+    other_wheel.write_bytes(probe_wheel.read_bytes())
+    for substituted_source in (
+        other_wheel.as_posix(),
+        (tmp_path / "missing" / probe_wheel.name).as_posix(),
+        "relative-wheel.whl",
+        tmp_path.as_posix(),
+    ):
+        receipt_path.write_text(
+            receipt_text.replace(recorded_source, substituted_source),
+            encoding="utf-8",
+        )
+        with pytest.raises(ConfigurationError, match="does not bind the source wheel"):
+            probe_persistent_uv_tool_identity(
+                uv_executable=uv,
+                tool_executable=str(executable),
+                provider_interpreter=str(provider),
+                source_artifact=probe_wheel,
+                distribution="clio-kit",
+                distribution_version=UV_TOOL_PROBE_VERSION,
+                entry_point="clio-kit",
+            )
+    receipt_path.write_text("[tool\n", encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="receipt is invalid"):
+        probe_persistent_uv_tool_identity(
+            uv_executable=uv,
+            tool_executable=str(executable),
+            provider_interpreter=str(provider),
+            source_artifact=probe_wheel,
+            distribution="clio-kit",
+            distribution_version=UV_TOOL_PROBE_VERSION,
+            entry_point="clio-kit",
+        )
+    receipt_path.write_bytes(receipt_payload)
+
     module_path = Path(
         subprocess.run(
             [
@@ -374,6 +412,98 @@ def test_real_uv_tool_install_binds_external_launcher_to_receipt_and_record(
             distribution_version=UV_TOOL_PROBE_VERSION,
             entry_point="clio-kit",
         )
+
+
+def test_real_uv_tool_install_accepts_canonical_mount_aliases(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Accept one uv tool whose visible home path resolves through a mount alias."""
+    uv = shutil.which("uv")
+    assert uv is not None
+    built_wheel = _build_uv_tool_layout_probe_wheel(tmp_path)
+    canonical_root = tmp_path / "canonical-home"
+    canonical_source = canonical_root / "source"
+    canonical_source.mkdir(parents=True)
+    canonical_wheel = canonical_source / built_wheel.name
+    shutil.copy2(built_wheel, canonical_wheel)
+
+    if os.name == "nt":
+        intermediate = canonical_root / "lexical-alias"
+        intermediate.mkdir()
+        visible_root = intermediate / ".."
+    else:
+        visible_root = tmp_path / "visible-home"
+        visible_root.symlink_to(canonical_root, target_is_directory=True)
+        assert visible_root.absolute() != visible_root.resolve()
+
+    visible_wheel = visible_root / "source" / built_wheel.name
+    tool_directory = visible_root / "tools"
+    tool_bin_directory = visible_root / "bin"
+    monkeypatch.setenv("UV_TOOL_DIR", str(tool_directory))
+    monkeypatch.setenv("UV_TOOL_BIN_DIR", str(tool_bin_directory))
+    monkeypatch.setenv("UV_CACHE_DIR", str(visible_root / "cache"))
+    monkeypatch.setenv("UV_LINK_MODE", "copy")
+    completed = subprocess.run(
+        [
+            uv,
+            "tool",
+            "install",
+            "--force",
+            "--python",
+            sys.executable,
+            "--offline",
+            "--no-index",
+            "--no-config",
+            str(visible_wheel),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert completed.returncode == 0, completed.stderr
+    executable = tool_bin_directory / ("clio-kit.exe" if os.name == "nt" else "clio-kit")
+    environment = tool_directory / "clio-kit"
+    provider = environment / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    direct_url = json.loads(
+        subprocess.run(
+            [
+                str(provider),
+                "-I",
+                "-c",
+                (
+                    "from importlib.metadata import distribution; "
+                    "print(distribution('clio-kit').read_text('direct_url.json'))"
+                ),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        ).stdout
+    )
+    receipt_text = (environment / "uv-receipt.toml").read_text(encoding="utf-8")
+    if os.name != "nt":
+        assert direct_url["url"] == visible_wheel.as_uri()
+        assert visible_wheel.as_posix() in receipt_text
+        assert provider.absolute().is_relative_to(environment.absolute())
+        assert provider.parent.resolve().is_relative_to(environment.resolve())
+
+    identity = probe_persistent_uv_tool_identity(
+        uv_executable=uv,
+        tool_executable=str(executable),
+        provider_interpreter=str(provider),
+        source_artifact=visible_wheel,
+        distribution="clio-kit",
+        distribution_version=UV_TOOL_PROBE_VERSION,
+        entry_point="clio-kit",
+    )
+
+    assert Path(identity.environment_prefix) == environment.resolve()
+    assert Path(identity.provider_interpreter).parent.resolve() == provider.parent.resolve()
+    assert Path(identity.source_artifact_path) == canonical_wheel.resolve()
+    assert Path(identity.uv_receipt_path).is_relative_to(environment.resolve())
 
 
 @pytest.mark.parametrize("server_name", ["jarvis", "spack"])

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -2,8 +2,13 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import shutil
 import sys
+from collections.abc import Callable
+from importlib import metadata
 from pathlib import Path
+from types import SimpleNamespace
 from typing import cast
 
 import pytest
@@ -126,6 +131,160 @@ def test_distribution_file_source_decodes_file_url_percent_escapes_once(
     )
 
     assert resolved == wheel.resolve()
+
+
+def test_native_jarvis_runtime_accepts_canonical_source_aliases(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep provider and execution provenance true across one home-mount alias."""
+    canonical_home = tmp_path / "mnt" / "common" / "operator"
+    canonical_home.mkdir(parents=True)
+    wheel = canonical_home / "jarvis_cd-1.2.2-py3-none-any.whl"
+    wheel.write_bytes(b"verified-jarvis-wheel")
+    visible_home = tmp_path / "home" / "operator"
+    visible_home.parent.mkdir()
+    try:
+        visible_home.symlink_to(canonical_home, target_is_directory=True)
+        visible_wheel = visible_home / wheel.name
+    except OSError:
+        alias_directory = canonical_home / "alias"
+        alias_directory.mkdir()
+        visible_wheel = alias_directory / ".." / wheel.name
+    source_url = {"value": visible_wheel.as_uri()}
+
+    def read_direct_url(_name: str) -> str:
+        return json.dumps({"url": source_url["value"]})
+
+    distribution = cast(
+        metadata.Distribution,
+        SimpleNamespace(
+            name="jarvis-cd",
+            version="1.2.2",
+            entry_points=[],
+            read_text=read_direct_url,
+        ),
+    )
+    capability = NativeJarvisExecutionCapability(
+        operations=[
+            "execution_handle.progress",
+            "pipeline.get_execution",
+            "pipeline.get_execution_progress",
+            "pipeline.run",
+        ]
+    )
+
+    def probe_execution(_python: str | None, _distribution: str) -> dict[str, object]:
+        return {
+            "executable": sys.executable,
+            "distribution": "jarvis-cd",
+            "distribution_version": "1.2.2",
+            "direct_url": source_url["value"],
+            "entry_points": [],
+        }
+
+    def find_distribution(_name: str) -> metadata.Distribution:
+        return distribution
+
+    def probe_capability(_python: str | None) -> NativeJarvisExecutionCapability:
+        return capability
+
+    def match_jarvis_executable(
+        _executable: str | None,
+        _python: str | None,
+        *,
+        runtime_command: list[str],
+    ) -> bool:
+        return bool(runtime_command)
+
+    monkeypatch.setattr(installation_module.metadata, "distribution", find_distribution)
+    monkeypatch.setattr(installation_module, "_probe_python_distribution", probe_execution)
+    monkeypatch.setattr(
+        installation_module,
+        "probe_jarvis_native_execution_capability",
+        probe_capability,
+    )
+    monkeypatch.setattr(
+        installation_module,
+        "_jarvis_executable_matches_interpreter",
+        match_jarvis_executable,
+    )
+    runtime_identity_probe_name = "_native_jarvis_component_runtime_identity"
+    runtime_identity_probe = cast(
+        Callable[[ComponentArtifactIdentity], dict[str, object]],
+        getattr(installation_module, runtime_identity_probe_name),
+    )
+    component = ComponentArtifactIdentity(
+        distribution="jarvis-cd",
+        distribution_version="1.2.2",
+        install_spec=str(wheel),
+        requested_source="wheel",
+        artifact_filename=wheel.name,
+        artifact_sha256=hashlib.sha256(wheel.read_bytes()).hexdigest(),
+        runtime_artifact_path=str(wheel.resolve()),
+        runtime_command=[sys.executable, "-m", "jarvis_cd"],
+        runtime_interpreters={"provider": sys.executable, "execution": sys.executable},
+        runtime_executables={"jarvis": sys.executable},
+        native_execution=capability,
+    )
+
+    identity = runtime_identity_probe(component)
+
+    assert identity["provider_interpreter_verified"] is True
+    assert identity["execution_source_verified"] is True
+    assert identity["runtime_artifact_path_verified"] is True
+    assert identity["execution_interpreter_verified"] is True
+    assert identity["verified"] is True
+
+    other = canonical_home / "other" / wheel.name
+    other.parent.mkdir()
+    other.write_bytes(wheel.read_bytes())
+    source_url["value"] = other.as_uri()
+    substituted = runtime_identity_probe(component)
+
+    assert substituted["provider_interpreter_verified"] is False
+    assert substituted["execution_source_verified"] is False
+    assert substituted["runtime_artifact_path_verified"] is False
+    assert substituted["execution_interpreter_verified"] is False
+    assert substituted["verified"] is False
+
+
+def test_jarvis_launcher_matches_a_uv_managed_python_symlink(tmp_path: Path) -> None:
+    """Bind JARVIS to the venv bin directory without following Python out of it."""
+    environment_bin = tmp_path / "environment" / "bin"
+    environment_bin.mkdir(parents=True)
+    python = environment_bin / ("python.exe" if os.name == "nt" else "python")
+    jarvis = environment_bin / ("jarvis.exe" if os.name == "nt" else "jarvis")
+    if os.name == "nt":
+        shutil.copy2(sys.executable, python)
+        shutil.copy2(sys.executable, jarvis)
+        executable = jarvis
+    else:
+        managed_python = tmp_path / "uv" / "python" / "bin" / "python3.12"
+        managed_python.parent.mkdir(parents=True)
+        managed_python.symlink_to(Path(sys.executable).resolve())
+        python.symlink_to(managed_python)
+        jarvis.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        jarvis.chmod(0o755)
+        external_bin = tmp_path / "external-bin"
+        external_bin.mkdir()
+        executable = external_bin / "jarvis"
+        executable.symlink_to(jarvis)
+        assert python.resolve().parent != environment_bin.resolve()
+
+    matcher_name = "_jarvis_executable_matches_interpreter"
+    matcher = cast(Callable[..., bool], getattr(installation_module, matcher_name))
+
+    assert matcher(str(executable), str(python), runtime_command=[str(executable), "--help"])
+
+    other = tmp_path / "other-bin" / executable.name
+    other.parent.mkdir()
+    if os.name == "nt":
+        shutil.copy2(sys.executable, other)
+    else:
+        other.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        other.chmod(0o755)
+    assert not matcher(str(other), str(python), runtime_command=[str(other), "--help"])
 
 
 def test_install_receipt_binds_running_package_to_wheel_bytes(tmp_path: Path) -> None:

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -51,7 +51,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
 
 def test_candidate_manifest_parser_accepts_the_exact_gnu_checksum_separator() -> None:
     digest = "a" * 64
-    wheel_name = "clio_relay-1.0.6-py3-none-any.whl"
+    wheel_name = "clio_relay-1.0.7-py3-none-any.whl"
     selector = re.compile(rf"^[0-9A-Fa-f]{{64}} [ *]{re.escape(wheel_name)}$")
     parser = re.compile(r"^([0-9A-Fa-f]{64}) [ *](.+)$")
 

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1612,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.0.6"
+    assert policy.release_version == "1.0.7"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.0.6"
+version = "1.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- accept `/home`-style mount aliases while binding persistent uv-tool providers, `direct_url.json`, and `uv-receipt.toml` to exact canonical files
- verify JARVIS provider/execution wheel provenance and uv-managed Python/JARVIS launcher locations without following the final Python symlink out of its environment
- reject relative, missing, directory, malformed, or different receipt sources, including distinct same-byte wheels
- advance the unpublished production candidate from 1.0.6 to 1.0.7 and update the release matrix digest

`v1.0.6` remains unpublished and was abandoned after its first Ares bootstrap report exposed this path-identity bug. GitHub release immutability remains deferred to 1.1; 1.0.7 follows the normal mutable 1.0 release path.

## Verification

- 219 focused installation, clio-kit contract, policy, matrix, and runbook tests passed with the exact SHA-pinned clio-kit 2.3.2 wheel
- 64 bootstrap and release-workflow tests passed
- repository-wide Ruff and Pyright passed
- isolated v1.0.7 wheel passed live Ares persistent uv-tool identity across `/home` -> `/mnt/common`
- live Ares JARVIS provider and execution provenance, native capability, execution interpreter, and launcher checks all passed