### PR TITLE
fix: harden v1.0.8 production upgrade paths

### DIFF
--- a/.github/workflows/live-validation-attest.yml
+++ b/.github/workflows/live-validation-attest.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing immutable-candidate draft tag, such as v1.0.1
+        description: Existing digest-bound candidate draft tag, such as v1.0.8
         required: true
         type: string
 

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing draft release tag, such as v1.0.1
+        description: Existing draft release tag, such as v1.0.8
         required: true
         type: string
       reviewed_main_sha:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
 
     steps:
-      - name: check out the exact private-repository tag commit
+      - name: check out the exact repository tag commit
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.sha }}

--- a/.github/workflows/stage-candidate.yml
+++ b/.github/workflows/stage-candidate.yml
@@ -1,4 +1,4 @@
-name: attest and stage immutable release candidate
+name: attest and stage digest-bound release candidate
 
 on:
   workflow_dispatch:
@@ -43,7 +43,7 @@ jobs:
           echo "workflow_sha=$DISPATCH_SHA" >> "$GITHUB_OUTPUT"
 
   stage:
-    name: verify, attest, and create immutable-identity draft
+    name: verify, attest, and create digest-bound draft
     runs-on: ubuntu-latest
     timeout-minutes: 45  # Bound GitHub API, artifact, governance, and attestation work.
     needs: authorize
@@ -305,7 +305,7 @@ jobs:
               --target "$SOURCE_COMMIT" \
               --draft \
               --title "$TAG_NAME" \
-              --notes "Immutable candidate wheel SHA-256: $wheel_sha. Live validation and PyPI promotion are pending."
+              --notes "Candidate wheel SHA-256: $wheel_sha. Live validation and PyPI promotion are pending. GitHub release immutability is deferred to 1.1."
           fi
           relay_release_resolve_eventually "$TAG_NAME" true \
             "$RUNNER_TEMP/release-after-create.json"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> The current development candidate is `1.0.7`. The `v1.0.0` candidate
+> The current development candidate is `1.0.8`. The `v1.0.0` candidate
 > was abandoned before publication after its acceptance runbook rejected the
 > staged GNU checksum format; `v1.0.1` was also abandoned before publication
 > after protected-main validation exposed a Windows lease-deletion race;
@@ -23,8 +23,11 @@ It is a piece of the federation layer for [`clio-agent`](https://github.com/iowa
 > Ares exposed a lexical-versus-canonical home-path mismatch in the JARVIS-CD
 > wheel provenance check; `v1.0.6` was abandoned after one failed bootstrap
 > report exposed the same mount-alias boundary in persistent uv-tool provider,
-> distribution-source, and receipt verification. The latest released live
-> evidence is `0.9.22`; `1.0.7` is not release-complete until its digest-bound
+> distribution-source, and receipt verification; `v1.0.7` was abandoned after
+> one failed bootstrap report exposed that the pre-1.0 state audit rejected
+> valid v0.9.22 output events and production-sized event histories before
+> migration. The latest released live evidence is `0.9.22`; `1.0.8` is not
+> release-complete until its digest-bound
 > candidate reports pass, its exact candidate is published, and the released-artifact
 > runs pass again. The published 1.0 GitHub release is intentionally mutable;
 > GitHub release immutability is deferred to 1.1. The policy currently selects the `ares` and `homelab`
@@ -182,7 +185,7 @@ uv run pyright
 uv run pytest
 ```
 
-The tag workflow builds and attests an immutable draft candidate. Independent
+The tag workflow builds and attests a digest-bound draft candidate. Independent
 maintainer sealing verifies its digest and live reports before promotion
 publishes those exact bytes to PyPI. Published-artifact evidence and PyPI
 digests must then pass before final verification publishes the GitHub release.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -40,6 +40,33 @@ back to an unbounded scan or read a partial index. The generated systemd user un
 uses `ExecStartPre` with `--all`, so a migration error prevents the worker from
 starting and remains visible in the unit journal.
 
+### Upgrade v0.9 output records
+
+Some v0.9 workers stored a complete stdout or stderr callback twice in one
+event. Those records can be larger than the current event limit. A normal
+`clio-relay init` audits this state but does not change it; when migration is
+required, it stops with the exact operator command:
+
+```powershell
+clio-relay init --migrate-legacy-output
+```
+
+Run that command only after every process writing the same queue has stopped.
+This includes endpoint workers, `clio-relay api start`, and any retained
+`clio-relay mcp-server` process.
+It preserves the original bytes in an owner-private archive, replaces the
+oversized event with a bounded compatibility record, and writes durable
+receipts so an interrupted migration resumes safely. Managed `cluster
+bootstrap` performs this sequence itself: it stops the configured worker before
+replacing packages, refuses to continue while any installed `clio-relay`
+process still owns the same physical queue, runs a final bounded source-to-index
+reconciliation under the queue lock, and restarts the service only if it was
+previously active. New managed queues hold shared core ownership for their full
+lifetime, so later migrations cannot overlap an API, MCP server, worker, or new
+queue-backed writer. Explicit migration returns a closed inspection object,
+never an unfenced writable queue. The migration does not delete jobs, logs, or
+scheduler work.
+
 Cluster names are local labels. `ares`, `homelab`, or a later institutional target are registry entries, not hardcoded behavior.
 Use `--scheduler-provider external` when JARVIS or another deployment driver owns
 all scheduler observation and cancellation.

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.0.7"
+$Version = "1.0.8"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.0.7"
+release_version: "1.0.8"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 5d44747f9632e818b3c52acde9e832ad46bb941d8aedfa20e590e872a23600e4
+acceptance_matrix_sha256: 1fac1e2ecec5f84528285d3a512876c2fe481d9ff7e65a6d166dc588fc810975
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -100,9 +100,10 @@ the protected workflow checkout are identical.
 The tag-push workflow rejects a tag that does not match the package version,
 checked-out commit, and freshly fetched `origin/main` commit. It runs the
 complete local gate, builds exactly one wheel and one source distribution, and
-creates `SHA256SUMS`, but has zero `GITHUB_TOKEN` permissions. It fetches the
-public tag without repository credentials and can upload only an Actions
-artifact. It cannot mint an OIDC identity, attest evidence, or create a release.
+creates `SHA256SUMS`, but grants `GITHUB_TOKEN` only read-only repository
+contents access. Checkout credentials are not persisted, and the workflow can
+upload only an Actions artifact. It cannot mint an OIDC identity, attest
+evidence, or create a release.
 
 After that read-only workflow succeeds, stage the payload by dispatching only
 from protected `main`:

--- a/docs/release.md
+++ b/docs/release.md
@@ -70,7 +70,7 @@ Commit the release change with a conventional commit, then create and push an
 exact matching tag:
 
 ```powershell
-$Tag = "v1.0.7"
+$Tag = "v1.0.8"
 git fetch origin main
 $ReviewedMainSha = (git rev-parse refs/remotes/origin/main).Trim()
 if ((git rev-parse HEAD).Trim() -ne $ReviewedMainSha) {
@@ -153,7 +153,7 @@ Download the draft wheel and manifest, verify both the digest and the signed
 tag-build provenance, and compute the digest locally:
 
 ```powershell
-$Tag = "v1.0.7"
+$Tag = "v1.0.8"
 New-Item -ItemType Directory -Force .clio-relay\candidate | Out-Null
 gh release download $Tag --pattern "*.whl" --pattern "SHA256SUMS" `
   --dir .clio-relay\candidate

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.0.7",
-  "matrix_sha256": "5d44747f9632e818b3c52acde9e832ad46bb941d8aedfa20e590e872a23600e4",
+  "release_version": "1.0.8",
+  "matrix_sha256": "1fac1e2ecec5f84528285d3a512876c2fe481d9ff7e65a6d166dc588fc810975",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.0.7"
+version = "1.0.8"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.0.7"
+__version__ = "1.0.8"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -57,6 +57,7 @@ _WORKER_WRITER_PROOF_PYTHON = r'''from __future__ import annotations
 import errno
 import json
 import os
+import posixpath
 import socket
 import stat
 import sys
@@ -164,12 +165,24 @@ def target_home(process_environment: dict[str, str], uid: int | None) -> str:
         fail(f"cannot resolve the inspected process home directory: {error}")
 
 
+def path_is_absolute(value: str) -> bool:
+    """Recognize target Linux roots even when the proof is tested on Windows."""
+    return value.startswith("/") or os.path.isabs(value)
+
+
+def path_join(base: str, *parts: str) -> str:
+    """Join target Linux paths without inheriting a Windows test host's flavor."""
+    if base.startswith("/"):
+        return posixpath.join(base, *parts)
+    return os.path.join(base, *parts)
+
+
 def expand_user(value: str, home: str) -> str:
     """Expand a user path with the inspected process's HOME semantics."""
     if value == "~":
         return home
     if value.startswith("~/"):
-        return os.path.join(home, value[2:])
+        return path_join(home, value[2:])
     if not value.startswith("~"):
         return value
     user, separator, suffix = value[1:].partition("/")
@@ -179,15 +192,20 @@ def expand_user(value: str, home: str) -> str:
         user_home = pwd.getpwnam(user).pw_dir
     except (ImportError, KeyError, OSError) as error:
         fail(f"cannot expand inspected core directory {value!r}: {error}")
-    return os.path.join(user_home, suffix) if separator else user_home
+    return path_join(user_home, suffix) if separator else user_home
 
 
 def canonical(value: str, *, cwd: str | None = None) -> str:
     """Return a non-strict canonical absolute path."""
-    if not os.path.isabs(value):
+    if not path_is_absolute(value):
         if cwd is None:
             fail(f"relative path {value!r} has no inspected working directory")
-        value = os.path.join(cwd, value)
+        value = path_join(cwd, value)
+    if os.name == "nt" and value.startswith("/"):
+        # The embedded proof runs on Linux in production.  Python 3.13 changed
+        # ntpath.isabs('/core') to false, so use the target path flavor when
+        # exercising the exact source in the Windows CI matrix.
+        return posixpath.normpath(value)
     return os.path.realpath(os.path.abspath(value))
 
 
@@ -201,8 +219,8 @@ def process_core_candidates(
     configured = process_environment.get("CLIO_RELAY_CORE_DIR")
     if configured:
         expanded = expand_user(configured, home)
-        cwd = None if os.path.isabs(expanded) else process_cwd(process)
-        if cwd is None and not os.path.isabs(expanded):
+        cwd = None if path_is_absolute(expanded) else process_cwd(process)
+        if cwd is None and not path_is_absolute(expanded):
             return None
         return {canonical(expanded, cwd=cwd)}
 
@@ -213,8 +231,8 @@ def process_core_candidates(
     # its cwd-relative compatibility directory.  /proc cannot prove which one
     # existed at process startup, so both are safety-relevant candidates.
     return {
-        canonical(os.path.join(home, ".local", "share", "clio-relay", "core")),
-        canonical(os.path.join(".clio-relay", "core"), cwd=cwd),
+        canonical(path_join(home, ".local", "share", "clio-relay", "core")),
+        canonical(path_join(".clio-relay", "core"), cwd=cwd),
     }
 
 

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -20,8 +20,14 @@ from urllib.request import urlretrieve
 from uuid import uuid4
 
 from clio_relay import __version__
+from clio_relay.deployment import endpoint_user_service_name
 from clio_relay.errors import ConfigurationError, RelayError
 from clio_relay.jarvis_mcp import CLIO_KIT_JARVIS_MCP_VERSION
+from clio_relay.remote_values import render_remote_shell_path
+from clio_relay.worker_lifetime_lock import (
+    WORKER_LIFETIME_GUARD_FD_ENV,
+    WORKER_LIFETIME_LOCK_NAME,
+)
 
 FRP_VERSION = "0.69.1"
 FRP_WINDOWS_AMD64_SHA256 = "829ac915f8655d4d4e021b8db61b46c3445205ed80d32b04cda7fa89d87c46e0"
@@ -43,6 +49,500 @@ JARVIS_CD_WHEEL_SHA256 = "f05454718a4efe4dadebefb98c83511ba3dcc662238c0c05430a1b
 CLIO_KIT_JARVIS_MCP_WHEEL_SHA256 = (
     "6763c500db777428edc57ed2e1157cefdbe54f9504f2374e9fdc8055870b7321"
 )
+DEFAULT_REMOTE_CORE_DIR = "$HOME/.local/share/clio-relay/core"
+DEFAULT_REMOTE_SPOOL_DIR = "$HOME/.local/share/clio-relay/spool"
+
+_WORKER_WRITER_PROOF_PYTHON = r'''from __future__ import annotations
+
+import errno
+import json
+import os
+import socket
+import stat
+import sys
+from pathlib import Path
+
+MAX_PROC_ENTRIES = 1_000_000
+MAX_OWNED_PROCESSES = 65_536
+MAX_PROC_FILE_BYTES = 1_048_576
+MAX_ENDPOINT_RECORDS = 10_000
+MAX_ENDPOINT_TOTAL_BYTES = 64 * 1_048_576
+
+
+def fail(message: str) -> "NoReturn":
+    """Stop the bootstrap because writer exclusion could not be proved."""
+    raise SystemExit(f"relay worker writer proof failed: {message}")
+
+
+def vanished(error: OSError) -> bool:
+    """Return whether a proc entry disappeared during inspection."""
+    return error.errno in {errno.ENOENT, errno.ESRCH}
+
+
+def read_bounded(path: Path) -> bytes | None:
+    """Read one proc pseudo-file without accepting an unbounded value."""
+    try:
+        with path.open("rb") as stream:
+            value = stream.read(MAX_PROC_FILE_BYTES + 1)
+    except OSError as error:
+        if vanished(error):
+            return None
+        fail(f"cannot inspect {path}: {error}")
+    if len(value) > MAX_PROC_FILE_BYTES:
+        fail(f"{path} exceeds the bounded inspection size")
+    return value
+
+
+def decode_nul_values(value: bytes) -> list[str]:
+    """Decode an exact NUL-delimited proc value with filesystem semantics."""
+    return [os.fsdecode(part) for part in value.split(b"\0") if part]
+
+
+def relay_process_invocation(argv: list[str]) -> list[str] | None:
+    """Return command arguments for one exact installed relay invocation."""
+    for index, argument in enumerate(argv):
+        if os.path.basename(argument) == "clio-relay":
+            return argv[index + 1 :]
+    return None
+
+
+def option_value(arguments: list[str], name: str) -> str | None:
+    """Return the last exact Click-style option value before an option terminator."""
+    found: str | None = None
+    index = 0
+    while index < len(arguments):
+        argument = arguments[index]
+        if argument == "--":
+            break
+        if argument == name:
+            if index + 1 >= len(arguments):
+                return None
+            found = arguments[index + 1]
+            index += 2
+            continue
+        prefix = f"{name}="
+        if argument.startswith(prefix):
+            found = argument[len(prefix) :]
+        index += 1
+    return found
+
+
+def environment(value: bytes) -> dict[str, str]:
+    """Parse the process environment without substring or shell matching."""
+    parsed: dict[str, str] = {}
+    for item in value.split(b"\0"):
+        if b"=" not in item:
+            continue
+        key, raw_value = item.split(b"=", 1)
+        parsed[os.fsdecode(key)] = os.fsdecode(raw_value)
+    return parsed
+
+
+def process_cwd(process: Path) -> str | None:
+    """Read a process working directory, accounting for an ordinary exit race."""
+    try:
+        return os.readlink(process / "cwd")
+    except OSError as error:
+        if vanished(error):
+            return None
+        fail(f"cannot inspect {process / 'cwd'}: {error}")
+
+
+def target_home(process_environment: dict[str, str], uid: int | None) -> str:
+    """Resolve Path.home() as the inspected process would resolve it."""
+    if "HOME" in process_environment:
+        # posixpath.expanduser maps an explicitly empty HOME to the filesystem
+        # root for both '~' and '~/...'; it does not fall back to passwd.
+        return process_environment["HOME"].rstrip("/") or "/"
+    if uid is None:
+        fail("an inspected process has no HOME and no numeric uid")
+    try:
+        import pwd
+
+        return pwd.getpwuid(uid).pw_dir
+    except (ImportError, KeyError, OSError) as error:
+        fail(f"cannot resolve the inspected process home directory: {error}")
+
+
+def expand_user(value: str, home: str) -> str:
+    """Expand a user path with the inspected process's HOME semantics."""
+    if value == "~":
+        return home
+    if value.startswith("~/"):
+        return os.path.join(home, value[2:])
+    if not value.startswith("~"):
+        return value
+    user, separator, suffix = value[1:].partition("/")
+    try:
+        import pwd
+
+        user_home = pwd.getpwnam(user).pw_dir
+    except (ImportError, KeyError, OSError) as error:
+        fail(f"cannot expand inspected core directory {value!r}: {error}")
+    return os.path.join(user_home, suffix) if separator else user_home
+
+
+def canonical(value: str, *, cwd: str | None = None) -> str:
+    """Return a non-strict canonical absolute path."""
+    if not os.path.isabs(value):
+        if cwd is None:
+            fail(f"relative path {value!r} has no inspected working directory")
+        value = os.path.join(cwd, value)
+    return os.path.realpath(os.path.abspath(value))
+
+
+def process_core_candidates(
+    process: Path,
+    process_environment: dict[str, str],
+    uid: int | None,
+) -> set[str] | None:
+    """Reconstruct every core path the live endpoint could have selected at startup."""
+    home = target_home(process_environment, uid)
+    configured = process_environment.get("CLIO_RELAY_CORE_DIR")
+    if configured:
+        expanded = expand_user(configured, home)
+        cwd = None if os.path.isabs(expanded) else process_cwd(process)
+        if cwd is None and not os.path.isabs(expanded):
+            return None
+        return {canonical(expanded, cwd=cwd)}
+
+    cwd = process_cwd(process)
+    if cwd is None:
+        return None
+    # RelaySettings selects the bootstrap directory when it exists, otherwise
+    # its cwd-relative compatibility directory.  /proc cannot prove which one
+    # existed at process startup, so both are safety-relevant candidates.
+    return {
+        canonical(os.path.join(home, ".local", "share", "clio-relay", "core")),
+        canonical(os.path.join(".clio-relay", "core"), cwd=cwd),
+    }
+
+
+def endpoint_record_pids(
+    expected_core: str,
+) -> dict[int, list[tuple[str, dict[str, object] | None]]]:
+    """Read bounded worker PID evidence from the exact core's endpoint records."""
+    endpoint_directory = Path(expected_core) / "endpoints"
+    try:
+        directory_stat = os.lstat(endpoint_directory)
+    except FileNotFoundError:
+        return {}
+    except OSError as error:
+        fail(f"cannot inspect endpoint evidence directory {endpoint_directory}: {error}")
+    if not stat.S_ISDIR(directory_stat.st_mode) or stat.S_ISLNK(directory_stat.st_mode):
+        fail(f"endpoint evidence path is not a real directory: {endpoint_directory}")
+    current_uid = os.getuid() if hasattr(os, "getuid") else None
+    if current_uid is not None and directory_stat.st_uid != current_uid:
+        fail(f"endpoint evidence directory has a foreign owner: {endpoint_directory}")
+
+    records: dict[int, list[tuple[str, dict[str, object] | None]]] = {}
+    record_count = 0
+    total_bytes = 0
+    try:
+        entries = os.scandir(endpoint_directory)
+    except OSError as error:
+        fail(f"cannot enumerate endpoint evidence {endpoint_directory}: {error}")
+    with entries:
+        for entry in entries:
+            if not entry.name.endswith(".json"):
+                continue
+            record_count += 1
+            if record_count > MAX_ENDPOINT_RECORDS:
+                fail("endpoint evidence exceeds the bounded record count")
+            path = Path(entry.path)
+            try:
+                before = os.lstat(path)
+            except OSError as error:
+                if vanished(error):
+                    fail(f"endpoint evidence changed during inspection: {path}")
+                fail(f"cannot inspect endpoint evidence {path}: {error}")
+            if (
+                not stat.S_ISREG(before.st_mode)
+                or before.st_nlink != 1
+                or (current_uid is not None and before.st_uid != current_uid)
+            ):
+                fail(f"endpoint evidence is not one owned regular file: {path}")
+            value = read_bounded(path)
+            if value is None:
+                fail(f"endpoint evidence disappeared during inspection: {path}")
+            total_bytes += len(value)
+            if total_bytes > MAX_ENDPOINT_TOTAL_BYTES:
+                fail("endpoint evidence exceeds the bounded aggregate size")
+            try:
+                after = os.lstat(path)
+            except OSError as error:
+                fail(f"endpoint evidence changed during inspection: {path}: {error}")
+            if (
+                before.st_dev != after.st_dev
+                or before.st_ino != after.st_ino
+                or before.st_size != after.st_size
+                or before.st_mtime_ns != after.st_mtime_ns
+            ):
+                fail(f"endpoint evidence changed during inspection: {path}")
+            try:
+                document = json.loads(value)
+            except (UnicodeDecodeError, json.JSONDecodeError) as error:
+                fail(f"endpoint evidence is not valid JSON: {path}: {error}")
+            if not isinstance(document, dict):
+                fail(f"endpoint evidence is not an object: {path}")
+            endpoint_id = document.get("endpoint_id")
+            role = document.get("role")
+            hostname = document.get("hostname")
+            pid = document.get("pid")
+            cluster = document.get("cluster")
+            metadata = document.get("metadata")
+            if not isinstance(endpoint_id, str) or path.stem != endpoint_id:
+                fail(f"endpoint evidence identity does not match its filename: {path}")
+            if role != "worker":
+                continue
+            if hostname != socket.gethostname():
+                continue
+            if isinstance(pid, bool) or not isinstance(pid, int) or pid <= 0:
+                fail(f"worker endpoint evidence has an invalid pid: {path}")
+            if not isinstance(cluster, str) or not cluster:
+                fail(f"worker endpoint evidence has no cluster: {path}")
+            process_identity: dict[str, object] | None = None
+            raw_identity = metadata.get("process_identity") if isinstance(metadata, dict) else None
+            if isinstance(raw_identity, dict):
+                identity_start_ticks = raw_identity.get("start_ticks")
+                identity_uid = raw_identity.get("uid")
+                identity_pid = raw_identity.get("pid")
+                if (
+                    raw_identity.get("schema_version") == "clio-relay.process-identity.v1"
+                    and isinstance(raw_identity.get("boot_id"), str)
+                    and bool(raw_identity["boot_id"])
+                    and len(raw_identity["boot_id"]) <= 128
+                    and isinstance(identity_start_ticks, int)
+                    and not isinstance(identity_start_ticks, bool)
+                    and identity_start_ticks > 0
+                    and isinstance(identity_uid, int)
+                    and not isinstance(identity_uid, bool)
+                    and identity_uid >= 0
+                    and isinstance(identity_pid, int)
+                    and not isinstance(identity_pid, bool)
+                    and identity_pid == pid
+                ):
+                    process_identity = raw_identity
+                # A malformed identity is deliberately treated as legacy PID
+                # evidence.  Only a complete exact identity may dismiss PID
+                # reuse; malformed metadata can never weaken writer proof.
+            records.setdefault(pid, []).append((cluster, process_identity))
+    return records
+
+
+def proc_boot_id(proc_root: Path) -> str:
+    """Read the exact Linux boot identity used by new endpoint records."""
+    value = read_bounded(proc_root / "sys" / "kernel" / "random" / "boot_id")
+    if value is None:
+        fail("cannot read Linux boot identity for endpoint evidence")
+    try:
+        boot_id = value.decode("ascii").strip()
+    except UnicodeDecodeError as error:
+        fail(f"Linux boot identity is invalid: {error}")
+    if not boot_id or len(boot_id) > 128:
+        fail("Linux boot identity is empty or oversized")
+    return boot_id
+
+
+def process_identity_matches(
+    raw_stat: bytes,
+    *,
+    process_pid: int,
+    process_uid: int,
+    boot_id: str,
+    identity: dict[str, object] | None,
+) -> bool:
+    """Match new exact identities; conservatively retain legacy PID evidence."""
+    closing_parenthesis = raw_stat.rfind(b")")
+    fields = raw_stat[closing_parenthesis + 1 :].split()
+    if closing_parenthesis < 0 or len(fields) <= 19:
+        fail("cannot parse live endpoint process generation")
+    if fields[0] == b"Z":
+        return False
+    if identity is None:
+        return True
+    try:
+        start_ticks = int(fields[19])
+    except ValueError as error:
+        fail(f"cannot parse live endpoint start ticks: {error}")
+    return (
+        identity.get("schema_version") == "clio-relay.process-identity.v1"
+        and identity.get("boot_id") == boot_id
+        and identity.get("start_ticks") == start_ticks
+        and identity.get("uid") == process_uid
+        and identity.get("pid") == process_pid
+    )
+
+
+def prove_no_writer(cluster: str, expected_core: str, proc_root: Path) -> None:
+    """Fail if a same-user long-lived process can write the configured core queue."""
+    expected = canonical(expected_core)
+    current_uid = os.getuid() if hasattr(os, "getuid") else None
+    endpoint_pids = endpoint_record_pids(expected)
+    boot_id = proc_boot_id(proc_root) if endpoint_pids else ""
+    total_entries = 0
+    owned_processes = 0
+    try:
+        entries = os.scandir(proc_root)
+    except OSError as error:
+        fail(f"cannot enumerate {proc_root}: {error}")
+    with entries:
+        for entry in entries:
+            if not entry.name.isdecimal():
+                continue
+            total_entries += 1
+            if total_entries > MAX_PROC_ENTRIES:
+                fail(f"{proc_root} exceeds the bounded process-entry count")
+            try:
+                process_uid = entry.stat(follow_symlinks=False).st_uid
+            except OSError as error:
+                if vanished(error):
+                    continue
+                fail(f"cannot identify process owner for {entry.path}: {error}")
+            if current_uid is not None and process_uid != current_uid:
+                continue
+            owned_processes += 1
+            if owned_processes > MAX_OWNED_PROCESSES:
+                fail("same-user process count exceeds the bounded inspection limit")
+            process = Path(entry.path)
+            endpoint_evidence = endpoint_pids.get(int(entry.name))
+            if endpoint_evidence is not None:
+                raw_stat = read_bounded(process / "stat")
+                if raw_stat is None:
+                    continue
+                for endpoint_cluster, process_identity in endpoint_evidence:
+                    if process_identity_matches(
+                        raw_stat,
+                        process_pid=int(entry.name),
+                        process_uid=process_uid,
+                        boot_id=boot_id,
+                        identity=process_identity,
+                    ):
+                        fail(
+                            f"live endpoint pid={entry.name} has exact-core record "
+                            f"cluster={endpoint_cluster!r} while bootstrapping cluster={cluster!r}"
+                        )
+            raw_cmdline = read_bounded(process / "cmdline")
+            if raw_cmdline is None:
+                continue
+            argv = decode_nul_values(raw_cmdline)
+            command = relay_process_invocation(argv)
+            if command is None:
+                continue
+            writer_kind = "clio-relay"
+            options = command
+            if command[:2] == ["endpoint", "start"]:
+                writer_kind = "endpoint"
+                options = command[2:]
+            elif command[:2] == ["api", "start"]:
+                writer_kind = "api"
+                options = command[2:]
+            elif command[:1] == ["mcp-server"]:
+                writer_kind = "mcp-server"
+                options = command[1:]
+            process_cluster = option_value(options, "--cluster")
+            raw_environment = read_bounded(process / "environ")
+            if raw_environment is None:
+                continue
+            candidates = process_core_candidates(
+                process,
+                environment(raw_environment),
+                process_uid,
+            )
+            if candidates is None:
+                continue
+            if expected in candidates:
+                if (
+                    writer_kind == "endpoint"
+                    and option_value(options, "--role") == "worker"
+                    and process_cluster is not None
+                ):
+                    fail(
+                        f"live endpoint pid={entry.name} still owns "
+                        f"cluster={process_cluster!r} core={expected!r} "
+                        f"while bootstrapping cluster={cluster!r}"
+                    )
+                if writer_kind in {"api", "mcp-server"}:
+                    fail(
+                        f"live {writer_kind} writer pid={entry.name} still owns "
+                        f"core={expected!r} while bootstrapping cluster={cluster!r}; "
+                        "stop or detach it before bootstrap"
+                    )
+                fail(
+                    f"live clio-relay process pid={entry.name} still owns "
+                    f"core={expected!r} while bootstrapping cluster={cluster!r}; "
+                    "wait for it to exit before bootstrap"
+                )
+    print("relay_worker_writer_proof=clear")
+
+
+if len(sys.argv) != 4:
+    fail("writer proof requires cluster, canonical core, and proc root")
+prove_no_writer(sys.argv[1], sys.argv[2], Path(sys.argv[3]))
+'''
+
+_WORKER_LIFETIME_EXCLUSIVE_GUARD_PYTHON = r'''from __future__ import annotations
+
+import errno
+import os
+import stat
+import sys
+import time
+from pathlib import Path
+
+
+def fail(message: str) -> "NoReturn":
+    """Fail inherited-FD validation with one operator-facing reason."""
+    raise SystemExit(f"worker lifetime inherited-fd proof failed: {message}")
+
+
+if len(sys.argv) != 4:
+    fail("proof requires canonical core, inherited fd, and lock filename")
+core_value, descriptor_value, lock_name = sys.argv[1:]
+try:
+    import fcntl
+
+    descriptor = int(descriptor_value)
+    if descriptor < 3:
+        fail("inherited descriptor is invalid")
+    core = Path(core_value)
+    core = core.resolve(strict=True)
+    core_stat = os.lstat(core)
+    if not stat.S_ISDIR(core_stat.st_mode) or stat.S_ISLNK(core_stat.st_mode):
+        fail("worker lifetime core is not a real directory")
+    if core_stat.st_uid != os.getuid():
+        fail("worker lifetime core has a foreign owner")
+    if stat.S_IMODE(core_stat.st_mode) & 0o022:
+        fail("worker lifetime core is writable by group or other users")
+
+    lock_path = core / lock_name
+    opened = os.fstat(descriptor)
+    linked = os.lstat(lock_path)
+    if (
+        not stat.S_ISREG(opened.st_mode)
+        or opened.st_nlink != 1
+        or opened.st_uid != os.getuid()
+        or stat.S_IMODE(opened.st_mode) & 0o077
+        or opened.st_dev != linked.st_dev
+        or opened.st_ino != linked.st_ino
+    ):
+        fail("worker lifetime lock is not one owner-private regular file")
+
+    deadline = time.monotonic() + 30.0
+    while True:
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            break
+        except OSError as lock_error:
+            if lock_error.errno not in {errno.EACCES, errno.EAGAIN}:
+                raise
+            if time.monotonic() >= deadline:
+                fail("timed out acquiring exclusive worker lifetime lock")
+            time.sleep(0.05)
+    print(f"relay_worker_lifetime_fd=exclusive:{descriptor}:{core}")
+except Exception as error:
+    fail(f"{type(error).__name__}: {error}")
+'''
 
 
 @dataclass(frozen=True)
@@ -138,6 +638,9 @@ def bootstrap_cluster_over_ssh(
     bootstrap_profile: str,
     ssh_host: str,
     source_root: Path,
+    cluster: str | None = None,
+    core_dir: str = DEFAULT_REMOTE_CORE_DIR,
+    spool_dir: str = DEFAULT_REMOTE_SPOOL_DIR,
     relay_wheel: Path | None = None,
     relay_artifact_sha256: str | None = None,
     agent_adapter: str = "exec",
@@ -149,6 +652,10 @@ def bootstrap_cluster_over_ssh(
     """Install relay dependencies and the current source tree on a cluster over SSH."""
     if bootstrap_profile != "linux-user":
         raise ConfigurationError(f"unsupported bootstrap profile: {bootstrap_profile}")
+    if cluster is not None:
+        endpoint_user_service_name(cluster)
+    render_remote_shell_path(core_dir, field="core_dir")
+    render_remote_shell_path(spool_dir, field="spool_dir")
     _validate_ssh_destination(ssh_host)
     if shutil.which("ssh") is None or shutil.which("scp") is None:
         raise ConfigurationError("ssh and scp are required for remote bootstrap")
@@ -193,6 +700,9 @@ def bootstrap_cluster_over_ssh(
             script_path.write_text(
                 render_linux_user_bootstrap_script(
                     frp_version=frp_version,
+                    cluster=cluster,
+                    core_dir=core_dir,
+                    spool_dir=spool_dir,
                     agent_adapter=agent_adapter,
                     agent_npm_package=agent_npm_package,
                     agent_npm_bin=agent_npm_bin,
@@ -221,6 +731,25 @@ def bootstrap_cluster_over_ssh(
         if receipt.get("invocation_id") != invocation_id:
             raise RelayError("bootstrap receipt does not match the completed invocation")
         install_receipt_sha256 = receipt.get("install_receipt_sha256")
+        worker_fence = receipt.get("worker_fence")
+        expected_worker_service = (
+            endpoint_user_service_name(cluster) if cluster is not None else None
+        )
+        managed_fence_valid = expected_worker_service is None
+        if expected_worker_service is not None and isinstance(worker_fence, dict):
+            typed_worker_fence = cast(dict[str, object], worker_fence)
+            worker_was_active = typed_worker_fence.get("was_active")
+            worker_restarted = typed_worker_fence.get("restarted")
+            managed_fence_valid = (
+                typed_worker_fence.get("managed") is True
+                and typed_worker_fence.get("service_name") == expected_worker_service
+                and typed_worker_fence.get("writer_proof") is True
+                and typed_worker_fence.get("writer_recheck") is True
+                and typed_worker_fence.get("lifetime_exclusive") is True
+                and type(worker_was_active) is bool
+                and type(worker_restarted) is bool
+                and worker_restarted is worker_was_active
+            )
         receipt_contract = {
             "schema_version": receipt.get("schema_version") == "clio-relay.bootstrap-receipt.v1",
             "bootstrap_profile": receipt.get("bootstrap_profile") == bootstrap_profile,
@@ -230,6 +759,7 @@ def bootstrap_cluster_over_ssh(
             and all(character in "0123456789abcdef" for character in install_receipt_sha256),
             "completed_at": isinstance(receipt.get("completed_at"), str)
             and bool(receipt.get("completed_at")),
+            "worker_fence": managed_fence_valid,
         }
         failed_contract = sorted(name for name, passed in receipt_contract.items() if not passed)
         if failed_contract:
@@ -256,9 +786,224 @@ def package_source_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
+def _worker_writer_proof_shell(*, rendered_core_dir: str, success_variable: str) -> str:
+    """Render one bounded legacy-writer proof against the configured core."""
+    return "\n".join(
+        [
+            (
+                'if ! python3 - "$WORKER_CLUSTER_NAME" '
+                f"{rendered_core_dir} /proc <<'__CLIO_RELAY_WORKER_WRITER_PROOF__'"
+            ),
+            _WORKER_WRITER_PROOF_PYTHON.rstrip(),
+            "__CLIO_RELAY_WORKER_WRITER_PROOF__",
+            "then",
+            ('  echo "cannot prove exclusive relay writer ownership for $WORKER_CLUSTER_NAME" >&2'),
+            "  exit 1",
+            "fi",
+            f"{success_variable}=1",
+        ]
+    )
+
+
+def _worker_upgrade_fence_script(
+    cluster: str | None,
+    *,
+    rendered_core_dir: str,
+) -> tuple[str, str, str, str]:
+    """Render managed fencing, recheck, migration command, and restart step."""
+    service_name = endpoint_user_service_name(cluster) if cluster is not None else ""
+    declarations = "\n".join(
+        [
+            f"WORKER_SERVICE_NAME={shlex.quote(service_name)}",
+            f"WORKER_CLUSTER_NAME={shlex.quote(cluster or '')}",
+            "WORKER_WAS_ACTIVE=0",
+            "WORKER_STOP_CONFIRMED=0",
+            "WORKER_WRITER_PROOF=0",
+            "WORKER_WRITER_RECHECK=0",
+            "WORKER_LIFETIME_EXCLUSIVE=0",
+            "WORKER_LIFETIME_GUARD_FD=",
+            "WORKER_LIFETIME_LOCK_PATH=",
+            "WORKER_RESTART_ATTEMPTED=0",
+            "WORKER_RESTARTED=0",
+        ]
+    )
+    if not service_name:
+        return declarations, "", "clio-relay init", ""
+    initial_proof = _worker_writer_proof_shell(
+        rendered_core_dir=rendered_core_dir,
+        success_variable="WORKER_WRITER_PROOF",
+    )
+    inherited_fd_check = "\n".join(
+        [
+            (
+                f'python3 - {rendered_core_dir} "$WORKER_LIFETIME_GUARD_FD" '
+                f"{shlex.quote(WORKER_LIFETIME_LOCK_NAME)} "
+                "<<'__CLIO_RELAY_WORKER_LIFETIME_FD__'"
+            ),
+            _WORKER_LIFETIME_EXCLUSIVE_GUARD_PYTHON.rstrip(),
+            "__CLIO_RELAY_WORKER_LIFETIME_FD__",
+        ]
+    )
+    recheck = "\n".join(
+        [
+            "bootstrap_require_worker_lifetime_guard",
+            _worker_writer_proof_shell(
+                rendered_core_dir=rendered_core_dir,
+                success_variable="WORKER_WRITER_RECHECK",
+            ),
+        ]
+    )
+    fence = "\n".join(
+        [
+            declarations,
+            "bootstrap_worker_fence_exit() {",
+            "  status=$?",
+            "  trap - EXIT",
+            '  if [ -n "$WORKER_LIFETIME_GUARD_FD" ]; then',
+            "    exec 8>&- || true",
+            "  fi",
+            (
+                '  if [ "$status" -ne 0 ] && [ "$WORKER_WAS_ACTIVE" = "1" ]'
+                ' && [ "$WORKER_RESTARTED" != "1" ]; then'
+            ),
+            '    if [ "$WORKER_RESTART_ATTEMPTED" = "1" ]; then',
+            (
+                '      if WORKER_EXIT_STATE="$(systemctl --user show '
+                '"$WORKER_SERVICE_NAME" --property=ActiveState --value 2>/dev/null)"; then'
+            ),
+            '        case "$WORKER_EXIT_STATE" in',
+            "          inactive|failed)",
+            (
+                '            echo "bootstrap failed; $WORKER_SERVICE_NAME is confirmed '
+                '$WORKER_EXIT_STATE after restart attempt; operator action is required" >&2'
+            ),
+            "            ;;",
+            "          *)",
+            (
+                '            echo "bootstrap failed after restart attempt; '
+                "$WORKER_SERVICE_NAME state is $WORKER_EXIT_STATE and requires "
+                'operator verification" >&2'
+            ),
+            "            ;;",
+            "        esac",
+            "      else",
+            (
+                '        echo "bootstrap failed after restart attempt; '
+                '$WORKER_SERVICE_NAME state is unknown and requires operator verification" >&2'
+            ),
+            "      fi",
+            '    elif [ "$WORKER_STOP_CONFIRMED" = "1" ]; then',
+            (
+                '      echo "bootstrap failed; $WORKER_SERVICE_NAME remains stopped; '
+                'operator action is required" >&2'
+            ),
+            "    else",
+            (
+                '      echo "bootstrap failed while fencing $WORKER_SERVICE_NAME; '
+                'worker state is unknown and requires operator verification" >&2'
+            ),
+            "    fi",
+            "  fi",
+            '  exit "$status"',
+            "}",
+            "trap bootstrap_worker_fence_exit EXIT",
+            "command -v systemctl >/dev/null 2>&1 || {",
+            '  echo "systemctl is required to fence the configured relay worker" >&2',
+            "  exit 1",
+            "}",
+            (
+                'if ! WORKER_LOAD_STATE="$(systemctl --user show "$WORKER_SERVICE_NAME" '
+                '--property=LoadState --value)"; then'
+            ),
+            '  echo "cannot inspect relay worker unit: $WORKER_SERVICE_NAME" >&2',
+            "  exit 1",
+            "fi",
+            (
+                'if ! WORKER_ACTIVE_STATE="$(systemctl --user show "$WORKER_SERVICE_NAME" '
+                '--property=ActiveState --value)"; then'
+            ),
+            '  echo "cannot inspect relay worker state: $WORKER_SERVICE_NAME" >&2',
+            "  exit 1",
+            "fi",
+            'case "$WORKER_LOAD_STATE:$WORKER_ACTIVE_STATE" in',
+            "  loaded:active|loaded:activating|loaded:reloading|loaded:deactivating)",
+            "    WORKER_WAS_ACTIVE=1",
+            '    systemctl --user stop "$WORKER_SERVICE_NAME"',
+            (
+                '    if ! WORKER_POST_STOP_STATE="$(systemctl --user show '
+                '"$WORKER_SERVICE_NAME" --property=ActiveState --value)"; then'
+            ),
+            '      echo "cannot verify stopped relay worker: $WORKER_SERVICE_NAME" >&2',
+            "      exit 1",
+            "    fi",
+            '    case "$WORKER_POST_STOP_STATE" in',
+            "      inactive|failed) WORKER_STOP_CONFIRMED=1 ;;",
+            "      *)",
+            (
+                '        echo "relay worker stop has unknown state '
+                '$WORKER_POST_STOP_STATE: $WORKER_SERVICE_NAME" >&2'
+            ),
+            "        exit 1",
+            "        ;;",
+            "    esac",
+            "    ;;",
+            "  loaded:inactive|loaded:failed|masked:inactive|not-found:inactive) ;;",
+            "  *)",
+            (
+                '    echo "refusing bootstrap with unknown relay worker state '
+                '$WORKER_LOAD_STATE:$WORKER_ACTIVE_STATE: $WORKER_SERVICE_NAME" >&2'
+            ),
+            "    exit 1",
+            "    ;;",
+            "esac",
+            initial_proof,
+            f"mkdir -p -- {rendered_core_dir}",
+            (
+                f"WORKER_LIFETIME_LOCK_PATH={rendered_core_dir}/"
+                f"{shlex.quote(WORKER_LIFETIME_LOCK_NAME)}"
+            ),
+            'exec 8<>"$WORKER_LIFETIME_LOCK_PATH"',
+            "WORKER_LIFETIME_GUARD_FD=8",
+            "bootstrap_require_worker_lifetime_guard() {",
+            inherited_fd_check,
+            "}",
+            "bootstrap_require_worker_lifetime_guard",
+            "WORKER_LIFETIME_EXCLUSIVE=1",
+        ]
+    )
+    restart = "\n".join(
+        [
+            'if [ "$WORKER_WAS_ACTIVE" = "1" ]; then',
+            "  bootstrap_require_worker_lifetime_guard",
+            "  WORKER_RESTART_ATTEMPTED=1",
+            '  systemctl --user start "$WORKER_SERVICE_NAME"',
+            (
+                '  if ! WORKER_POST_START_STATE="$(systemctl --user show '
+                '"$WORKER_SERVICE_NAME" --property=ActiveState --value)"; then'
+            ),
+            '    echo "cannot verify restarted relay worker: $WORKER_SERVICE_NAME" >&2',
+            "    exit 1",
+            "  fi",
+            '  if [ "$WORKER_POST_START_STATE" != "active" ]; then',
+            (
+                '    echo "relay worker did not become active '
+                '($WORKER_POST_START_STATE): $WORKER_SERVICE_NAME" >&2'
+            ),
+            "    exit 1",
+            "  fi",
+            "  WORKER_RESTARTED=1",
+            "fi",
+        ]
+    )
+    return fence, recheck, "clio-relay init --migrate-legacy-output", restart
+
+
 def render_linux_user_bootstrap_script(
     *,
     frp_version: str = FRP_VERSION,
+    cluster: str | None = None,
+    core_dir: str = DEFAULT_REMOTE_CORE_DIR,
+    spool_dir: str = DEFAULT_REMOTE_SPOOL_DIR,
     agent_adapter: str = "exec",
     agent_npm_package: str | None = None,
     agent_npm_bin: str | None = None,
@@ -272,6 +1017,12 @@ def render_linux_user_bootstrap_script(
     source_archive_sha256: str | None = None,
 ) -> str:
     """Render the idempotent shell script used for the current Linux cluster bootstrap."""
+    rendered_core_dir = render_remote_shell_path(core_dir, field="core_dir")
+    rendered_spool_dir = render_remote_shell_path(spool_dir, field="spool_dir")
+    worker_fence, worker_recheck, init_command, worker_restart = _worker_upgrade_fence_script(
+        cluster,
+        rendered_core_dir=rendered_core_dir,
+    )
     rendered_agent_adapter = shlex.quote(agent_adapter)
     rendered_agent_args = shlex.quote(" ".join(agent_args or []))
     rendered_agent_npm_package = shlex.quote(agent_npm_package or "")
@@ -345,6 +1096,7 @@ if ! flock -n 9; then
   echo "another clio-relay bootstrap is already running" >&2
   exit 1
 fi
+{worker_fence}
 
 cd "$HOME/.local/src"
 FRP_VERSION="{frp_version}"
@@ -787,14 +1539,24 @@ jarvis init \
   "$HOME/.local/share/clio-relay/jarvis-shared"
 jarvis repo add "$DEST/jarvis-packages/clio_relay" --force true
 
-CLIO_RELAY_CORE_DIR="$HOME/.local/share/clio-relay/core" \
-CLIO_RELAY_SPOOL_DIR="$HOME/.local/share/clio-relay/spool" \
+{worker_recheck}
+CLIO_RELAY_CORE_DIR={rendered_core_dir} \
+CLIO_RELAY_SPOOL_DIR={rendered_spool_dir} \
 CLIO_RELAY_JARVIS_BIN="$HOME/.local/bin/jarvis" \
 CLIO_RELAY_FRPC_BIN="$HOME/.local/bin/frpc" \
 CLIO_RELAY_AGENT_BIN="${{AGENT_BIN:-agent}}" \
 CLIO_RELAY_AGENT_ADAPTER={rendered_agent_adapter} \
 CLIO_RELAY_AGENT_ARGS={rendered_agent_args} \
-clio-relay init
+{WORKER_LIFETIME_GUARD_FD_ENV}="$WORKER_LIFETIME_GUARD_FD" \
+{init_command}
+{worker_restart}
+
+export CLIO_RELAY_BOOTSTRAP_WORKER_SERVICE_NAME="$WORKER_SERVICE_NAME"
+export CLIO_RELAY_BOOTSTRAP_WORKER_WAS_ACTIVE="$WORKER_WAS_ACTIVE"
+export CLIO_RELAY_BOOTSTRAP_WORKER_WRITER_PROOF="$WORKER_WRITER_PROOF"
+export CLIO_RELAY_BOOTSTRAP_WORKER_WRITER_RECHECK="$WORKER_WRITER_RECHECK"
+export CLIO_RELAY_BOOTSTRAP_WORKER_LIFETIME_EXCLUSIVE="$WORKER_LIFETIME_EXCLUSIVE"
+export CLIO_RELAY_BOOTSTRAP_WORKER_RESTARTED="$WORKER_RESTARTED"
 
 python3 - <<'__CLIO_RELAY_BOOTSTRAP_RECEIPT__'
 import hashlib
@@ -805,12 +1567,29 @@ from pathlib import Path
 
 install_receipt = Path.home() / ".local/share/clio-relay/install-receipt.json"
 install_receipt_sha256 = hashlib.sha256(install_receipt.read_bytes()).hexdigest()
+worker_service_name = os.environ["CLIO_RELAY_BOOTSTRAP_WORKER_SERVICE_NAME"] or None
+worker_was_active = os.environ["CLIO_RELAY_BOOTSTRAP_WORKER_WAS_ACTIVE"] == "1"
+worker_writer_proof = os.environ["CLIO_RELAY_BOOTSTRAP_WORKER_WRITER_PROOF"] == "1"
+worker_writer_recheck = os.environ["CLIO_RELAY_BOOTSTRAP_WORKER_WRITER_RECHECK"] == "1"
+worker_lifetime_exclusive = (
+    os.environ["CLIO_RELAY_BOOTSTRAP_WORKER_LIFETIME_EXCLUSIVE"] == "1"
+)
+worker_restarted = os.environ["CLIO_RELAY_BOOTSTRAP_WORKER_RESTARTED"] == "1"
 receipt = {{
     "schema_version": "clio-relay.bootstrap-receipt.v1",
     "invocation_id": {invocation_id!r},
     "bootstrap_profile": "linux-user",
     "relay_install_spec": {relay_install_spec!r},
     "install_receipt_sha256": install_receipt_sha256,
+    "worker_fence": {{
+        "managed": worker_service_name is not None,
+        "service_name": worker_service_name,
+        "was_active": worker_was_active,
+        "writer_proof": worker_writer_proof,
+        "writer_recheck": worker_writer_recheck,
+        "lifetime_exclusive": worker_lifetime_exclusive,
+        "restarted": worker_restarted,
+    }},
     "completed_at": datetime.now(timezone.utc).isoformat(),
 }}
 destination = Path.home() / ".local/share/clio-relay/bootstrap-receipt.json"

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -282,10 +282,20 @@ def storage_status() -> None:
 
 
 @app.command()
-def init() -> None:
+def init(
+    migrate_legacy_output: Annotated[
+        bool,
+        typer.Option(
+            help=(
+                "Authorize migration of exact oversized v0.9 output events after every "
+                "queue writer has been stopped and verified inactive."
+            )
+        ),
+    ] = False,
+) -> None:
     """Initialize local queue, spool, and cluster registry files."""
     settings = RelaySettings.from_env()
-    storage_managed_queue(settings)
+    storage_managed_queue(settings, migrate_legacy_output=migrate_legacy_output)
     registry = ClusterRegistry.load(default_registry_path())
     typer.echo(
         f"initialized core={settings.core_dir} spool={settings.spool_dir} "
@@ -969,11 +979,14 @@ def endpoint_start(
             provider_for_scheduler(selected_scheduler) if role == EndpointRole.WORKER else None
         ),
     )
-    worker.register()
-    if once:
-        worker.run_once()
-        return
-    worker.serve_forever()
+    try:
+        worker.register()
+        if once:
+            worker.run_once()
+            return
+        worker.serve_forever()
+    finally:
+        worker.close()
 
 
 @endpoint_app.command("status")
@@ -2773,6 +2786,9 @@ def cluster_bootstrap(
                     bootstrap_profile=definition.bootstrap_profile,
                     ssh_host=ssh_host or definition.ssh_host,
                     source_root=package_source_root(),
+                    cluster=definition.name,
+                    core_dir=definition.core_dir,
+                    spool_dir=definition.spool_dir,
                     relay_wheel=relay_wheel,
                     relay_artifact_sha256=validation.install_source.artifact_sha256,
                     agent_adapter=definition.agent_adapter,

--- a/src/clio_relay/cluster_config.py
+++ b/src/clio_relay/cluster_config.py
@@ -15,10 +15,11 @@ from typing import Any, BinaryIO, Literal, cast
 from uuid import uuid4
 
 from filelock import FileLock
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
 
 from clio_relay.errors import ConfigurationError
 from clio_relay.models import validate_mcp_env_from
+from clio_relay.remote_values import validate_remote_path
 
 CLUSTER_REGISTRY_ENV = "CLIO_RELAY_CLUSTER_REGISTRY"
 MAX_CLUSTER_REGISTRY_BYTES = 4 * 1024 * 1024
@@ -410,6 +411,15 @@ class ClusterDefinition(BaseModel):
             )
         return value
 
+    @field_validator("core_dir", "spool_dir")
+    @classmethod
+    def _validate_remote_data_path(cls, value: str, info: ValidationInfo) -> str:
+        try:
+            validate_remote_path(value, field=info.field_name or "remote data path")
+        except ConfigurationError as error:
+            raise ValueError(str(error)) from error
+        return value
+
     @field_validator("remote_mcp_servers")
     @classmethod
     def _remote_mcp_names_must_not_be_blank(
@@ -440,11 +450,16 @@ class ClusterDefinition(BaseModel):
     def _validate_spack_executable(cls, value: str | None) -> str | None:
         if value is None:
             return None
-        if value != value.strip() or any(character in value for character in "\x00\r\n"):
-            raise ValueError("spack_executable must be one absolute remote path")
-        path = PurePosixPath(value)
-        if not path.is_absolute() or ".." in path.parts:
-            raise ValueError("spack_executable must be one absolute remote path")
+        try:
+            validate_remote_path(value, field="spack_executable")
+        except ConfigurationError as error:
+            raise ValueError(
+                "spack_executable must be one absolute remote path or start with $HOME/"
+            ) from error
+        if value != value.strip() or ".." in PurePosixPath(value).parts:
+            raise ValueError(
+                "spack_executable must be one absolute remote path or start with $HOME/"
+            )
         return value
 
     @model_validator(mode="after")

--- a/src/clio_relay/command_evidence.py
+++ b/src/clio_relay/command_evidence.py
@@ -90,6 +90,21 @@ def command_evidence(
     )
 
 
+def bounded_error_detail(value: str | None) -> str | None:
+    """Return one UTF-8-safe diagnostic bounded for durable error records."""
+    if value is None:
+        return None
+    normalized = value.encode("utf-8", errors="replace").decode("utf-8")
+    _marker, diagnostic_offset = _first_diagnostic(normalized)
+    bounded, _metadata = _bounded_diagnostic_text(
+        normalized,
+        max_bytes=ERROR_DETAIL_MAX_BYTES,
+        tail_bytes=ERROR_DETAIL_SUMMARY_TAIL_BYTES,
+        diagnostic_offset=diagnostic_offset,
+    )
+    return bounded
+
+
 def _first_diagnostic(output: str) -> tuple[str | None, int | None]:
     matches: list[tuple[int, str]] = []
     offset = 0

--- a/src/clio_relay/core_queue.py
+++ b/src/clio_relay/core_queue.py
@@ -33,6 +33,7 @@ from clio_relay.cluster_config import (
     ensure_private_configuration_path,
     open_private_atomic_file,
 )
+from clio_relay.command_evidence import bounded_error_detail
 from clio_relay.errors import ConfigurationError, NotFoundError, QueueConflictError
 from clio_relay.filesystem_paths import internal_filesystem_path, logical_filesystem_path
 from clio_relay.identifiers import filesystem_key, validate_durable_record_id
@@ -71,6 +72,11 @@ from clio_relay.pagination import (
     validate_response_page_limit,
 )
 from clio_relay.worker_concurrency import KindConcurrencyInput, normalize_kind_concurrency
+from clio_relay.worker_lifetime_lock import (
+    LockedCoreIdentity,
+    exclusive_migration_lifetime,
+    require_active_locked_core,
+)
 
 Record = TypeVar("Record", bound=BaseModel)
 _LeaseExpiryReference = tuple[int, str, JobKind, str, str, str, str]
@@ -79,6 +85,8 @@ _UNSET = object()
 # slower filesystems (notably Windows endpoint storage).  Keep the wait bounded,
 # but allow enough time for a healthy owner to finish its critical section.
 DEFAULT_CORE_LOCK_TIMEOUT_SECONDS = 30.0
+MIN_SCHEDULER_CANCEL_CLAIM_LEASE_SECONDS = 1.0
+MAX_SCHEDULER_CANCEL_CLAIM_LEASE_SECONDS = 300.0
 ATOMIC_REPLACE_ATTEMPTS = 25
 ATOMIC_REPLACE_RETRY_SECONDS = 0.02
 WRITE_STAGING_FAMILY = "write_staging"
@@ -104,6 +112,18 @@ GC_TRASH_SCHEMA = "clio-relay.gc-trash.v1"
 MAX_GC_PURGE_DEPTH = 4_096
 MAX_GC_PURGE_SCAN_ENTRIES = 10_000
 DEFAULT_RECORD_MAX_BYTES = 1_048_576
+LEGACY_OUTPUT_MIGRATION_SCHEMA = "clio-relay.legacy-output-migration.v1"
+LEGACY_OUTPUT_COMPATIBILITY_SCHEMA = "clio-relay.legacy-output-compatibility.v1"
+LEGACY_OUTPUT_RECEIPT_SCHEMA = "clio-relay.legacy-output-receipt.v1"
+# v0.9 wrote one complete subprocess callback twice in every output event: once
+# as ``message`` and once as ``payload.text``.  Keep the compatibility reader
+# bounded independently from the ordinary event limit.  New events remain
+# limited to 256 KiB and endpoint output is split into 64-KiB chunks.
+MAX_LEGACY_OUTPUT_RECORD_BYTES = 16 * 1_048_576
+MAX_LEGACY_OUTPUT_MIGRATION_BYTES = 256 * 1_048_576
+MAX_LEGACY_OUTPUT_MIGRATION_RECORDS = 10_000
+MAX_LEGACY_EVENT_AUDIT_DIRECTORIES = 100_000
+MAX_LEGACY_EVENT_AUDIT_RECORDS = 1_000_000
 RECORD_FAMILY_MAX_BYTES: dict[str, int] = {
     "active_gateway_refs_by_job": 1_048_576,
     "active_gateway_refs_by_session": 65_536,
@@ -128,6 +148,9 @@ RECORD_FAMILY_MAX_BYTES: dict[str, int] = {
     "jobs_active": 1_048_576,
     "jobs_queued": 1_048_576,
     "leases": 65_536,
+    "legacy_output_archives": MAX_LEGACY_OUTPUT_RECORD_BYTES,
+    "legacy_output_receipts": 65_536,
+    "legacy_output_retired": 65_536,
     "leases_by_job": 65_536,
     "lease_indexes": 65_536,
     "migrations": 262_144,
@@ -160,13 +183,21 @@ class _TransientRecordReplacement(RuntimeError):
 class LegacyQueueStateError(QueueConflictError):
     """Machine-readable refusal for unsafe pre-1.0 canonical queue state."""
 
-    def __init__(self, *, family: str, path: Path, reason: str) -> None:
+    def __init__(
+        self,
+        *,
+        family: str,
+        path: Path,
+        reason: str,
+        action: str | None = None,
+    ) -> None:
         self.report: dict[str, str] = {
             "schema_version": "clio-relay.legacy-state-audit.v1",
             "family": family,
             "path": str(logical_filesystem_path(path)),
             "reason": reason,
-            "action": (
+            "action": action
+            or (
                 "move the unsafe state aside or export records with portable durable IDs "
                 "before retrying"
             ),
@@ -309,6 +340,38 @@ class IdempotentSubmissionResolution:
 
 
 @dataclass(frozen=True, slots=True)
+class SchedulerCancelIdentityRegistration:
+    """Atomic result for one durable scheduler-cancellation identity registration."""
+
+    record: SchedulerCancelPending
+    disposition_created: bool
+
+
+@dataclass(frozen=True, slots=True)
+class SchedulerCancelAttemptClaim:
+    """Exclusive durable lease for one external scheduler cancellation attempt."""
+
+    claim_id: str
+    scheduler_job_id: str
+    provider: str
+    attempt: int
+    claimed_at: datetime
+    expires_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class SchedulerCancelConfirmationClaim:
+    """Exclusive durable lease for one scheduler cancellation confirmation poll."""
+
+    claim_id: str
+    scheduler_job_id: str
+    provider: str
+    confirmation_attempt: int
+    claimed_at: datetime
+    expires_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
 class _LeaseIndexIdentity:
     """Exact immutable fields used by every operational lease reference."""
 
@@ -318,6 +381,32 @@ class _LeaseIndexIdentity:
     cluster: str
     job_kind: JobKind
     expires_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class _LegacyOutputAudit:
+    """Bounded totals established before any legacy-output migration write."""
+
+    marker_complete: bool
+    event_records: int
+    migration_records: int
+    archive_bytes: int
+    migration_keys: tuple[tuple[str, int], ...] = ()
+    receipt_manifest_sha256: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _LegacyOutputRecord:
+    """One exact v0.9 output event and its deterministic replacement."""
+
+    original: RelayEvent
+    original_bytes: bytes
+    original_sha256: str
+    archive_relative_path: str
+    replacement: RelayEvent
+    replacement_bytes: bytes
+    replacement_sha256: str
+    representation: Literal["payload_text", "archive"]
 
 
 class ClioCoreQueue:
@@ -333,18 +422,25 @@ class ClioCoreQueue:
             raise ValueError("lock_timeout_seconds must be positive")
         self.root = logical_filesystem_path(root)
         self._storage_root = internal_filesystem_path(self.root, force_extended=True)
+        self._lock_timeout_seconds = lock_timeout_seconds
         self._lock = _FairBoundedFileLock(
             str(self._storage_root / ".lock"),
             timeout=lock_timeout_seconds,
         )
         self._initialized = False
+        self._migration_lifetime_guarded = False
 
-    def _audit_legacy_state_before_initialization(self) -> None:
+    def _audit_legacy_state_before_initialization(self) -> _LegacyOutputAudit:
         """Refuse unsafe v0.9 canonical state before creating or changing files."""
         try:
             root_stat = os.lstat(self._storage_root)
         except FileNotFoundError:
-            return
+            return _LegacyOutputAudit(
+                marker_complete=False,
+                event_records=0,
+                migration_records=0,
+                archive_bytes=0,
+            )
         except OSError as error:
             raise LegacyQueueStateError(
                 family="root",
@@ -392,11 +488,7 @@ class ClioCoreQueue:
                 model=model,
                 identity_field=identity_field,
             )
-        self._audit_legacy_event_family(
-            "events",
-            model=RelayEvent,
-            identity_field="job_id",
-        )
+        legacy_output_audit = self._audit_legacy_output_state_before_initialization()
         self._audit_legacy_event_family(
             "task_events",
             model=TaskTimelineEvent,
@@ -408,6 +500,7 @@ class ClioCoreQueue:
             identity_field="job_id",
         )
         self._audit_legacy_idempotency_family()
+        return legacy_output_audit
 
     def _require_legacy_family_directory(self, family: str) -> Path | None:
         directory = self._storage_root / family
@@ -482,6 +575,1026 @@ class ClioCoreQueue:
                     path=path,
                     reason=f"filename/content identity mismatch for {identity_field}",
                 )
+
+    def _legacy_output_marker_path(self) -> Path:
+        return self._storage_root / "migrations" / "legacy-output-v1.json"
+
+    def _legacy_output_archive_path(self, job_id: str, seq: int) -> Path:
+        return self._storage_root / "legacy_output_archives" / job_id / f"{seq:020d}.json"
+
+    def _legacy_output_receipt_path(self, job_id: str, seq: int) -> Path:
+        return self._storage_root / "legacy_output_receipts" / job_id / f"{seq:020d}.json"
+
+    def _read_legacy_output_marker(self) -> _LegacyOutputAudit | None:
+        marker_path = self._legacy_output_marker_path()
+        if _path_lstat(marker_path) is None:
+            return None
+        migrations = self._require_legacy_family_directory("migrations")
+        if migrations is None:
+            raise LegacyQueueStateError(
+                family="migrations",
+                path=marker_path,
+                reason="legacy-output marker has no owned migrations directory",
+            )
+        try:
+            raw = self._read_json_document(marker_path)
+        except (OSError, ValueError, QueueConflictError) as error:
+            raise LegacyQueueStateError(
+                family="migrations",
+                path=marker_path,
+                reason=f"legacy-output marker is invalid: {type(error).__name__}",
+            ) from error
+        expected_keys = {
+            "schema_version",
+            "complete",
+            "event_records",
+            "migration_records",
+            "archive_bytes",
+            "receipt_manifest_sha256",
+        }
+        if not isinstance(raw, dict):
+            raise LegacyQueueStateError(
+                family="migrations",
+                path=marker_path,
+                reason="legacy-output marker has an unknown schema shape",
+            )
+        marker = cast(dict[str, object], raw)
+        if set(marker) != expected_keys:
+            raise LegacyQueueStateError(
+                family="migrations",
+                path=marker_path,
+                reason="legacy-output marker has an unknown schema shape",
+            )
+        event_records = marker.get("event_records")
+        migration_records = marker.get("migration_records")
+        archive_bytes = marker.get("archive_bytes")
+        receipt_manifest_sha256 = marker.get("receipt_manifest_sha256")
+        if (
+            marker.get("schema_version") != LEGACY_OUTPUT_MIGRATION_SCHEMA
+            or marker.get("complete") is not True
+            or isinstance(event_records, bool)
+            or not isinstance(event_records, int)
+            or not 0 <= event_records <= MAX_LEGACY_EVENT_AUDIT_RECORDS
+            or isinstance(migration_records, bool)
+            or not isinstance(migration_records, int)
+            or not 0 <= migration_records <= MAX_LEGACY_OUTPUT_MIGRATION_RECORDS
+            or isinstance(archive_bytes, bool)
+            or not isinstance(archive_bytes, int)
+            or not 0 <= archive_bytes <= MAX_LEGACY_OUTPUT_MIGRATION_BYTES
+            or not _is_sha256_digest(receipt_manifest_sha256)
+        ):
+            raise LegacyQueueStateError(
+                family="migrations",
+                path=marker_path,
+                reason="legacy-output marker fields are invalid",
+            )
+        for family in (
+            "legacy_output_archives",
+            "legacy_output_receipts",
+            "legacy_output_retired",
+        ):
+            family_path = self._storage_root / family
+            if self._require_legacy_family_directory(family) is None:
+                raise LegacyQueueStateError(
+                    family=family,
+                    path=family_path,
+                    reason=("legacy-output completion marker requires its owned record directory"),
+                )
+        return _LegacyOutputAudit(
+            marker_complete=True,
+            event_records=event_records,
+            migration_records=migration_records,
+            archive_bytes=archive_bytes,
+            receipt_manifest_sha256=cast(str, receipt_manifest_sha256),
+        )
+
+    def _iter_legacy_event_paths(
+        self,
+        family: str,
+        *,
+        max_directories: int,
+        max_records: int,
+    ) -> Iterable[tuple[Path, str, int]]:
+        directory = self._require_legacy_family_directory(family)
+        if directory is None:
+            return
+        directory_count = 0
+        record_count = 0
+        try:
+            with os.scandir(directory) as identity_entries:
+                for identity_entry in identity_entries:
+                    directory_count += 1
+                    identity_directory = Path(identity_entry.path)
+                    if directory_count > max_directories:
+                        raise LegacyQueueStateError(
+                            family=family,
+                            path=directory,
+                            reason=(
+                                "event identity directories exceed the bounded legacy audit "
+                                f"limit of {max_directories}"
+                            ),
+                        )
+                    try:
+                        directory_stat = os.lstat(identity_directory)
+                    except OSError as error:
+                        raise LegacyQueueStateError(
+                            family=family,
+                            path=identity_directory,
+                            reason=(
+                                f"cannot inspect event identity directory: {type(error).__name__}"
+                            ),
+                        ) from error
+                    if not stat.S_ISDIR(directory_stat.st_mode) or _record_is_reparse(
+                        directory_stat
+                    ):
+                        raise LegacyQueueStateError(
+                            family=family,
+                            path=identity_directory,
+                            reason="event identity entry is not an owned directory",
+                        )
+                    identity = self._require_legacy_durable_id(
+                        family,
+                        identity_directory,
+                        identity_directory.name,
+                    )
+                    try:
+                        with os.scandir(identity_directory) as event_entries:
+                            for event_entry in event_entries:
+                                record_count += 1
+                                path = Path(event_entry.path)
+                                if record_count > max_records:
+                                    raise LegacyQueueStateError(
+                                        family=family,
+                                        path=identity_directory,
+                                        reason=(
+                                            "event family exceeds the bounded legacy audit "
+                                            f"limit of {max_records} records"
+                                        ),
+                                    )
+                                self._require_legacy_regular_json(family, path)
+                                sequence_text = path.name.removesuffix(".json")
+                                if (
+                                    len(sequence_text) != 20
+                                    or not sequence_text.isascii()
+                                    or not sequence_text.isdigit()
+                                ):
+                                    raise LegacyQueueStateError(
+                                        family=family,
+                                        path=path,
+                                        reason=(
+                                            "event filename is not a canonical 20-digit sequence"
+                                        ),
+                                    )
+                                yield path, identity, int(sequence_text)
+                    except LegacyQueueStateError:
+                        raise
+                    except OSError as error:
+                        raise LegacyQueueStateError(
+                            family=family,
+                            path=identity_directory,
+                            reason=(
+                                f"cannot scan event identity directory: {type(error).__name__}"
+                            ),
+                        ) from error
+        except LegacyQueueStateError:
+            raise
+        except OSError as error:
+            raise LegacyQueueStateError(
+                family=family,
+                path=directory,
+                reason=f"cannot scan canonical event family: {type(error).__name__}",
+            ) from error
+
+    def _read_v09_legacy_output_record(
+        self,
+        path: Path,
+        *,
+        job_id: str,
+        seq: int,
+    ) -> _LegacyOutputRecord:
+        path_stat = os.lstat(path)
+        ordinary_limit = RECORD_FAMILY_MAX_BYTES["events"]
+        if path_stat.st_size <= ordinary_limit:
+            raise ValueError("legacy output source is not oversized")
+        if path_stat.st_size > MAX_LEGACY_OUTPUT_RECORD_BYTES:
+            raise QueueConflictError(
+                "legacy output event exceeds the bounded compatibility limit of "
+                f"{MAX_LEGACY_OUTPUT_RECORD_BYTES} bytes"
+            )
+        original_bytes = _read_bounded_record_bytes_once(
+            path,
+            limit=MAX_LEGACY_OUTPUT_RECORD_BYTES,
+        )
+        try:
+            raw = json.loads(original_bytes)
+        except json.JSONDecodeError as error:
+            raise ValueError("legacy output event is not valid JSON") from error
+        expected_keys = {
+            "job_id",
+            "seq",
+            "event_type",
+            "message",
+            "level",
+            "created_at",
+            "payload",
+        }
+        if not isinstance(raw, dict):
+            raise ValueError("legacy output event has an unknown top-level shape")
+        document = cast(dict[str, object], raw)
+        if set(document) != expected_keys:
+            raise ValueError("legacy output event has an unknown top-level shape")
+        payload = document.get("payload")
+        if not isinstance(payload, dict):
+            raise ValueError("legacy output event payload is not the exact v0.9 shape")
+        typed_payload = cast(dict[str, object], payload)
+        if set(typed_payload) != {"stream", "text"}:
+            raise ValueError("legacy output event payload is not the exact v0.9 shape")
+        event_type = document.get("event_type")
+        stream = typed_payload.get("stream")
+        text = typed_payload.get("text")
+        message = document.get("message")
+        if (
+            event_type not in {"stdout.delta", "stderr.delta"}
+            or stream not in {"stdout", "stderr"}
+            or event_type != f"{stream}.delta"
+            or document.get("level") != "info"
+            or not isinstance(text, str)
+            or not isinstance(message, str)
+            or (text.rstrip("\n") or f"{stream} output") != message
+        ):
+            raise ValueError("legacy output event is not an exact duplicated v0.9 delta")
+        original = RelayEvent.model_validate(document)
+        if original.job_id != job_id or original.seq != seq:
+            raise ValueError("legacy output filename/content identity mismatch")
+        original_sha256 = hashlib.sha256(original_bytes).hexdigest()
+        archive_relative_path = (
+            Path("legacy_output_archives") / job_id / f"{seq:020d}.json"
+        ).as_posix()
+
+        def replacement(representation: Literal["payload_text", "archive"]) -> RelayEvent:
+            compatibility = {
+                "schema_version": LEGACY_OUTPUT_COMPATIBILITY_SCHEMA,
+                "archive_path": archive_relative_path,
+                "archive_sha256": original_sha256,
+                "archive_size_bytes": len(original_bytes),
+                "original_message_utf8_bytes": len(message.encode("utf-8")),
+                "original_payload_text_utf8_bytes": len(text.encode("utf-8")),
+                "representation": representation,
+            }
+            replacement_message = (
+                f"Legacy {stream} output preserved in payload.text "
+                f"({len(text.encode('utf-8'))} UTF-8 bytes)"
+                if representation == "payload_text"
+                else f"Legacy {stream} output archived ({len(text.encode('utf-8'))} UTF-8 bytes)"
+            )
+            replacement_payload: dict[str, object] = {
+                "stream": stream,
+                "legacy_output": compatibility,
+            }
+            if representation == "payload_text":
+                replacement_payload["text"] = text
+            return original.model_copy(
+                update={
+                    "message": replacement_message,
+                    "payload": replacement_payload,
+                }
+            )
+
+        representation: Literal["payload_text", "archive"] = "payload_text"
+        replacement_record = replacement(representation)
+        replacement_bytes = replacement_record.model_dump_json(indent=2).encode("utf-8")
+        if len(replacement_bytes) > ordinary_limit:
+            representation = "archive"
+            replacement_record = replacement(representation)
+            replacement_bytes = replacement_record.model_dump_json(indent=2).encode("utf-8")
+        if len(replacement_bytes) > ordinary_limit:
+            raise QueueConflictError("legacy output compatibility event exceeds the event limit")
+        return _LegacyOutputRecord(
+            original=original,
+            original_bytes=original_bytes,
+            original_sha256=original_sha256,
+            archive_relative_path=archive_relative_path,
+            replacement=replacement_record,
+            replacement_bytes=replacement_bytes,
+            replacement_sha256=hashlib.sha256(replacement_bytes).hexdigest(),
+            representation=representation,
+        )
+
+    @staticmethod
+    def _legacy_output_receipt(record: _LegacyOutputRecord) -> dict[str, object]:
+        return {
+            "schema_version": LEGACY_OUTPUT_RECEIPT_SCHEMA,
+            "job_id": record.original.job_id,
+            "seq": record.original.seq,
+            "event_type": record.original.event_type,
+            "archive_path": record.archive_relative_path,
+            "archive_sha256": record.original_sha256,
+            "archive_size_bytes": len(record.original_bytes),
+            "replacement_sha256": record.replacement_sha256,
+            "replacement_size_bytes": len(record.replacement_bytes),
+            "representation": record.representation,
+        }
+
+    def _validate_legacy_output_archive(
+        self,
+        path: Path,
+        record: _LegacyOutputRecord,
+    ) -> None:
+        try:
+            archived = _read_bounded_record_bytes(path)
+        except (OSError, QueueConflictError) as error:
+            raise LegacyQueueStateError(
+                family="legacy_output_archives",
+                path=path,
+                reason=f"legacy output archive is invalid: {type(error).__name__}",
+            ) from error
+        if archived != record.original_bytes:
+            raise LegacyQueueStateError(
+                family="legacy_output_archives",
+                path=path,
+                reason="legacy output archive does not exactly match its original event",
+            )
+
+    def _validate_legacy_output_receipt(
+        self,
+        path: Path,
+        record: _LegacyOutputRecord,
+    ) -> None:
+        raw = self._read_legacy_output_receipt_document(
+            path,
+            job_id=record.original.job_id,
+            seq=record.original.seq,
+        )
+        if raw != self._legacy_output_receipt(record):
+            raise LegacyQueueStateError(
+                family=_record_family(path),
+                path=path,
+                reason="legacy output receipt does not match archive and replacement",
+            )
+
+    def _read_legacy_output_receipt_document(
+        self,
+        path: Path,
+        *,
+        job_id: str,
+        seq: int,
+    ) -> dict[str, object]:
+        """Read one self-validating active or retired migration receipt."""
+        family = _record_family(path)
+        try:
+            raw = self._read_json_document(path)
+        except (OSError, ValueError, QueueConflictError) as error:
+            raise LegacyQueueStateError(
+                family=family,
+                path=path,
+                reason=f"legacy output receipt is invalid: {type(error).__name__}",
+            ) from error
+        expected_keys = {
+            "schema_version",
+            "job_id",
+            "seq",
+            "event_type",
+            "archive_path",
+            "archive_sha256",
+            "archive_size_bytes",
+            "replacement_sha256",
+            "replacement_size_bytes",
+            "representation",
+        }
+        if not isinstance(raw, dict):
+            raise LegacyQueueStateError(
+                family=family,
+                path=path,
+                reason="legacy output receipt has an unknown schema shape",
+            )
+        receipt = cast(dict[str, object], raw)
+        if set(receipt) != expected_keys:
+            raise LegacyQueueStateError(
+                family=family,
+                path=path,
+                reason="legacy output receipt has an unknown schema shape",
+            )
+        archive_size = receipt.get("archive_size_bytes")
+        replacement_size = receipt.get("replacement_size_bytes")
+        expected_archive_path = (
+            Path("legacy_output_archives") / job_id / f"{seq:020d}.json"
+        ).as_posix()
+        if (
+            receipt.get("schema_version") != LEGACY_OUTPUT_RECEIPT_SCHEMA
+            or receipt.get("job_id") != job_id
+            or receipt.get("seq") != seq
+            or receipt.get("event_type") not in {"stdout.delta", "stderr.delta"}
+            or receipt.get("archive_path") != expected_archive_path
+            or not _is_sha256_digest(receipt.get("archive_sha256"))
+            or isinstance(archive_size, bool)
+            or not isinstance(archive_size, int)
+            or not RECORD_FAMILY_MAX_BYTES["events"] < archive_size
+            or archive_size > MAX_LEGACY_OUTPUT_RECORD_BYTES
+            or not _is_sha256_digest(receipt.get("replacement_sha256"))
+            or isinstance(replacement_size, bool)
+            or not isinstance(replacement_size, int)
+            or not 0 < replacement_size <= RECORD_FAMILY_MAX_BYTES["events"]
+            or receipt.get("representation") not in {"payload_text", "archive"}
+        ):
+            raise LegacyQueueStateError(
+                family=family,
+                path=path,
+                reason="legacy output receipt fields are invalid",
+            )
+        return receipt
+
+    @staticmethod
+    def _legacy_output_receipt_manifest_sha256(
+        receipt_paths: dict[tuple[str, int], Path],
+    ) -> str:
+        """Hash exact immutable receipt bytes independently of active/retired location."""
+        digest = hashlib.sha256()
+        for (job_id, seq), path in sorted(receipt_paths.items()):
+            identity = f"{job_id}\0{seq:020d}\0".encode()
+            receipt_bytes = _read_bounded_record_bytes(path)
+            digest.update(len(identity).to_bytes(8, "big"))
+            digest.update(identity)
+            digest.update(len(receipt_bytes).to_bytes(8, "big"))
+            digest.update(receipt_bytes)
+        return digest.hexdigest()
+
+    def _record_from_legacy_compatibility_event(
+        self,
+        path: Path,
+        event: RelayEvent,
+        event_bytes: bytes,
+        *,
+        job_id: str,
+        seq: int,
+    ) -> _LegacyOutputRecord:
+        payload = event.payload
+        compatibility = payload.get("legacy_output")
+        if not isinstance(compatibility, dict):
+            raise LegacyQueueStateError(
+                family="events",
+                path=path,
+                reason="legacy output compatibility metadata is not an object",
+            )
+        typed_compatibility = cast(dict[str, object], compatibility)
+        expected_keys = {
+            "schema_version",
+            "archive_path",
+            "archive_sha256",
+            "archive_size_bytes",
+            "original_message_utf8_bytes",
+            "original_payload_text_utf8_bytes",
+            "representation",
+        }
+        if (
+            set(typed_compatibility) != expected_keys
+            or typed_compatibility.get("schema_version") != LEGACY_OUTPUT_COMPATIBILITY_SCHEMA
+        ):
+            raise LegacyQueueStateError(
+                family="events",
+                path=path,
+                reason="legacy output compatibility metadata has an unknown schema",
+            )
+        representation = typed_compatibility.get("representation")
+        expected_payload_keys = (
+            {"stream", "text", "legacy_output"}
+            if representation == "payload_text"
+            else {"stream", "legacy_output"}
+        )
+        if (
+            representation not in {"payload_text", "archive"}
+            or set(payload) != expected_payload_keys
+        ):
+            raise LegacyQueueStateError(
+                family="events",
+                path=path,
+                reason="legacy output compatibility payload has an unknown shape",
+            )
+        archive_path = self._legacy_output_archive_path(job_id, seq)
+        if (
+            typed_compatibility.get("archive_path")
+            != archive_path.relative_to(self._storage_root).as_posix()
+        ):
+            raise LegacyQueueStateError(
+                family="events",
+                path=path,
+                reason="legacy output compatibility archive path is not canonical",
+            )
+        try:
+            original = self._read_v09_legacy_output_record(
+                archive_path,
+                job_id=job_id,
+                seq=seq,
+            )
+        except (OSError, ValueError, QueueConflictError) as error:
+            raise LegacyQueueStateError(
+                family="legacy_output_archives",
+                path=archive_path,
+                reason=f"legacy output archive is invalid: {type(error).__name__}",
+            ) from error
+        if event != original.replacement or event_bytes != original.replacement_bytes:
+            raise LegacyQueueStateError(
+                family="events",
+                path=path,
+                reason="legacy output compatibility event does not match its exact archive",
+            )
+        return original
+
+    def _audit_one_legacy_output_event(
+        self,
+        path: Path,
+        *,
+        job_id: str,
+        seq: int,
+    ) -> _LegacyOutputRecord | None:
+        try:
+            path_stat = os.lstat(path)
+            if path_stat.st_size > RECORD_FAMILY_MAX_BYTES["events"]:
+                record = self._read_v09_legacy_output_record(
+                    path,
+                    job_id=job_id,
+                    seq=seq,
+                )
+                archive_path = self._legacy_output_archive_path(job_id, seq)
+                if _path_lstat(archive_path) is not None:
+                    self._validate_legacy_output_archive(archive_path, record)
+                receipt_path = self._legacy_output_receipt_path(job_id, seq)
+                if _path_lstat(receipt_path) is not None:
+                    raise LegacyQueueStateError(
+                        family="legacy_output_receipts",
+                        path=receipt_path,
+                        reason="receipt exists before the compatibility event replacement",
+                    )
+                return record
+            event_bytes = _read_bounded_record_bytes(path)
+            event = RelayEvent.model_validate_json(event_bytes)
+        except LegacyQueueStateError:
+            raise
+        except (OSError, ValueError, QueueConflictError) as error:
+            raise LegacyQueueStateError(
+                family="events",
+                path=path,
+                reason=f"event record is invalid: {type(error).__name__}: {error}",
+            ) from error
+        if event.job_id != job_id:
+            raise LegacyQueueStateError(
+                family="events",
+                path=path,
+                reason="event directory/content identity mismatch for job_id",
+            )
+        if event.seq != seq:
+            raise LegacyQueueStateError(
+                family="events",
+                path=path,
+                reason="event filename/content sequence mismatch",
+            )
+        if "legacy_output" not in event.payload:
+            return None
+        record = self._record_from_legacy_compatibility_event(
+            path,
+            event,
+            event_bytes,
+            job_id=job_id,
+            seq=seq,
+        )
+        receipt_path = self._legacy_output_receipt_path(job_id, seq)
+        if _path_lstat(receipt_path) is not None:
+            self._validate_legacy_output_receipt(receipt_path, record)
+        return record
+
+    def _iter_legacy_output_auxiliary_paths(
+        self,
+        family: Literal[
+            "legacy_output_archives",
+            "legacy_output_receipts",
+            "legacy_output_retired",
+        ],
+    ) -> Iterable[tuple[Path, str, int]]:
+        yield from self._iter_legacy_event_paths(
+            family,
+            max_directories=MAX_LEGACY_OUTPUT_MIGRATION_RECORDS,
+            max_records=MAX_LEGACY_OUTPUT_MIGRATION_RECORDS,
+        )
+
+    def _audit_legacy_output_auxiliary_state(self) -> None:
+        for family in ("legacy_output_archives", "legacy_output_receipts"):
+            for path, job_id, seq in self._iter_legacy_output_auxiliary_paths(family):
+                event_path = self._storage_root / "events" / job_id / f"{seq:020d}.json"
+                if _path_lstat(event_path) is None:
+                    raise LegacyQueueStateError(
+                        family=family,
+                        path=path,
+                        reason="legacy output auxiliary record has no canonical event",
+                    )
+                record = self._audit_one_legacy_output_event(
+                    event_path,
+                    job_id=job_id,
+                    seq=seq,
+                )
+                if record is None:
+                    raise LegacyQueueStateError(
+                        family=family,
+                        path=path,
+                        reason="legacy output auxiliary record points to an ordinary event",
+                    )
+                archive_path = self._legacy_output_archive_path(job_id, seq)
+                if _path_lstat(archive_path) is None:
+                    raise LegacyQueueStateError(
+                        family=family,
+                        path=path,
+                        reason="legacy output archive is missing",
+                    )
+                self._validate_legacy_output_archive(archive_path, record)
+                if family == "legacy_output_receipts":
+                    if event_path.stat().st_size > RECORD_FAMILY_MAX_BYTES["events"]:
+                        raise LegacyQueueStateError(
+                            family=family,
+                            path=path,
+                            reason="receipt exists before the compatibility event replacement",
+                        )
+                    self._validate_legacy_output_receipt(path, record)
+
+        for path, _job_id, _seq in self._iter_legacy_output_auxiliary_paths(
+            "legacy_output_retired"
+        ):
+            raise LegacyQueueStateError(
+                family="legacy_output_retired",
+                path=path,
+                reason="retired receipt exists before legacy-output migration completed",
+            )
+
+    def _validate_retired_legacy_output_receipt(
+        self,
+        path: Path,
+        receipt: dict[str, object],
+        *,
+        job_id: str,
+        seq: int,
+    ) -> None:
+        """Validate durable GC evidence and every canonical component still present."""
+        tombstone = self._read_optional(self._job_tombstone_path(job_id), JobTombstone)
+        if tombstone is None or tombstone.job_id != job_id or not tombstone.records_trash_started:
+            raise LegacyQueueStateError(
+                family="legacy_output_retired",
+                path=path,
+                reason="retired receipt has no authorized terminal-job GC tombstone",
+            )
+        archive_path = self._legacy_output_archive_path(job_id, seq)
+        event_path = self._storage_root / "events" / job_id / f"{seq:020d}.json"
+        archive_present = _path_lstat(archive_path) is not None
+        event_present = _path_lstat(event_path) is not None
+        record: _LegacyOutputRecord | None = None
+        if archive_present:
+            try:
+                record = self._read_v09_legacy_output_record(
+                    archive_path,
+                    job_id=job_id,
+                    seq=seq,
+                )
+            except (OSError, ValueError, QueueConflictError) as error:
+                raise LegacyQueueStateError(
+                    family="legacy_output_archives",
+                    path=archive_path,
+                    reason=f"retired legacy output archive is invalid: {type(error).__name__}",
+                ) from error
+            self._validate_legacy_output_archive(archive_path, record)
+            if receipt != self._legacy_output_receipt(record):
+                raise LegacyQueueStateError(
+                    family="legacy_output_retired",
+                    path=path,
+                    reason="retired receipt does not match its remaining archive",
+                )
+        if not event_present:
+            return
+        try:
+            event_bytes = _read_bounded_record_bytes(event_path)
+            event = RelayEvent.model_validate_json(event_bytes)
+        except (OSError, ValueError, QueueConflictError) as error:
+            raise LegacyQueueStateError(
+                family="events",
+                path=event_path,
+                reason=f"retired legacy output event is invalid: {type(error).__name__}",
+            ) from error
+        if (
+            event.job_id != job_id
+            or event.seq != seq
+            or event.event_type != receipt.get("event_type")
+            or len(event_bytes) != receipt.get("replacement_size_bytes")
+            or hashlib.sha256(event_bytes).hexdigest() != receipt.get("replacement_sha256")
+        ):
+            raise LegacyQueueStateError(
+                family="events",
+                path=event_path,
+                reason="retired legacy output event does not match its receipt",
+            )
+        compatibility = event.payload.get("legacy_output")
+        if not isinstance(compatibility, dict):
+            raise LegacyQueueStateError(
+                family="events",
+                path=event_path,
+                reason="retired legacy output event has no compatibility metadata",
+            )
+        typed_compatibility = cast(dict[str, object], compatibility)
+        if (
+            typed_compatibility.get("schema_version") != LEGACY_OUTPUT_COMPATIBILITY_SCHEMA
+            or typed_compatibility.get("archive_path") != receipt.get("archive_path")
+            or typed_compatibility.get("archive_sha256") != receipt.get("archive_sha256")
+            or typed_compatibility.get("archive_size_bytes") != receipt.get("archive_size_bytes")
+            or typed_compatibility.get("representation") != receipt.get("representation")
+        ):
+            raise LegacyQueueStateError(
+                family="events",
+                path=event_path,
+                reason="retired compatibility metadata does not match its receipt",
+            )
+        if record is not None and (
+            event != record.replacement or event_bytes != record.replacement_bytes
+        ):
+            raise LegacyQueueStateError(
+                family="events",
+                path=event_path,
+                reason="retired compatibility event does not match its remaining archive",
+            )
+
+    def _audit_completed_legacy_output_state(self, marker: _LegacyOutputAudit) -> None:
+        """Boundedly verify every active or GC-retired migration receipt."""
+        receipts: dict[tuple[str, int], tuple[str, Path, dict[str, object]]] = {}
+        receipt_paths: dict[tuple[str, int], Path] = {}
+        archive_bytes = 0
+        for family in ("legacy_output_receipts", "legacy_output_retired"):
+            for path, job_id, seq in self._iter_legacy_output_auxiliary_paths(family):
+                key = (job_id, seq)
+                if key in receipts:
+                    raise LegacyQueueStateError(
+                        family=family,
+                        path=path,
+                        reason="legacy output identity exists in active and retired receipts",
+                    )
+                receipt = self._read_legacy_output_receipt_document(
+                    path,
+                    job_id=job_id,
+                    seq=seq,
+                )
+                receipts[key] = (family, path, receipt)
+                receipt_paths[key] = path
+                archive_bytes += cast(int, receipt["archive_size_bytes"])
+                if len(receipts) > MAX_LEGACY_OUTPUT_MIGRATION_RECORDS:
+                    raise LegacyQueueStateError(
+                        family=family,
+                        path=path,
+                        reason="legacy output receipts exceed the bounded migration limit",
+                    )
+
+        if (
+            len(receipts) != marker.migration_records
+            or archive_bytes != marker.archive_bytes
+            or self._legacy_output_receipt_manifest_sha256(receipt_paths)
+            != marker.receipt_manifest_sha256
+        ):
+            raise LegacyQueueStateError(
+                family="migrations",
+                path=self._legacy_output_marker_path(),
+                reason=("legacy-output marker totals do not match active and retired receipts"),
+            )
+
+        for (job_id, seq), (family, path, receipt) in receipts.items():
+            if family == "legacy_output_retired":
+                self._validate_retired_legacy_output_receipt(
+                    path,
+                    receipt,
+                    job_id=job_id,
+                    seq=seq,
+                )
+                continue
+            event_path = self._storage_root / "events" / job_id / f"{seq:020d}.json"
+            archive_path = self._legacy_output_archive_path(job_id, seq)
+            if _path_lstat(event_path) is None or _path_lstat(archive_path) is None:
+                raise LegacyQueueStateError(
+                    family=family,
+                    path=path,
+                    reason="active receipt is missing its canonical event or archive",
+                )
+            record = self._audit_one_legacy_output_event(
+                event_path,
+                job_id=job_id,
+                seq=seq,
+            )
+            if record is None or event_path.stat().st_size > RECORD_FAMILY_MAX_BYTES["events"]:
+                raise LegacyQueueStateError(
+                    family=family,
+                    path=path,
+                    reason="active receipt does not point to a compatibility event",
+                )
+            self._validate_legacy_output_archive(archive_path, record)
+            self._validate_legacy_output_receipt(path, record)
+
+        for archive_path, job_id, seq in self._iter_legacy_output_auxiliary_paths(
+            "legacy_output_archives"
+        ):
+            if (job_id, seq) not in receipts:
+                raise LegacyQueueStateError(
+                    family="legacy_output_archives",
+                    path=archive_path,
+                    reason="legacy output archive has no active or retired receipt",
+                )
+
+    def _audit_legacy_output_state_before_initialization(self) -> _LegacyOutputAudit:
+        marker = self._read_legacy_output_marker()
+        if marker is not None:
+            with self._lock:
+                locked_marker = self._read_legacy_output_marker()
+                if locked_marker is None or locked_marker != marker:
+                    raise QueueConflictError(
+                        "legacy-output completion marker changed while taking the queue lock"
+                    )
+                self._audit_completed_legacy_output_state(locked_marker)
+                return locked_marker
+        event_records = 0
+        migration_records = 0
+        archive_bytes = 0
+        migration_keys: list[tuple[str, int]] = []
+        for path, job_id, seq in self._iter_legacy_event_paths(
+            "events",
+            max_directories=MAX_LEGACY_EVENT_AUDIT_DIRECTORIES,
+            max_records=MAX_LEGACY_EVENT_AUDIT_RECORDS,
+        ):
+            event_records += 1
+            record = self._audit_one_legacy_output_event(
+                path,
+                job_id=job_id,
+                seq=seq,
+            )
+            if record is None:
+                continue
+            migration_records += 1
+            migration_keys.append((job_id, seq))
+            archive_bytes += len(record.original_bytes)
+            if migration_records > MAX_LEGACY_OUTPUT_MIGRATION_RECORDS:
+                raise LegacyQueueStateError(
+                    family="events",
+                    path=path,
+                    reason=(
+                        "legacy output migration exceeds the bounded record limit of "
+                        f"{MAX_LEGACY_OUTPUT_MIGRATION_RECORDS}"
+                    ),
+                )
+            if archive_bytes > MAX_LEGACY_OUTPUT_MIGRATION_BYTES:
+                raise LegacyQueueStateError(
+                    family="events",
+                    path=path,
+                    reason=(
+                        "legacy output migration exceeds the bounded aggregate byte limit "
+                        f"of {MAX_LEGACY_OUTPUT_MIGRATION_BYTES}"
+                    ),
+                )
+        self._audit_legacy_output_auxiliary_state()
+        return _LegacyOutputAudit(
+            marker_complete=False,
+            event_records=event_records,
+            migration_records=migration_records,
+            archive_bytes=archive_bytes,
+            migration_keys=tuple(migration_keys),
+        )
+
+    def _write_legacy_output_archive(
+        self,
+        path: Path,
+        record: _LegacyOutputRecord,
+    ) -> None:
+        if _path_lstat(path) is not None:
+            self._validate_legacy_output_archive(path, record)
+            return
+        self._write_bytes(
+            path,
+            record.original_bytes,
+            max_bytes=MAX_LEGACY_OUTPUT_RECORD_BYTES,
+        )
+        self._validate_legacy_output_archive(path, record)
+
+    def _write_legacy_output_receipt(
+        self,
+        path: Path,
+        record: _LegacyOutputRecord,
+    ) -> None:
+        if _path_lstat(path) is not None:
+            self._validate_legacy_output_receipt(path, record)
+            return
+        self._write_json(path, self._legacy_output_receipt(record))
+        self._validate_legacy_output_receipt(path, record)
+
+    def _migrate_legacy_output_events_unlocked(
+        self,
+        audit: _LegacyOutputAudit,
+    ) -> None:
+        """Archive and replace exact v0.9 output records after a complete audit."""
+        if audit.marker_complete:
+            return
+        if len(audit.migration_keys) != audit.migration_records:
+            raise QueueConflictError("legacy output migration plan is incomplete")
+        migration_records = 0
+        archive_bytes = 0
+        for job_id, seq in audit.migration_keys:
+            path = self._storage_root / "events" / job_id / f"{seq:020d}.json"
+            if _path_lstat(path) is None:
+                raise QueueConflictError(
+                    f"legacy output event disappeared after its complete audit: {path}"
+                )
+            was_oversized = path.stat().st_size > RECORD_FAMILY_MAX_BYTES["events"]
+            record = self._audit_one_legacy_output_event(
+                path,
+                job_id=job_id,
+                seq=seq,
+            )
+            if record is None:
+                continue
+            migration_records += 1
+            archive_bytes += len(record.original_bytes)
+            archive_path = self._legacy_output_archive_path(job_id, seq)
+            receipt_path = self._legacy_output_receipt_path(job_id, seq)
+            if was_oversized:
+                self._write_legacy_output_archive(archive_path, record)
+                self._after_legacy_output_migration_phase("archive", path)
+                current = _read_bounded_record_bytes_once(
+                    path,
+                    limit=MAX_LEGACY_OUTPUT_RECORD_BYTES,
+                )
+                if current != record.original_bytes:
+                    raise QueueConflictError(
+                        f"legacy output event changed after validation: {path}"
+                    )
+                self._write_bytes(
+                    path,
+                    record.replacement_bytes,
+                    max_bytes=RECORD_FAMILY_MAX_BYTES["events"],
+                )
+                self._after_legacy_output_migration_phase("replacement", path)
+            self._write_legacy_output_receipt(receipt_path, record)
+            self._after_legacy_output_migration_phase("receipt", path)
+        observed = _LegacyOutputAudit(
+            marker_complete=False,
+            event_records=audit.event_records,
+            migration_records=migration_records,
+            archive_bytes=archive_bytes,
+            migration_keys=audit.migration_keys,
+        )
+        if observed != audit:
+            raise QueueConflictError("legacy output state changed after its complete audit")
+        self._audit_legacy_output_auxiliary_state()
+        receipt_paths = {
+            (job_id, seq): path
+            for path, job_id, seq in self._iter_legacy_output_auxiliary_paths(
+                "legacy_output_receipts"
+            )
+        }
+        if len(receipt_paths) != migration_records:
+            raise QueueConflictError("legacy output receipt manifest is incomplete")
+        receipt_manifest_sha256 = self._legacy_output_receipt_manifest_sha256(receipt_paths)
+        marker: dict[str, object] = {
+            "schema_version": LEGACY_OUTPUT_MIGRATION_SCHEMA,
+            "complete": True,
+            "event_records": audit.event_records,
+            "migration_records": migration_records,
+            "archive_bytes": archive_bytes,
+            "receipt_manifest_sha256": receipt_manifest_sha256,
+        }
+        self._write_json(self._legacy_output_marker_path(), marker)
+        self._after_legacy_output_migration_phase(
+            "marker",
+            self._legacy_output_marker_path(),
+        )
+        durable_marker = self._read_legacy_output_marker()
+        if durable_marker is None or durable_marker != _LegacyOutputAudit(
+            marker_complete=True,
+            event_records=audit.event_records,
+            migration_records=migration_records,
+            archive_bytes=archive_bytes,
+            receipt_manifest_sha256=receipt_manifest_sha256,
+        ):
+            raise QueueConflictError("legacy output migration marker was not durable")
+
+    def _require_legacy_output_migration_authorized(
+        self,
+        audit: _LegacyOutputAudit,
+        *,
+        migrate_legacy_output: bool,
+    ) -> None:
+        if audit.marker_complete or audit.migration_records == 0 or migrate_legacy_output:
+            return
+        raise LegacyQueueStateError(
+            family="events",
+            path=self._storage_root / "events",
+            reason=(
+                f"{audit.migration_records} exact v0.9 output event(s) require an explicitly "
+                "authorized compatibility migration"
+            ),
+            action=(
+                "stop and verify every process that can write this queue, then run "
+                "clio-relay init --migrate-legacy-output"
+            ),
+        )
+
+    @staticmethod
+    def _after_legacy_output_migration_phase(_phase: str, _path: Path) -> None:
+        """Fault-injection seam after each durable legacy-output phase."""
 
     def _audit_legacy_event_family(
         self,
@@ -649,13 +1762,39 @@ class ClioCoreQueue:
                 reason=f"canonical identity is not portable: {error}",
             ) from error
 
-    def initialize(self) -> None:
+    def initialize(
+        self,
+        *,
+        migrate_legacy_output: bool = False,
+        locked_core: LockedCoreIdentity | None = None,
+    ) -> None:
         """Create the record families used by the queue."""
+        if locked_core is not None:
+            if not migrate_legacy_output or self._migration_lifetime_guarded:
+                raise ConfigurationError(
+                    "locked-core authority is only valid for the outer migration scope"
+                )
+            require_active_locked_core(locked_core)
+            self._initialize_under_locked_core(locked_core)
+            return
+        if migrate_legacy_output and not self._migration_lifetime_guarded:
+            with exclusive_migration_lifetime(self.root) as locked_core:
+                self.initialize(
+                    migrate_legacy_output=True,
+                    locked_core=locked_core,
+                )
+            return
         if self._initialized:
             with self._lock:
                 self._ensure_extended_migration_state()
             return
-        self._audit_legacy_state_before_initialization()
+        # The first pass is deliberately read-only: an unsafe family must fail
+        # before initialize creates even the migration/archive directories.
+        legacy_output_audit = self._audit_legacy_state_before_initialization()
+        self._require_legacy_output_migration_authorized(
+            legacy_output_audit,
+            migrate_legacy_output=migrate_legacy_output,
+        )
         for family in (
             "endpoints",
             "endpoints_fresh",
@@ -669,6 +1808,9 @@ class ClioCoreQueue:
             "leases_by_cluster_kind",
             "leases_by_expiry",
             "events",
+            "legacy_output_archives",
+            "legacy_output_receipts",
+            "legacy_output_retired",
             "artifacts",
             "progress",
             "task_events",
@@ -720,7 +1862,19 @@ class ClioCoreQueue:
                 exist_ok=True,
             )
         with self._lock:
+            # Revalidate once under the cross-process lock before the one-time
+            # migration.  This closes the audit/write race without retaining an
+            # unbounded path plan in memory; only the independently bounded set of
+            # migration keys is retained, so writes do not require a third history
+            # scan.  The durable completion marker makes both passes skip deep
+            # event history on every later startup.
+            legacy_output_audit = self._audit_legacy_state_before_initialization()
+            self._require_legacy_output_migration_authorized(
+                legacy_output_audit,
+                migrate_legacy_output=migrate_legacy_output,
+            )
             self._purge_write_staging_unlocked()
+            self._migrate_legacy_output_events_unlocked(legacy_output_audit)
             migration_path = self._storage_root / "migrations" / "index-v1.json"
             if not migration_path.exists():
                 has_legacy_jobs = (
@@ -802,7 +1956,44 @@ class ClioCoreQueue:
             else:
                 self._ensure_extended_migration_state()
             self._recover_pending_transitions_unlocked()
-        self._initialized = True
+            self._initialized = True
+
+    def _initialize_under_locked_core(self, locked_core: LockedCoreIdentity) -> None:
+        """Pin all migration I/O to one authenticated locked core identity."""
+        require_active_locked_core(locked_core)
+        original_storage_root = self._storage_root
+        try:
+            queue_root_before = os.stat(original_storage_root)
+        except OSError as exc:
+            raise ConfigurationError(
+                f"migration queue root identity cannot be verified: {exc}"
+            ) from exc
+        expected_identity = (locked_core.device, locked_core.inode)
+        if (queue_root_before.st_dev, queue_root_before.st_ino) != expected_identity:
+            raise ConfigurationError("migration queue root does not match its core lifetime lock")
+        # Pin every migration read and write to the canonical directory whose
+        # inode is locked. A stable mount alias remains accepted, while an
+        # in-flight alias retarget can never redirect writes to an unlocked root.
+        self.root = logical_filesystem_path(locked_core.root)
+        self._storage_root = internal_filesystem_path(
+            locked_core.root,
+            force_extended=True,
+        )
+        self._lock = _FairBoundedFileLock(
+            str(self._storage_root / ".lock"),
+            timeout=self._lock_timeout_seconds,
+        )
+        self._migration_lifetime_guarded = True
+        try:
+            self.initialize(migrate_legacy_output=True)
+        finally:
+            self._migration_lifetime_guarded = False
+        try:
+            queue_root_after = os.stat(original_storage_root)
+        except OSError as exc:
+            raise ConfigurationError(f"migration queue root identity changed: {exc}") from exc
+        if (queue_root_after.st_dev, queue_root_after.st_ino) != expected_identity:
+            raise ConfigurationError("migration queue root identity changed while locked")
 
     def reconcile_pending_transitions(self) -> None:
         """Replay bounded write-ahead transitions left by another process."""
@@ -1049,6 +2240,7 @@ class ClioCoreQueue:
                 finalize["complete"] = not has_more
                 self._write_index_migration_state(state)
                 return state
+            self._reconcile_index_migration_sources_unlocked()
             state["complete"] = True
             self._write_index_migration_state(state)
             return state
@@ -2837,6 +4029,24 @@ class ClioCoreQueue:
         ownership_verified: bool,
     ) -> SchedulerCancelPending:
         """Add a verified pending identity or a terminal refused disposition."""
+        return self.register_scheduler_cancel_identity_once(
+            job_id,
+            cluster=cluster,
+            scheduler_job_id=scheduler_job_id,
+            provider=provider,
+            ownership_verified=ownership_verified,
+        ).record
+
+    def register_scheduler_cancel_identity_once(
+        self,
+        job_id: str,
+        *,
+        cluster: str,
+        scheduler_job_id: str,
+        provider: str | None,
+        ownership_verified: bool,
+    ) -> SchedulerCancelIdentityRegistration:
+        """Register an identity and report whether this call created its disposition."""
         job_id = self._require_durable_record_id(job_id, field="job_id")
         self.initialize()
         with self._lock:
@@ -2871,7 +4081,10 @@ class ClioCoreQueue:
                     existing.state is not SchedulerCancelDispositionState.REFUSED
                     or not ownership_verified
                 ):
-                    return record
+                    return SchedulerCancelIdentityRegistration(
+                        record=record,
+                        disposition_created=False,
+                    )
                 dispositions[existing_index] = candidate.model_copy(
                     update={
                         "attempts": existing.attempts,
@@ -2885,7 +4098,11 @@ class ClioCoreQueue:
                     "updated_at": utc_now(),
                 }
             )
-            return self._persist_scheduler_cancel_record_unlocked(updated)
+            persisted = self._persist_scheduler_cancel_record_unlocked(updated)
+            return SchedulerCancelIdentityRegistration(
+                record=persisted,
+                disposition_created=existing_index is None,
+            )
 
     def finalize_scheduler_cancel_identities(
         self,
@@ -2907,6 +4124,132 @@ class ClioCoreQueue:
             )
             return self._persist_scheduler_cancel_record_unlocked(updated)
 
+    def claim_scheduler_cancel_attempt(
+        self,
+        job_id: str,
+        *,
+        cluster: str,
+        scheduler_job_id: str,
+        provider: str,
+        lease_seconds: float,
+        now: datetime | None = None,
+    ) -> SchedulerCancelAttemptClaim | None:
+        """Atomically claim one due external cancellation attempt.
+
+        The claim is persisted while holding the cross-process queue lock. An
+        unexpired claim excludes every other worker, while an abandoned claim
+        becomes recoverable after its bounded lease expires.
+        """
+        job_id = self._require_durable_record_id(job_id, field="job_id")
+        if not provider:
+            raise ValueError("scheduler cancellation provider must not be empty")
+        if not (
+            MIN_SCHEDULER_CANCEL_CLAIM_LEASE_SECONDS
+            <= lease_seconds
+            <= MAX_SCHEDULER_CANCEL_CLAIM_LEASE_SECONDS
+        ):
+            raise ValueError(
+                "scheduler cancellation claim lease must be between "
+                f"{MIN_SCHEDULER_CANCEL_CLAIM_LEASE_SECONDS:g} and "
+                f"{MAX_SCHEDULER_CANCEL_CLAIM_LEASE_SECONDS:g} seconds"
+            )
+        observed_at = now or utc_now()
+        self.initialize()
+        with self._lock:
+            completed_path = self._scheduler_cancel_record_path(
+                "scheduler_cancel_dispositions",
+                cluster,
+                job_id,
+            )
+            completed = self._read_optional(completed_path, SchedulerCancelPending)
+            if completed is not None:
+                if (
+                    completed.job_id != job_id
+                    or completed.cluster != cluster
+                    or not completed.complete
+                ):
+                    raise QueueConflictError(
+                        f"scheduler cancellation disposition identity mismatch: {completed_path}"
+                    )
+                _unlink_durable_path(
+                    self._scheduler_cancel_record_path(
+                        "scheduler_cancel_pending",
+                        cluster,
+                        job_id,
+                    ),
+                    missing_ok=True,
+                )
+                return None
+            pending_path = self._scheduler_cancel_record_path(
+                "scheduler_cancel_pending",
+                cluster,
+                job_id,
+            )
+            record = self._read_optional(pending_path, SchedulerCancelPending)
+            if record is None:
+                raise QueueConflictError(f"scheduler cancellation is not pending: {job_id}")
+            if record.job_id != job_id or record.cluster != cluster:
+                raise QueueConflictError(
+                    f"scheduler cancellation identity mismatch: {pending_path}"
+                )
+            if record.identity_resolution != "resolved":
+                return None
+            dispositions = list(record.dispositions)
+            index = next(
+                (
+                    position
+                    for position, item in enumerate(dispositions)
+                    if item.scheduler_job_id == scheduler_job_id
+                ),
+                None,
+            )
+            if index is None:
+                raise QueueConflictError(
+                    f"scheduler cancellation identity is not registered: {scheduler_job_id}"
+                )
+            current = dispositions[index]
+            if current.state not in {
+                SchedulerCancelDispositionState.PENDING,
+                SchedulerCancelDispositionState.RETRY_WAIT,
+            }:
+                return None
+            if current.next_attempt_at is not None and current.next_attempt_at > observed_at:
+                return None
+            if (
+                current.attempt_claim_id is not None
+                and current.attempt_claim_expires_at is not None
+                and current.attempt_claim_expires_at > observed_at
+            ):
+                return None
+            if current.provider is not None and current.provider != provider:
+                raise QueueConflictError(
+                    "scheduler cancellation provider changed for "
+                    f"{scheduler_job_id}: {current.provider} != {provider}"
+                )
+            claim_id = validate_durable_record_id(f"cancelclaim_{uuid4().hex}")
+            expires_at = observed_at + timedelta(seconds=lease_seconds)
+            dispositions[index] = current.model_copy(
+                update={
+                    "provider": provider,
+                    "attempt_claim_id": claim_id,
+                    "attempt_claimed_at": observed_at,
+                    "attempt_claim_expires_at": expires_at,
+                    "updated_at": observed_at,
+                }
+            )
+            updated = record.model_copy(
+                update={"dispositions": dispositions, "updated_at": observed_at}
+            )
+            self._persist_scheduler_cancel_record_unlocked(updated)
+            return SchedulerCancelAttemptClaim(
+                claim_id=claim_id,
+                scheduler_job_id=scheduler_job_id,
+                provider=provider,
+                attempt=current.attempts + 1,
+                claimed_at=observed_at,
+                expires_at=expires_at,
+            )
+
     def record_scheduler_cancel_attempt(
         self,
         job_id: str,
@@ -2914,16 +4257,55 @@ class ClioCoreQueue:
         cluster: str,
         scheduler_job_id: str,
         provider: str,
+        claim_id: str,
         accepted: bool,
         error: str | None,
         max_attempts: int,
         retry_delay_seconds: float,
-    ) -> SchedulerCancelPending:
-        """Persist one scheduler cancellation attempt and its next/final disposition."""
+        now: datetime | None = None,
+    ) -> SchedulerCancelPending | None:
+        """Persist a claimed attempt, or ignore a stale claimant idempotently."""
         job_id = self._require_durable_record_id(job_id, field="job_id")
+        claim_id = validate_durable_record_id(claim_id)
+        observed_at = now or utc_now()
         self.initialize()
         with self._lock:
-            record = self._require_scheduler_cancel_pending_unlocked(job_id, cluster=cluster)
+            completed_path = self._scheduler_cancel_record_path(
+                "scheduler_cancel_dispositions",
+                cluster,
+                job_id,
+            )
+            completed = self._read_optional(completed_path, SchedulerCancelPending)
+            if completed is not None:
+                if (
+                    completed.job_id != job_id
+                    or completed.cluster != cluster
+                    or not completed.complete
+                ):
+                    raise QueueConflictError(
+                        f"scheduler cancellation disposition identity mismatch: {completed_path}"
+                    )
+                _unlink_durable_path(
+                    self._scheduler_cancel_record_path(
+                        "scheduler_cancel_pending",
+                        cluster,
+                        job_id,
+                    ),
+                    missing_ok=True,
+                )
+                return None
+            pending_path = self._scheduler_cancel_record_path(
+                "scheduler_cancel_pending",
+                cluster,
+                job_id,
+            )
+            record = self._read_optional(pending_path, SchedulerCancelPending)
+            if record is None:
+                raise QueueConflictError(f"scheduler cancellation is not pending: {job_id}")
+            if record.job_id != job_id or record.cluster != cluster:
+                raise QueueConflictError(
+                    f"scheduler cancellation identity mismatch: {pending_path}"
+                )
             dispositions = list(record.dispositions)
             index = next(
                 (
@@ -2938,33 +4320,166 @@ class ClioCoreQueue:
                     f"scheduler cancellation identity is not registered: {scheduler_job_id}"
                 )
             current = dispositions[index]
+            if current.attempt_claim_id != claim_id:
+                return None
+            if current.provider is not None and current.provider != provider:
+                raise QueueConflictError(
+                    "scheduler cancellation provider changed for "
+                    f"{scheduler_job_id}: {current.provider} != {provider}"
+                )
             attempts = current.attempts + 1
+            bounded_error = bounded_error_detail(error)
             if accepted:
                 state = SchedulerCancelDispositionState.CANCEL_REQUESTED
-                next_attempt_at = utc_now() + timedelta(seconds=retry_delay_seconds)
+                # Make the first confirmation immediately claimable.  The
+                # successful worker still polls eagerly, while a crash between
+                # acceptance and polling leaves due work for another worker.
+                next_attempt_at = observed_at
                 last_error = None
             elif attempts >= max_attempts:
                 state = SchedulerCancelDispositionState.EXHAUSTED
                 next_attempt_at = None
-                last_error = error or "scheduler cancellation failed"
+                last_error = bounded_error or "scheduler cancellation failed"
             else:
                 state = SchedulerCancelDispositionState.RETRY_WAIT
-                next_attempt_at = utc_now() + timedelta(seconds=retry_delay_seconds)
-                last_error = error or "scheduler cancellation failed"
-            dispositions[index] = current.model_copy(
-                update={
+                next_attempt_at = observed_at + timedelta(seconds=retry_delay_seconds)
+                last_error = bounded_error or "scheduler cancellation failed"
+            dispositions[index] = SchedulerCancelDisposition.model_validate(
+                {
+                    **current.model_dump(),
                     "provider": provider,
                     "state": state,
                     "attempts": attempts,
                     "next_attempt_at": next_attempt_at,
                     "last_error": last_error,
-                    "updated_at": utc_now(),
+                    "attempt_claim_id": None,
+                    "attempt_claimed_at": None,
+                    "attempt_claim_expires_at": None,
+                    "updated_at": observed_at,
+                },
+            )
+            updated = record.model_copy(
+                update={"dispositions": dispositions, "updated_at": observed_at}
+            )
+            return self._persist_scheduler_cancel_record_unlocked(updated)
+
+    def claim_scheduler_cancel_confirmation(
+        self,
+        job_id: str,
+        *,
+        cluster: str,
+        scheduler_job_id: str,
+        provider: str,
+        lease_seconds: float,
+        now: datetime | None = None,
+    ) -> SchedulerCancelConfirmationClaim | None:
+        """Atomically claim one due scheduler cancellation confirmation poll."""
+        job_id = self._require_durable_record_id(job_id, field="job_id")
+        if not provider:
+            raise ValueError("scheduler cancellation provider must not be empty")
+        if not (
+            MIN_SCHEDULER_CANCEL_CLAIM_LEASE_SECONDS
+            <= lease_seconds
+            <= MAX_SCHEDULER_CANCEL_CLAIM_LEASE_SECONDS
+        ):
+            raise ValueError(
+                "scheduler cancellation confirmation claim lease must be between "
+                f"{MIN_SCHEDULER_CANCEL_CLAIM_LEASE_SECONDS:g} and "
+                f"{MAX_SCHEDULER_CANCEL_CLAIM_LEASE_SECONDS:g} seconds"
+            )
+        observed_at = now or utc_now()
+        self.initialize()
+        with self._lock:
+            completed_path = self._scheduler_cancel_record_path(
+                "scheduler_cancel_dispositions",
+                cluster,
+                job_id,
+            )
+            completed = self._read_optional(completed_path, SchedulerCancelPending)
+            if completed is not None:
+                if (
+                    completed.job_id != job_id
+                    or completed.cluster != cluster
+                    or not completed.complete
+                ):
+                    raise QueueConflictError(
+                        f"scheduler cancellation disposition identity mismatch: {completed_path}"
+                    )
+                _unlink_durable_path(
+                    self._scheduler_cancel_record_path(
+                        "scheduler_cancel_pending",
+                        cluster,
+                        job_id,
+                    ),
+                    missing_ok=True,
+                )
+                return None
+            pending_path = self._scheduler_cancel_record_path(
+                "scheduler_cancel_pending",
+                cluster,
+                job_id,
+            )
+            record = self._read_optional(pending_path, SchedulerCancelPending)
+            if record is None:
+                raise QueueConflictError(f"scheduler cancellation is not pending: {job_id}")
+            if record.job_id != job_id or record.cluster != cluster:
+                raise QueueConflictError(
+                    f"scheduler cancellation identity mismatch: {pending_path}"
+                )
+            if record.identity_resolution != "resolved":
+                return None
+            dispositions = list(record.dispositions)
+            index = next(
+                (
+                    position
+                    for position, item in enumerate(dispositions)
+                    if item.scheduler_job_id == scheduler_job_id
+                ),
+                None,
+            )
+            if index is None:
+                raise QueueConflictError(
+                    f"scheduler cancellation identity is not registered: {scheduler_job_id}"
+                )
+            current = dispositions[index]
+            if current.state is not SchedulerCancelDispositionState.CANCEL_REQUESTED:
+                return None
+            if current.next_attempt_at is not None and current.next_attempt_at > observed_at:
+                return None
+            if (
+                current.confirmation_claim_id is not None
+                and current.confirmation_claim_expires_at is not None
+                and current.confirmation_claim_expires_at > observed_at
+            ):
+                return None
+            if current.provider is not None and current.provider != provider:
+                raise QueueConflictError(
+                    "scheduler cancellation provider changed for "
+                    f"{scheduler_job_id}: {current.provider} != {provider}"
+                )
+            claim_id = validate_durable_record_id(f"confirmclaim_{uuid4().hex}")
+            expires_at = observed_at + timedelta(seconds=lease_seconds)
+            dispositions[index] = current.model_copy(
+                update={
+                    "provider": provider,
+                    "confirmation_claim_id": claim_id,
+                    "confirmation_claimed_at": observed_at,
+                    "confirmation_claim_expires_at": expires_at,
+                    "updated_at": observed_at,
                 }
             )
             updated = record.model_copy(
-                update={"dispositions": dispositions, "updated_at": utc_now()}
+                update={"dispositions": dispositions, "updated_at": observed_at}
             )
-            return self._persist_scheduler_cancel_record_unlocked(updated)
+            self._persist_scheduler_cancel_record_unlocked(updated)
+            return SchedulerCancelConfirmationClaim(
+                claim_id=claim_id,
+                scheduler_job_id=scheduler_job_id,
+                provider=provider,
+                confirmation_attempt=current.confirmation_attempts + 1,
+                claimed_at=observed_at,
+                expires_at=expires_at,
+            )
 
     def record_scheduler_cancel_observation(
         self,
@@ -2972,17 +4487,57 @@ class ClioCoreQueue:
         *,
         cluster: str,
         scheduler_job_id: str,
+        provider: str,
+        claim_id: str,
         phase: SchedulerPhase,
         not_found: bool,
         error: str | None,
         max_confirmation_attempts: int,
         retry_delay_seconds: float,
-    ) -> SchedulerCancelPending:
-        """Persist provider confirmation after a cancellation request was accepted."""
+        now: datetime | None = None,
+    ) -> SchedulerCancelPending | None:
+        """Persist a claimed confirmation, or ignore a stale claimant idempotently."""
         job_id = self._require_durable_record_id(job_id, field="job_id")
+        claim_id = validate_durable_record_id(claim_id)
+        observed_at = now or utc_now()
         self.initialize()
         with self._lock:
-            record = self._require_scheduler_cancel_pending_unlocked(job_id, cluster=cluster)
+            completed_path = self._scheduler_cancel_record_path(
+                "scheduler_cancel_dispositions",
+                cluster,
+                job_id,
+            )
+            completed = self._read_optional(completed_path, SchedulerCancelPending)
+            if completed is not None:
+                if (
+                    completed.job_id != job_id
+                    or completed.cluster != cluster
+                    or not completed.complete
+                ):
+                    raise QueueConflictError(
+                        f"scheduler cancellation disposition identity mismatch: {completed_path}"
+                    )
+                _unlink_durable_path(
+                    self._scheduler_cancel_record_path(
+                        "scheduler_cancel_pending",
+                        cluster,
+                        job_id,
+                    ),
+                    missing_ok=True,
+                )
+                return None
+            pending_path = self._scheduler_cancel_record_path(
+                "scheduler_cancel_pending",
+                cluster,
+                job_id,
+            )
+            record = self._read_optional(pending_path, SchedulerCancelPending)
+            if record is None:
+                raise QueueConflictError(f"scheduler cancellation is not pending: {job_id}")
+            if record.job_id != job_id or record.cluster != cluster:
+                raise QueueConflictError(
+                    f"scheduler cancellation identity mismatch: {pending_path}"
+                )
             dispositions = list(record.dispositions)
             index = next(
                 (
@@ -2997,7 +4552,15 @@ class ClioCoreQueue:
                     f"scheduler cancellation identity is not registered: {scheduler_job_id}"
                 )
             current = dispositions[index]
+            if current.confirmation_claim_id != claim_id:
+                return None
+            if current.provider is not None and current.provider != provider:
+                raise QueueConflictError(
+                    "scheduler cancellation provider changed for "
+                    f"{scheduler_job_id}: {current.provider} != {provider}"
+                )
             confirmations = current.confirmation_attempts + 1
+            bounded_error = bounded_error_detail(error)
             if phase is SchedulerPhase.CANCELED:
                 state = SchedulerCancelDispositionState.CANCELED
                 next_attempt_at = None
@@ -3013,24 +4576,28 @@ class ClioCoreQueue:
             elif confirmations >= max_confirmation_attempts:
                 state = SchedulerCancelDispositionState.EXHAUSTED
                 next_attempt_at = None
-                last_error = error or (
+                last_error = bounded_error or (
                     f"scheduler cancellation was not confirmed terminal: {phase.value}"
                 )
             else:
                 state = SchedulerCancelDispositionState.CANCEL_REQUESTED
-                next_attempt_at = utc_now() + timedelta(seconds=retry_delay_seconds)
-                last_error = error
-            dispositions[index] = current.model_copy(
-                update={
+                next_attempt_at = observed_at + timedelta(seconds=retry_delay_seconds)
+                last_error = bounded_error
+            dispositions[index] = SchedulerCancelDisposition.model_validate(
+                {
+                    **current.model_dump(),
                     "state": state,
                     "confirmation_attempts": confirmations,
                     "next_attempt_at": next_attempt_at,
                     "last_error": last_error,
-                    "updated_at": utc_now(),
-                }
+                    "confirmation_claim_id": None,
+                    "confirmation_claimed_at": None,
+                    "confirmation_claim_expires_at": None,
+                    "updated_at": observed_at,
+                },
             )
             updated = record.model_copy(
-                update={"dispositions": dispositions, "updated_at": utc_now()}
+                update={"dispositions": dispositions, "updated_at": observed_at}
             )
             return self._persist_scheduler_cancel_record_unlocked(updated)
 
@@ -3048,9 +4615,25 @@ class ClioCoreQueue:
             record = self._require_scheduler_cancel_pending_unlocked(job_id, cluster=cluster)
             if record.dispositions and not superseded:
                 return record
+            dispositions = record.dispositions
+            if superseded:
+                dispositions = [
+                    item.model_copy(
+                        update={
+                            "attempt_claim_id": None,
+                            "attempt_claimed_at": None,
+                            "attempt_claim_expires_at": None,
+                            "confirmation_claim_id": None,
+                            "confirmation_claimed_at": None,
+                            "confirmation_claim_expires_at": None,
+                        }
+                    )
+                    for item in dispositions
+                ]
             updated = record.model_copy(
                 update={
                     "identity_resolution": "superseded" if superseded else "none",
+                    "dispositions": dispositions,
                     "updated_at": utc_now(),
                 }
             )
@@ -7564,6 +9147,40 @@ class ClioCoreQueue:
         self._write(self._job_tombstone_path(tombstone.job_id), updated)
         return updated
 
+    def _retire_legacy_output_receipts_unlocked(self, tombstone: JobTombstone) -> bool:
+        """Atomically retain small migration receipts before job data enters GC trash."""
+        if not tombstone.records_trash_started:
+            raise QueueConflictError(
+                f"legacy output receipts cannot retire before GC authorization: {tombstone.job_id}"
+            )
+        job_id = self._durable_key(tombstone.job_id)
+        source = self._storage_root / "legacy_output_receipts" / job_id
+        destination = self._storage_root / "legacy_output_retired" / job_id
+        source_stat = _path_lstat(source)
+        destination_stat = _path_lstat(destination)
+        if source_stat is not None and destination_stat is not None:
+            raise QueueConflictError(
+                f"active and retired legacy output receipts both exist: {tombstone.job_id}"
+            )
+        if source_stat is None:
+            if destination_stat is not None and (
+                not stat.S_ISDIR(destination_stat.st_mode) or _record_is_reparse(destination_stat)
+            ):
+                raise QueueConflictError(
+                    f"retired legacy output receipt root is unsafe: {destination}"
+                )
+            return False
+        if not stat.S_ISDIR(source_stat.st_mode) or _record_is_reparse(source_stat):
+            raise QueueConflictError(f"active legacy output receipt root is unsafe: {source}")
+        moved = _move_gc_path(source, destination)
+        if moved:
+            self._fsync_write_directory(source.parent)
+            self._fsync_write_directory(destination.parent)
+        retired_stat = os.lstat(destination)
+        if not stat.S_ISDIR(retired_stat.st_mode) or _record_is_reparse(retired_stat):
+            raise QueueConflictError(f"retired legacy output receipt root is unsafe: {destination}")
+        return moved
+
     def _trash_job_roots_unlocked(
         self,
         tombstone: JobTombstone,
@@ -7577,6 +9194,7 @@ class ClioCoreQueue:
         trash = self._job_gc_trash_path(job_id)
         directory_families = (
             "events",
+            "legacy_output_archives",
             "tasks_by_job",
             "leases_by_job",
             "artifacts_by_job",
@@ -7611,12 +9229,16 @@ class ClioCoreQueue:
             )
         )
         actions = 0
+        if self._retire_legacy_output_receipts_unlocked(tombstone):
+            actions += 1
         for source, destination in moves:
             if actions >= limit:
                 break
             if _move_gc_path(source, destination):
                 actions += 1
-        complete = all(not source.exists() for source, _destination in moves)
+        complete = not (
+            self._storage_root / "legacy_output_receipts" / safe_job_id
+        ).exists() and all(not source.exists() for source, _destination in moves)
         return actions, complete
 
     def _trash_job_references_unlocked(
@@ -8161,6 +9783,88 @@ class ClioCoreQueue:
             return
         raise QueueConflictError(f"index migration record mismatch: {family}")
 
+    def _reconcile_index_migration_sources_unlocked(self) -> None:
+        """Rebuild every migrated index from one bounded canonical-source snapshot.
+
+        A pre-1.0 writer can add a flat record after a family's cursor has reached
+        the end of that directory.  Migration completion therefore cannot trust
+        cursors alone.  This final pass runs while the queue lock is held, validates
+        every canonical source family against the normal bounded-scan limit, and
+        idempotently projects each record into every index it owns before the
+        completion marker is written.
+        """
+        source_models: dict[str, type[BaseModel]] = {
+            "jobs": RelayJob,
+            "tasks": RelayTask,
+            "leases": Lease,
+            "artifacts": ArtifactRef,
+            "progress": ProgressRecord,
+            "endpoints": EndpointRegistration,
+            "gateway_sessions": GatewaySession,
+            "monitor_rules": MonitorRule,
+        }
+        source_records: dict[str, list[BaseModel]] = {}
+        for family, model in source_models.items():
+            records, truncated = self._scan_many(
+                self._storage_root / family,
+                model,
+                limit=MAX_BOUNDED_SCAN_RECORDS,
+            )
+            if truncated:
+                raise QueueConflictError(
+                    "index migration final reconciliation exceeded its safety bound of "
+                    f"{MAX_BOUNDED_SCAN_RECORDS} records for {family}"
+                )
+            source_records[family] = records
+
+        for family in ("jobs", "tasks", "leases", "artifacts", "progress"):
+            for record in source_records[family]:
+                self._migrate_record_unlocked(family, record)
+
+        for family in _ORDER_FAMILIES:
+            for record in source_records[family]:
+                self._migrate_order_record_unlocked(family, record)
+
+        global_order_identity_fields = {
+            "endpoints": "endpoint_id",
+            "jobs": "job_id",
+            "gateway_sessions": "session_id",
+            "monitor_rules": "rule_id",
+        }
+        for family, identity_field in global_order_identity_fields.items():
+            for record in source_records[family]:
+                record_id = getattr(record, identity_field, None)
+                if not isinstance(record_id, str) or not record_id:
+                    raise QueueConflictError(
+                        f"global-order record identity is invalid: {family}/{identity_field}"
+                    )
+                self._ensure_global_order_entry_unlocked(family, record_id)
+
+        for family in _RETENTION_INDEX_FAMILIES:
+            for record in source_records[family]:
+                self._migrate_retention_record_unlocked(family, record)
+
+        for family in _OPERATIONAL_INDEX_FAMILIES:
+            if family == "leases":
+                continue
+            for record in source_records[family]:
+                self._migrate_operational_record_unlocked(family, record)
+
+        lease_repair_intent = self._write_transition_intent_unlocked(
+            "lease_index_repair",
+            "migration-v1-final-reconcile",
+            {"limit": MAX_LIVE_LEASE_RECORDS},
+        )
+        self._apply_lease_index_repair_intent_unlocked(
+            lease_repair_intent,
+            {"limit": MAX_LIVE_LEASE_RECORDS},
+        )
+
+        for record in source_records["jobs"]:
+            if not isinstance(record, RelayJob):
+                raise QueueConflictError("job finalization record is invalid")
+            self._finalize_job_index_unlocked(record.job_id)
+
     def _migrate_retention_record_unlocked(self, family: str, record: BaseModel) -> None:
         if family == "jobs" and isinstance(record, RelayJob):
             self._initialize_job_index_unlocked(record.job_id)
@@ -8449,7 +10153,14 @@ class ClioCoreQueue:
         return filesystem_key(value, domain=domain)
 
     def _write(self, path: Path, record: BaseModel) -> None:
-        self._write_text(path, record.model_dump_json(indent=2))
+        # Scheduler cancellation records may contain the contract maximum of
+        # 1,000 dispositions.  Claim fields were added after v1.0.7, so writing
+        # six explicit nulls per legacy disposition would make a previously
+        # valid record exceed its durable family limit.  Missing optional fields
+        # retain the same Pydantic defaults; an active claim is still serialized
+        # in full because each of its values is non-null.
+        exclude_none = isinstance(record, SchedulerCancelPending)
+        self._write_text(path, record.model_dump_json(indent=2, exclude_none=exclude_none))
 
     def _write_json(self, path: Path, record: dict[str, object]) -> None:
         self._write_text(path, json.dumps(record))
@@ -8549,16 +10260,22 @@ class ClioCoreQueue:
             self._fsync_write_directory(staging)
 
     def _write_text(self, path: Path, text: str) -> None:
+        self._write_bytes(
+            path,
+            text.encode("utf-8"),
+            max_bytes=_record_max_bytes(path),
+        )
+
+    def _write_bytes(self, path: Path, payload: bytes, *, max_bytes: int) -> None:
+        """Atomically write owner-private bytes below the queue root."""
         try:
             logical_path = logical_filesystem_path(path)
             internal_path = internal_filesystem_path(logical_path, force_extended=True)
         except ValueError as error:
             raise QueueConflictError(f"queue write path is unsupported: {path}") from error
-        payload = text.encode("utf-8")
-        limit = _record_max_bytes(internal_path)
-        if len(payload) > limit:
+        if max_bytes < 1 or len(payload) > max_bytes:
             raise QueueConflictError(
-                f"{_record_family(internal_path)} record exceeds the {limit}-byte limit: "
+                f"{_record_family(internal_path)} record exceeds the {max_bytes}-byte limit: "
                 f"{logical_path}"
             )
         target_parent_stat = self._require_safe_write_directory(internal_path.parent)
@@ -8970,23 +10687,42 @@ def _scheduler_cancel_record_is_due(
         return False
     if record.identity_resolution == "pending":
         return True
-    return any(
-        item.state is SchedulerCancelDispositionState.PENDING
-        or (
-            item.state
-            in {
-                SchedulerCancelDispositionState.RETRY_WAIT,
-                SchedulerCancelDispositionState.CANCEL_REQUESTED,
-            }
-            and (item.next_attempt_at is None or item.next_attempt_at <= now)
-        )
-        for item in record.dispositions
-    )
+    return any(_scheduler_cancel_disposition_is_due(item, now) for item in record.dispositions)
+
+
+def _scheduler_cancel_disposition_is_due(
+    disposition: SchedulerCancelDisposition,
+    now: datetime,
+) -> bool:
+    """Return whether one disposition has work not held by a live attempt claim."""
+    if disposition.state in {
+        SchedulerCancelDispositionState.PENDING,
+        SchedulerCancelDispositionState.RETRY_WAIT,
+    }:
+        if (
+            disposition.attempt_claim_id is not None
+            and disposition.attempt_claim_expires_at is not None
+            and disposition.attempt_claim_expires_at > now
+        ):
+            return False
+        return disposition.next_attempt_at is None or disposition.next_attempt_at <= now
+    if disposition.state is not SchedulerCancelDispositionState.CANCEL_REQUESTED:
+        return False
+    if (
+        disposition.confirmation_claim_id is not None
+        and disposition.confirmation_claim_expires_at is not None
+        and disposition.confirmation_claim_expires_at > now
+    ):
+        return False
+    return disposition.next_attempt_at is None or disposition.next_attempt_at <= now
 
 
 def _scheduler_cancel_due_sort_key(record: SchedulerCancelPending) -> tuple[datetime, str]:
     due_times = [
-        item.next_attempt_at or record.requested_at
+        item.attempt_claim_expires_at
+        or item.confirmation_claim_expires_at
+        or item.next_attempt_at
+        or record.requested_at
         for item in record.dispositions
         if item.state
         in {

--- a/src/clio_relay/deployment.py
+++ b/src/clio_relay/deployment.py
@@ -14,6 +14,11 @@ from clio_relay.errors import RelayError
 from clio_relay.identifiers import filesystem_key
 from clio_relay.installation import INSTALL_RECEIPT_PATH_ENV
 from clio_relay.jarvis_mcp import JARVIS_MCP_COMMAND_ENV, JARVIS_MCP_SPACK_COMMAND_ENV
+from clio_relay.remote_values import (
+    remote_value_expands_home,
+    render_systemd_remote_path,
+    render_systemd_remote_value,
+)
 from clio_relay.worker_concurrency import KindConcurrencyInput, kind_concurrency_metadata
 
 _SYSTEMD_UNQUOTED_ARGUMENT = re.compile(r"[A-Za-z0-9_./:@%+=,{}-]+\Z")
@@ -31,11 +36,23 @@ def render_endpoint_user_service(
     """Render a user-level systemd service for a configured worker endpoint."""
     if concurrency < 1:
         raise RelayError("worker concurrency must be at least 1")
-    core_dir = _systemd_home_path(definition.core_dir)
-    spool_dir = _systemd_home_path(definition.spool_dir)
-    jarvis_bin = _systemd_home_path(definition.jarvis_bin or "$HOME/.local/bin/jarvis")
-    frpc_bin = _systemd_home_path(definition.frpc_bin or "$HOME/.local/bin/frpc")
-    agent_bin = _systemd_home_path(_configured_agent_bin(definition))
+    core_source = definition.core_dir
+    spool_source = definition.spool_dir
+    jarvis_source = definition.jarvis_bin or "$HOME/.local/bin/jarvis"
+    frpc_source = definition.frpc_bin or "$HOME/.local/bin/frpc"
+    agent_source = _configured_agent_bin(definition)
+    spack_source = definition.spack_executable
+    core_dir = render_systemd_remote_path(core_source, field="core_dir")
+    spool_dir = render_systemd_remote_path(spool_source, field="spool_dir")
+    jarvis_bin = render_systemd_remote_value(
+        jarvis_source,
+        field="jarvis_bin",
+    )
+    frpc_bin = render_systemd_remote_value(
+        frpc_source,
+        field="frpc_bin",
+    )
+    agent_bin = render_systemd_remote_value(agent_source, field="agent_bin")
     agent_args = " ".join(definition.agent_args)
     kind_limits = kind_concurrency_metadata(kind_concurrency)
     jarvis_mcp_line = _optional_environment_line(
@@ -44,7 +61,15 @@ def render_endpoint_user_service(
     )
     jarvis_mcp_spack_line = _optional_environment_line(
         JARVIS_MCP_SPACK_COMMAND_ENV,
-        definition.spack_executable,
+        (
+            render_systemd_remote_value(
+                spack_source,
+                field="spack_executable",
+            )
+            if spack_source is not None
+            else None
+        ),
+        allow_home_specifier=(spack_source is not None and remote_value_expands_home(spack_source)),
     )
     exec_start_arguments = [
         relay_bin,
@@ -71,6 +96,31 @@ def render_endpoint_user_service(
         )
     )
     description_cluster = _systemd_exec_argument(cluster, allow_home_specifier=False)
+    core_line = _environment_line(
+        "CLIO_RELAY_CORE_DIR",
+        core_dir,
+        allow_home_specifier=remote_value_expands_home(core_source),
+    )
+    spool_line = _environment_line(
+        "CLIO_RELAY_SPOOL_DIR",
+        spool_dir,
+        allow_home_specifier=remote_value_expands_home(spool_source),
+    )
+    jarvis_line = _environment_line(
+        "CLIO_RELAY_JARVIS_BIN",
+        jarvis_bin,
+        allow_home_specifier=remote_value_expands_home(jarvis_source),
+    )
+    frpc_line = _environment_line(
+        "CLIO_RELAY_FRPC_BIN",
+        frpc_bin,
+        allow_home_specifier=remote_value_expands_home(frpc_source),
+    )
+    agent_line = _environment_line(
+        "CLIO_RELAY_AGENT_BIN",
+        agent_bin,
+        allow_home_specifier=remote_value_expands_home(agent_source),
+    )
     return f"""[Unit]
 Description=clio-relay worker endpoint for {description_cluster}
 After=network-online.target
@@ -78,11 +128,11 @@ After=network-online.target
 [Service]
 Type=simple
 Environment="PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin"
-{_environment_line("CLIO_RELAY_CORE_DIR", core_dir, allow_home_specifier=True)}
-{_environment_line("CLIO_RELAY_SPOOL_DIR", spool_dir, allow_home_specifier=True)}
-{_environment_line("CLIO_RELAY_JARVIS_BIN", jarvis_bin, allow_home_specifier=True)}
-{_environment_line("CLIO_RELAY_FRPC_BIN", frpc_bin, allow_home_specifier=True)}
-{_environment_line("CLIO_RELAY_AGENT_BIN", agent_bin, allow_home_specifier=True)}
+{core_line}
+{spool_line}
+{jarvis_line}
+{frpc_line}
+{agent_line}
 {_environment_line("CLIO_RELAY_AGENT_ADAPTER", definition.agent_adapter)}
 {_environment_line("CLIO_RELAY_AGENT_ARGS", agent_args)}
 Environment="{INSTALL_RECEIPT_PATH_ENV}=%h/.local/share/clio-relay/install-receipt.json"
@@ -111,7 +161,7 @@ def install_endpoint_user_service_over_ssh(
     _validate_ssh_destination(ssh_host)
     if not isfinite(timeout_seconds) or timeout_seconds <= 0:
         raise RelayError("endpoint service SSH timeout must be finite and positive")
-    service_name = _systemd_service_name(cluster)
+    service_name = endpoint_user_service_name(cluster)
     remote_script = _remote_install_script(
         service_name=service_name,
         service_text=service_text,
@@ -174,14 +224,15 @@ def write_endpoint_user_service(path: Path, service_text: str) -> Path:
     return path
 
 
-def _systemd_home_path(value: str) -> str:
-    return value.replace("$HOME", "%h")
-
-
-def _optional_environment_line(name: str, value: str | None) -> str:
+def _optional_environment_line(
+    name: str,
+    value: str | None,
+    *,
+    allow_home_specifier: bool = False,
+) -> str:
     if value is None or value == "":
         return ""
-    return _environment_line(name, value)
+    return _environment_line(name, value, allow_home_specifier=allow_home_specifier)
 
 
 def _environment_line(
@@ -195,10 +246,8 @@ def _environment_line(
         not (character.isupper() or character.isdigit() or character == "_") for character in name
     ):
         raise RelayError(f"unsafe systemd environment name: {name!r}")
-    assignment = _systemd_escape(
-        f"{name}={value}",
-        allow_home_specifier=allow_home_specifier,
-    )
+    escaped_value = _systemd_escape(value, allow_home_specifier=allow_home_specifier)
+    assignment = f"{name}={escaped_value}"
     return f'Environment="{assignment}"'
 
 
@@ -214,9 +263,10 @@ def _systemd_escape(value: str, *, allow_home_specifier: bool) -> str:
     """Escape one value using systemd.syntax quoted-string rules."""
     if "\x00" in value:
         raise RelayError("systemd values cannot contain NUL")
-    escaped_specifiers = value.replace("%", "%%")
-    if allow_home_specifier:
-        escaped_specifiers = escaped_specifiers.replace("%%h", "%h")
+    if allow_home_specifier and value.startswith("%h"):
+        escaped_specifiers = "%h" + value.removeprefix("%h").replace("%", "%%")
+    else:
+        escaped_specifiers = value.replace("%", "%%")
     rendered: list[str] = []
     for character in escaped_specifiers:
         if character == "\\":
@@ -236,8 +286,8 @@ def _systemd_escape(value: str, *, allow_home_specifier: bool) -> str:
     return "".join(rendered)
 
 
-def _systemd_service_name(cluster: str) -> str:
-    """Map one logical cluster label to a portable deterministic unit name."""
+def endpoint_user_service_name(cluster: str) -> str:
+    """Map one logical cluster label to its portable deterministic worker unit name."""
     key = filesystem_key(cluster, domain="systemd-cluster")
     return f"clio-relay-worker-{key}.service"
 

--- a/src/clio_relay/doctor.py
+++ b/src/clio_relay/doctor.py
@@ -9,6 +9,7 @@ import subprocess
 from clio_relay.cluster_config import ClusterDefinition
 from clio_relay.config import RelaySettings
 from clio_relay.errors import ConfigurationError, RelayError
+from clio_relay.remote_values import render_remote_shell_value
 
 
 def check_required_binary(name: str, value: str) -> str:
@@ -42,9 +43,15 @@ def run_doctor(
 
 def run_cluster_doctor(definition: ClusterDefinition) -> list[str]:
     """Run live cluster-side checks over SSH and return status lines."""
-    jarvis_bin = _shell_double_quote(definition.jarvis_bin or "$HOME/.local/bin/jarvis")
-    frpc_bin = _shell_double_quote(definition.frpc_bin or "$HOME/.local/bin/frpc")
-    agent_bin = _shell_double_quote(definition.agent_bin or "")
+    jarvis_bin = render_remote_shell_value(
+        definition.jarvis_bin or "$HOME/.local/bin/jarvis",
+        field="jarvis_bin",
+    )
+    frpc_bin = render_remote_shell_value(
+        definition.frpc_bin or "$HOME/.local/bin/frpc",
+        field="frpc_bin",
+    )
+    agent_bin = render_remote_shell_value(definition.agent_bin or "", field="agent_bin")
     agent_npm_bin = shlex.quote(definition.agent_npm_bin or "")
     script = f"""set -euo pipefail
 export PATH="$HOME/.local/bin:$PATH"
@@ -85,7 +92,3 @@ echo "clio_relay=$(clio-relay --help | head -n 1)"
         detail = stderr.strip() or stdout.strip()
         raise RelayError(f"cluster doctor failed for {definition.name}: {detail}")
     return stdout.splitlines()
-
-
-def _shell_double_quote(value: str) -> str:
-    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'

--- a/src/clio_relay/endpoint.py
+++ b/src/clio_relay/endpoint.py
@@ -30,6 +30,7 @@ import yaml
 from filelock import FileLock, Timeout
 
 from clio_relay import process_containment
+from clio_relay.command_evidence import bounded_error_detail
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import DEFAULT_EXACT_RECORD_LIMIT, ClioCoreQueue
 from clio_relay.errors import ConfigurationError, QueueConflictError, RelayError
@@ -58,6 +59,7 @@ from clio_relay.models import (
     RelayTask,
     RemoteAgentTaskSpec,
     SchedulerCancelDispositionState,
+    SchedulerCancelPending,
     SchedulerPhase,
     SchedulerStatus,
     utc_now,
@@ -103,6 +105,7 @@ from clio_relay.worker_concurrency import (
     kind_concurrency_metadata,
     normalize_kind_concurrency,
 )
+from clio_relay.worker_lifetime_lock import WorkerLifetimeLock
 
 
 @dataclass
@@ -177,6 +180,8 @@ class EndpointWorker:
     scheduler_cancel_confirmation_max_attempts = 5
     scheduler_cancel_retry_base_seconds = 2.0
     scheduler_cancel_retry_max_seconds = 30.0
+    scheduler_cancel_claim_lease_seconds = 60.0
+    scheduler_cancel_confirmation_claim_lease_seconds = 60.0
     scheduler_poll_interval_seconds = 5.0
 
     def __init__(
@@ -198,33 +203,109 @@ class EndpointWorker:
         self.cluster = cluster
         self.concurrency = concurrency
         self.kind_concurrency = normalize_kind_concurrency(kind_concurrency)
+        self._closed = False
+        self._queue_root_path: Path | None = None
+        self._queue_root_identity: tuple[int, int] | None = None
+        self._worker_lifetime_lock: WorkerLifetimeLock | None = None
+        self._owned_managed_queue: StorageManagedQueue | None = None
+        if self.role == EndpointRole.WORKER:
+            lifetime_core = queue.root if queue is not None else settings.core_dir
+            self._worker_lifetime_lock = WorkerLifetimeLock(
+                lifetime_core,
+                mode="shared",
+            ).acquire()
+            settings = settings.model_copy(update={"core_dir": self._worker_lifetime_lock.core_dir})
         self.settings = settings
-        resolved_queue = queue if queue is not None else storage_managed_queue(settings)
-        managed_runtime = (
-            resolved_queue.storage_runtime
-            if isinstance(resolved_queue, StorageManagedQueue)
-            else None
-        )
-        if (
-            storage_runtime is not None
-            and managed_runtime is not None
-            and storage_runtime is not managed_runtime
-        ):
-            raise ConfigurationError("worker storage runtime must match its managed queue instance")
-        self.queue = resolved_queue
-        self.provider = provider or JarvisCdProvider(
-            jarvis_bin=settings.jarvis_bin,
-            agent_bin=settings.agent_bin,
-            agent_adapter=settings.agent_adapter,
-            agent_args=settings.agent_args,
-        )
-        self.scheduler_provider = scheduler_provider
-        self.storage_runtime = storage_runtime or managed_runtime
-        self._scheduler_last_poll: dict[tuple[str, str], float] = {}
-        self.endpoint: EndpointRegistration | None = None
+        try:
+            resolved_queue = (
+                queue
+                if queue is not None
+                else storage_managed_queue(
+                    settings,
+                    writer_lifetime_lock=self._worker_lifetime_lock,
+                )
+            )
+            if self.role == EndpointRole.WORKER:
+                canonical_stat = os.stat(settings.core_dir)
+                queue_stat = os.stat(resolved_queue.root)
+                if (queue_stat.st_dev, queue_stat.st_ino) != (
+                    canonical_stat.st_dev,
+                    canonical_stat.st_ino,
+                ):
+                    raise ConfigurationError(
+                        "worker queue root does not match its core lifetime lock"
+                    )
+                self._queue_root_path = resolved_queue.root
+                self._queue_root_identity = (queue_stat.st_dev, queue_stat.st_ino)
+            managed_runtime = (
+                resolved_queue.storage_runtime
+                if isinstance(resolved_queue, StorageManagedQueue)
+                else None
+            )
+            if queue is None and isinstance(resolved_queue, StorageManagedQueue):
+                self._owned_managed_queue = resolved_queue
+            if (
+                storage_runtime is not None
+                and managed_runtime is not None
+                and storage_runtime is not managed_runtime
+            ):
+                raise ConfigurationError(
+                    "worker storage runtime must match its managed queue instance"
+                )
+            self.queue = resolved_queue
+            self.provider = provider or JarvisCdProvider(
+                jarvis_bin=settings.jarvis_bin,
+                agent_bin=settings.agent_bin,
+                agent_adapter=settings.agent_adapter,
+                agent_args=settings.agent_args,
+            )
+            self.scheduler_provider = scheduler_provider
+            self.storage_runtime = storage_runtime or managed_runtime
+            self._scheduler_last_poll: dict[tuple[str, str], float] = {}
+            self.endpoint: EndpointRegistration | None = None
+        except BaseException:
+            self.close()
+            raise
+
+    def close(self) -> None:
+        """Release endpoint-owned queue and core-scoped lifetime ownership."""
+        self._closed = True
+        owned_queue = self._owned_managed_queue
+        self._owned_managed_queue = None
+        if owned_queue is not None:
+            owned_queue.close()
+        lifetime_lock = self._worker_lifetime_lock
+        if lifetime_lock is None:
+            return
+        self._worker_lifetime_lock = None
+        lifetime_lock.release()
+
+    def __del__(self) -> None:
+        with suppress(Exception):
+            self.close()
+
+    def _require_open_queue_identity(self) -> None:
+        """Reject use after close or after an injected queue alias is retargeted."""
+        if self._closed:
+            raise ConfigurationError("endpoint worker is closed")
+        if self.role != EndpointRole.WORKER:
+            return
+        queue_root = self._queue_root_path
+        expected = self._queue_root_identity
+        if queue_root is None or expected is None or self._worker_lifetime_lock is None:
+            raise ConfigurationError("worker lifetime ownership is incomplete")
+        try:
+            observed_stat = os.stat(queue_root)
+        except OSError as exc:
+            raise ConfigurationError(
+                f"worker queue root identity cannot be verified: {exc}"
+            ) from exc
+        if (observed_stat.st_dev, observed_stat.st_ino) != expected:
+            raise ConfigurationError("worker queue root identity changed after lifetime locking")
 
     def register(self) -> EndpointRegistration:
         """Register this endpoint in the durable queue."""
+        self._require_open_queue_identity()
         metadata: dict[str, object] = {
             "concurrency": self.concurrency,
             "kind_concurrency": kind_concurrency_metadata(self.kind_concurrency),
@@ -234,6 +315,9 @@ class EndpointWorker:
             metadata["worker_supervisor"] = True
         if self.role == EndpointRole.WORKER:
             metadata["installation_info"] = _worker_installation_snapshot()
+            process_identity = _worker_process_identity()
+            if process_identity is not None:
+                metadata["process_identity"] = process_identity
             metadata["scheduler_provider"] = (
                 self.scheduler_provider.name if self.scheduler_provider is not None else "external"
             )
@@ -249,6 +333,7 @@ class EndpointWorker:
 
     def run_once(self) -> RelayJob | None:
         """Run one leased cluster job if available."""
+        self._require_open_queue_identity()
         if self.role != EndpointRole.WORKER:
             return None
         endpoint = self.endpoint or self.register()
@@ -310,6 +395,7 @@ class EndpointWorker:
 
     def serve_forever(self, *, poll_seconds: float = 2.0) -> None:
         """Run the endpoint loop until interrupted."""
+        self._require_open_queue_identity()
         self.register()
         if self.role == EndpointRole.DESKTOP:
             while True:
@@ -3381,7 +3467,7 @@ class EndpointWorker:
     ) -> None:
         runtime_metadata = job.metadata.get("runtime_metadata")
         observed_scheduler_job_id = scheduler_job_id
-        if isinstance(runtime_metadata, dict):
+        if observed_scheduler_job_id is None and isinstance(runtime_metadata, dict):
             typed_runtime = cast(dict[str, Any], runtime_metadata)
             candidate = typed_runtime.get("scheduler_job_id")
             if isinstance(candidate, str):
@@ -3425,14 +3511,15 @@ class EndpointWorker:
             try:
                 status = provider.poll(scheduler_job_id)
             except RelayError as exc:
+                error_detail = bounded_error_detail(str(exc)) or type(exc).__name__
                 self.queue.append_event(
                     job.job_id,
                     "scheduler.poll_failed",
-                    f"Scheduler status polling failed for {scheduler_job_id}: {exc}",
+                    f"Scheduler status polling failed for {scheduler_job_id}: {error_detail}",
                     payload={
                         "scheduler": provider.name,
                         "scheduler_job_id": scheduler_job_id,
-                        "error": str(exc),
+                        "error": error_detail,
                     },
                 )
                 continue
@@ -3453,6 +3540,12 @@ class EndpointWorker:
         *,
         task_id: str | None,
     ) -> None:
+        provider = self._scheduler_provider_for_job(job)
+        status = _normalized_scheduler_status(
+            status,
+            expected_scheduler=provider.name,
+            expected_scheduler_job_id=scheduler_job_id,
+        )
         tasks = self._bounded_job_tasks(job.job_id)
         target_task_id = task_id or _task_id_for_scheduler_job(tasks, scheduler_job_id)
         if target_task_id is None:
@@ -3517,14 +3610,14 @@ class EndpointWorker:
         provider = self._scheduler_provider_for_job(job)
         for scheduler_job_id in scheduler_job_ids:
             ownership_verified = self._scheduler_job_id_is_owned(job, scheduler_job_id)
-            self.queue.register_scheduler_cancel_identity(
+            registration = self.queue.register_scheduler_cancel_identity_once(
                 job.job_id,
                 cluster=job.cluster,
                 scheduler_job_id=scheduler_job_id,
                 provider=provider.name,
                 ownership_verified=ownership_verified,
             )
-            if not ownership_verified:
+            if not ownership_verified and registration.disposition_created:
                 self.queue.append_event(
                     job.job_id,
                     "scheduler.cancel_refused",
@@ -3553,7 +3646,6 @@ class EndpointWorker:
                 job,
                 provider,
                 disposition.scheduler_job_id,
-                confirmation_attempts=disposition.confirmation_attempts,
             )
         due_dispositions = [
             item
@@ -3566,6 +3658,16 @@ class EndpointWorker:
         ]
         for disposition in due_dispositions:
             scheduler_job_id = disposition.scheduler_job_id
+            claim = self.queue.claim_scheduler_cancel_attempt(
+                job.job_id,
+                cluster=job.cluster,
+                scheduler_job_id=scheduler_job_id,
+                provider=provider.name,
+                lease_seconds=self.scheduler_cancel_claim_lease_seconds,
+                now=utc_now(),
+            )
+            if claim is None:
+                continue
             try:
                 result = provider.cancel(scheduler_job_id)
             except (OSError, RelayError) as exc:
@@ -3575,21 +3677,26 @@ class EndpointWorker:
                     "",
                     str(exc),
                 )
-            attempt = disposition.attempts + 1
+            error_detail = bounded_error_detail(result.stderr) if result.stderr else None
+            attempt = claim.attempt
             retry_delay = min(
                 self.scheduler_cancel_retry_base_seconds * 2 ** (attempt - 1),
                 self.scheduler_cancel_retry_max_seconds,
             )
-            self.queue.record_scheduler_cancel_attempt(
+            recorded = self.queue.record_scheduler_cancel_attempt(
                 job.job_id,
                 cluster=job.cluster,
                 scheduler_job_id=scheduler_job_id,
                 provider=provider.name,
+                claim_id=claim.claim_id,
                 accepted=result.returncode == 0,
-                error=result.stderr or None,
+                error=error_detail,
                 max_attempts=self.scheduler_cancel_max_attempts,
                 retry_delay_seconds=retry_delay,
+                now=utc_now(),
             )
+            if recorded is None:
+                continue
             if result.returncode == 0:
                 self.queue.append_event(
                     job.job_id,
@@ -3600,43 +3707,7 @@ class EndpointWorker:
                         "scheduler_job_id": scheduler_job_id,
                     },
                 )
-                try:
-                    status = provider.poll(scheduler_job_id)
-                except RelayError as exc:
-                    status = SchedulerStatus(
-                        scheduler=provider.name,
-                        scheduler_job_id=scheduler_job_id,
-                        phase=SchedulerPhase.UNKNOWN,
-                        reason="scheduler cancellation was accepted but status polling failed",
-                        queue_position_note=str(exc),
-                    )
-                if status.phase == SchedulerPhase.UNKNOWN:
-                    status = status.model_copy(
-                        update={
-                            "reason": "scheduler cancellation requested; confirmation pending",
-                            "queue_position_note": (
-                                status.queue_position_note
-                                or "provider did not return a terminal scheduler record yet"
-                            ),
-                        }
-                    )
-                self._record_scheduler_status(
-                    job,
-                    [scheduler_job_id],
-                    scheduler_job_id,
-                    status,
-                    task_id=None,
-                )
-                self.queue.record_scheduler_cancel_observation(
-                    job.job_id,
-                    cluster=job.cluster,
-                    scheduler_job_id=scheduler_job_id,
-                    phase=status.phase,
-                    not_found=_scheduler_status_is_not_found(status),
-                    error=status.queue_position_note,
-                    max_confirmation_attempts=self.scheduler_cancel_confirmation_max_attempts,
-                    retry_delay_seconds=self.scheduler_cancel_retry_base_seconds,
-                )
+                self._confirm_scheduler_cancellation(job, provider, scheduler_job_id)
                 continue
             self.queue.append_event(
                 job.job_id,
@@ -3646,7 +3717,7 @@ class EndpointWorker:
                     "scheduler": provider.name,
                     "scheduler_job_id": scheduler_job_id,
                     "returncode": result.returncode,
-                    "stderr": result.stderr,
+                    "stderr": error_detail,
                     "attempt": attempt,
                     "max_attempts": self.scheduler_cancel_max_attempts,
                     "retryable": attempt < self.scheduler_cancel_max_attempts,
@@ -3661,48 +3732,60 @@ class EndpointWorker:
             now=utc_now(),
         )
         for pending_record in pending_records:
+            self._reconcile_canceled_scheduler_job(pending_record)
+
+    def _reconcile_canceled_scheduler_job(
+        self,
+        pending_record: SchedulerCancelPending,
+    ) -> None:
+        """Resolve one durable scheduler-cancellation record idempotently."""
+        try:
+            job = self.queue.get_job(pending_record.job_id)
+        except RelayError:
+            return
+        if pending_record.reason == "operator_request" and not self._scheduler_cancel_was_requested(
+            job.job_id
+        ):
             try:
-                job = self.queue.get_job(pending_record.job_id)
-            except RelayError:
-                continue
-            if (
-                pending_record.reason == "operator_request"
-                and not self._scheduler_cancel_was_requested(job.job_id)
-            ):
                 self.queue.complete_scheduler_cancel_identity_scan(
                     job.job_id,
                     cluster=self.cluster,
                     superseded=True,
                 )
-                continue
-            observed_ids: set[str] = set()
-            owned_ids: set[str] = set()
-            for task in self._bounded_job_tasks(job.job_id):
-                observed_scheduler_job_ids = _scheduler_job_ids_from_metadata(task.metadata)
-                scheduler_job_ids = _owned_scheduler_job_ids_from_metadata(
-                    task.metadata,
-                    relay_job_id=job.job_id,
-                    task_id=task.task_id,
+            except QueueConflictError:
+                completed = self.queue.get_scheduler_cancel_disposition(
+                    job.job_id,
+                    cluster=job.cluster,
                 )
-                observed_ids.update(observed_scheduler_job_ids)
-                owned_ids.update(scheduler_job_ids)
-            if pending_record.identity_resolution == "pending":
-                provider = self._scheduler_provider_for_job(job)
+                if completed is None:
+                    raise
+            return
+        observed_ids: set[str] = set()
+        owned_ids: set[str] = set()
+        for task in self._bounded_job_tasks(job.job_id):
+            observed_scheduler_job_ids = _scheduler_job_ids_from_metadata(task.metadata)
+            scheduler_job_ids = _owned_scheduler_job_ids_from_metadata(
+                task.metadata,
+                relay_job_id=job.job_id,
+                task_id=task.task_id,
+            )
+            observed_ids.update(observed_scheduler_job_ids)
+            owned_ids.update(scheduler_job_ids)
+        if pending_record.identity_resolution == "pending":
+            provider = self._scheduler_provider_for_job(job)
+            newly_refused: list[str] = []
+            try:
                 for scheduler_job_id in sorted(observed_ids):
                     ownership_verified = scheduler_job_id in owned_ids
-                    self.queue.register_scheduler_cancel_identity(
+                    registration = self.queue.register_scheduler_cancel_identity_once(
                         job.job_id,
                         cluster=job.cluster,
                         scheduler_job_id=scheduler_job_id,
                         provider=provider.name,
                         ownership_verified=ownership_verified,
                     )
-                    if not ownership_verified:
-                        self._record_scheduler_cancel_refused(
-                            job,
-                            scheduler_job_id=scheduler_job_id,
-                            metadata_source="unverified_durable_metadata",
-                        )
+                    if not ownership_verified and registration.disposition_created:
+                        newly_refused.append(scheduler_job_id)
                 if observed_ids:
                     self.queue.finalize_scheduler_cancel_identities(
                         job.job_id,
@@ -3717,45 +3800,88 @@ class EndpointWorker:
                         job.job_id,
                         cluster=job.cluster,
                     )
-                    continue
+                    return
                 else:
-                    continue
-            if owned_ids:
-                self._cancel_scheduler_jobs(job, sorted(owned_ids))
+                    return
+            except QueueConflictError:
+                completed = self.queue.get_scheduler_cancel_disposition(
+                    job.job_id,
+                    cluster=job.cluster,
+                )
+                if completed is not None:
+                    return
+                raise
+            for scheduler_job_id in newly_refused:
+                self._record_scheduler_cancel_refused(
+                    job,
+                    scheduler_job_id=scheduler_job_id,
+                    metadata_source="unverified_durable_metadata",
+                )
+        if owned_ids:
+            self._cancel_scheduler_jobs(job, sorted(owned_ids))
 
     def _confirm_scheduler_cancellation(
         self,
         job: RelayJob,
         provider: SchedulerProvider,
         scheduler_job_id: str,
-        *,
-        confirmation_attempts: int,
     ) -> None:
         """Poll one accepted cancellation until the exact scheduler id is terminal."""
+        claim = self.queue.claim_scheduler_cancel_confirmation(
+            job.job_id,
+            cluster=job.cluster,
+            scheduler_job_id=scheduler_job_id,
+            provider=provider.name,
+            lease_seconds=self.scheduler_cancel_confirmation_claim_lease_seconds,
+            now=utc_now(),
+        )
+        if claim is None:
+            return
         try:
             status = provider.poll(scheduler_job_id)
         except RelayError as exc:
+            error_detail = bounded_error_detail(str(exc)) or type(exc).__name__
             status = SchedulerStatus(
                 scheduler=provider.name,
                 scheduler_job_id=scheduler_job_id,
                 phase=SchedulerPhase.UNKNOWN,
                 reason="scheduler cancellation confirmation failed",
-                queue_position_note=str(exc),
+                queue_position_note=error_detail,
+            )
+        status = _normalized_scheduler_status(
+            status,
+            expected_scheduler=provider.name,
+            expected_scheduler_job_id=scheduler_job_id,
+        )
+        if status.phase == SchedulerPhase.UNKNOWN:
+            status = status.model_copy(
+                update={
+                    "reason": "scheduler cancellation requested; confirmation pending",
+                    "queue_position_note": (
+                        status.queue_position_note
+                        or "provider did not return a terminal scheduler record yet"
+                    ),
+                }
             )
         retry_delay = min(
-            self.scheduler_cancel_retry_base_seconds * 2**confirmation_attempts,
+            self.scheduler_cancel_retry_base_seconds * 2 ** (claim.confirmation_attempt - 1),
             self.scheduler_cancel_retry_max_seconds,
         )
-        self.queue.record_scheduler_cancel_observation(
+        recorded = self.queue.record_scheduler_cancel_observation(
             job.job_id,
             cluster=job.cluster,
             scheduler_job_id=scheduler_job_id,
+            provider=provider.name,
+            claim_id=claim.claim_id,
             phase=status.phase,
             not_found=_scheduler_status_is_not_found(status),
             error=status.queue_position_note,
             max_confirmation_attempts=self.scheduler_cancel_confirmation_max_attempts,
             retry_delay_seconds=retry_delay,
+            now=utc_now(),
         )
+        if recorded is None:
+            return
         self._record_scheduler_status(
             job,
             [scheduler_job_id],
@@ -3892,6 +4018,40 @@ def _worker_installation_snapshot() -> dict[str, object]:
         }
 
 
+def _worker_process_identity() -> dict[str, object] | None:
+    """Return exact Linux process-generation evidence for durable endpoint records."""
+    if os.name != "posix" or not hasattr(os, "getuid"):
+        return None
+    try:
+        boot_id = (
+            Path("/proc/sys/kernel/random/boot_id")
+            .read_text(
+                encoding="ascii",
+            )
+            .strip()
+        )
+        raw_stat = Path("/proc/self/stat").read_bytes()
+    except OSError:
+        return None
+    if not boot_id or len(boot_id) > 128 or len(raw_stat) > 4096:
+        return None
+    closing_parenthesis = raw_stat.rfind(b")")
+    fields = raw_stat[closing_parenthesis + 1 :].split()
+    if closing_parenthesis < 0 or len(fields) <= 19:
+        return None
+    try:
+        start_ticks = int(fields[19])
+    except ValueError:
+        return None
+    return {
+        "schema_version": "clio-relay.process-identity.v1",
+        "boot_id": boot_id,
+        "start_ticks": start_ticks,
+        "uid": os.getuid(),
+        "pid": os.getpid(),
+    }
+
+
 def bootstrap_cluster_environment(settings: RelaySettings) -> None:
     """Create endpoint directories and verify required executables are configured."""
     internal_filesystem_path(settings.core_dir, force_extended=True).mkdir(
@@ -4024,6 +4184,56 @@ def _trusted_jarvis_mcp_result(
 def _scheduler_status_is_not_found(status: SchedulerStatus) -> bool:
     """Recognize a provider's exact-job not-found terminal observation."""
     return status.phase is SchedulerPhase.UNKNOWN and status.record_found is False
+
+
+_SCHEDULER_STATUS_TEXT_FIELDS = (
+    "raw_state",
+    "reason",
+    "partition",
+    "qos",
+    "user",
+    "memory",
+    "submit_time",
+    "eligible_time",
+    "start_time",
+    "elapsed",
+    "time_limit",
+    "queue_position_scope",
+    "queue_position_note",
+)
+
+
+def _normalized_scheduler_status(
+    status: SchedulerStatus,
+    *,
+    expected_scheduler: str,
+    expected_scheduler_job_id: str,
+) -> SchedulerStatus:
+    """Bind provider status to the requested identity and bound all durable text."""
+    if (
+        status.scheduler != expected_scheduler
+        or status.scheduler_job_id != expected_scheduler_job_id
+    ):
+        detail = bounded_error_detail(
+            "scheduler provider returned mismatched identity: "
+            f"expected scheduler={expected_scheduler!r} "
+            f"job_id={expected_scheduler_job_id!r}; "
+            f"observed scheduler={status.scheduler!r} job_id={status.scheduler_job_id!r}"
+        )
+        return SchedulerStatus(
+            scheduler=expected_scheduler,
+            scheduler_job_id=expected_scheduler_job_id,
+            phase=SchedulerPhase.UNKNOWN,
+            reason="scheduler provider response identity mismatch",
+            queue_position_note=detail,
+            observed_at=status.observed_at,
+        )
+    payload = status.model_dump(mode="python")
+    for field_name in _SCHEDULER_STATUS_TEXT_FIELDS:
+        value = payload.get(field_name)
+        if isinstance(value, str):
+            payload[field_name] = bounded_error_detail(value)
+    return SchedulerStatus.model_validate(payload)
 
 
 def _configured_scheduler_provider_name(provider: SchedulerProvider | None) -> str:

--- a/src/clio_relay/http_api.py
+++ b/src/clio_relay/http_api.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 import asyncio
 import json
 import secrets
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Annotated, TypeVar, cast
 
@@ -376,7 +377,18 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
     resolved = settings or RelaySettings.from_env()
     queue = storage_managed_queue(resolved)
     queue.initialize()
-    app = FastAPI(title="clio-relay")
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
+        """Retain shared core ownership for the API process lifetime."""
+        if queue.closed:
+            raise RuntimeError("clio-relay API application cannot restart after shutdown")
+        try:
+            yield
+        finally:
+            queue.close()
+
+    app = FastAPI(title="clio-relay", lifespan=lifespan)
     auth_dependency = Depends(_require_api_token(resolved))
 
     def ensure_intake_open() -> None:

--- a/src/clio_relay/live_acceptance.py
+++ b/src/clio_relay/live_acceptance.py
@@ -37,6 +37,7 @@ from clio_relay.pagination import MAX_RESPONSE_PAGE_RECORDS
 from clio_relay.progress_provenance import (
     validate_package_progress_acceptance_metadata,
 )
+from clio_relay.remote_values import render_remote_shell_path, render_remote_shell_value
 from clio_relay.runtime_metadata import RUNTIME_METADATA_SCHEMA, RuntimeMetadataSource
 from clio_relay.transport_probe import (
     run_frp_direct_http_probe,
@@ -1870,21 +1871,22 @@ def _remote_env(definition: ClusterDefinition) -> str:
     jarvis_bin = definition.jarvis_bin or "$HOME/.local/bin/jarvis"
     frpc_bin = definition.frpc_bin or "$HOME/.local/bin/frpc"
     agent_bin = _cluster_agent_bin(definition)
+    rendered_core_dir = render_remote_shell_path(definition.core_dir, field="core_dir")
+    rendered_spool_dir = render_remote_shell_path(definition.spool_dir, field="spool_dir")
+    rendered_jarvis_bin = render_remote_shell_value(jarvis_bin, field="jarvis_bin")
+    rendered_frpc_bin = render_remote_shell_value(frpc_bin, field="frpc_bin")
+    rendered_agent_bin = render_remote_shell_value(agent_bin, field="agent_bin")
     return " ".join(
         [
             'export PATH="$HOME/.local/bin:$PATH";',
-            f"export CLIO_RELAY_CORE_DIR={_shell_double_quoted(definition.core_dir)};",
-            f"export CLIO_RELAY_SPOOL_DIR={_shell_double_quoted(definition.spool_dir)};",
-            f"export CLIO_RELAY_JARVIS_BIN={_shell_double_quoted(jarvis_bin)};",
-            f"export CLIO_RELAY_FRPC_BIN={_shell_double_quoted(frpc_bin)};",
-            f"export CLIO_RELAY_AGENT_BIN={_shell_double_quoted(agent_bin)};",
+            f"export CLIO_RELAY_CORE_DIR={rendered_core_dir};",
+            f"export CLIO_RELAY_SPOOL_DIR={rendered_spool_dir};",
+            f"export CLIO_RELAY_JARVIS_BIN={rendered_jarvis_bin};",
+            f"export CLIO_RELAY_FRPC_BIN={rendered_frpc_bin};",
+            f"export CLIO_RELAY_AGENT_BIN={rendered_agent_bin};",
             f"export CLIO_RELAY_AGENT_ADAPTER={shlex.quote(definition.agent_adapter)};",
         ]
     )
-
-
-def _shell_double_quoted(value: str) -> str:
-    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
 
 
 def _cluster_agent_bin(definition: ClusterDefinition) -> str:

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -155,28 +155,31 @@ def serve_stdio(
     queue.initialize()
     session = McpSessionState()
     first_line = True
-    for line in stdin:
-        if first_line:
-            line = line.removeprefix("\ufeff")
-            first_line = False
-        if not line.strip():
-            continue
-        try:
-            request = json.loads(line)
-        except JSONDecodeError as exc:
-            response = _error(None, -32700, f"parse error: {exc.msg}")
-        else:
-            response = handle_request(
-                request,
-                queue=queue,
-                settings=resolved,
-                profile=resolved_profile,
-                session=session,
-            )
-        if response is None:
-            continue
-        stdout.write(json.dumps(response, separators=(",", ":")) + "\n")
-        stdout.flush()
+    try:
+        for line in stdin:
+            if first_line:
+                line = line.removeprefix("\ufeff")
+                first_line = False
+            if not line.strip():
+                continue
+            try:
+                request = json.loads(line)
+            except JSONDecodeError as exc:
+                response = _error(None, -32700, f"parse error: {exc.msg}")
+            else:
+                response = handle_request(
+                    request,
+                    queue=queue,
+                    settings=resolved,
+                    profile=resolved_profile,
+                    session=session,
+                )
+            if response is None:
+                continue
+            stdout.write(json.dumps(response, separators=(",", ":")) + "\n")
+            stdout.flush()
+    finally:
+        queue.close()
 
 
 def handle_request(

--- a/src/clio_relay/models.py
+++ b/src/clio_relay/models.py
@@ -192,7 +192,62 @@ class SchedulerCancelDisposition(BaseModel):
     confirmation_attempts: int = Field(default=0, ge=0, le=100)
     next_attempt_at: datetime | None = None
     last_error: str | None = Field(default=None, max_length=16_384)
+    attempt_claim_id: DurableRecordId | None = None
+    attempt_claimed_at: datetime | None = None
+    attempt_claim_expires_at: datetime | None = None
+    confirmation_claim_id: DurableRecordId | None = None
+    confirmation_claimed_at: datetime | None = None
+    confirmation_claim_expires_at: datetime | None = None
     updated_at: datetime = Field(default_factory=utc_now)
+
+    @model_validator(mode="after")
+    def validate_attempt_claim(self) -> SchedulerCancelDisposition:
+        """Require one complete, bounded-lifecycle claim on retryable work."""
+        claim_values = (
+            self.attempt_claim_id,
+            self.attempt_claimed_at,
+            self.attempt_claim_expires_at,
+        )
+        populated = sum(value is not None for value in claim_values)
+        if populated not in {0, len(claim_values)}:
+            raise ValueError("scheduler cancellation attempt claim must be complete")
+        if self.attempt_claim_id is None:
+            return self
+        if self.state not in {
+            SchedulerCancelDispositionState.PENDING,
+            SchedulerCancelDispositionState.RETRY_WAIT,
+        }:
+            raise ValueError("scheduler cancellation attempt claim requires retryable state")
+        claimed_at = self.attempt_claimed_at
+        expires_at = self.attempt_claim_expires_at
+        if claimed_at is None or expires_at is None or expires_at <= claimed_at:
+            raise ValueError("scheduler cancellation attempt claim must expire after acquisition")
+        return self
+
+    @model_validator(mode="after")
+    def validate_confirmation_claim(self) -> SchedulerCancelDisposition:
+        """Require one complete, bounded-lifecycle claim on confirmation work."""
+        claim_values = (
+            self.confirmation_claim_id,
+            self.confirmation_claimed_at,
+            self.confirmation_claim_expires_at,
+        )
+        populated = sum(value is not None for value in claim_values)
+        if populated not in {0, len(claim_values)}:
+            raise ValueError("scheduler cancellation confirmation claim must be complete")
+        if self.confirmation_claim_id is None:
+            return self
+        if self.state is not SchedulerCancelDispositionState.CANCEL_REQUESTED:
+            raise ValueError(
+                "scheduler cancellation confirmation claim requires cancel-requested state"
+            )
+        claimed_at = self.confirmation_claimed_at
+        expires_at = self.confirmation_claim_expires_at
+        if claimed_at is None or expires_at is None or expires_at <= claimed_at:
+            raise ValueError(
+                "scheduler cancellation confirmation claim must expire after acquisition"
+            )
+        return self
 
 
 def _empty_scheduler_cancel_dispositions() -> list[SchedulerCancelDisposition]:

--- a/src/clio_relay/remote_cli.py
+++ b/src/clio_relay/remote_cli.py
@@ -18,6 +18,7 @@ import yaml
 from clio_relay.cluster_config import ClusterDefinition
 from clio_relay.errors import ConfigurationError, RelayError
 from clio_relay.jarvis_mcp import JARVIS_MCP_SPACK_COMMAND_ENV
+from clio_relay.remote_values import render_remote_shell_path, render_remote_shell_value
 
 _REMOTE_COMMAND_TIMEOUT_SECONDS: ContextVar[float | None] = ContextVar(
     "clio_relay_remote_command_timeout_seconds",
@@ -154,17 +155,22 @@ def remote_env(definition: ClusterDefinition) -> str:
     jarvis_bin = definition.jarvis_bin or "$HOME/.local/bin/jarvis"
     frpc_bin = definition.frpc_bin or "$HOME/.local/bin/frpc"
     agent_bin = _cluster_agent_bin(definition)
+    rendered_core_dir = render_remote_shell_path(definition.core_dir, field="core_dir")
+    rendered_spool_dir = render_remote_shell_path(definition.spool_dir, field="spool_dir")
+    rendered_jarvis_bin = render_remote_shell_value(jarvis_bin, field="jarvis_bin")
+    rendered_frpc_bin = render_remote_shell_value(frpc_bin, field="frpc_bin")
+    rendered_agent_bin = render_remote_shell_value(agent_bin, field="agent_bin")
     exports = [
         'export PATH="$HOME/.local/bin:$PATH";',
         'export UV="$HOME/.local/bin/uv";',
         'export CLIO_RELAY_VALIDATION_TOOL_EXECUTABLE="$HOME/.local/bin/clio-relay";',
         "export CLIO_RELAY_CLI_MODE=local;",
         f"export CLIO_RELAY_REMOTE_CLUSTER={shlex.quote(definition.name)};",
-        f"export CLIO_RELAY_CORE_DIR={_shell_double_quoted(definition.core_dir)};",
-        f"export CLIO_RELAY_SPOOL_DIR={_shell_double_quoted(definition.spool_dir)};",
-        f"export CLIO_RELAY_JARVIS_BIN={_shell_double_quoted(jarvis_bin)};",
-        f"export CLIO_RELAY_FRPC_BIN={_shell_double_quoted(frpc_bin)};",
-        f"export CLIO_RELAY_AGENT_BIN={_shell_double_quoted(agent_bin)};",
+        f"export CLIO_RELAY_CORE_DIR={rendered_core_dir};",
+        f"export CLIO_RELAY_SPOOL_DIR={rendered_spool_dir};",
+        f"export CLIO_RELAY_JARVIS_BIN={rendered_jarvis_bin};",
+        f"export CLIO_RELAY_FRPC_BIN={rendered_frpc_bin};",
+        f"export CLIO_RELAY_AGENT_BIN={rendered_agent_bin};",
         f"export CLIO_RELAY_AGENT_ADAPTER={shlex.quote(definition.agent_adapter)};",
     ]
     if definition.agent_args:
@@ -173,7 +179,8 @@ def remote_env(definition: ClusterDefinition) -> str:
         )
     if definition.spack_executable is not None:
         exports.append(
-            f"export {JARVIS_MCP_SPACK_COMMAND_ENV}={shlex.quote(definition.spack_executable)};"
+            f"export {JARVIS_MCP_SPACK_COMMAND_ENV}="
+            f"{render_remote_shell_value(definition.spack_executable, field='spack_executable')};"
         )
     for name in _VALIDATION_PROVENANCE_ENV:
         value = os.environ.get(name)
@@ -253,10 +260,6 @@ def _cluster_agent_bin(definition: ClusterDefinition) -> str:
     if definition.agent_npm_bin is not None:
         return f"$HOME/.local/bin/{definition.agent_npm_bin}"
     return "agent"
-
-
-def _shell_double_quoted(value: str) -> str:
-    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
 
 
 def _command_error(prefix: str, result: subprocess.CompletedProcess[bytes]) -> str:

--- a/src/clio_relay/remote_values.py
+++ b/src/clio_relay/remote_values.py
@@ -1,0 +1,76 @@
+"""Safe rendering for operator-configured values used on remote Linux targets."""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+
+from clio_relay.errors import ConfigurationError
+
+REMOTE_HOME_TOKEN = "$HOME"
+SYSTEMD_HOME_SPECIFIER = "%h"
+
+
+def render_remote_shell_value(value: str, *, field: str) -> str:
+    """Quote a remote shell value while expanding only a leading ``$HOME`` token."""
+    _validate_remote_value(value, field=field)
+    home_suffix = _leading_home_suffix(value)
+    if home_suffix is None:
+        return f'"{_escape_shell_double_quoted(value)}"'
+    return f'"$HOME{_escape_shell_double_quoted(home_suffix)}"'
+
+
+def render_remote_shell_path(value: str, *, field: str) -> str:
+    """Render an absolute remote POSIX path with controlled leading HOME expansion."""
+    validate_remote_path(value, field=field)
+    return render_remote_shell_value(value, field=field)
+
+
+def render_systemd_remote_path(value: str, *, field: str) -> str:
+    """Render an absolute remote path for systemd with controlled HOME conversion."""
+    validate_remote_path(value, field=field)
+    return render_systemd_remote_value(value, field=field)
+
+
+def render_systemd_remote_value(value: str, *, field: str) -> str:
+    """Convert only a leading remote ``$HOME`` token into systemd's ``%h`` specifier."""
+    _validate_remote_value(value, field=field)
+    home_suffix = _leading_home_suffix(value)
+    if home_suffix is None:
+        return value
+    return f"{SYSTEMD_HOME_SPECIFIER}{home_suffix}"
+
+
+def remote_value_expands_home(value: str) -> bool:
+    """Return whether an original configured value requests leading HOME expansion."""
+    return _leading_home_suffix(value) is not None
+
+
+def validate_remote_path(value: str, *, field: str) -> None:
+    """Require an absolute POSIX path or one anchored by an exact leading HOME token."""
+    _validate_remote_value(value, field=field)
+    if not value:
+        raise ConfigurationError(f"remote {field} must be a nonempty path")
+    if _leading_home_suffix(value) is None and not PurePosixPath(value).is_absolute():
+        raise ConfigurationError(
+            f"remote {field} must be an absolute POSIX path or start with $HOME/"
+        )
+
+
+def _leading_home_suffix(value: str) -> str | None:
+    """Return the suffix when HOME is one exact leading token, otherwise ``None``."""
+    if value == REMOTE_HOME_TOKEN:
+        return ""
+    if value.startswith(f"{REMOTE_HOME_TOKEN}/"):
+        return value.removeprefix(REMOTE_HOME_TOKEN)
+    return None
+
+
+def _validate_remote_value(value: str, *, field: str) -> None:
+    """Reject control characters before a value enters shell or systemd syntax."""
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise ConfigurationError(f"remote {field} must not contain control characters")
+
+
+def _escape_shell_double_quoted(value: str) -> str:
+    """Escape every character that remains active inside POSIX double quotes."""
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("$", "\\$").replace("`", "\\`")

--- a/src/clio_relay/service_runtime.py
+++ b/src/clio_relay/service_runtime.py
@@ -38,6 +38,7 @@ from clio_relay.relay_host import (
     render_frpc_visitor_config,
 )
 from clio_relay.remote_cli import remote_env
+from clio_relay.remote_values import render_remote_shell_value
 from clio_relay.scheduler_providers import provider_for_scheduler
 from clio_relay.session_lifecycle import CleanupResource
 
@@ -3107,7 +3108,7 @@ data = base64.b64decode({encoded!r}).decode("utf-8")
 with open(path, "w", encoding="utf-8") as handle:
     handle.write(data)
 __CLIO_WRITE_FRPC__
-frpc_bin={_shell_double_quote(frpc_bin)}
+frpc_bin={render_remote_shell_value(frpc_bin, field="frpc_bin")}
 owner_token={shlex.quote(owner_token)}
 connector_generation_id={shlex.quote(connector_generation_id)}
 pid=""
@@ -4308,7 +4309,3 @@ def _frp_proxy_type(transport_mode: str) -> str:
     if normalized in {"frp-xtcp", "frp-xtcp-wss", "xtcp", "direct", "nat-bypass"}:
         return "xtcp"
     raise ConfigurationError(f"unsupported service runtime transport mode: {transport_mode}")
-
-
-def _shell_double_quote(value: str) -> str:
-    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'

--- a/src/clio_relay/storage_runtime.py
+++ b/src/clio_relay/storage_runtime.py
@@ -8,10 +8,11 @@ the authoritative active-job index, and a cheap running-child guard.
 from __future__ import annotations
 
 import json
+import os
 import threading
 import time
 from collections.abc import Generator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -23,7 +24,7 @@ from clio_relay.core_queue import (
     MAX_LIVE_LEASE_RECORDS,
     ClioCoreQueue,
 )
-from clio_relay.errors import NotFoundError, QueueConflictError, RelayError
+from clio_relay.errors import ConfigurationError, NotFoundError, QueueConflictError, RelayError
 from clio_relay.filesystem_paths import internal_filesystem_path, logical_filesystem_path
 from clio_relay.models import (
     TERMINAL_STATES,
@@ -41,6 +42,11 @@ from clio_relay.storage_policy import (
     StorageReason,
 )
 from clio_relay.worker_concurrency import KindConcurrencyInput, normalize_kind_concurrency
+from clio_relay.worker_lifetime_lock import (
+    LockedCoreIdentity,
+    WorkerLifetimeLock,
+    exclusive_migration_lifetime,
+)
 
 if TYPE_CHECKING:
     from clio_relay.config import RelaySettings
@@ -324,12 +330,73 @@ class StorageManagedQueue(ClioCoreQueue):
         root: Path,
         *,
         storage_runtime: StorageRuntime,
+        writer_lifetime_lock: WorkerLifetimeLock | None = None,
+        owns_writer_lifetime_lock: bool = False,
         lock_timeout_seconds: float = DEFAULT_CORE_LOCK_TIMEOUT_SECONDS,
     ) -> None:
+        self._closed = False
         if Path(root).absolute() != storage_runtime.config.core_root.absolute():
             raise ValueError("managed queue root must match the storage runtime core root")
+        if owns_writer_lifetime_lock and writer_lifetime_lock is None:
+            raise ValueError("an owned writer lifetime lock must be provided")
+        if writer_lifetime_lock is not None:
+            if not writer_lifetime_lock.acquired or writer_lifetime_lock.mode != "shared":
+                raise ValueError("managed queue writer lifetime lock must hold shared ownership")
+            root_stat = os.stat(root)
+            lock_stat = os.stat(writer_lifetime_lock.core_dir)
+            if (root_stat.st_dev, root_stat.st_ino) != (lock_stat.st_dev, lock_stat.st_ino):
+                raise ValueError("managed queue root must match its writer lifetime lock")
         super().__init__(root, lock_timeout_seconds=lock_timeout_seconds)
         self.storage_runtime = storage_runtime
+        self._writer_lifetime_lock = writer_lifetime_lock
+        self._owns_writer_lifetime_lock = owns_writer_lifetime_lock
+
+    def __getattribute__(self, name: str) -> object:
+        """Reject every public queue operation after lifetime ownership ends."""
+        value = super().__getattribute__(name)
+        if name == "close" or name.startswith("_") or not callable(value):
+            return value
+        try:
+            closed = super().__getattribute__("_closed")
+        except AttributeError:
+            return value
+        if closed:
+            raise ConfigurationError("managed queue is closed and cannot perform operations")
+        return value
+
+    @property
+    def closed(self) -> bool:
+        """Return whether this queue's writer lifetime has ended."""
+        return self._closed
+
+    def initialize(
+        self,
+        *,
+        migrate_legacy_output: bool = False,
+        locked_core: LockedCoreIdentity | None = None,
+    ) -> None:
+        """Initialize only while this managed queue retains writer ownership."""
+        if self._closed:
+            raise ConfigurationError("managed queue is closed and cannot perform operations")
+        super().initialize(
+            migrate_legacy_output=migrate_legacy_output,
+            locked_core=locked_core,
+        )
+
+    def close(self) -> None:
+        """Release queue-owned core writer lifetime ownership."""
+        self._closed = True
+        if not self._owns_writer_lifetime_lock:
+            return
+        self._owns_writer_lifetime_lock = False
+        lifetime_lock = self._writer_lifetime_lock
+        self._writer_lifetime_lock = None
+        if lifetime_lock is not None:
+            lifetime_lock.release()
+
+    def __del__(self) -> None:
+        with suppress(Exception):
+            self.close()
 
     @contextmanager
     def _acquire_lock_with_replay(self) -> Generator[None]:
@@ -668,13 +735,55 @@ class StorageManagedQueue(ClioCoreQueue):
             return
 
 
-def storage_managed_queue(settings: RelaySettings) -> StorageManagedQueue:
-    """Create the production queue, complete bounded migration, and reconcile storage."""
-    runtime = storage_runtime_from_settings(settings)
-    queue = StorageManagedQueue(settings.core_dir, storage_runtime=runtime)
-    queue.initialize()
-    _complete_bounded_index_migration(queue, runtime)
-    runtime.reconcile_startup(queue)
+def storage_managed_queue(
+    settings: RelaySettings,
+    *,
+    migrate_legacy_output: bool = False,
+    writer_lifetime_lock: WorkerLifetimeLock | None = None,
+) -> StorageManagedQueue:
+    """Create a production queue under shared writer or exclusive migration ownership."""
+    if migrate_legacy_output:
+        if writer_lifetime_lock is not None:
+            raise ValueError("migration cannot reuse shared writer lifetime ownership")
+        with exclusive_migration_lifetime(settings.core_dir) as locked_core:
+            pinned_settings = settings.model_copy(update={"core_dir": locked_core.root})
+            runtime = storage_runtime_from_settings(pinned_settings)
+            queue = StorageManagedQueue(locked_core.root, storage_runtime=runtime)
+            queue.initialize(
+                migrate_legacy_output=True,
+                locked_core=locked_core,
+            )
+            _complete_bounded_index_migration(queue, runtime)
+            runtime.reconcile_startup(queue)
+            queue.close()
+            return queue
+    owned_lifetime_lock: WorkerLifetimeLock | None = None
+    lifetime_lock = writer_lifetime_lock
+    if lifetime_lock is None:
+        owned_lifetime_lock = WorkerLifetimeLock(settings.core_dir, mode="shared").acquire()
+        lifetime_lock = owned_lifetime_lock
+    if not lifetime_lock.acquired or lifetime_lock.mode != "shared":
+        raise ValueError("production queue requires acquired shared writer lifetime ownership")
+    pinned_settings = settings.model_copy(update={"core_dir": lifetime_lock.core_dir})
+    try:
+        # Audit and initialize before StorageRuntime or StoragePolicy can create
+        # `.storage`. A normal startup that encounters legacy output remains a
+        # read-only refusal with respect to storage accounting and spool state.
+        ClioCoreQueue(lifetime_lock.core_dir).initialize()
+        runtime = storage_runtime_from_settings(pinned_settings)
+        queue = StorageManagedQueue(
+            lifetime_lock.core_dir,
+            storage_runtime=runtime,
+            writer_lifetime_lock=lifetime_lock,
+            owns_writer_lifetime_lock=owned_lifetime_lock is not None,
+        )
+        queue.initialize()
+        _complete_bounded_index_migration(queue, runtime)
+        runtime.reconcile_startup(queue)
+    except BaseException:
+        if owned_lifetime_lock is not None:
+            owned_lifetime_lock.release()
+        raise
     return queue
 
 

--- a/src/clio_relay/transport_probe.py
+++ b/src/clio_relay/transport_probe.py
@@ -26,6 +26,7 @@ from clio_relay.relay_host import (
     render_frpc_config,
     render_frpc_visitor_config,
 )
+from clio_relay.remote_values import render_remote_shell_path, render_remote_shell_value
 from clio_relay.session_lifecycle import (
     CleanupResource,
     SessionLifecycleReport,
@@ -1195,11 +1196,11 @@ def _remote_probe_script(
     return f"""set -euo pipefail
 umask 077
 export PATH="$HOME/.local/bin:$PATH"
-export CLIO_RELAY_CORE_DIR={_shell_double_quote(definition.core_dir)}
-export CLIO_RELAY_SPOOL_DIR={_shell_double_quote(definition.spool_dir)}
-export CLIO_RELAY_JARVIS_BIN={_shell_double_quote(jarvis_bin)}
-export CLIO_RELAY_FRPC_BIN={_shell_double_quote(frpc_bin)}
-export CLIO_RELAY_AGENT_BIN={_shell_double_quote(agent_bin)}
+export CLIO_RELAY_CORE_DIR={render_remote_shell_path(definition.core_dir, field="core_dir")}
+export CLIO_RELAY_SPOOL_DIR={render_remote_shell_path(definition.spool_dir, field="spool_dir")}
+export CLIO_RELAY_JARVIS_BIN={render_remote_shell_value(jarvis_bin, field="jarvis_bin")}
+export CLIO_RELAY_FRPC_BIN={render_remote_shell_value(frpc_bin, field="frpc_bin")}
+export CLIO_RELAY_AGENT_BIN={render_remote_shell_value(agent_bin, field="agent_bin")}
 export CLIO_RELAY_AGENT_ADAPTER={_shell_single_quote(definition.agent_adapter)}
 {token_export}
 tmp="$(mktemp -d)"
@@ -1794,10 +1795,6 @@ def _process_output_message(process: ManagedProcess, fallback: str) -> str:
 
 def _shell_single_quote(value: str) -> str:
     return "'" + value.replace("'", "'\"'\"'") + "'"
-
-
-def _shell_double_quote(value: str) -> str:
-    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
 
 
 def _cluster_agent_bin(definition: ClusterDefinition) -> str:

--- a/src/clio_relay/worker_lifetime_lock.py
+++ b/src/clio_relay/worker_lifetime_lock.py
@@ -1,0 +1,463 @@
+"""Core-scoped lifetime locking for relay worker and migration exclusion."""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import importlib
+import os
+import stat
+import time
+from collections.abc import Generator
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import TracebackType
+from typing import Any, Literal, Protocol, cast
+
+from clio_relay.cluster_config import (
+    ensure_private_configuration_directory,
+    ensure_private_configuration_path,
+)
+from clio_relay.errors import ConfigurationError
+from clio_relay.filesystem_paths import internal_filesystem_path, logical_filesystem_path
+
+WORKER_LIFETIME_LOCK_NAME = ".clio-relay-worker-lifetime.lock"
+WORKER_LIFETIME_GUARD_FD_ENV = "CLIO_RELAY_WORKER_LIFETIME_GUARD_FD"
+WORKER_LIFETIME_GUARD_PID_ENV = "CLIO_RELAY_WORKER_LIFETIME_GUARD_PID"
+WORKER_LIFETIME_GUARD_READY_ENV = "CLIO_RELAY_WORKER_LIFETIME_GUARD_READY"
+_LOCK_RETRY_SECONDS = 0.05
+_LOCKED_CORE_AUTHORITY = object()
+
+
+class _FcntlModule(Protocol):
+    """Typed surface used from the platform-only ``fcntl`` module."""
+
+    LOCK_EX: int
+    LOCK_NB: int
+    LOCK_SH: int
+    LOCK_UN: int
+
+    def flock(self, fd: int, operation: int) -> Any:
+        """Apply an advisory lock operation to ``fd``."""
+
+
+class _WindowsOverlapped(ctypes.Structure):
+    """Portable declaration of the Windows ``OVERLAPPED`` structure."""
+
+    _fields_ = [
+        ("Internal", ctypes.c_size_t),
+        ("InternalHigh", ctypes.c_size_t),
+        ("Offset", ctypes.c_ulong),
+        ("OffsetHigh", ctypes.c_ulong),
+        ("hEvent", ctypes.c_void_p),
+    ]
+
+
+class WorkerLifetimeLockUnavailable(ConfigurationError):
+    """The lifetime lock is healthy but incompatible ownership is active."""
+
+
+@dataclass
+class LockedCoreIdentity:
+    """Canonical physical core pinned by one acquired lifetime lock."""
+
+    root: Path
+    device: int
+    inode: int
+    _authority: object = field(repr=False)
+    _active: bool = field(default=True, repr=False)
+
+    def require_active(self) -> None:
+        """Reject forged or already-released lifetime ownership."""
+        if self._authority is not _LOCKED_CORE_AUTHORITY or not self._active:
+            raise ConfigurationError("migration locked-core authority is not active")
+
+    def deactivate(self) -> None:
+        """End this identity's authorized lifetime scope."""
+        self._active = False
+
+
+def require_active_locked_core(identity: LockedCoreIdentity) -> None:
+    """Reject forged or out-of-scope migration lock identities."""
+    identity.require_active()
+
+
+def _locked_core_identity(root: Path, file_stat: os.stat_result) -> LockedCoreIdentity:
+    return LockedCoreIdentity(
+        root=root,
+        device=file_stat.st_dev,
+        inode=file_stat.st_ino,
+        _authority=_LOCKED_CORE_AUTHORITY,
+    )
+
+
+class WorkerLifetimeLock:
+    """Hold shared worker or exclusive migration ownership for one core directory.
+
+    Worker processes use ``shared`` mode for their complete lifetime. Managed
+    bootstrap uses the same byte-range lock in ``exclusive`` mode so a newly
+    installed worker can start under systemd but cannot initialize its queue
+    until migration has finished and bootstrap releases the lock.
+    """
+
+    def __init__(
+        self,
+        core_dir: Path,
+        *,
+        mode: Literal["shared", "exclusive"],
+        timeout_seconds: float | None = None,
+    ) -> None:
+        if timeout_seconds is not None and timeout_seconds < 0:
+            raise ValueError("worker lifetime lock timeout must be non-negative")
+        self.core_dir = logical_filesystem_path(core_dir)
+        self.mode = mode
+        self.timeout_seconds = timeout_seconds
+        self.path = self.core_dir / WORKER_LIFETIME_LOCK_NAME
+        self._fd: int | None = None
+        self._windows_overlapped: _WindowsOverlapped | None = None
+
+    @property
+    def acquired(self) -> bool:
+        """Return whether this instance currently owns its OS lock."""
+        return self._fd is not None
+
+    def acquire(self) -> WorkerLifetimeLock:
+        """Acquire the configured shared or exclusive OS lock."""
+        if self._fd is not None:
+            raise RuntimeError("worker lifetime lock is already acquired")
+        fd, canonical_core = _open_private_lock_file(self.core_dir)
+        try:
+            if os.name == "nt":
+                overlapped = _acquire_windows_lock(
+                    fd,
+                    exclusive=self.mode == "exclusive",
+                    timeout_seconds=self.timeout_seconds,
+                )
+                self._windows_overlapped = overlapped
+            else:
+                _acquire_posix_lock(
+                    fd,
+                    exclusive=self.mode == "exclusive",
+                    timeout_seconds=self.timeout_seconds,
+                )
+        except BaseException:
+            os.close(fd)
+            raise
+        self._fd = fd
+        self.core_dir = logical_filesystem_path(canonical_core)
+        self.path = self.core_dir / WORKER_LIFETIME_LOCK_NAME
+        return self
+
+    def release(self) -> None:
+        """Release the OS lock and its non-inheritable file descriptor."""
+        fd = self._fd
+        if fd is None:
+            return
+        self._fd = None
+        try:
+            if os.name == "nt":
+                _release_windows_lock(fd, self._windows_overlapped)
+            else:
+                _release_posix_lock(fd)
+        finally:
+            self._windows_overlapped = None
+            os.close(fd)
+
+    def __enter__(self) -> WorkerLifetimeLock:
+        """Acquire this lock for a context-managed lifetime."""
+        return self.acquire()
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc_value: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        """Release this context-managed lifetime lock."""
+        self.release()
+
+    def __del__(self) -> None:
+        with suppress(Exception):
+            self.release()
+
+
+def _open_private_lock_file(core_dir: Path) -> tuple[int, Path]:
+    internal_core = internal_filesystem_path(core_dir, force_extended=True)
+    try:
+        internal_core.mkdir(parents=True, exist_ok=True, mode=0o700)
+        resolved_core = internal_core.resolve(strict=True)
+        ensure_private_configuration_directory(resolved_core)
+        directory_stat = os.lstat(resolved_core)
+    except OSError as exc:
+        raise ConfigurationError(f"cannot prepare worker lifetime lock directory: {exc}") from exc
+    if not stat.S_ISDIR(directory_stat.st_mode) or _is_reparse(directory_stat):
+        raise ConfigurationError("worker lifetime lock core must be a real directory")
+    current_uid = _current_uid()
+    if current_uid is not None:
+        if directory_stat.st_uid != current_uid:
+            raise ConfigurationError("worker lifetime lock core must be owned by the current user")
+        if stat.S_IMODE(directory_stat.st_mode) & 0o022:
+            raise ConfigurationError(
+                "worker lifetime lock core must not be group- or world-writable"
+            )
+
+    lock_path = resolved_core / WORKER_LIFETIME_LOCK_NAME
+    flags = os.O_RDWR | os.O_CREAT
+    flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOINHERIT", 0)
+    flags |= getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    created = False
+    try:
+        fd = os.open(lock_path, flags | os.O_EXCL, 0o600)
+        created = True
+    except FileExistsError:
+        try:
+            fd = os.open(lock_path, flags, 0o600)
+        except OSError as exc:
+            raise ConfigurationError(f"cannot open private worker lifetime lock: {exc}") from exc
+    except OSError as exc:
+        raise ConfigurationError(f"cannot open private worker lifetime lock: {exc}") from exc
+    if os.name == "nt" and created:
+        # The Windows ACL verifier opens a metadata handle that conflicts with
+        # the CRT descriptor's sharing mode. The containing directory is
+        # already private, so close, pin the ACL, and reopen before identity
+        # verification and locking.
+        os.close(fd)
+        ensure_private_configuration_path(lock_path, directory=False)
+        try:
+            fd = os.open(lock_path, flags, 0o600)
+        except OSError as exc:
+            raise ConfigurationError(f"cannot reopen private worker lifetime lock: {exc}") from exc
+    try:
+        os.set_inheritable(fd, False)
+        opened_stat = os.fstat(fd)
+        path_stat = os.lstat(lock_path)
+        if (
+            not stat.S_ISREG(opened_stat.st_mode)
+            or _is_reparse(opened_stat)
+            or opened_stat.st_nlink != 1
+            or path_stat.st_dev != opened_stat.st_dev
+            or path_stat.st_ino != opened_stat.st_ino
+        ):
+            raise ConfigurationError("worker lifetime lock must be one owned regular file")
+        if os.name != "nt":
+            ensure_private_configuration_path(lock_path, directory=False)
+        if current_uid is not None:
+            if opened_stat.st_uid != current_uid:
+                raise ConfigurationError("worker lifetime lock must be owned by the current user")
+            if stat.S_IMODE(opened_stat.st_mode) & 0o077:
+                raise ConfigurationError("worker lifetime lock permissions must be owner-private")
+    except BaseException:
+        os.close(fd)
+        raise
+    return fd, resolved_core
+
+
+def _acquire_posix_lock(
+    fd: int,
+    *,
+    exclusive: bool,
+    timeout_seconds: float | None,
+) -> None:
+    try:
+        fcntl = cast(_FcntlModule, importlib.import_module("fcntl"))
+    except ImportError as exc:
+        raise ConfigurationError("POSIX worker lifetime locking requires fcntl") from exc
+    operation = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+    if timeout_seconds is None:
+        fcntl.flock(fd, operation)
+        return
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        try:
+            fcntl.flock(fd, operation | fcntl.LOCK_NB)
+            return
+        except OSError as exc:
+            if exc.errno not in {errno.EACCES, errno.EAGAIN}:
+                raise ConfigurationError(f"cannot acquire worker lifetime lock: {exc}") from exc
+            if time.monotonic() >= deadline:
+                raise WorkerLifetimeLockUnavailable(
+                    "timed out acquiring worker lifetime lock"
+                ) from exc
+            time.sleep(min(_LOCK_RETRY_SECONDS, max(0.0, deadline - time.monotonic())))
+
+
+def _release_posix_lock(fd: int) -> None:
+    fcntl = cast(_FcntlModule, importlib.import_module("fcntl"))
+
+    fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+def _acquire_windows_lock(
+    fd: int,
+    *,
+    exclusive: bool,
+    timeout_seconds: float | None,
+) -> _WindowsOverlapped:
+    import msvcrt
+    from ctypes import wintypes
+
+    win_dll: Any = ctypes.WinDLL  # pyright: ignore[reportAttributeAccessIssue]
+    kernel32 = win_dll("kernel32", use_last_error=True)
+    lock_file_ex = kernel32.LockFileEx
+    lock_file_ex.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.POINTER(_WindowsOverlapped),
+    ]
+    lock_file_ex.restype = wintypes.BOOL
+    handle = wintypes.HANDLE(msvcrt.get_osfhandle(fd))
+    overlapped = _WindowsOverlapped()
+    exclusive_flag = 0x00000002 if exclusive else 0
+    if timeout_seconds is None:
+        if not lock_file_ex(handle, exclusive_flag, 0, 1, 0, ctypes.byref(overlapped)):
+            error = ctypes.get_last_error()
+            raise ConfigurationError(f"cannot acquire worker lifetime lock: WinError {error}")
+        return overlapped
+
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        flags = exclusive_flag | 0x00000001
+        if lock_file_ex(handle, flags, 0, 1, 0, ctypes.byref(overlapped)):
+            return overlapped
+        error = ctypes.get_last_error()
+        if error != 33:
+            raise ConfigurationError(f"cannot acquire worker lifetime lock: WinError {error}")
+        if time.monotonic() >= deadline:
+            raise WorkerLifetimeLockUnavailable("timed out acquiring worker lifetime lock")
+        time.sleep(min(_LOCK_RETRY_SECONDS, max(0.0, deadline - time.monotonic())))
+
+
+def _release_windows_lock(fd: int, overlapped: _WindowsOverlapped | None) -> None:
+    if overlapped is None:
+        raise RuntimeError("Windows worker lifetime lock has no OVERLAPPED state")
+    import msvcrt
+    from ctypes import wintypes
+
+    win_dll: Any = ctypes.WinDLL  # pyright: ignore[reportAttributeAccessIssue]
+    kernel32 = win_dll("kernel32", use_last_error=True)
+    unlock_file_ex = kernel32.UnlockFileEx
+    unlock_file_ex.restype = wintypes.BOOL
+    handle = wintypes.HANDLE(msvcrt.get_osfhandle(fd))
+    if not unlock_file_ex(handle, 0, 1, 0, ctypes.byref(overlapped)):
+        error = ctypes.get_last_error()
+        raise OSError(error, f"cannot release worker lifetime lock: WinError {error}")
+
+
+def _is_reparse(file_stat: os.stat_result) -> bool:
+    attributes = getattr(file_stat, "st_file_attributes", 0) or 0
+    return bool(attributes & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400))
+
+
+def _current_uid() -> int | None:
+    """Return the current POSIX uid when the platform exposes one."""
+    getuid = getattr(os, "getuid", None)
+    if not callable(getuid):
+        return None
+    uid = getuid()
+    if not isinstance(uid, int):
+        raise ConfigurationError("operating system returned an invalid current uid")
+    return uid
+
+
+@contextmanager
+def exclusive_migration_lifetime(
+    core_dir: Path,
+) -> Generator[LockedCoreIdentity, None, None]:
+    """Hold or validate exclusive core ownership for an authorized migration."""
+    guard_fd = os.getenv(WORKER_LIFETIME_GUARD_FD_ENV)
+    guard_pid = os.getenv(WORKER_LIFETIME_GUARD_PID_ENV)
+    guard_ready = os.getenv(WORKER_LIFETIME_GUARD_READY_ENV)
+    if guard_fd is None and guard_pid is None and guard_ready is None:
+        with WorkerLifetimeLock(core_dir, mode="exclusive") as lifetime_lock:
+            locked_stat = os.stat(lifetime_lock.core_dir)
+            identity = _locked_core_identity(lifetime_lock.core_dir, locked_stat)
+            try:
+                yield identity
+            finally:
+                identity.deactivate()
+        return
+    if not guard_fd or guard_pid is not None or guard_ready is not None:
+        raise ConfigurationError(
+            "external worker lifetime ownership requires only one inherited guard fd"
+        )
+    locked_identity = _validate_and_acquire_inherited_migration_guard(
+        core_dir,
+        guard_fd=guard_fd,
+    )
+    # Do not unlock or close the inherited descriptor here. The bootstrap shell
+    # owns the same open-file description and deliberately retains EX across
+    # package replacement, migration, service restart, and its EXIT trap. This
+    # process's inherited copy independently retains EX if that shell dies while
+    # migration is running.
+    try:
+        yield locked_identity
+    finally:
+        locked_identity.deactivate()
+
+
+def _validate_and_acquire_inherited_migration_guard(
+    core_dir: Path,
+    *,
+    guard_fd: str,
+) -> LockedCoreIdentity:
+    """Validate and acquire EX on bootstrap's exact inherited lock descriptor."""
+    current_uid = _current_uid()
+    if os.name != "posix" or current_uid is None:
+        raise ConfigurationError("inherited worker lifetime guards require POSIX flock")
+    try:
+        descriptor = int(guard_fd)
+    except ValueError as exc:
+        raise ConfigurationError("inherited worker lifetime guard fd is invalid") from exc
+    if descriptor < 3:
+        raise ConfigurationError("inherited worker lifetime guard fd is invalid")
+    try:
+        opened_stat = os.fstat(descriptor)
+    except OSError as exc:
+        raise ConfigurationError("inherited worker lifetime guard fd is not open") from exc
+    try:
+        canonical_core = internal_filesystem_path(
+            core_dir,
+            force_extended=True,
+        ).resolve(strict=True)
+        ensure_private_configuration_directory(canonical_core)
+        core_stat = os.lstat(canonical_core)
+        lock_path = canonical_core / WORKER_LIFETIME_LOCK_NAME
+        linked_stat = os.lstat(lock_path)
+    except OSError as exc:
+        raise ConfigurationError(
+            f"inherited worker lifetime guard identity cannot be verified: {exc}"
+        ) from exc
+    if (
+        not stat.S_ISDIR(core_stat.st_mode)
+        or _is_reparse(core_stat)
+        or core_stat.st_uid != current_uid
+        or stat.S_IMODE(core_stat.st_mode) & 0o022
+    ):
+        raise ConfigurationError(
+            "inherited worker lifetime core is not one private owned directory"
+        )
+    if (
+        not stat.S_ISREG(opened_stat.st_mode)
+        or _is_reparse(opened_stat)
+        or opened_stat.st_nlink != 1
+        or opened_stat.st_uid != current_uid
+        or stat.S_IMODE(opened_stat.st_mode) & 0o077
+        or opened_stat.st_dev != linked_stat.st_dev
+        or opened_stat.st_ino != linked_stat.st_ino
+    ):
+        raise ConfigurationError(
+            "inherited worker lifetime guard is not the core's private lock file"
+        )
+    _acquire_posix_lock(
+        descriptor,
+        exclusive=True,
+        timeout_seconds=30.0,
+    )
+    return _locked_core_identity(
+        logical_filesystem_path(canonical_core),
+        core_stat,
+    )

--- a/src/clio_relay/worker_lifetime_lock.py
+++ b/src/clio_relay/worker_lifetime_lock.py
@@ -8,7 +8,7 @@ import importlib
 import os
 import stat
 import time
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -40,6 +40,32 @@ class _FcntlModule(Protocol):
 
     def flock(self, fd: int, operation: int) -> Any:
         """Apply an advisory lock operation to ``fd``."""
+
+
+class _WindowsFunction(Protocol):
+    """Typed callable surface for one dynamically loaded Win32 function."""
+
+    argtypes: list[object]
+    restype: object
+
+    def __call__(self, *args: object) -> int:
+        """Invoke the configured Win32 function."""
+        ...
+
+
+class _WindowsKernel32(Protocol):
+    """Win32 lock functions loaded only on Windows."""
+
+    LockFileEx: _WindowsFunction
+    UnlockFileEx: _WindowsFunction
+
+
+def _runtime_attribute(module: object, name: str) -> object:
+    """Read an OS-specific module attribute without platform-stub narrowing."""
+    try:
+        return vars(module)[name]
+    except KeyError as exc:
+        raise RuntimeError(f"platform runtime attribute is unavailable: {name}") from exc
 
 
 class _WindowsOverlapped(ctypes.Structure):
@@ -297,7 +323,18 @@ def _acquire_windows_lock(
     import msvcrt
     from ctypes import wintypes
 
-    win_dll: Any = ctypes.WinDLL  # pyright: ignore[reportAttributeAccessIssue]
+    win_dll = cast(
+        Callable[..., _WindowsKernel32],
+        _runtime_attribute(ctypes, "WinDLL"),
+    )
+    get_last_error = cast(
+        Callable[[], int],
+        _runtime_attribute(ctypes, "get_last_error"),
+    )
+    get_osfhandle = cast(
+        Callable[[int], int],
+        _runtime_attribute(msvcrt, "get_osfhandle"),
+    )
     kernel32 = win_dll("kernel32", use_last_error=True)
     lock_file_ex = kernel32.LockFileEx
     lock_file_ex.argtypes = [
@@ -309,12 +346,12 @@ def _acquire_windows_lock(
         ctypes.POINTER(_WindowsOverlapped),
     ]
     lock_file_ex.restype = wintypes.BOOL
-    handle = wintypes.HANDLE(msvcrt.get_osfhandle(fd))
+    handle = wintypes.HANDLE(get_osfhandle(fd))
     overlapped = _WindowsOverlapped()
     exclusive_flag = 0x00000002 if exclusive else 0
     if timeout_seconds is None:
         if not lock_file_ex(handle, exclusive_flag, 0, 1, 0, ctypes.byref(overlapped)):
-            error = ctypes.get_last_error()
+            error = get_last_error()
             raise ConfigurationError(f"cannot acquire worker lifetime lock: WinError {error}")
         return overlapped
 
@@ -323,7 +360,7 @@ def _acquire_windows_lock(
         flags = exclusive_flag | 0x00000001
         if lock_file_ex(handle, flags, 0, 1, 0, ctypes.byref(overlapped)):
             return overlapped
-        error = ctypes.get_last_error()
+        error = get_last_error()
         if error != 33:
             raise ConfigurationError(f"cannot acquire worker lifetime lock: WinError {error}")
         if time.monotonic() >= deadline:
@@ -337,13 +374,24 @@ def _release_windows_lock(fd: int, overlapped: _WindowsOverlapped | None) -> Non
     import msvcrt
     from ctypes import wintypes
 
-    win_dll: Any = ctypes.WinDLL  # pyright: ignore[reportAttributeAccessIssue]
+    win_dll = cast(
+        Callable[..., _WindowsKernel32],
+        _runtime_attribute(ctypes, "WinDLL"),
+    )
+    get_last_error = cast(
+        Callable[[], int],
+        _runtime_attribute(ctypes, "get_last_error"),
+    )
+    get_osfhandle = cast(
+        Callable[[int], int],
+        _runtime_attribute(msvcrt, "get_osfhandle"),
+    )
     kernel32 = win_dll("kernel32", use_last_error=True)
     unlock_file_ex = kernel32.UnlockFileEx
     unlock_file_ex.restype = wintypes.BOOL
-    handle = wintypes.HANDLE(msvcrt.get_osfhandle(fd))
+    handle = wintypes.HANDLE(get_osfhandle(fd))
     if not unlock_file_ex(handle, 0, 1, 0, ctypes.byref(overlapped)):
-        error = ctypes.get_last_error()
+        error = get_last_error()
         raise OSError(error, f"cannot release worker lifetime lock: WinError {error}")
 
 

--- a/tests/test_bootstrap_cluster_paths.py
+++ b/tests/test_bootstrap_cluster_paths.py
@@ -1,0 +1,735 @@
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from clio_relay import bootstrap, cli
+from clio_relay.bootstrap import (
+    DEFAULT_REMOTE_CORE_DIR,
+    DEFAULT_REMOTE_SPOOL_DIR,
+    BootstrapArchive,
+    render_linux_user_bootstrap_script,
+)
+from clio_relay.cluster_config import ClusterDefinition, ClusterRegistry
+from clio_relay.deployment import endpoint_user_service_name
+from clio_relay.errors import ConfigurationError
+
+
+def test_bootstrap_data_directory_defaults_remain_backward_compatible() -> None:
+    """Default bootstrap state remains in the established remote user directories."""
+    script = render_linux_user_bootstrap_script()
+
+    assert f'CLIO_RELAY_CORE_DIR="{DEFAULT_REMOTE_CORE_DIR}" ' in script
+    assert f'CLIO_RELAY_SPOOL_DIR="{DEFAULT_REMOTE_SPOOL_DIR}" ' in script
+
+
+def test_bootstrap_renders_custom_data_directories_without_shell_evaluation() -> None:
+    """Only the leading HOME token expands; configured suffixes remain literal data."""
+    core_dir = "$HOME/relay state/core$(touch /tmp/not-executed)"
+    spool_dir = "/srv/clio state/spool's"
+
+    script = render_linux_user_bootstrap_script(core_dir=core_dir, spool_dir=spool_dir)
+
+    assert 'CLIO_RELAY_CORE_DIR="$HOME/relay state/core\\$(touch /tmp/not-executed)" ' in script
+    assert f'CLIO_RELAY_SPOOL_DIR="{spool_dir}" ' in script
+    assert f'CLIO_RELAY_CORE_DIR="{DEFAULT_REMOTE_CORE_DIR}"' not in script
+    assert f'CLIO_RELAY_SPOOL_DIR="{DEFAULT_REMOTE_SPOOL_DIR}"' not in script
+
+
+def test_managed_bootstrap_fences_worker_around_migration() -> None:
+    """A configured worker is stopped before replacement and restarted after migration."""
+    cluster = "Operator Target"
+    service_name = endpoint_user_service_name(cluster)
+
+    script = render_linux_user_bootstrap_script(cluster=cluster)
+
+    stop = 'systemctl --user stop "$WORKER_SERVICE_NAME"'
+    writer_proof = 'if ! python3 - "$WORKER_CLUSTER_NAME"'
+    install = 'install -m 0755 "frp_${FRP_VERSION}_linux_amd64/frpc"'
+    relay_replace = "uv tool install --force --python 3.12 --no-config"
+    migrate = "clio-relay init --migrate-legacy-output"
+    restart = 'systemctl --user start "$WORKER_SERVICE_NAME"'
+    first_proof = script.index(writer_proof)
+    second_proof = script.index(writer_proof, first_proof + 1)
+    relay_replacement = script.rindex(relay_replace)
+    assert f"WORKER_SERVICE_NAME={service_name}" in script
+    assert script.index(stop) < first_proof < script.index(install)
+    assert script.index(install) < relay_replacement < second_proof
+    assert second_proof < script.index(migrate) < script.index(restart)
+    assert "WORKER_WRITER_PROOF=1" in script
+    assert 'exec 9>"$HOME/.local/share/clio-relay/bootstrap.lock"' in script
+    assert "if ! flock -n 9; then" in script
+    assert 'exec 8<>"$WORKER_LIFETIME_LOCK_PATH"' in script
+    assert "WORKER_LIFETIME_GUARD_FD=8" in script
+    assert 'exec 9<>"$WORKER_LIFETIME_LOCK_PATH"' not in script
+    assert "remains stopped" in script
+    assert "worker state is unknown and requires operator verification" in script
+
+
+def test_standalone_bootstrap_cannot_mutate_legacy_output() -> None:
+    """Without a managed cluster identity bootstrap uses the fail-closed ordinary init path."""
+    script = render_linux_user_bootstrap_script()
+
+    assert "WORKER_SERVICE_NAME=''" in script
+    assert "systemctl --user stop" not in script
+    assert "clio-relay init --migrate-legacy-output" not in script
+    assert "clio-relay init" in script
+
+
+def _fake_proc_process(
+    proc_root: Path,
+    *,
+    pid: int,
+    argv: list[str],
+    environment: dict[str, str],
+    state: str = "S",
+    start_ticks: int = 42,
+) -> None:
+    """Create bounded proc-like argv and environment fixtures for the embedded proof."""
+    process = proc_root / str(pid)
+    process.mkdir(parents=True)
+    process.joinpath("cmdline").write_bytes(
+        b"\0".join(os.fsencode(argument) for argument in argv) + b"\0"
+    )
+    process.joinpath("environ").write_bytes(
+        b"\0".join(os.fsencode(f"{name}={value}") for name, value in environment.items()) + b"\0"
+    )
+    process.joinpath("stat").write_text(
+        f"{pid} (python worker) {state} " + " ".join(["0"] * 18 + [str(start_ticks)]) + "\n",
+        encoding="ascii",
+    )
+    boot_id = proc_root / "sys" / "kernel" / "random" / "boot_id"
+    boot_id.parent.mkdir(parents=True, exist_ok=True)
+    boot_id.write_text("test-boot\n", encoding="ascii")
+
+
+def _write_worker_endpoint_record(
+    core_dir: Path,
+    *,
+    endpoint_id: str,
+    pid: int,
+    cluster: str,
+    process_identity: dict[str, object] | None = None,
+) -> None:
+    """Write one cross-version endpoint record used by the live-PID proof."""
+    endpoint_dir = core_dir / "endpoints"
+    endpoint_dir.mkdir(parents=True, exist_ok=True)
+    metadata: dict[str, object] = {}
+    if process_identity is not None:
+        metadata["process_identity"] = process_identity
+    document = {
+        "endpoint_id": endpoint_id,
+        "role": "worker",
+        "cluster": cluster,
+        "hostname": socket.gethostname(),
+        "pid": pid,
+        "registered_at": "2000-01-01T00:00:00Z",
+        "last_seen_at": "2000-01-01T00:00:00Z",
+        "metadata": metadata,
+    }
+    (endpoint_dir / f"{endpoint_id}.json").write_text(
+        json.dumps(document),
+        encoding="utf-8",
+    )
+
+
+def _fixture_uid() -> int:
+    """Return a deterministic uid for cross-platform process identity fixtures."""
+    getuid = getattr(os, "getuid", None)
+    if not callable(getuid):
+        return 0
+    uid = getuid()
+    return uid if isinstance(uid, int) else 0
+
+
+def _run_writer_proof(
+    proc_root: Path, *, cluster: str, core_dir: Path
+) -> subprocess.CompletedProcess[str]:
+    """Execute the exact Python source embedded in managed bootstrap scripts."""
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            vars(bootstrap)["_WORKER_WRITER_PROOF_PYTHON"],
+            cluster,
+            str(core_dir),
+            str(proc_root),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_embedded_writer_proof_rejects_exact_live_worker(
+    tmp_path: Path,
+) -> None:
+    """Exact console argv and environment ownership stop migration."""
+    proc_root = tmp_path / "proc"
+    core_dir = tmp_path / "core"
+    _fake_proc_process(
+        proc_root,
+        pid=1729,
+        argv=[
+            "/usr/bin/python3",
+            "/home/operator/.local/bin/clio-relay",
+            "endpoint",
+            "start",
+            "--role",
+            "worker",
+            "--cluster",
+            "custom",
+        ],
+        environment={
+            "HOME": str(tmp_path),
+            "CLIO_RELAY_CORE_DIR": str(tmp_path / "unused" / ".." / "core"),
+        },
+    )
+
+    result = _run_writer_proof(proc_root, cluster="custom", core_dir=core_dir)
+
+    assert result.returncode != 0
+    assert "live endpoint pid=1729" in result.stderr
+    assert "cluster='custom'" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("argv", "writer_kind"),
+    [
+        (
+            [
+                "/home/operator/.local/bin/clio-relay",
+                "api",
+                "start",
+                "--host",
+                "127.0.0.1",
+            ],
+            "api",
+        ),
+        (
+            [
+                "/home/operator/.local/bin/clio-relay",
+                "mcp-server",
+                "--profile",
+                "user",
+            ],
+            "mcp-server",
+        ),
+    ],
+)
+def test_embedded_writer_proof_rejects_every_same_core_long_lived_writer(
+    tmp_path: Path,
+    argv: list[str],
+    writer_kind: str,
+) -> None:
+    """Retained cluster API and MCP processes cannot outlive an index migration."""
+    proc_root = tmp_path / "proc"
+    core_dir = tmp_path / "core"
+    _fake_proc_process(
+        proc_root,
+        pid=1738,
+        argv=argv,
+        environment={"HOME": str(tmp_path), "CLIO_RELAY_CORE_DIR": str(core_dir)},
+    )
+
+    result = _run_writer_proof(proc_root, cluster="custom", core_dir=core_dir)
+
+    assert result.returncode != 0
+    assert f"live {writer_kind} writer pid=1738" in result.stderr
+    assert "stop or detach it before bootstrap" in result.stderr
+
+
+def test_embedded_writer_proof_allows_long_lived_writer_on_different_core(
+    tmp_path: Path,
+) -> None:
+    """Long-lived relay processes remain isolated by physical core identity."""
+    proc_root = tmp_path / "proc"
+    _fake_proc_process(
+        proc_root,
+        pid=1739,
+        argv=["/home/operator/.local/bin/clio-relay", "api", "start"],
+        environment={
+            "HOME": str(tmp_path),
+            "CLIO_RELAY_CORE_DIR": str(tmp_path / "different-core"),
+        },
+    )
+
+    result = _run_writer_proof(
+        proc_root,
+        cluster="custom",
+        core_dir=tmp_path / "expected-core",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_embedded_writer_proof_rejects_in_flight_same_core_cli_writer(
+    tmp_path: Path,
+) -> None:
+    """A short-lived pre-upgrade CLI process cannot outlive final reconciliation."""
+    proc_root = tmp_path / "proc"
+    core_dir = tmp_path / "core"
+    _fake_proc_process(
+        proc_root,
+        pid=1744,
+        argv=[
+            "/usr/bin/python3",
+            "/home/operator/.local/bin/clio-relay",
+            "job",
+            "submit",
+            "--cluster",
+            "custom",
+        ],
+        environment={"HOME": str(tmp_path), "CLIO_RELAY_CORE_DIR": str(core_dir)},
+    )
+
+    result = _run_writer_proof(proc_root, cluster="custom", core_dir=core_dir)
+
+    assert result.returncode != 0
+    assert "live clio-relay process pid=1744" in result.stderr
+    assert "wait for it to exit before bootstrap" in result.stderr
+
+
+def test_embedded_writer_proof_does_not_claim_python_module_argv(tmp_path: Path) -> None:
+    """A generic Python module shape is not treated as a proven console invocation."""
+    proc_root = tmp_path / "proc"
+    _fake_proc_process(
+        proc_root,
+        pid=1728,
+        argv=[
+            "/usr/bin/python3",
+            "-m",
+            "clio_relay.cli",
+            "endpoint",
+            "start",
+            "--role=worker",
+            "--cluster=custom",
+        ],
+        environment={"HOME": str(tmp_path), "CLIO_RELAY_CORE_DIR": str(tmp_path / "core")},
+    )
+
+    result = _run_writer_proof(
+        proc_root,
+        cluster="custom",
+        core_dir=tmp_path / "core",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_embedded_writer_proof_uses_legacy_endpoint_pid_for_python_wrapper(
+    tmp_path: Path,
+) -> None:
+    """An exact-core legacy record blocks a live wrapper without recognizable argv."""
+    proc_root = tmp_path / "proc"
+    core_dir = tmp_path / "core"
+    _fake_proc_process(
+        proc_root,
+        pid=1740,
+        argv=["/usr/bin/python3", "-c", "run_worker()"],
+        environment={"HOME": str(tmp_path)},
+    )
+    _write_worker_endpoint_record(
+        core_dir,
+        endpoint_id="legacy_wrapper",
+        pid=1740,
+        cluster="other",
+    )
+
+    result = _run_writer_proof(proc_root, cluster="custom", core_dir=core_dir)
+
+    assert result.returncode != 0
+    assert "live endpoint pid=1740 has exact-core record" in result.stderr
+
+
+def test_embedded_writer_proof_only_dismisses_well_formed_stale_identity(
+    tmp_path: Path,
+) -> None:
+    """Exact generation mismatch permits PID reuse; malformed identity remains conservative."""
+    proc_root = tmp_path / "proc"
+    stale_core = tmp_path / "stale-core"
+    malformed_core = tmp_path / "malformed-core"
+    _fake_proc_process(
+        proc_root,
+        pid=1741,
+        argv=["/usr/bin/python3", "-c", "unrelated()"],
+        environment={"HOME": str(tmp_path)},
+        start_ticks=99,
+    )
+    _write_worker_endpoint_record(
+        stale_core,
+        endpoint_id="stale_generation",
+        pid=1741,
+        cluster="old",
+        process_identity={
+            "schema_version": "clio-relay.process-identity.v1",
+            "boot_id": "test-boot",
+            "start_ticks": 98,
+            "uid": _fixture_uid(),
+            "pid": 1741,
+        },
+    )
+    _write_worker_endpoint_record(
+        malformed_core,
+        endpoint_id="malformed_generation",
+        pid=1741,
+        cluster="old",
+        process_identity={"schema_version": "clio-relay.process-identity.v1"},
+    )
+
+    stale = _run_writer_proof(proc_root, cluster="custom", core_dir=stale_core)
+    malformed = _run_writer_proof(proc_root, cluster="custom", core_dir=malformed_core)
+
+    assert stale.returncode == 0, stale.stderr
+    assert malformed.returncode != 0
+    assert "live endpoint pid=1741" in malformed.stderr
+
+
+def test_embedded_writer_proof_retains_duplicate_pid_evidence(tmp_path: Path) -> None:
+    """A stale exact record cannot overwrite conservative legacy evidence for one PID."""
+    proc_root = tmp_path / "proc"
+    core_dir = tmp_path / "core"
+    _fake_proc_process(
+        proc_root,
+        pid=1742,
+        argv=[],
+        environment={"HOME": str(tmp_path)},
+        start_ticks=200,
+    )
+    _write_worker_endpoint_record(
+        core_dir,
+        endpoint_id="a_legacy",
+        pid=1742,
+        cluster="legacy",
+    )
+    _write_worker_endpoint_record(
+        core_dir,
+        endpoint_id="z_stale",
+        pid=1742,
+        cluster="stale",
+        process_identity={
+            "schema_version": "clio-relay.process-identity.v1",
+            "boot_id": "test-boot",
+            "start_ticks": 199,
+            "uid": _fixture_uid(),
+            "pid": 1742,
+        },
+    )
+
+    result = _run_writer_proof(proc_root, cluster="custom", core_dir=core_dir)
+
+    assert result.returncode != 0
+    assert "cluster='legacy'" in result.stderr
+
+
+def test_embedded_writer_proof_matches_empty_home_semantics(tmp_path: Path) -> None:
+    """An explicitly empty HOME maps a tilde core to root like RelaySettings."""
+    proc_root = tmp_path / "proc"
+    _fake_proc_process(
+        proc_root,
+        pid=1743,
+        argv=[
+            "/home/operator/.local/bin/clio-relay",
+            "endpoint",
+            "start",
+            "--role=worker",
+            "--cluster=custom",
+        ],
+        environment={"HOME": "", "CLIO_RELAY_CORE_DIR": "~/core"},
+    )
+
+    result = _run_writer_proof(proc_root, cluster="custom", core_dir=Path("/core"))
+
+    assert result.returncode != 0
+    assert "live endpoint pid=1743" in result.stderr
+
+
+def test_embedded_writer_proof_uses_exact_environment_fields(tmp_path: Path) -> None:
+    """Substrings and unrelated environment fields cannot manufacture a core collision."""
+    proc_root = tmp_path / "proc"
+    expected_core = tmp_path / "expected-core"
+    different_core = tmp_path / "different-core"
+    _fake_proc_process(
+        proc_root,
+        pid=1730,
+        argv=[
+            "/home/operator/.local/bin/clio-relay",
+            "endpoint",
+            "start",
+            "--role",
+            "worker",
+            "--cluster",
+            "custom-suffix",
+            "--label=clio-relay endpoint start --cluster custom",
+        ],
+        environment={
+            "HOME": str(tmp_path),
+            "CLIO_RELAY_CORE_DIR": str(different_core),
+            "UNRELATED": f"CLIO_RELAY_CORE_DIR={expected_core}",
+        },
+    )
+    _fake_proc_process(
+        proc_root,
+        pid=1732,
+        argv=[
+            "/home/operator/.local/bin/clio-relay",
+            "endpoint",
+            "start",
+            "--role=worker",
+            "--cluster=custom",
+        ],
+        environment={
+            "HOME": str(tmp_path),
+            "CLIO_RELAY_CORE_DIR": str(different_core),
+            "UNRELATED": f"CLIO_RELAY_CORE_DIR={expected_core}",
+        },
+    )
+
+    result = _run_writer_proof(proc_root, cluster="custom", core_dir=expected_core)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "relay_worker_writer_proof=clear"
+
+
+def test_embedded_writer_proof_rejects_other_cluster_worker_on_same_core(
+    tmp_path: Path,
+) -> None:
+    """Core ownership, not a cluster label, fences the core-wide migration."""
+    proc_root = tmp_path / "proc"
+    core_dir = tmp_path / "shared-core"
+    _fake_proc_process(
+        proc_root,
+        pid=1733,
+        argv=[
+            "/home/operator/.local/bin/clio-relay",
+            "endpoint",
+            "start",
+            "--role=worker",
+            "--cluster=other-cluster",
+        ],
+        environment={
+            "HOME": str(tmp_path),
+            "CLIO_RELAY_CORE_DIR": str(core_dir),
+        },
+    )
+
+    result = _run_writer_proof(proc_root, cluster="custom", core_dir=core_dir)
+
+    assert result.returncode != 0
+    assert "cluster='other-cluster'" in result.stderr
+    assert "bootstrapping cluster='custom'" in result.stderr
+
+
+def test_embedded_writer_proof_allows_other_cluster_worker_on_different_core(
+    tmp_path: Path,
+) -> None:
+    """A different cluster remains harmless when it owns a different core queue."""
+    proc_root = tmp_path / "proc"
+    _fake_proc_process(
+        proc_root,
+        pid=1734,
+        argv=[
+            "/home/operator/.local/bin/clio-relay",
+            "endpoint",
+            "start",
+            "--role",
+            "worker",
+            "--cluster",
+            "other-cluster",
+        ],
+        environment={
+            "HOME": str(tmp_path),
+            "CLIO_RELAY_CORE_DIR": str(tmp_path / "different-core"),
+        },
+    )
+
+    result = _run_writer_proof(
+        proc_root,
+        cluster="custom",
+        core_dir=tmp_path / "expected-core",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "relay_worker_writer_proof=clear"
+
+
+def test_embedded_writer_proof_fails_closed_on_oversized_proc_value(tmp_path: Path) -> None:
+    """The proof never accepts an argv value beyond its explicit read bound."""
+    proc_root = tmp_path / "proc"
+    process = proc_root / "1731"
+    process.mkdir(parents=True)
+    process.joinpath("cmdline").write_bytes(b"x" * (1_048_576 + 1))
+    process.joinpath("environ").write_bytes(b"")
+
+    result = _run_writer_proof(proc_root, cluster="custom", core_dir=tmp_path / "core")
+
+    assert result.returncode != 0
+    assert "exceeds the bounded inspection size" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("core_dir", "relative/core"),
+        ("spool_dir", "$USER/relay-spool"),
+        ("core_dir", "$HOME/relay\ncore"),
+    ],
+)
+def test_bootstrap_rejects_ambiguous_remote_data_directories(field: str, value: str) -> None:
+    """Bootstrap refuses paths whose expansion or shell boundaries are ambiguous."""
+    arguments = {
+        "core_dir": DEFAULT_REMOTE_CORE_DIR,
+        "spool_dir": DEFAULT_REMOTE_SPOOL_DIR,
+    }
+    arguments[field] = value
+
+    with pytest.raises(ConfigurationError, match=field):
+        render_linux_user_bootstrap_script(
+            core_dir=arguments["core_dir"],
+            spool_dir=arguments["spool_dir"],
+        )
+
+
+def test_bootstrap_over_ssh_forwards_configured_data_directories(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The SSH bootstrap carries both configured directories into script rendering."""
+    captured: dict[str, object] = {}
+
+    def fake_create_bootstrap_archive(
+        *,
+        source_root: Path,
+        archive: Path,
+        relay_wheel: Path | None,
+    ) -> BootstrapArchive:
+        assert source_root == tmp_path
+        assert relay_wheel is None
+        archive.write_bytes(b"archive")
+        return BootstrapArchive(archive=archive, install_spec="clio-relay==1.0.0")
+
+    def fake_render_linux_user_bootstrap_script(**kwargs: object) -> str:
+        captured.update(kwargs)
+        return "set -euo pipefail\n"
+
+    receipt = {
+        "schema_version": "clio-relay.bootstrap-receipt.v1",
+        "invocation_id": "bootstrap_paths",
+        "bootstrap_profile": "linux-user",
+        "relay_install_spec": "clio-relay==1.0.0",
+        "install_receipt_sha256": "a" * 64,
+        "worker_fence": {
+            "managed": True,
+            "service_name": endpoint_user_service_name("custom"),
+            "was_active": True,
+            "writer_proof": True,
+            "writer_recheck": True,
+            "lifetime_exclusive": True,
+            "restarted": True,
+        },
+        "completed_at": "2026-07-14T00:00:00Z",
+    }
+
+    def fake_run(command: list[str]) -> subprocess.CompletedProcess[str]:
+        stdout = (
+            json.dumps(receipt)
+            if command[-2:] == ["cat", "$HOME/.local/share/clio-relay/bootstrap-receipt.json"]
+            else ""
+        )
+        return subprocess.CompletedProcess(command, 0, stdout, "")
+
+    monkeypatch.setattr(bootstrap, "create_bootstrap_archive", fake_create_bootstrap_archive)
+    monkeypatch.setattr(
+        bootstrap,
+        "render_linux_user_bootstrap_script",
+        fake_render_linux_user_bootstrap_script,
+    )
+    monkeypatch.setattr(bootstrap, "_run", fake_run)
+    monkeypatch.setattr(bootstrap, "uuid4", lambda: SimpleNamespace(hex="paths"))
+
+    def fake_which(executable: str) -> str:
+        return executable
+
+    monkeypatch.setattr(bootstrap.shutil, "which", fake_which)
+
+    bootstrap.bootstrap_cluster_over_ssh(
+        bootstrap_profile="linux-user",
+        ssh_host="cluster.example.test",
+        source_root=tmp_path,
+        cluster="custom",
+        core_dir="$HOME/custom/core",
+        spool_dir="/srv/custom/spool",
+    )
+
+    assert captured["cluster"] == "custom"
+    assert captured["core_dir"] == "$HOME/custom/core"
+    assert captured["spool_dir"] == "/srv/custom/spool"
+
+
+def test_cluster_bootstrap_cli_uses_configured_data_directories(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cluster command propagates its registry's queue and spool locations."""
+    monkeypatch.chdir(tmp_path)
+    ClusterRegistry(
+        clusters={
+            "custom": ClusterDefinition(
+                name="custom",
+                ssh_host="cluster.example.test",
+                core_dir="$HOME/operator core",
+                spool_dir="/srv/operator spool",
+            )
+        }
+    ).save(tmp_path / ".clio-relay" / "clusters.json")
+    wheel = tmp_path / "clio_relay-1.0.0-py3-none-any.whl"
+    wheel.write_bytes(b"wheel")
+    captured: dict[str, object] = {}
+
+    def fake_bootstrap_cluster_over_ssh(**kwargs: object) -> list[str]:
+        captured.update(kwargs)
+        receipt = {
+            "schema_version": "clio-relay.bootstrap-receipt.v1",
+            "invocation_id": "bootstrap_custom_paths",
+            "bootstrap_profile": "linux-user",
+            "relay_install_spec": "clio-relay==1.0.0",
+            "install_receipt_sha256": "b" * 64,
+            "completed_at": "2026-07-14T00:00:00Z",
+        }
+        return [
+            "bootstrap_receipt=/home/test/.local/share/clio-relay/bootstrap-receipt.json",
+            "bootstrap_receipt_json=" + json.dumps(receipt, sort_keys=True),
+        ]
+
+    def fake_remote_target_identity(_definition: ClusterDefinition) -> dict[str, Any]:
+        return {"verified": True}
+
+    monkeypatch.setattr(cli, "package_source_root", lambda: tmp_path / "package")
+    monkeypatch.setattr(cli, "bootstrap_cluster_over_ssh", fake_bootstrap_cluster_over_ssh)
+    monkeypatch.setattr(cli, "_remote_target_identity", fake_remote_target_identity)
+
+    result = CliRunner().invoke(
+        cli.app,
+        [
+            "cluster",
+            "bootstrap",
+            "--cluster",
+            "custom",
+            "--relay-wheel",
+            str(wheel),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["cluster"] == "custom"
+    assert captured["core_dir"] == "$HOME/operator core"
+    assert captured["spool_dir"] == "/srv/operator spool"

--- a/tests/test_bootstrap_cluster_paths.py
+++ b/tests/test_bootstrap_cluster_paths.py
@@ -5,7 +5,7 @@ import os
 import socket
 import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from types import SimpleNamespace
 from typing import Any
 
@@ -152,7 +152,10 @@ def _fixture_uid() -> int:
 
 
 def _run_writer_proof(
-    proc_root: Path, *, cluster: str, core_dir: Path
+    proc_root: Path,
+    *,
+    cluster: str,
+    core_dir: Path | PurePosixPath,
 ) -> subprocess.CompletedProcess[str]:
     """Execute the exact Python source embedded in managed bootstrap scripts."""
     return subprocess.run(
@@ -447,7 +450,11 @@ def test_embedded_writer_proof_matches_empty_home_semantics(tmp_path: Path) -> N
         environment={"HOME": "", "CLIO_RELAY_CORE_DIR": "~/core"},
     )
 
-    result = _run_writer_proof(proc_root, cluster="custom", core_dir=Path("/core"))
+    result = _run_writer_proof(
+        proc_root,
+        cluster="custom",
+        core_dir=PurePosixPath("/core"),
+    )
 
     assert result.returncode != 0
     assert "live endpoint pid=1743" in result.stderr

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1330,7 +1330,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "5d44747f9632e818b3c52acde9e832ad46bb941d8aedfa20e590e872a23600e4"
+        "1fac1e2ecec5f84528285d3a512876c2fe481d9ff7e65a6d166dc588fc810975"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4392,6 +4392,31 @@ def test_cli_init_creates_empty_cluster_registry(
     assert registry.clusters == {}
 
 
+def test_cli_init_threads_explicit_legacy_output_migration_authorization(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(tmp_path / "core"))
+    monkeypatch.setenv("CLIO_RELAY_SPOOL_DIR", str(tmp_path / "spool"))
+    observed: list[bool] = []
+
+    def capture_authorization(
+        _settings: object,
+        *,
+        migrate_legacy_output: bool = False,
+    ) -> object:
+        observed.append(migrate_legacy_output)
+        return object()
+
+    monkeypatch.setattr(cli, "storage_managed_queue", capture_authorization)
+
+    result = CliRunner().invoke(app, ["init", "--migrate-legacy-output"])
+
+    assert result.exit_code == 0
+    assert observed == [True]
+
+
 def test_cli_cluster_add_writes_explicit_definition(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -268,6 +268,9 @@ def test_endpoint_worker_with_explicit_provider_does_not_require_remote_registry
         def run_once(self) -> None:
             captured["ran_once"] = True
 
+        def close(self) -> None:
+            captured["closed"] = True
+
     def make_worker(**kwargs: object) -> FakeWorker:
         captured.update(kwargs)
         return FakeWorker()
@@ -298,6 +301,7 @@ def test_endpoint_worker_with_explicit_provider_does_not_require_remote_registry
     assert captured["cluster"] == "homelab"
     assert captured["registered"] is True
     assert captured["ran_once"] is True
+    assert captured["closed"] is True
     provider = cast(SchedulerProvider, captured["scheduler_provider"])
     assert provider.name == "external"
 
@@ -318,6 +322,9 @@ def test_endpoint_worker_without_explicit_provider_uses_cluster_registry(
 
         def run_once(self) -> None:
             captured["ran_once"] = True
+
+        def close(self) -> None:
+            captured["closed"] = True
 
     def make_worker(**kwargs: object) -> FakeWorker:
         captured.update(kwargs)
@@ -345,6 +352,7 @@ def test_endpoint_worker_without_explicit_provider_uses_cluster_registry(
 
     assert result.exit_code == 0
     assert captured["registry_cluster"] == "configured-cluster"
+    assert captured["closed"] is True
     provider = cast(SchedulerProvider, captured["scheduler_provider"])
     assert provider.name == "slurm"
 

--- a/tests/test_command_evidence.py
+++ b/tests/test_command_evidence.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from clio_relay.command_evidence import (
     ERROR_DETAIL_MAX_BYTES,
     EVIDENCE_EXCERPT_MAX_BYTES,
+    bounded_error_detail,
     command_evidence,
 )
 
@@ -78,3 +79,13 @@ def test_large_output_without_marker_keeps_start_and_tail() -> None:
     assert evidence.excerpt.startswith("initial command context")
     assert evidence.excerpt.endswith("final failure status")
     assert evidence.metadata["diagnostic_marker"] is None
+
+
+def test_bounded_error_detail_handles_oversized_and_invalid_unicode() -> None:
+    """Provider diagnostics are UTF-8 safe and fit durable record limits."""
+    detail = bounded_error_detail("first cause\ud800" + ("x" * 300_000) + "final status")
+
+    assert detail is not None
+    assert detail.startswith("first cause?")
+    assert detail.endswith("final status")
+    assert len(detail.encode("utf-8")) <= ERROR_DETAIL_MAX_BYTES

--- a/tests/test_doctor_and_relay_host.py
+++ b/tests/test_doctor_and_relay_host.py
@@ -242,7 +242,7 @@ def test_endpoint_user_service_escapes_arbitrary_labels_and_values() -> None:
         definition=ClusterDefinition(
             name="Target GPU",
             ssh_host="target-gpu",
-            agent_bin='/opt/agent "current"\nEnvironment=FORGED=1',
+            agent_bin='/opt/agent "current" %n',
         ),
     )
 
@@ -250,7 +250,7 @@ def test_endpoint_user_service_escapes_arbitrary_labels_and_values() -> None:
     assert rendered.count("\nEnvironment=") == 9
     assert "\\nExecStart=/bin/false" in rendered
     assert "%%n" in rendered
-    assert "\\nEnvironment=FORGED=1" in rendered
+    assert 'CLIO_RELAY_AGENT_BIN=/opt/agent \\"current\\" %%n' in rendered
 
 
 def test_endpoint_service_install_uses_safe_unit_name_and_bounded_ssh(

--- a/tests/test_legacy_output_migration.py
+++ b/tests/test_legacy_output_migration.py
@@ -1,0 +1,621 @@
+"""Production upgrade coverage for v0.9 duplicated output events."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+import clio_relay.core_queue as core_queue_module
+from clio_relay.core_queue import ClioCoreQueue, LegacyQueueStateError
+from clio_relay.errors import QueueConflictError
+from clio_relay.models import JobKind, JobState, JobTombstone, RelayEvent, utc_now
+
+
+def _event_path(root: Path, job_id: str, seq: int) -> Path:
+    path = root / "events" / job_id / f"{seq:020d}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _write_event(root: Path, event: RelayEvent) -> bytes:
+    payload = event.model_dump_json(indent=2).encode("utf-8")
+    _event_path(root, event.job_id, event.seq).write_bytes(payload)
+    return payload
+
+
+def _write_v09_output_event(
+    root: Path,
+    *,
+    job_id: str = "job_legacy_output",
+    seq: int = 1,
+    text: str,
+    stream: Literal["stdout", "stderr"] = "stdout",
+) -> bytes:
+    event = RelayEvent(
+        job_id=job_id,
+        seq=seq,
+        event_type=f"{stream}.delta",
+        message=text.rstrip("\n") or f"{stream} output",
+        payload={"stream": stream, "text": text},
+    )
+    return _write_event(root, event)
+
+
+def _archive_path(root: Path, job_id: str, seq: int) -> Path:
+    return root / "legacy_output_archives" / job_id / f"{seq:020d}.json"
+
+
+def _receipt_path(root: Path, job_id: str, seq: int) -> Path:
+    return root / "legacy_output_receipts" / job_id / f"{seq:020d}.json"
+
+
+def _marker_path(root: Path) -> Path:
+    return root / "migrations" / "legacy-output-v1.json"
+
+
+def _no_migration_fault(_phase: str, _path: Path) -> None:
+    return
+
+
+def test_legacy_output_migration_requires_explicit_authorization(tmp_path: Path) -> None:
+    """Ordinary startup cannot mutate valid v0.9 output without an explicit operator gate."""
+    root = tmp_path / "core"
+    original = _write_v09_output_event(root, text=("authorization\n" * 40_000))
+
+    with pytest.raises(LegacyQueueStateError) as raised:
+        ClioCoreQueue(root).initialize()
+
+    assert "clio-relay init --migrate-legacy-output" in raised.value.report["action"]
+    assert _event_path(root, "job_legacy_output", 1).read_bytes() == original
+    assert not (root / "legacy_output_archives").exists()
+    assert not (root / "legacy_output_receipts").exists()
+    assert not _marker_path(root).exists()
+
+    ClioCoreQueue(root).initialize(migrate_legacy_output=True)
+    assert _marker_path(root).is_file()
+
+
+def test_multimegabyte_v09_output_is_archived_and_sequence_is_preserved(
+    tmp_path: Path,
+) -> None:
+    """A multi-MiB callback becomes one bounded same-sequence archive reference."""
+    root = tmp_path / "core"
+    job_id = "job_multimegabyte"
+    first = RelayEvent(job_id=job_id, seq=1, event_type="job.started", message="started")
+    last = RelayEvent(job_id=job_id, seq=3, event_type="job.succeeded", message="done")
+    first_bytes = _write_event(root, first)
+    original = _write_v09_output_event(
+        root,
+        job_id=job_id,
+        seq=2,
+        text=("large-output-line\n" * 140_000),
+    )
+    last_bytes = _write_event(root, last)
+    assert len(original) > 2 * 1_048_576
+
+    ClioCoreQueue(root).initialize(migrate_legacy_output=True)
+
+    event_directory = root / "events" / job_id
+    assert [path.name for path in sorted(event_directory.glob("*.json"))] == [
+        "00000000000000000001.json",
+        "00000000000000000002.json",
+        "00000000000000000003.json",
+    ]
+    assert (event_directory / "00000000000000000001.json").read_bytes() == first_bytes
+    assert (event_directory / "00000000000000000003.json").read_bytes() == last_bytes
+    replacement_path = event_directory / "00000000000000000002.json"
+    replacement_bytes = replacement_path.read_bytes()
+    replacement = RelayEvent.model_validate_json(replacement_bytes)
+    assert replacement.seq == 2
+    assert replacement.event_type == "stdout.delta"
+    assert len(replacement_bytes) <= core_queue_module.RECORD_FAMILY_MAX_BYTES["events"]
+    compatibility = replacement.payload["legacy_output"]
+    assert compatibility["representation"] == "archive"
+    archive = _archive_path(root, job_id, 2)
+    assert archive.read_bytes() == original
+    receipt = json.loads(_receipt_path(root, job_id, 2).read_bytes())
+    assert receipt["archive_sha256"] == hashlib.sha256(original).hexdigest()
+    assert receipt["archive_size_bytes"] == len(original)
+    assert receipt["replacement_sha256"] == hashlib.sha256(replacement_bytes).hexdigest()
+    assert receipt["replacement_size_bytes"] == len(replacement_bytes)
+    marker = json.loads(_marker_path(root).read_bytes())
+    assert marker["complete"] is True
+    assert marker["event_records"] == 3
+    assert marker["migration_records"] == 1
+    assert marker["archive_bytes"] == len(original)
+
+
+def test_migration_preserves_payload_text_that_fits_the_normal_event_cap(
+    tmp_path: Path,
+) -> None:
+    """A moderately oversized duplicate preserves the historical payload contract."""
+    root = tmp_path / "core"
+    text = ("visible-output" * 12_000) + "\n"
+    original = _write_v09_output_event(root, text=text)
+    assert len(original) > core_queue_module.RECORD_FAMILY_MAX_BYTES["events"]
+
+    ClioCoreQueue(root).initialize(migrate_legacy_output=True)
+
+    replacement = RelayEvent.model_validate_json(
+        _event_path(root, "job_legacy_output", 1).read_bytes()
+    )
+    assert replacement.message.startswith("Legacy stdout output preserved in payload.text")
+    assert replacement.payload["legacy_output"]["representation"] == "payload_text"
+    assert replacement.payload["text"] == text
+    assert _archive_path(root, "job_legacy_output", 1).read_bytes() == original
+
+
+def test_newline_only_v09_output_uses_the_exact_fallback_message(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The v0.9 fallback message remains eligible when output is only newlines."""
+    root = tmp_path / "core"
+    monkeypatch.setitem(core_queue_module.RECORD_FAMILY_MAX_BYTES, "events", 2_048)
+    original = _write_v09_output_event(root, text="\n" * 2_000)
+    assert len(original) > core_queue_module.RECORD_FAMILY_MAX_BYTES["events"]
+
+    ClioCoreQueue(root).initialize(migrate_legacy_output=True)
+
+    replacement = RelayEvent.model_validate_json(
+        _event_path(root, "job_legacy_output", 1).read_bytes()
+    )
+    assert replacement.message.startswith("Legacy stdout output archived")
+    assert replacement.payload["legacy_output"]["representation"] == "archive"
+    assert _archive_path(root, "job_legacy_output", 1).read_bytes() == original
+
+
+@pytest.mark.parametrize("phase", ["archive", "replacement", "receipt", "marker"])
+def test_migration_recovers_idempotently_from_each_durable_phase_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    phase: str,
+) -> None:
+    """Every durable migration phase is restartable without rewriting evidence."""
+    root = tmp_path / phase
+    job_id = f"job_crash_{phase}"
+    original = _write_v09_output_event(
+        root,
+        job_id=job_id,
+        text=("crash-recovery\n" * 120_000),
+    )
+    failed = False
+
+    def crash_after(selected_phase: str, _path: Path) -> None:
+        nonlocal failed
+        if selected_phase == phase and not failed:
+            failed = True
+            raise RuntimeError(f"simulated {phase} crash")
+
+    monkeypatch.setattr(
+        ClioCoreQueue,
+        "_after_legacy_output_migration_phase",
+        staticmethod(crash_after),
+    )
+    with pytest.raises(RuntimeError, match=f"simulated {phase} crash"):
+        ClioCoreQueue(root).initialize(migrate_legacy_output=True)
+
+    archive = _archive_path(root, job_id, 1)
+    event = _event_path(root, job_id, 1)
+    assert archive.read_bytes() == original
+    assert _receipt_path(root, job_id, 1).exists() is (phase in {"receipt", "marker"})
+    assert _marker_path(root).exists() is (phase == "marker")
+    if phase == "archive":
+        assert event.read_bytes() == original
+    else:
+        assert event.read_bytes() != original
+
+    monkeypatch.setattr(
+        ClioCoreQueue,
+        "_after_legacy_output_migration_phase",
+        staticmethod(_no_migration_fault),
+    )
+    ClioCoreQueue(root).initialize(migrate_legacy_output=True)
+    completed_event = event.read_bytes()
+    completed_archive = archive.read_bytes()
+    completed_receipt = _receipt_path(root, job_id, 1).read_bytes()
+    completed_marker = _marker_path(root).read_bytes()
+
+    ClioCoreQueue(root).initialize()
+
+    assert event.read_bytes() == completed_event
+    assert archive.read_bytes() == completed_archive == original
+    assert _receipt_path(root, job_id, 1).read_bytes() == completed_receipt
+    assert _marker_path(root).read_bytes() == completed_marker
+
+
+def test_complete_marker_skips_later_deep_event_history_scans(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The durable completion marker makes subsequent startup constant in history size."""
+    root = tmp_path / "core"
+    _write_v09_output_event(root, text=("marker\n" * 80_000))
+    ClioCoreQueue(root).initialize(migrate_legacy_output=True)
+    original_iterator = ClioCoreQueue._iter_legacy_event_paths  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+
+    def refuse_history_scan(
+        _self: ClioCoreQueue,
+        _family: str,
+        *,
+        max_directories: int,
+        max_records: int,
+    ) -> object:
+        if _family == "events":
+            raise AssertionError("completed migration must not scan event history")
+        return original_iterator(
+            _self,
+            _family,
+            max_directories=max_directories,
+            max_records=max_records,
+        )
+
+    monkeypatch.setattr(ClioCoreQueue, "_iter_legacy_event_paths", refuse_history_scan)
+    ClioCoreQueue(root).initialize()
+
+
+@pytest.mark.parametrize(
+    "family",
+    ["legacy_output_archives", "legacy_output_receipts", "legacy_output_retired"],
+)
+def test_complete_marker_requires_every_owned_evidence_root(
+    tmp_path: Path,
+    family: str,
+) -> None:
+    """A completion marker cannot silently recreate a deleted evidence family."""
+    root = tmp_path / family
+    _write_v09_output_event(root, text=("owned-root\n" * 40_000))
+    ClioCoreQueue(root).initialize(migrate_legacy_output=True)
+    shutil.rmtree(root / family)
+
+    with pytest.raises(LegacyQueueStateError, match="requires its owned record directory"):
+        ClioCoreQueue(root).initialize()
+
+    assert not (root / family).exists()
+
+
+@pytest.mark.parametrize("deleted", ["archive", "receipt", "all"])
+def test_complete_marker_detects_deleted_migration_evidence(
+    tmp_path: Path,
+    deleted: str,
+) -> None:
+    """The bounded receipt manifest distinguishes evidence loss from completion."""
+    root = tmp_path / deleted
+    job_id = "job_marker_evidence"
+    _write_v09_output_event(
+        root,
+        job_id=job_id,
+        text=("marker-evidence\n" * 40_000),
+    )
+    ClioCoreQueue(root).initialize(migrate_legacy_output=True)
+    if deleted in {"archive", "all"}:
+        _archive_path(root, job_id, 1).unlink()
+    if deleted in {"receipt", "all"}:
+        _receipt_path(root, job_id, 1).unlink()
+    if deleted == "all":
+        _event_path(root, job_id, 1).unlink()
+
+    with pytest.raises(LegacyQueueStateError):
+        ClioCoreQueue(root).initialize()
+
+
+def test_complete_marker_detects_schema_valid_retired_receipt_corruption(
+    tmp_path: Path,
+) -> None:
+    """The marker manifest authenticates retired receipt bytes after large data is gone."""
+    root = tmp_path / "retired-corruption"
+    job_id = "job_retired_corruption"
+    _write_v09_output_event(
+        root,
+        job_id=job_id,
+        text=("retired-corruption\n" * 40_000),
+    )
+    queue = ClioCoreQueue(root)
+    queue.initialize(migrate_legacy_output=True)
+    now = utc_now()
+    tombstone = JobTombstone(
+        job_id=job_id,
+        cluster="ares",
+        kind=JobKind.REMOTE_AGENT,
+        final_state=JobState.SUCCEEDED,
+        idempotency_key="retired-corruption",
+        job_digest="b" * 64,
+        created_at=now,
+        updated_at=now,
+        external_quarantine_id="retired-corruption",
+        records_trash_started=True,
+    )
+    queue._write(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        queue._job_tombstone_path(job_id),  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        tombstone,
+    )
+    queue._trash_job_roots_unlocked(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        tombstone,
+        limit=100,
+    )
+    retired = root / "legacy_output_retired" / job_id / "00000000000000000001.json"
+    receipt = json.loads(retired.read_bytes())
+    receipt["archive_sha256"] = "c" * 64
+    retired.write_text(json.dumps(receipt), encoding="utf-8")
+
+    with pytest.raises(LegacyQueueStateError, match="marker totals"):
+        ClioCoreQueue(root).initialize()
+
+
+@pytest.mark.parametrize("limit", [1, 2, 3])
+def test_retired_receipt_manifest_survives_each_gc_root_move(
+    tmp_path: Path,
+    limit: int,
+) -> None:
+    """Startup accepts only tombstone-authorized receipt retirement across GC crashes."""
+    root = tmp_path / f"gc-{limit}"
+    job_id = f"job_gc_phase_{limit}"
+    _write_v09_output_event(
+        root,
+        job_id=job_id,
+        text=("gc-phase\n" * 40_000),
+    )
+    queue = ClioCoreQueue(root)
+    queue.initialize(migrate_legacy_output=True)
+    now = utc_now()
+    tombstone = JobTombstone(
+        job_id=job_id,
+        cluster="ares",
+        kind=JobKind.REMOTE_AGENT,
+        final_state=JobState.SUCCEEDED,
+        idempotency_key=f"gc-phase-{limit}",
+        job_digest="d" * 64,
+        created_at=now,
+        updated_at=now,
+        external_quarantine_id=f"gc-phase-{limit}",
+        records_trash_started=True,
+    )
+    queue._write(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        queue._job_tombstone_path(job_id),  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        tombstone,
+    )
+
+    moved, _complete = queue._trash_job_roots_unlocked(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        tombstone,
+        limit=limit,
+    )
+
+    assert moved == limit
+    assert not (root / "legacy_output_receipts" / job_id).exists()
+    assert (root / "legacy_output_retired" / job_id / "00000000000000000001.json").is_file()
+    ClioCoreQueue(root).initialize()
+
+
+def test_event_audit_streams_beyond_the_previous_global_scan_cap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Event history no longer inherits the old 10k all-family materialization cap."""
+    root = tmp_path / "core"
+    job_id = "job_many_events"
+    for seq in range(1, 6):
+        _write_event(
+            root,
+            RelayEvent(
+                job_id=job_id,
+                seq=seq,
+                event_type="stdout.delta",
+                message=f"line {seq}",
+                payload={"stream": "stdout", "text": f"line {seq}\n"},
+            ),
+        )
+    monkeypatch.setattr(core_queue_module, "MAX_BOUNDED_SCAN_RECORDS", 2)
+    monkeypatch.setattr(core_queue_module, "MAX_LEGACY_EVENT_AUDIT_RECORDS", 10)
+
+    ClioCoreQueue(root).initialize()
+
+    marker = json.loads(_marker_path(root).read_bytes())
+    assert marker["event_records"] == 5
+    assert marker["migration_records"] == 0
+
+
+def test_all_legacy_families_are_validated_before_any_output_archive_write(
+    tmp_path: Path,
+) -> None:
+    """An unrelated unsafe canonical record prevents every migration mutation."""
+    root = tmp_path / "core"
+    _write_v09_output_event(root, text=("blocked\n" * 80_000))
+    jobs = root / "jobs"
+    jobs.mkdir()
+    (jobs / "Unsafe Job.json").write_text("{}", encoding="utf-8")
+
+    with pytest.raises(LegacyQueueStateError):
+        ClioCoreQueue(root).initialize()
+
+    assert not (root / "legacy_output_archives").exists()
+    assert not (root / "legacy_output_receipts").exists()
+    assert not (root / "migrations").exists()
+
+
+def test_unknown_oversized_output_shape_fails_closed(tmp_path: Path) -> None:
+    """Only the exact v0.9 duplicated delta shape is eligible for migration."""
+    root = tmp_path / "core"
+    text = "x" * 180_000
+    event = RelayEvent(
+        job_id="job_unknown_shape",
+        seq=1,
+        event_type="stdout.delta",
+        message=text,
+        payload={"stream": "stdout", "text": f"different-{text}"},
+    )
+    original = _write_event(root, event)
+    assert len(original) > core_queue_module.RECORD_FAMILY_MAX_BYTES["events"]
+
+    with pytest.raises(LegacyQueueStateError, match="exact duplicated v0.9 delta"):
+        ClioCoreQueue(root).initialize()
+
+    assert _event_path(root, event.job_id, event.seq).read_bytes() == original
+    assert not (root / "legacy_output_archives").exists()
+
+
+def test_legacy_output_per_record_and_aggregate_budgets_fail_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both the individual read budget and aggregate archive budget are enforced."""
+    per_record_root = tmp_path / "per-record"
+    per_record = _write_v09_output_event(
+        per_record_root,
+        text=("per-record\n" * 40_000),
+    )
+    monkeypatch.setattr(
+        core_queue_module,
+        "MAX_LEGACY_OUTPUT_RECORD_BYTES",
+        len(per_record) - 1,
+    )
+    with pytest.raises(LegacyQueueStateError, match="bounded compatibility limit"):
+        ClioCoreQueue(per_record_root).initialize()
+    assert not (per_record_root / "legacy_output_archives").exists()
+
+    monkeypatch.setattr(
+        core_queue_module,
+        "MAX_LEGACY_OUTPUT_RECORD_BYTES",
+        16 * 1_048_576,
+    )
+    aggregate_root = tmp_path / "aggregate"
+    first = _write_v09_output_event(
+        aggregate_root,
+        job_id="job_aggregate",
+        seq=1,
+        text=("aggregate-one\n" * 30_000),
+    )
+    second = _write_v09_output_event(
+        aggregate_root,
+        job_id="job_aggregate",
+        seq=2,
+        text=("aggregate-two\n" * 30_000),
+    )
+    monkeypatch.setattr(
+        core_queue_module,
+        "MAX_LEGACY_OUTPUT_MIGRATION_BYTES",
+        len(first) + len(second) - 1,
+    )
+    with pytest.raises(LegacyQueueStateError, match="aggregate byte limit"):
+        ClioCoreQueue(aggregate_root).initialize()
+    assert not (aggregate_root / "legacy_output_archives").exists()
+
+
+def test_hard_linked_legacy_event_and_archive_fail_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Neither a source event nor a recovery archive may have another hard link."""
+    source_root = tmp_path / "source-link"
+    source = _event_path(source_root, "job_linked_source", 1)
+    source.write_bytes(
+        _write_v09_output_event(
+            tmp_path / "source-template",
+            job_id="job_linked_source",
+            text=("linked-source\n" * 40_000),
+        )
+    )
+    os.link(source, source_root / "operator-hard-link.json")
+    with pytest.raises(LegacyQueueStateError):
+        ClioCoreQueue(source_root).initialize()
+    assert not (source_root / "legacy_output_archives").exists()
+
+    archive_root = tmp_path / "archive-link"
+    _write_v09_output_event(
+        archive_root,
+        job_id="job_linked_archive",
+        text=("linked-archive\n" * 40_000),
+    )
+
+    def crash_after_archive(phase: str, _path: Path) -> None:
+        if phase == "archive":
+            raise RuntimeError("archive ready")
+
+    monkeypatch.setattr(
+        ClioCoreQueue,
+        "_after_legacy_output_migration_phase",
+        staticmethod(crash_after_archive),
+    )
+    with pytest.raises(RuntimeError, match="archive ready"):
+        ClioCoreQueue(archive_root).initialize(migrate_legacy_output=True)
+    archive = _archive_path(archive_root, "job_linked_archive", 1)
+    os.link(archive, archive_root / "operator-archive-hard-link.json")
+    monkeypatch.setattr(
+        ClioCoreQueue,
+        "_after_legacy_output_migration_phase",
+        staticmethod(_no_migration_fault),
+    )
+    with pytest.raises(LegacyQueueStateError):
+        ClioCoreQueue(archive_root).initialize(migrate_legacy_output=True)
+    assert not _marker_path(archive_root).exists()
+
+
+def test_current_event_writes_remain_bounded_to_256_kib(tmp_path: Path) -> None:
+    """The compatibility archive limit never weakens ordinary event writes."""
+    queue = ClioCoreQueue(tmp_path / "core")
+    queue.initialize()
+    text = "x" * 180_000
+
+    with pytest.raises(QueueConflictError, match="262144-byte limit"):
+        queue.append_event(
+            "job_current_write",
+            "stdout.delta",
+            text,
+            payload={"stream": "stdout", "text": f"{text}\n"},
+        )
+
+    assert not list((queue.root / "events" / "job_current_write").glob("*.json"))
+
+
+def test_terminal_job_gc_retires_receipts_before_trashing_large_output_roots(
+    tmp_path: Path,
+) -> None:
+    """Small receipts remain durable while event and archive roots enter quarantine."""
+    root = tmp_path / "core"
+    job_id = "job_legacy_gc"
+    _write_v09_output_event(
+        root,
+        job_id=job_id,
+        text=("gc-owned-output\n" * 40_000),
+    )
+    queue = ClioCoreQueue(root)
+    queue.initialize(migrate_legacy_output=True)
+    now = utc_now()
+    tombstone = JobTombstone(
+        job_id=job_id,
+        cluster="ares",
+        kind=JobKind.REMOTE_AGENT,
+        final_state=JobState.SUCCEEDED,
+        idempotency_key="legacy-gc",
+        job_digest="a" * 64,
+        created_at=now,
+        updated_at=now,
+        external_quarantine_id="test-quarantine",
+        records_trash_started=True,
+    )
+    queue._write(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        queue._job_tombstone_path(job_id),  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        tombstone,
+    )
+
+    moved, complete = queue._trash_job_roots_unlocked(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        tombstone,
+        limit=100,
+    )
+
+    trash = root / "gc_trash" / job_id / "owned"
+    assert complete is True
+    assert moved >= 3
+    assert not (root / "events" / job_id).exists()
+    assert not (root / "legacy_output_archives" / job_id).exists()
+    assert not (root / "legacy_output_receipts" / job_id).exists()
+    assert (root / "legacy_output_retired" / job_id / "00000000000000000001.json").is_file()
+    assert (trash / "events" / "00000000000000000001.json").is_file()
+    assert (trash / "legacy_output_archives" / "00000000000000000001.json").is_file()
+
+    ClioCoreQueue(root).initialize()

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -6,9 +6,10 @@ import shutil
 import threading
 import time
 from pathlib import Path
+from typing import cast
 
 import pytest
-from filelock import Timeout
+from filelock import FileLock, Timeout
 
 import clio_relay.core_queue as core_queue_module
 from clio_relay.core_queue import DEFAULT_CORE_LOCK_TIMEOUT_SECONDS, ClioCoreQueue
@@ -1095,6 +1096,57 @@ def test_legacy_queue_requires_and_completes_crash_safe_bounded_index_migration(
     assert migrated_progress[0].sequence == 1
     lease = queue.acquire_next_job("worker-after-migration", cluster="ares")
     assert lease is not None and lease.job_id == job.job_id
+
+
+def test_index_migration_reconciles_flat_job_written_after_finalize_cursor(
+    tmp_path: Path,
+) -> None:
+    """A late pre-1.0 flat write must be indexed before migration completes."""
+    (tmp_path / "jobs").mkdir(parents=True)
+    first = RelayJob(
+        cluster="configured-target",
+        kind=JobKind.JARVIS,
+        spec=JarvisRunSpec(command=["true"]),
+        idempotency_key="first-flat-job",
+    )
+    (tmp_path / "jobs" / f"{first.job_id}.json").write_text(
+        first.model_dump_json(indent=2),
+        encoding="utf-8",
+    )
+
+    queue = ClioCoreQueue(tmp_path)
+    state = queue.index_migration_status()
+    batches = 0
+    while True:
+        finalize = state.get("finalize")
+        assert isinstance(finalize, dict)
+        finalize = cast(dict[str, object], finalize)
+        if finalize.get("complete") is True and state.get("complete") is False:
+            break
+        state = queue.migrate_indexes_batch(batch_size=1)
+        batches += 1
+        assert batches < 40
+
+    late = RelayJob(
+        cluster="configured-target",
+        kind=JobKind.JARVIS,
+        spec=JarvisRunSpec(command=["true"]),
+        idempotency_key="late-flat-job",
+    )
+    with FileLock(str(tmp_path / ".lock")):
+        (tmp_path / "jobs" / f"{late.job_id}.json").write_text(
+            late.model_dump_json(indent=2),
+            encoding="utf-8",
+        )
+
+    completed = queue.migrate_indexes_batch(batch_size=1)
+    jobs, next_cursor, total = queue.list_jobs_page(limit=10)
+
+    assert completed["complete"] is True
+    assert next_cursor is None
+    assert total == 2
+    assert [job.job_id for job in jobs] == [first.job_id, late.job_id]
+    assert (tmp_path / "jobs_queued" / f"{late.job_id}.json").is_file()
 
 
 def test_leasing_reads_active_index_not_terminal_history(

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -51,7 +51,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
 
 def test_candidate_manifest_parser_accepts_the_exact_gnu_checksum_separator() -> None:
     digest = "a" * 64
-    wheel_name = "clio_relay-1.0.7-py3-none-any.whl"
+    wheel_name = "clio_relay-1.0.8-py3-none-any.whl"
     selector = re.compile(rf"^[0-9A-Fa-f]{{64}} [ *]{re.escape(wheel_name)}$")
     parser = re.compile(r"^([0-9A-Fa-f]{64}) [ *](.+)$")
 

--- a/tests/test_remote_cli.py
+++ b/tests/test_remote_cli.py
@@ -24,7 +24,7 @@ def test_remote_env_exports_operator_configured_jarvis_spack_executable() -> Non
         )
     )
 
-    assert "export JARVIS_MCP_SPACK_COMMAND=/home/operator/spack/bin/spack;" in rendered
+    assert 'export JARVIS_MCP_SPACK_COMMAND="/home/operator/spack/bin/spack";' in rendered
     assert 'export UV="$HOME/.local/bin/uv";' in rendered
     assert 'export CLIO_RELAY_VALIDATION_TOOL_EXECUTABLE="$HOME/.local/bin/clio-relay";' in rendered
 

--- a/tests/test_remote_value_contract.py
+++ b/tests/test_remote_value_contract.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable
+from typing import Protocol, cast
+
+import pytest
+
+import clio_relay.live_acceptance as live_acceptance
+import clio_relay.service_runtime as service_runtime
+import clio_relay.transport_probe as transport_probe
+from clio_relay.cluster_config import ClusterDefinition
+from clio_relay.deployment import render_endpoint_user_service
+from clio_relay.doctor import run_cluster_doctor
+from clio_relay.errors import ConfigurationError
+from clio_relay.remote_cli import remote_env
+from clio_relay.remote_values import (
+    render_remote_shell_path,
+    render_remote_shell_value,
+    render_systemd_remote_path,
+    render_systemd_remote_value,
+)
+
+
+class _RemoteRenderer(Protocol):
+    def __call__(self, value: str, *, field: str) -> str:
+        """Render one configured remote value."""
+        ...
+
+
+def _configured_definition() -> ClusterDefinition:
+    return ClusterDefinition(
+        name="custom",
+        ssh_host="cluster.example.test",
+        core_dir="$HOME/core dir/o'hare$(touch /tmp/core)`id`$CORE_SUFFIX",
+        spool_dir="/srv/$HOME/spool dir/$(touch /tmp/spool)`id`$SPOOL_SUFFIX",
+        jarvis_bin="$HOME/bin/jarvis $(touch /tmp/jarvis)`id`$JARVIS_SUFFIX",
+        frpc_bin="/opt/$HOME/frpc $(touch /tmp/frpc)`id`$FRPC_SUFFIX",
+        agent_bin="$HOME/bin/agent $(touch /tmp/agent)`id`$AGENT_SUFFIX",
+    )
+
+
+def test_remote_value_contract_expands_only_exact_leading_home() -> None:
+    """Shell and systemd renderers preserve every non-leading expansion token literally."""
+    leading = "$HOME/state dir/o'hare$(touch /tmp/x)`id`$VALUE_SUFFIX"
+    absolute = "/srv/$HOME/state dir/o'hare$(touch /tmp/y)`id`$VALUE_SUFFIX"
+
+    assert render_remote_shell_value(leading, field="value") == (
+        '"$HOME/state dir/o\'hare\\$(touch /tmp/x)\\`id\\`\\$VALUE_SUFFIX"'
+    )
+    assert render_remote_shell_value(absolute, field="value") == (
+        '"/srv/\\$HOME/state dir/o\'hare\\$(touch /tmp/y)\\`id\\`\\$VALUE_SUFFIX"'
+    )
+    assert render_systemd_remote_value(leading, field="value") == (
+        "%h/state dir/o'hare$(touch /tmp/x)`id`$VALUE_SUFFIX"
+    )
+    assert render_systemd_remote_value(absolute, field="value") == absolute
+
+
+@pytest.mark.parametrize("value", ["relative/path", "$USER/path", "$HOME-other/path", ""])
+def test_remote_path_contract_requires_an_unambiguous_absolute_path(value: str) -> None:
+    """State paths cannot depend on an unspecified remote working directory or variable."""
+    with pytest.raises(ConfigurationError, match="absolute POSIX path|nonempty path"):
+        render_remote_shell_path(value, field="core_dir")
+
+
+@pytest.mark.parametrize(
+    "renderer",
+    [
+        render_remote_shell_value,
+        render_remote_shell_path,
+        render_systemd_remote_value,
+        render_systemd_remote_path,
+    ],
+)
+def test_remote_value_contract_rejects_controls(renderer: _RemoteRenderer) -> None:
+    """No remote rendering surface accepts control characters."""
+    with pytest.raises(ConfigurationError, match="control characters"):
+        renderer("$HOME/path\nforged", field="path")
+
+
+def test_remote_environment_surfaces_share_the_value_contract() -> None:
+    """CLI, acceptance, and transport probes render identical configured meanings."""
+    definition = _configured_definition()
+    rendered_core_dir = render_remote_shell_path(definition.core_dir, field="core_dir")
+    rendered_spool_dir = render_remote_shell_path(definition.spool_dir, field="spool_dir")
+    rendered_jarvis_bin = render_remote_shell_value(
+        definition.jarvis_bin or "",
+        field="jarvis_bin",
+    )
+    rendered_frpc_bin = render_remote_shell_value(
+        definition.frpc_bin or "",
+        field="frpc_bin",
+    )
+    rendered_agent_bin = render_remote_shell_value(
+        definition.agent_bin or "",
+        field="agent_bin",
+    )
+    expected = [
+        f"CLIO_RELAY_CORE_DIR={rendered_core_dir}",
+        f"CLIO_RELAY_SPOOL_DIR={rendered_spool_dir}",
+        f"CLIO_RELAY_JARVIS_BIN={rendered_jarvis_bin}",
+        f"CLIO_RELAY_FRPC_BIN={rendered_frpc_bin}",
+        f"CLIO_RELAY_AGENT_BIN={rendered_agent_bin}",
+    ]
+
+    cli_environment = remote_env(definition)
+    acceptance_env_renderer = cast(
+        Callable[..., str],
+        vars(live_acceptance)["_remote_env"],
+    )
+    probe_script_renderer = cast(
+        Callable[..., str],
+        vars(transport_probe)["_remote_probe_script"],
+    )
+    acceptance_environment = acceptance_env_renderer(definition)
+    probe_script = probe_script_renderer(
+        cluster=definition.name,
+        definition=definition,
+        probe_id="probe-contract",
+        api_token=None,
+        api_port=8765,
+        frpc_config="",
+    )
+
+    for assignment in expected:
+        assert assignment in cli_environment
+        assert assignment in acceptance_environment
+        assert assignment in probe_script
+
+
+def test_doctor_and_connector_runtime_share_safe_bin_rendering(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Diagnostic and connector scripts cannot reevaluate configured executable values."""
+    definition = _configured_definition()
+    doctor_scripts: list[str] = []
+
+    def fake_run(
+        command: list[str],
+        *,
+        input: bytes,
+        capture_output: bool,
+        check: bool,
+    ) -> subprocess.CompletedProcess[bytes]:
+        assert capture_output is True
+        assert check is False
+        doctor_scripts.append(input.decode("utf-8"))
+        return subprocess.CompletedProcess(command, 0, b"", b"")
+
+    monkeypatch.setattr("clio_relay.doctor.subprocess.run", fake_run)
+    run_cluster_doctor(definition)
+
+    expected_frpc = render_remote_shell_value(definition.frpc_bin or "", field="frpc_bin")
+    expected_jarvis = render_remote_shell_value(definition.jarvis_bin or "", field="jarvis_bin")
+    expected_agent = render_remote_shell_value(definition.agent_bin or "", field="agent_bin")
+    assert f"FRPC_BIN={expected_frpc}" in doctor_scripts[0]
+    assert f"JARVIS_BIN={expected_jarvis}" in doctor_scripts[0]
+    assert f"AGENT_BIN={expected_agent}" in doctor_scripts[0]
+
+    connector_script_renderer = cast(
+        Callable[..., str],
+        vars(service_runtime)["_remote_frpc_start_script"],
+    )
+    connector_script = connector_script_renderer(
+        definition=definition,
+        session_id="session-contract",
+        config_text="serverAddr = 'relay.example.test'\n",
+        owner_token="owner-token",
+        connector_generation_id="generation-id",
+    )
+    assert f"frpc_bin={expected_frpc}" in connector_script
+
+
+def test_endpoint_service_expands_only_leading_home_specifiers() -> None:
+    """Systemd receives one leading home specifier while literal HOME text stays literal."""
+    definition = ClusterDefinition(
+        name="custom",
+        ssh_host="cluster.example.test",
+        core_dir="$HOME/core $CORE_SUFFIX%h",
+        spool_dir="/srv/$HOME/spool $SPOOL_SUFFIX%h",
+        jarvis_bin="$HOME/bin/jarvis$(literal)%h",
+        frpc_bin="/opt/$HOME/frpc$(literal)%h",
+        agent_bin="$HOME/bin/agent`literal`$AGENT_SUFFIX%h",
+        spack_executable="$HOME/bin/spack $SPACK_SUFFIX%h",
+    )
+
+    service = render_endpoint_user_service(cluster="custom", definition=definition)
+
+    assert 'Environment="CLIO_RELAY_CORE_DIR=%h/core $CORE_SUFFIX%%h"' in service
+    assert 'Environment="CLIO_RELAY_SPOOL_DIR=/srv/$HOME/spool $SPOOL_SUFFIX%%h"' in service
+    assert 'Environment="CLIO_RELAY_JARVIS_BIN=%h/bin/jarvis$(literal)%%h"' in service
+    assert 'Environment="CLIO_RELAY_FRPC_BIN=/opt/$HOME/frpc$(literal)%%h"' in service
+    assert 'Environment="CLIO_RELAY_AGENT_BIN=%h/bin/agent`literal`$AGENT_SUFFIX%%h"' in service
+    assert 'Environment="JARVIS_MCP_SPACK_COMMAND=%h/bin/spack $SPACK_SUFFIX%%h"' in service
+    assert "/srv/%h/spool" not in service
+
+
+def test_endpoint_service_preserves_literal_leading_systemd_specifier() -> None:
+    """Only configured HOME syntax can authorize a systemd home specifier."""
+    definition = ClusterDefinition(
+        name="custom",
+        ssh_host="cluster.example.test",
+        jarvis_bin="%h/bin/jarvis",
+        frpc_bin="%h/bin/frpc",
+        agent_bin="%h/bin/agent",
+        spack_executable="/%h/bin/spack",
+    )
+
+    service = render_endpoint_user_service(cluster="custom", definition=definition)
+
+    assert 'Environment="CLIO_RELAY_JARVIS_BIN=%%h/bin/jarvis"' in service
+    assert 'Environment="CLIO_RELAY_FRPC_BIN=%%h/bin/frpc"' in service
+    assert 'Environment="CLIO_RELAY_AGENT_BIN=%%h/bin/agent"' in service
+    assert 'Environment="JARVIS_MCP_SPACK_COMMAND=/%%h/bin/spack"' in service
+
+
+def test_endpoint_service_rejects_control_characters_in_remote_values() -> None:
+    """Systemd rendering fails instead of encoding a control-bearing executable value."""
+    definition = ClusterDefinition(
+        name="custom",
+        ssh_host="cluster.example.test",
+        agent_bin="/opt/agent\nEnvironment=FORGED=1",
+    )
+
+    with pytest.raises(ConfigurationError, match="agent_bin.*control characters"):
+        render_endpoint_user_service(cluster="custom", definition=definition)

--- a/tests/test_scheduler_cancel_attempt_claims.py
+++ b/tests/test_scheduler_cancel_attempt_claims.py
@@ -1,0 +1,989 @@
+"""Concurrency regressions for durable scheduler-cancellation claims."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import threading
+from contextlib import suppress
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, cast
+
+from pytest import MonkeyPatch
+
+from clio_relay.config import RelaySettings
+from clio_relay.core_queue import ClioCoreQueue
+from clio_relay.endpoint import EndpointWorker
+from clio_relay.errors import RelayError
+from clio_relay.models import (
+    Cursor,
+    EndpointRole,
+    JarvisRunSpec,
+    JobKind,
+    JobState,
+    RelayJob,
+    RelayTask,
+    SchedulerCancelDisposition,
+    SchedulerCancelDispositionState,
+    SchedulerCancelPending,
+    SchedulerPhase,
+    SchedulerStatus,
+)
+from clio_relay.relay_ops import cancel_job
+from clio_relay.scheduler_providers import ExternalSchedulerProvider
+
+
+class _BarrierScheduler(ExternalSchedulerProvider):
+    """Hold the first cancellation long enough for a racing worker to contend."""
+
+    def __init__(self) -> None:
+        self.cancel_calls: list[str] = []
+        self._calls_lock = threading.Lock()
+        self._cancel_barrier = threading.Barrier(2)
+
+    def cancel(self, scheduler_job_id: str) -> subprocess.CompletedProcess[str]:
+        """Record the invocation and synchronize a possible duplicate caller."""
+        with self._calls_lock:
+            self.cancel_calls.append(scheduler_job_id)
+        with suppress(threading.BrokenBarrierError):
+            self._cancel_barrier.wait(timeout=0.5)
+        return subprocess.CompletedProcess(
+            [self.name, scheduler_job_id],
+            1,
+            "",
+            "deterministic retryable failure",
+        )
+
+
+class _BlockingConfirmationScheduler(ExternalSchedulerProvider):
+    """Hold the first confirmation poll while recording any duplicate poll."""
+
+    def __init__(self, *, recovered_phase: SchedulerPhase = SchedulerPhase.UNKNOWN) -> None:
+        self.poll_calls: list[str] = []
+        self.first_poll_entered = threading.Event()
+        self.release_first_poll = threading.Event()
+        self._calls_lock = threading.Lock()
+        self._recovered_phase = recovered_phase
+
+    def poll(self, scheduler_job_id: str) -> SchedulerStatus:
+        """Block the first caller and return the configured phase to a recovered caller."""
+        with self._calls_lock:
+            self.poll_calls.append(scheduler_job_id)
+            call_number = len(self.poll_calls)
+        if call_number == 1:
+            self.first_poll_entered.set()
+            if not self.release_first_poll.wait(timeout=5):
+                raise AssertionError("timed out waiting to release the first confirmation poll")
+            phase = SchedulerPhase.UNKNOWN
+        else:
+            phase = self._recovered_phase
+        return SchedulerStatus(
+            scheduler=self.name,
+            scheduler_job_id=scheduler_job_id,
+            phase=phase,
+            reason="cancellation confirmation test observation",
+        )
+
+
+class _OversizedFailureScheduler(ExternalSchedulerProvider):
+    """Return a provider diagnostic far larger than any durable record."""
+
+    def cancel(self, scheduler_job_id: str) -> subprocess.CompletedProcess[str]:
+        """Return one deterministic oversized cancellation failure."""
+        return subprocess.CompletedProcess(
+            [self.name, scheduler_job_id],
+            1,
+            "",
+            "first scheduler cause\n" + ("x" * 300_000) + "\nfinal scheduler status",
+        )
+
+
+class _MismatchedConfirmationScheduler(ExternalSchedulerProvider):
+    """Return a terminal observation for an identity that was never requested."""
+
+    def poll(self, scheduler_job_id: str) -> SchedulerStatus:
+        """Deliberately violate both provider response identity fields."""
+        return SchedulerStatus(
+            scheduler="slurm",
+            scheduler_job_id=f"other-{scheduler_job_id}",
+            phase=SchedulerPhase.CANCELED,
+            record_found=True,
+            reason="wrong scheduler record",
+        )
+
+
+class _OversizedStatusScheduler(ExternalSchedulerProvider):
+    """Return a correctly identified status carrying oversized provider text."""
+
+    def poll(self, scheduler_job_id: str) -> SchedulerStatus:
+        """Return a large status that must be normalized before persistence."""
+        detail = "provider detail start\n" + ("y" * 300_000) + "\nprovider detail end"
+        return SchedulerStatus(
+            scheduler=self.name,
+            scheduler_job_id=scheduler_job_id,
+            phase=SchedulerPhase.RUNNING,
+            reason=detail,
+            queue_position_note=detail,
+        )
+
+
+class _OversizedPollFailureScheduler(ExternalSchedulerProvider):
+    """Raise an oversized provider exception before a status exists."""
+
+    def poll(self, scheduler_job_id: str) -> SchedulerStatus:
+        """Raise a diagnostic that must fit one poll-failure event."""
+        del scheduler_job_id
+        raise RelayError("poll cause\n" + ("z" * 300_000) + "\npoll summary")
+
+
+def _canceled_job_with_owned_scheduler_identity(
+    queue: ClioCoreQueue,
+    *,
+    scheduler_job_id: str,
+) -> RelayJob:
+    """Create canceled relay work with an authenticated scheduler identity."""
+    job = queue.submit_job(
+        RelayJob(
+            cluster="ares",
+            kind=JobKind.JARVIS,
+            spec=JarvisRunSpec(command=["sleep", "60"]),
+            idempotency_key=f"owned-scheduler-cancel-{scheduler_job_id}",
+        )
+    )
+    task = RelayTask(
+        job_id=job.job_id,
+        name="jarvis.execution",
+        state=JobState.RUNNING,
+    )
+    queue.append_task(
+        task.model_copy(
+            update={
+                "metadata": {
+                    "scheduler": "external",
+                    "scheduler_job_ids": [scheduler_job_id],
+                    "scheduler_job_ownership": [
+                        {
+                            "scheduler_job_id": scheduler_job_id,
+                            "scheduler_provider": "external",
+                            "relay_job_id": job.job_id,
+                            "task_id": task.task_id,
+                            "execution_id": f"execution-{scheduler_job_id}",
+                            "runtime_metadata_source": "jarvis_sidecar",
+                            "ownership_verified": True,
+                            "proof": "authenticated_runtime_sidecar",
+                        }
+                    ],
+                }
+            }
+        )
+    )
+    canceled = cancel_job(queue, job.job_id, cancel_scheduler=True)
+    assert canceled.state is JobState.CANCELED
+    return canceled
+
+
+def _claim_ready_scheduler_identity(
+    queue: ClioCoreQueue,
+    job: RelayJob,
+    *,
+    scheduler_job_id: str,
+) -> None:
+    """Register and finalize one owned cancellation identity without a worker."""
+    queue.register_scheduler_cancel_identity(
+        job.job_id,
+        cluster=job.cluster,
+        scheduler_job_id=scheduler_job_id,
+        provider="external",
+        ownership_verified=True,
+    )
+    queue.finalize_scheduler_cancel_identities(job.job_id, cluster=job.cluster)
+
+
+def _accept_scheduler_cancellation_without_polling(
+    queue: ClioCoreQueue,
+    job: RelayJob,
+    *,
+    scheduler_job_id: str,
+    now: datetime,
+) -> None:
+    """Persist one accepted cancellation so confirmation work is immediately due."""
+    _claim_ready_scheduler_identity(queue, job, scheduler_job_id=scheduler_job_id)
+    claim = queue.claim_scheduler_cancel_attempt(
+        job.job_id,
+        cluster=job.cluster,
+        scheduler_job_id=scheduler_job_id,
+        provider="external",
+        lease_seconds=5,
+        now=now,
+    )
+    assert claim is not None
+    accepted = queue.record_scheduler_cancel_attempt(
+        job.job_id,
+        cluster=job.cluster,
+        scheduler_job_id=scheduler_job_id,
+        provider="external",
+        claim_id=claim.claim_id,
+        accepted=True,
+        error=None,
+        max_attempts=5,
+        retry_delay_seconds=2,
+        now=now,
+    )
+    assert accepted is not None
+    assert accepted.dispositions[0].state is SchedulerCancelDispositionState.CANCEL_REQUESTED
+
+
+def test_oversized_cancel_failure_is_bounded_in_state_and_event(tmp_path: Path) -> None:
+    """Provider stderr cannot strand a claim or exceed a durable event record."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    scheduler_job_id = "oversized-cancel-24680"
+    job = _canceled_job_with_owned_scheduler_identity(
+        queue,
+        scheduler_job_id=scheduler_job_id,
+    )
+    stale = queue.get_scheduler_cancel_pending(job.job_id, cluster=job.cluster)
+    assert stale is not None
+    scheduler = _OversizedFailureScheduler()
+    worker = EndpointWorker(
+        role=EndpointRole.WORKER,
+        settings=settings,
+        cluster="ares",
+        queue=queue,
+        scheduler_provider=scheduler,
+    )
+    worker.scheduler_cancel_retry_base_seconds = 3_600
+    try:
+        cast(Any, worker)._reconcile_canceled_scheduler_job(stale)
+    finally:
+        worker.close()
+
+    reloaded = ClioCoreQueue(settings.core_dir).get_scheduler_cancel_pending(
+        job.job_id,
+        cluster=job.cluster,
+    )
+    assert reloaded is not None
+    error = reloaded.dispositions[0].last_error
+    assert error is not None
+    assert error.startswith("first scheduler cause")
+    assert error.endswith("final scheduler status")
+    assert len(error.encode("utf-8")) <= 4_096
+    events, _ = queue.drain_events(Cursor(job_id=job.job_id), limit=100)
+    failed = [event for event in events if event.event_type == "scheduler.cancel_failed"]
+    assert len(failed) == 1
+    event_error = failed[0].payload["stderr"]
+    assert isinstance(event_error, str)
+    assert len(event_error.encode("utf-8")) <= 4_096
+
+
+def test_mismatched_terminal_status_cannot_confirm_requested_job(tmp_path: Path) -> None:
+    """A provider response for another scheduler identity remains nonterminal."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    scheduler_job_id = "requested-confirmation-13579"
+    job = _canceled_job_with_owned_scheduler_identity(
+        queue,
+        scheduler_job_id=scheduler_job_id,
+    )
+    _accept_scheduler_cancellation_without_polling(
+        queue,
+        job,
+        scheduler_job_id=scheduler_job_id,
+        now=datetime.now(UTC) - timedelta(seconds=1),
+    )
+    scheduler = _MismatchedConfirmationScheduler()
+    worker = EndpointWorker(
+        role=EndpointRole.WORKER,
+        settings=settings,
+        cluster="ares",
+        queue=queue,
+        scheduler_provider=scheduler,
+    )
+    try:
+        cast(Any, worker)._confirm_scheduler_cancellation(
+            job,
+            scheduler,
+            scheduler_job_id,
+        )
+    finally:
+        worker.close()
+
+    pending = queue.get_scheduler_cancel_pending(job.job_id, cluster=job.cluster)
+    assert pending is not None
+    disposition = pending.dispositions[0]
+    assert disposition.state is SchedulerCancelDispositionState.CANCEL_REQUESTED
+    assert disposition.confirmation_attempts == 1
+    assert disposition.last_error is not None
+    assert "mismatched identity" in disposition.last_error
+    tasks, truncated = queue.scan_job_tasks(job.job_id, limit=10)
+    assert truncated is False
+    status = tasks[0].metadata["scheduler_status"]
+    assert status["scheduler"] == "external"
+    assert status["scheduler_job_id"] == scheduler_job_id
+    assert status["phase"] == SchedulerPhase.UNKNOWN.value
+
+
+def test_oversized_scheduler_status_is_bounded_before_task_and_event_write(
+    tmp_path: Path,
+) -> None:
+    """Every provider-owned status string is bounded at the scheduler boundary."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    scheduler_job_id = "oversized-status-97531"
+    job = _canceled_job_with_owned_scheduler_identity(
+        queue,
+        scheduler_job_id=scheduler_job_id,
+    )
+    task = queue.scan_job_tasks(job.job_id, limit=10)[0][0]
+    scheduler = _OversizedStatusScheduler()
+    worker = EndpointWorker(
+        role=EndpointRole.WORKER,
+        settings=settings,
+        cluster="ares",
+        queue=queue,
+        scheduler_provider=scheduler,
+    )
+    try:
+        cast(Any, worker)._refresh_scheduler_status(
+            job,
+            [scheduler_job_id],
+            task_id=task.task_id,
+            force=True,
+        )
+    finally:
+        worker.close()
+
+    persisted_tasks = queue.scan_job_tasks(job.job_id, limit=10)[0]
+    persisted_task = next(item for item in persisted_tasks if item.task_id == task.task_id)
+    status = persisted_task.metadata["scheduler_status"]
+    for field_name in ("reason", "queue_position_note"):
+        value = status[field_name]
+        assert isinstance(value, str)
+        assert value.startswith("provider detail start")
+        assert value.endswith("provider detail end")
+        assert len(value.encode("utf-8")) <= 4_096
+    events, _ = queue.drain_events(Cursor(job_id=job.job_id), limit=100)
+    running = [event for event in events if event.event_type == "scheduler.running"]
+    assert len(running) == 1
+    assert len(json.dumps(running[0].payload).encode("utf-8")) < 262_144
+
+
+def test_oversized_scheduler_poll_exception_is_bounded_before_event_write(
+    tmp_path: Path,
+) -> None:
+    """A provider exception cannot exceed the durable scheduler event limit."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    scheduler_job_id = "oversized-poll-error-86420"
+    job = _canceled_job_with_owned_scheduler_identity(
+        queue,
+        scheduler_job_id=scheduler_job_id,
+    )
+    task = queue.scan_job_tasks(job.job_id, limit=10)[0][0]
+    worker = EndpointWorker(
+        role=EndpointRole.WORKER,
+        settings=settings,
+        cluster="ares",
+        queue=queue,
+        scheduler_provider=_OversizedPollFailureScheduler(),
+    )
+    try:
+        cast(Any, worker)._refresh_scheduler_status(
+            job,
+            [scheduler_job_id],
+            task_id=task.task_id,
+            force=True,
+        )
+    finally:
+        worker.close()
+
+    events, _ = queue.drain_events(Cursor(job_id=job.job_id), limit=100)
+    failed = [event for event in events if event.event_type == "scheduler.poll_failed"]
+    assert len(failed) == 1
+    error = failed[0].payload["error"]
+    assert isinstance(error, str)
+    assert error.startswith("poll cause")
+    assert error.endswith("poll summary")
+    assert len(error.encode("utf-8")) <= 4_096
+
+
+def test_concurrent_worker_slots_invoke_scheduler_cancel_exactly_once(tmp_path: Path) -> None:
+    """Two stale worker snapshots cannot cross the provider boundary together."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    setup_queue = ClioCoreQueue(settings.core_dir)
+    scheduler_job_id = "concurrent-owned-24680"
+    job = _canceled_job_with_owned_scheduler_identity(
+        setup_queue,
+        scheduler_job_id=scheduler_job_id,
+    )
+    stale = setup_queue.get_scheduler_cancel_pending(job.job_id, cluster=job.cluster)
+    assert stale is not None
+    scheduler = _BarrierScheduler()
+    workers = [
+        EndpointWorker(
+            role=EndpointRole.WORKER,
+            settings=settings,
+            cluster="ares",
+            queue=ClioCoreQueue(settings.core_dir),
+            scheduler_provider=scheduler,
+        )
+        for _ in range(2)
+    ]
+    for worker in workers:
+        worker.scheduler_cancel_retry_base_seconds = 3_600
+    start = threading.Barrier(3)
+    errors: list[BaseException] = []
+    errors_lock = threading.Lock()
+
+    def reconcile(worker: EndpointWorker) -> None:
+        try:
+            start.wait(timeout=5)
+            cast(Any, worker)._reconcile_canceled_scheduler_job(stale)
+        except BaseException as exc:  # pragma: no cover - asserted in the parent thread
+            with errors_lock:
+                errors.append(exc)
+
+    threads = [threading.Thread(target=reconcile, args=(worker,)) for worker in workers]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=5)
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert errors == []
+    assert scheduler.cancel_calls == [scheduler_job_id]
+    pending = setup_queue.get_scheduler_cancel_pending(job.job_id, cluster=job.cluster)
+    assert pending is not None
+    disposition = pending.dispositions[0]
+    assert disposition.state is SchedulerCancelDispositionState.RETRY_WAIT
+    assert disposition.attempts == 1
+    assert disposition.attempt_claim_id is None
+
+
+def test_concurrent_worker_slots_poll_cancel_confirmation_exactly_once(tmp_path: Path) -> None:
+    """Two due snapshots cannot spend duplicate confirmation attempts."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    setup_queue = ClioCoreQueue(settings.core_dir)
+    scheduler_job_id = "concurrent-confirmation-86420"
+    job = _canceled_job_with_owned_scheduler_identity(
+        setup_queue,
+        scheduler_job_id=scheduler_job_id,
+    )
+    _accept_scheduler_cancellation_without_polling(
+        setup_queue,
+        job,
+        scheduler_job_id=scheduler_job_id,
+        now=datetime.now(UTC) - timedelta(seconds=1),
+    )
+    stale = setup_queue.get_scheduler_cancel_pending(job.job_id, cluster=job.cluster)
+    assert stale is not None
+    scheduler = _BlockingConfirmationScheduler()
+    workers = [
+        EndpointWorker(
+            role=EndpointRole.WORKER,
+            settings=settings,
+            cluster="ares",
+            queue=ClioCoreQueue(settings.core_dir),
+            scheduler_provider=scheduler,
+        )
+        for _ in range(2)
+    ]
+    for worker in workers:
+        worker.scheduler_cancel_retry_base_seconds = 3_600
+    start = threading.Barrier(3)
+    one_worker_finished = threading.Event()
+    errors: list[BaseException] = []
+    errors_lock = threading.Lock()
+
+    def reconcile(worker: EndpointWorker) -> None:
+        try:
+            start.wait(timeout=5)
+            cast(Any, worker)._reconcile_canceled_scheduler_job(stale)
+        except BaseException as exc:  # pragma: no cover - asserted in the parent thread
+            with errors_lock:
+                errors.append(exc)
+        finally:
+            one_worker_finished.set()
+
+    threads = [threading.Thread(target=reconcile, args=(worker,)) for worker in workers]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=5)
+    assert scheduler.first_poll_entered.wait(timeout=5)
+    assert one_worker_finished.wait(timeout=5)
+    scheduler.release_first_poll.set()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert errors == []
+    assert scheduler.poll_calls == [scheduler_job_id]
+    pending = setup_queue.get_scheduler_cancel_pending(job.job_id, cluster=job.cluster)
+    assert pending is not None
+    disposition = pending.dispositions[0]
+    assert disposition.state is SchedulerCancelDispositionState.CANCEL_REQUESTED
+    assert disposition.confirmation_attempts == 1
+    assert disposition.confirmation_claim_id is None
+    assert disposition.confirmation_claimed_at is None
+    assert disposition.confirmation_claim_expires_at is None
+
+
+def test_expired_confirmation_claim_recovers_without_spending_an_attempt(
+    tmp_path: Path,
+) -> None:
+    """A crashed poller leaves a lease another worker can recover without budget loss."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    first_queue = ClioCoreQueue(settings.core_dir)
+    scheduler_job_id = "confirmation-crash-75319"
+    job = _canceled_job_with_owned_scheduler_identity(
+        first_queue,
+        scheduler_job_id=scheduler_job_id,
+    )
+    accepted_at = datetime(2026, 7, 14, 15, 0, tzinfo=UTC)
+    _accept_scheduler_cancellation_without_polling(
+        first_queue,
+        job,
+        scheduler_job_id=scheduler_job_id,
+        now=accepted_at,
+    )
+    first_claim = first_queue.claim_scheduler_cancel_confirmation(
+        job.job_id,
+        cluster=job.cluster,
+        scheduler_job_id=scheduler_job_id,
+        provider="external",
+        lease_seconds=5,
+        now=accepted_at,
+    )
+    assert first_claim is not None
+    assert first_claim.confirmation_attempt == 1
+
+    recovering_queue = ClioCoreQueue(settings.core_dir)
+    due_before_expiry, _ = recovering_queue.scan_due_scheduler_cancellations(
+        cluster=job.cluster,
+        limit=10,
+        now=accepted_at + timedelta(seconds=4),
+    )
+    assert due_before_expiry == []
+    assert (
+        recovering_queue.claim_scheduler_cancel_confirmation(
+            job.job_id,
+            cluster=job.cluster,
+            scheduler_job_id=scheduler_job_id,
+            provider="external",
+            lease_seconds=5,
+            now=accepted_at + timedelta(seconds=4),
+        )
+        is None
+    )
+
+    recovered_claim = recovering_queue.claim_scheduler_cancel_confirmation(
+        job.job_id,
+        cluster=job.cluster,
+        scheduler_job_id=scheduler_job_id,
+        provider="external",
+        lease_seconds=5,
+        now=accepted_at + timedelta(seconds=5),
+    )
+    assert recovered_claim is not None
+    assert recovered_claim.claim_id != first_claim.claim_id
+    assert recovered_claim.confirmation_attempt == first_claim.confirmation_attempt == 1
+    assert (
+        first_queue.record_scheduler_cancel_observation(
+            job.job_id,
+            cluster=job.cluster,
+            scheduler_job_id=scheduler_job_id,
+            provider="external",
+            claim_id=first_claim.claim_id,
+            phase=SchedulerPhase.UNKNOWN,
+            not_found=False,
+            error="late result from crashed confirmation poller",
+            max_confirmation_attempts=5,
+            retry_delay_seconds=30,
+            now=accepted_at + timedelta(seconds=6),
+        )
+        is None
+    )
+    after_stale = recovering_queue.get_scheduler_cancel_pending(
+        job.job_id,
+        cluster=job.cluster,
+    )
+    assert after_stale is not None
+    assert after_stale.dispositions[0].confirmation_attempts == 0
+
+    updated = recovering_queue.record_scheduler_cancel_observation(
+        job.job_id,
+        cluster=job.cluster,
+        scheduler_job_id=scheduler_job_id,
+        provider="external",
+        claim_id=recovered_claim.claim_id,
+        phase=SchedulerPhase.UNKNOWN,
+        not_found=False,
+        error="scheduler still canceling",
+        max_confirmation_attempts=5,
+        retry_delay_seconds=30,
+        now=accepted_at + timedelta(seconds=6),
+    )
+    assert updated is not None
+    disposition = updated.dispositions[0]
+    assert disposition.state is SchedulerCancelDispositionState.CANCEL_REQUESTED
+    assert disposition.confirmation_attempts == 1
+    assert disposition.confirmation_claim_id is None
+
+
+def test_recovered_canceled_confirmation_survives_late_unknown_without_worker_error(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A late stale UNKNOWN cannot overwrite CANCELED or escape a worker slot."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    setup_queue = ClioCoreQueue(settings.core_dir)
+    scheduler_job_id = "terminal-confirmation-race-64208"
+    job = _canceled_job_with_owned_scheduler_identity(
+        setup_queue,
+        scheduler_job_id=scheduler_job_id,
+    )
+    clock = [datetime(2026, 7, 14, 16, 0, tzinfo=UTC)]
+    monkeypatch.setattr("clio_relay.endpoint.utc_now", lambda: clock[0])
+    _accept_scheduler_cancellation_without_polling(
+        setup_queue,
+        job,
+        scheduler_job_id=scheduler_job_id,
+        now=clock[0],
+    )
+    stale = setup_queue.get_scheduler_cancel_pending(job.job_id, cluster=job.cluster)
+    assert stale is not None
+    scheduler = _BlockingConfirmationScheduler(recovered_phase=SchedulerPhase.CANCELED)
+    workers = [
+        EndpointWorker(
+            role=EndpointRole.WORKER,
+            settings=settings,
+            cluster="ares",
+            queue=ClioCoreQueue(settings.core_dir),
+            scheduler_provider=scheduler,
+        )
+        for _ in range(2)
+    ]
+    for worker in workers:
+        worker.scheduler_cancel_confirmation_claim_lease_seconds = 5
+    errors: list[BaseException] = []
+    errors_lock = threading.Lock()
+
+    def reconcile(worker: EndpointWorker) -> None:
+        try:
+            cast(Any, worker)._reconcile_canceled_scheduler_job(stale)
+        except BaseException as exc:  # pragma: no cover - asserted in the parent thread
+            with errors_lock:
+                errors.append(exc)
+
+    stale_thread = threading.Thread(target=reconcile, args=(workers[0],))
+    stale_thread.start()
+    assert scheduler.first_poll_entered.wait(timeout=5)
+    clock[0] += timedelta(seconds=5)
+
+    recovered_thread = threading.Thread(target=reconcile, args=(workers[1],))
+    recovered_thread.start()
+    recovered_thread.join(timeout=10)
+    assert not recovered_thread.is_alive()
+    completed = setup_queue.get_scheduler_cancel_disposition(job.job_id, cluster=job.cluster)
+    assert completed is not None
+    assert completed.dispositions[0].state is SchedulerCancelDispositionState.CANCELED
+    assert completed.dispositions[0].confirmation_attempts == 1
+
+    scheduler.release_first_poll.set()
+    stale_thread.join(timeout=10)
+    assert not stale_thread.is_alive()
+    assert errors == []
+    assert scheduler.poll_calls == [scheduler_job_id, scheduler_job_id]
+    persisted = setup_queue.get_scheduler_cancel_disposition(job.job_id, cluster=job.cluster)
+    assert persisted == completed
+    task = setup_queue.list_tasks(job.job_id)[0]
+    scheduler_status = cast(dict[str, object], task.metadata["scheduler_status"])
+    assert scheduler_status["phase"] == SchedulerPhase.CANCELED.value
+
+
+def test_expired_scheduler_cancel_claim_is_recovered_without_spending_an_attempt(
+    tmp_path: Path,
+) -> None:
+    """A process crash leaves a bounded lease that another queue can reclaim."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    first_queue = ClioCoreQueue(settings.core_dir)
+    scheduler_job_id = "crash-recovery-13579"
+    job = _canceled_job_with_owned_scheduler_identity(
+        first_queue,
+        scheduler_job_id=scheduler_job_id,
+    )
+    _claim_ready_scheduler_identity(
+        first_queue,
+        job,
+        scheduler_job_id=scheduler_job_id,
+    )
+    acquired_at = datetime(2026, 7, 14, 12, 0, tzinfo=UTC)
+    first_claim = first_queue.claim_scheduler_cancel_attempt(
+        job.job_id,
+        cluster=job.cluster,
+        scheduler_job_id=scheduler_job_id,
+        provider="external",
+        lease_seconds=5,
+        now=acquired_at,
+    )
+    assert first_claim is not None
+
+    recovering_queue = ClioCoreQueue(settings.core_dir)
+    due_before_expiry, _ = recovering_queue.scan_due_scheduler_cancellations(
+        cluster=job.cluster,
+        limit=10,
+        now=acquired_at + timedelta(seconds=4),
+    )
+    assert due_before_expiry == []
+    assert (
+        recovering_queue.claim_scheduler_cancel_attempt(
+            job.job_id,
+            cluster=job.cluster,
+            scheduler_job_id=scheduler_job_id,
+            provider="external",
+            lease_seconds=5,
+            now=acquired_at + timedelta(seconds=4),
+        )
+        is None
+    )
+
+    recovered_claim = recovering_queue.claim_scheduler_cancel_attempt(
+        job.job_id,
+        cluster=job.cluster,
+        scheduler_job_id=scheduler_job_id,
+        provider="external",
+        lease_seconds=5,
+        now=acquired_at + timedelta(seconds=5),
+    )
+    assert recovered_claim is not None
+    assert recovered_claim.claim_id != first_claim.claim_id
+    assert recovered_claim.attempt == first_claim.attempt == 1
+    assert (
+        first_queue.record_scheduler_cancel_attempt(
+            job.job_id,
+            cluster=job.cluster,
+            scheduler_job_id=scheduler_job_id,
+            provider="external",
+            claim_id=first_claim.claim_id,
+            accepted=False,
+            error="late result from crashed claimant",
+            max_attempts=5,
+            retry_delay_seconds=30,
+            now=acquired_at + timedelta(seconds=6),
+        )
+        is None
+    )
+
+    updated = recovering_queue.record_scheduler_cancel_attempt(
+        job.job_id,
+        cluster=job.cluster,
+        scheduler_job_id=scheduler_job_id,
+        provider="external",
+        claim_id=recovered_claim.claim_id,
+        accepted=False,
+        error="scheduler temporarily unavailable",
+        max_attempts=5,
+        retry_delay_seconds=30,
+        now=acquired_at + timedelta(seconds=6),
+    )
+    assert updated is not None
+    disposition = updated.dispositions[0]
+    assert disposition.state is SchedulerCancelDispositionState.RETRY_WAIT
+    assert disposition.attempts == 1
+    assert disposition.attempt_claim_id is None
+    assert disposition.attempt_claimed_at is None
+    assert disposition.attempt_claim_expires_at is None
+
+
+def test_terminalized_scheduler_cancel_ignores_late_claim_completion(tmp_path: Path) -> None:
+    """A superseding terminal transition makes a late in-flight result a no-op."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    scheduler_job_id = "terminal-race-97531"
+    job = _canceled_job_with_owned_scheduler_identity(
+        queue,
+        scheduler_job_id=scheduler_job_id,
+    )
+    _claim_ready_scheduler_identity(queue, job, scheduler_job_id=scheduler_job_id)
+    claim = queue.claim_scheduler_cancel_attempt(
+        job.job_id,
+        cluster=job.cluster,
+        scheduler_job_id=scheduler_job_id,
+        provider="external",
+        lease_seconds=5,
+    )
+    assert claim is not None
+
+    terminal = queue.complete_scheduler_cancel_identity_scan(
+        job.job_id,
+        cluster=job.cluster,
+        superseded=True,
+    )
+    assert terminal.complete is True
+    assert terminal.dispositions[0].attempt_claim_id is None
+    assert (
+        queue.record_scheduler_cancel_attempt(
+            job.job_id,
+            cluster=job.cluster,
+            scheduler_job_id=scheduler_job_id,
+            provider="external",
+            claim_id=claim.claim_id,
+            accepted=True,
+            error=None,
+            max_attempts=5,
+            retry_delay_seconds=2,
+        )
+        is None
+    )
+    persisted = queue.get_scheduler_cancel_disposition(job.job_id, cluster=job.cluster)
+    assert persisted == terminal
+
+
+def test_maximum_legacy_pending_record_remains_writable_with_cancel_claims(
+    tmp_path: Path,
+) -> None:
+    """Unset claim fields cannot inflate a valid 1,000-disposition legacy record."""
+    root = tmp_path / "core"
+    queue = ClioCoreQueue(root)
+    queue.initialize()
+    job_id = "job_legacy_max_cancel"
+    cluster = "ares"
+    legacy = SchedulerCancelPending(
+        job_id=job_id,
+        cluster=cluster,
+        identity_resolution="resolved",
+        dispositions=[
+            SchedulerCancelDisposition(scheduler_job_id=str(index), provider="slurm")
+            for index in range(1_000)
+        ],
+    )
+    legacy_document = legacy.model_dump(mode="json")
+    for disposition in legacy_document["dispositions"]:
+        for field in (
+            "attempt_claim_id",
+            "attempt_claimed_at",
+            "attempt_claim_expires_at",
+            "confirmation_claim_id",
+            "confirmation_claimed_at",
+            "confirmation_claim_expires_at",
+        ):
+            disposition.pop(field)
+    pending_path = cast(Any, queue)._scheduler_cancel_record_path(
+        "scheduler_cancel_pending",
+        cluster,
+        job_id,
+    )
+    pending_path.parent.mkdir(parents=True, exist_ok=True)
+    legacy_bytes = json.dumps(legacy_document, indent=2).encode("utf-8")
+    assert len(legacy_bytes) <= 262_144
+    pending_path.write_bytes(legacy_bytes)
+
+    reloaded = queue.get_scheduler_cancel_pending(job_id, cluster=cluster)
+    assert reloaded is not None
+    assert len(reloaded.dispositions) == 1_000
+    acquired_at = datetime(2026, 7, 14, 14, 0, tzinfo=UTC)
+    claim = queue.claim_scheduler_cancel_attempt(
+        job_id,
+        cluster=cluster,
+        scheduler_job_id="0",
+        provider="slurm",
+        lease_seconds=5,
+        now=acquired_at,
+    )
+    assert claim is not None
+    claimed_document = json.loads(pending_path.read_bytes())
+    claimed = claimed_document["dispositions"][0]
+    assert claimed["attempt_claim_id"] == claim.claim_id
+    assert "attempt_claimed_at" in claimed
+    assert "attempt_claim_expires_at" in claimed
+    assert all(
+        "attempt_claim_id" not in disposition
+        for disposition in claimed_document["dispositions"][1:]
+    )
+
+    updated = queue.record_scheduler_cancel_attempt(
+        job_id,
+        cluster=cluster,
+        scheduler_job_id="0",
+        provider="slurm",
+        claim_id=claim.claim_id,
+        accepted=False,
+        error="retry",
+        max_attempts=5,
+        retry_delay_seconds=1,
+        now=acquired_at + timedelta(seconds=1),
+    )
+    assert updated is not None
+    assert pending_path.stat().st_size <= 262_144
+    cleared_document = json.loads(pending_path.read_bytes())
+    assert all(
+        "attempt_claim_id" not in disposition
+        and "attempt_claimed_at" not in disposition
+        and "attempt_claim_expires_at" not in disposition
+        for disposition in cleared_document["dispositions"]
+    )
+
+    recovered = queue.claim_scheduler_cancel_attempt(
+        job_id,
+        cluster=cluster,
+        scheduler_job_id="0",
+        provider="slurm",
+        lease_seconds=5,
+        now=acquired_at + timedelta(seconds=3),
+    )
+    assert recovered is not None
+    accepted = queue.record_scheduler_cancel_attempt(
+        job_id,
+        cluster=cluster,
+        scheduler_job_id="0",
+        provider="slurm",
+        claim_id=recovered.claim_id,
+        accepted=True,
+        error=None,
+        max_attempts=5,
+        retry_delay_seconds=1,
+        now=acquired_at + timedelta(seconds=3),
+    )
+    assert accepted is not None
+    confirmation_claim = queue.claim_scheduler_cancel_confirmation(
+        job_id,
+        cluster=cluster,
+        scheduler_job_id="0",
+        provider="slurm",
+        lease_seconds=5,
+        now=acquired_at + timedelta(seconds=3),
+    )
+    assert confirmation_claim is not None
+    confirmation_document = json.loads(pending_path.read_bytes())
+    confirming = confirmation_document["dispositions"][0]
+    assert confirming["confirmation_claim_id"] == confirmation_claim.claim_id
+    assert "confirmation_claimed_at" in confirming
+    assert "confirmation_claim_expires_at" in confirming
+    assert all(
+        "confirmation_claim_id" not in disposition
+        for disposition in confirmation_document["dispositions"][1:]
+    )
+    terminal = queue.complete_scheduler_cancel_identity_scan(
+        job_id,
+        cluster=cluster,
+        superseded=True,
+    )
+    assert terminal.complete is True
+    completed_path = cast(Any, queue)._scheduler_cancel_record_path(
+        "scheduler_cancel_dispositions",
+        cluster,
+        job_id,
+    )
+    completed_document = json.loads(completed_path.read_bytes())
+    assert all(
+        "attempt_claim_id" not in disposition
+        and "attempt_claimed_at" not in disposition
+        and "attempt_claim_expires_at" not in disposition
+        and "confirmation_claim_id" not in disposition
+        and "confirmation_claimed_at" not in disposition
+        and "confirmation_claim_expires_at" not in disposition
+        for disposition in completed_document["dispositions"]
+    )
+    assert queue.get_scheduler_cancel_disposition(job_id, cluster=cluster) == terminal

--- a/tests/test_scheduler_cancel_refusal_idempotency.py
+++ b/tests/test_scheduler_cancel_refusal_idempotency.py
@@ -1,0 +1,338 @@
+"""Regression coverage for durable scheduler-cancellation refusal reconciliation."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any, cast
+
+from clio_relay.config import RelaySettings
+from clio_relay.core_queue import ClioCoreQueue
+from clio_relay.endpoint import EndpointWorker
+from clio_relay.models import (
+    Cursor,
+    EndpointRole,
+    JarvisRunSpec,
+    JobKind,
+    JobState,
+    RelayEvent,
+    RelayJob,
+    RelayTask,
+    SchedulerCancelDispositionState,
+)
+from clio_relay.relay_ops import cancel_job
+from clio_relay.scheduler_providers import ExternalSchedulerProvider
+
+
+class _RecordingExternalScheduler(ExternalSchedulerProvider):
+    """Record any cancellation that incorrectly crosses the ownership boundary."""
+
+    def __init__(self) -> None:
+        self.canceled: list[str] = []
+
+    def cancel(self, scheduler_job_id: str) -> subprocess.CompletedProcess[str]:
+        """Record and delegate an unexpected external cancellation request."""
+        self.canceled.append(scheduler_job_id)
+        return super().cancel(scheduler_job_id)
+
+
+def _canceled_job_with_unowned_scheduler_identity(
+    queue: ClioCoreQueue,
+    *,
+    idempotency_key: str,
+    scheduler_job_id: str,
+) -> RelayJob:
+    """Create a canceled job carrying only legacy, unverified scheduler metadata."""
+    job = queue.submit_job(
+        RelayJob(
+            cluster="ares",
+            kind=JobKind.JARVIS,
+            spec=JarvisRunSpec(command=["sleep", "60"]),
+            idempotency_key=idempotency_key,
+        )
+    )
+    queue.append_task(
+        RelayTask(
+            job_id=job.job_id,
+            name="jarvis.execution",
+            state=JobState.RUNNING,
+            metadata={"scheduler": "external", "scheduler_job_ids": [scheduler_job_id]},
+        )
+    )
+    canceled = cancel_job(queue, job.job_id, cancel_scheduler=True)
+    assert canceled.state is JobState.CANCELED
+    return canceled
+
+
+def _canceled_job_with_mixed_scheduler_identities(
+    queue: ClioCoreQueue,
+    *,
+    owned_scheduler_job_id: str,
+    unowned_scheduler_job_id: str,
+) -> RelayJob:
+    """Create a canceled job whose owned cancellation remains retryable."""
+    job = queue.submit_job(
+        RelayJob(
+            cluster="ares",
+            kind=JobKind.JARVIS,
+            spec=JarvisRunSpec(command=["sleep", "60"]),
+            idempotency_key="mixed-scheduler-identities",
+        )
+    )
+    task = RelayTask(
+        job_id=job.job_id,
+        name="jarvis.execution",
+        state=JobState.RUNNING,
+    )
+    queue.append_task(
+        task.model_copy(
+            update={
+                "metadata": {
+                    "scheduler": "external",
+                    "scheduler_job_ids": [
+                        owned_scheduler_job_id,
+                        unowned_scheduler_job_id,
+                    ],
+                    "scheduler_job_ownership": [
+                        {
+                            "scheduler_job_id": owned_scheduler_job_id,
+                            "scheduler_provider": "external",
+                            "relay_job_id": job.job_id,
+                            "task_id": task.task_id,
+                            "execution_id": f"execution-{owned_scheduler_job_id}",
+                            "runtime_metadata_source": "jarvis_sidecar",
+                            "ownership_verified": True,
+                            "proof": "authenticated_runtime_sidecar",
+                        }
+                    ],
+                }
+            }
+        )
+    )
+    canceled = cancel_job(queue, job.job_id, cancel_scheduler=True)
+    assert canceled.state is JobState.CANCELED
+    return canceled
+
+
+def _worker(
+    settings: RelaySettings,
+    queue: ClioCoreQueue,
+    scheduler: _RecordingExternalScheduler,
+) -> EndpointWorker:
+    """Create and register the worker used for public-loop reconciliation tests."""
+    worker = EndpointWorker(
+        role=EndpointRole.WORKER,
+        settings=settings,
+        cluster="ares",
+        queue=queue,
+        scheduler_provider=scheduler,
+    )
+    worker.register()
+    return worker
+
+
+def _scheduler_refusal_events(queue: ClioCoreQueue, job_id: str) -> list[RelayEvent]:
+    """Return the bounded refusal-event set for one compact regression fixture."""
+    events, _ = queue.drain_events(Cursor(job_id=job_id), limit=100)
+    return [event for event in events if event.event_type == "scheduler.cancel_refused"]
+
+
+def test_repeated_unowned_cancel_reconciliation_is_terminal_and_idempotent(
+    tmp_path: Path,
+) -> None:
+    """Repeated worker polls emit one refusal and retain one terminal disposition."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    job = _canceled_job_with_unowned_scheduler_identity(
+        queue,
+        idempotency_key="fresh-unowned-cancel",
+        scheduler_job_id="legacy-unowned-24680",
+    )
+    scheduler = _RecordingExternalScheduler()
+    worker = _worker(settings, queue, scheduler)
+
+    for _ in range(3):
+        assert worker.run_once() is None
+
+    refused = _scheduler_refusal_events(queue, job.job_id)
+    disposition = queue.get_scheduler_cancel_disposition(job.job_id, cluster=job.cluster)
+    assert len(refused) == 1
+    assert refused[0].payload == {
+        "scheduler_job_id": "legacy-unowned-24680",
+        "metadata_source": "unverified_durable_metadata",
+        "ownership_verified": False,
+    }
+    assert disposition is not None
+    assert disposition.complete is True
+    assert disposition.identity_resolution == "resolved"
+    assert [item.state for item in disposition.dispositions] == [
+        SchedulerCancelDispositionState.REFUSED
+    ]
+    assert queue.get_scheduler_cancel_pending(job.job_id, cluster=job.cluster) is None
+    assert scheduler.canceled == []
+
+
+def test_restart_finalizes_existing_refusal_without_emitting_it_again(tmp_path: Path) -> None:
+    """A crash after recording refusal cannot restart an unbounded event loop."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    scheduler_job_id = "legacy-unowned-13579"
+    job = _canceled_job_with_unowned_scheduler_identity(
+        queue,
+        idempotency_key="interrupted-unowned-cancel",
+        scheduler_job_id=scheduler_job_id,
+    )
+    pending = queue.register_scheduler_cancel_identity(
+        job.job_id,
+        cluster=job.cluster,
+        scheduler_job_id=scheduler_job_id,
+        provider="external",
+        ownership_verified=False,
+    )
+    assert pending.identity_resolution == "pending"
+    assert [item.state for item in pending.dispositions] == [
+        SchedulerCancelDispositionState.REFUSED
+    ]
+    queue.append_event(
+        job.job_id,
+        "scheduler.cancel_refused",
+        "Refused scheduler cancellation because no owned scheduler identity was available",
+        payload={
+            "scheduler_job_id": scheduler_job_id,
+            "metadata_source": "unverified_durable_metadata",
+            "ownership_verified": False,
+        },
+    )
+    scheduler = _RecordingExternalScheduler()
+    worker = _worker(settings, queue, scheduler)
+
+    for _ in range(3):
+        assert worker.run_once() is None
+
+    disposition = queue.get_scheduler_cancel_disposition(job.job_id, cluster=job.cluster)
+    assert len(_scheduler_refusal_events(queue, job.job_id)) == 1
+    assert disposition is not None
+    assert disposition.complete is True
+    assert disposition.identity_resolution == "resolved"
+    assert [item.scheduler_job_id for item in disposition.dispositions] == [scheduler_job_id]
+    assert [item.state for item in disposition.dispositions] == [
+        SchedulerCancelDispositionState.REFUSED
+    ]
+    assert queue.get_scheduler_cancel_pending(job.job_id, cluster=job.cluster) is None
+    assert scheduler.canceled == []
+
+
+def test_stale_mixed_identity_reconciliations_emit_one_refusal_across_restart(
+    tmp_path: Path,
+) -> None:
+    """Only the atomic creator emits while an owned retry keeps the record pending."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    owned_scheduler_job_id = "owned-retry-24680"
+    unowned_scheduler_job_id = "unowned-refused-13579"
+    job = _canceled_job_with_mixed_scheduler_identities(
+        queue,
+        owned_scheduler_job_id=owned_scheduler_job_id,
+        unowned_scheduler_job_id=unowned_scheduler_job_id,
+    )
+    stale = queue.get_scheduler_cancel_pending(job.job_id, cluster=job.cluster)
+    assert stale is not None
+    scheduler = _RecordingExternalScheduler()
+    worker = EndpointWorker(
+        role=EndpointRole.WORKER,
+        settings=settings,
+        cluster="ares",
+        queue=queue,
+        scheduler_provider=scheduler,
+    )
+    worker.scheduler_cancel_retry_base_seconds = 3_600
+    reconcile = cast(Any, worker)._reconcile_canceled_scheduler_job
+
+    reconcile(stale)
+    reconcile(stale)
+    restarted = _worker(settings, queue, scheduler)
+    restarted.scheduler_cancel_retry_base_seconds = 3_600
+    assert restarted.run_once() is None
+
+    refused = _scheduler_refusal_events(queue, job.job_id)
+    pending = queue.get_scheduler_cancel_pending(job.job_id, cluster=job.cluster)
+    assert len(refused) == 1
+    assert refused[0].payload["scheduler_job_id"] == unowned_scheduler_job_id
+    assert queue.get_scheduler_cancel_disposition(job.job_id, cluster=job.cluster) is None
+    assert pending is not None
+    assert pending.identity_resolution == "resolved"
+    assert {item.scheduler_job_id: item.state for item in pending.dispositions} == {
+        owned_scheduler_job_id: SchedulerCancelDispositionState.RETRY_WAIT,
+        unowned_scheduler_job_id: SchedulerCancelDispositionState.REFUSED,
+    }
+    assert scheduler.canceled == [owned_scheduler_job_id]
+
+
+def test_explicit_refusal_identity_wins_over_job_runtime_metadata(tmp_path: Path) -> None:
+    """A task-level refusal event cannot be relabeled with a job-level scheduler id."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    job = queue.submit_job(
+        RelayJob(
+            cluster="ares",
+            kind=JobKind.JARVIS,
+            spec=JarvisRunSpec(command=["true"]),
+            idempotency_key="explicit-refusal-identity",
+            metadata={
+                "runtime_metadata": {
+                    "scheduler_job_id": "job-level-111",
+                    "source": "jarvis_sidecar",
+                }
+            },
+        )
+    )
+    worker = EndpointWorker(
+        role=EndpointRole.WORKER,
+        settings=settings,
+        cluster="ares",
+        queue=queue,
+        scheduler_provider=_RecordingExternalScheduler(),
+    )
+
+    cast(Any, worker)._record_scheduler_cancel_refused(
+        job,
+        scheduler_job_id="task-level-222",
+        metadata_source="unverified_durable_metadata",
+    )
+
+    refused = _scheduler_refusal_events(queue, job.job_id)
+    assert len(refused) == 1
+    assert refused[0].payload == {
+        "scheduler_job_id": "task-level-222",
+        "metadata_source": "unverified_durable_metadata",
+        "ownership_verified": False,
+    }
+
+
+def test_stale_superseded_operator_request_completion_is_idempotent(tmp_path: Path) -> None:
+    """Two slots may terminalize one pre-job-write cancellation record safely."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    job = queue.submit_job(
+        RelayJob(
+            cluster="ares",
+            kind=JobKind.JARVIS,
+            spec=JarvisRunSpec(command=["true"]),
+            idempotency_key="stale-superseded-operator-request",
+        )
+    )
+    queue.ensure_scheduler_cancel_pending(job.job_id, reason="operator_request")
+    stale = queue.get_scheduler_cancel_pending(job.job_id, cluster=job.cluster)
+    assert stale is not None
+    worker = _worker(settings, queue, _RecordingExternalScheduler())
+    reconcile = cast(Any, worker)._reconcile_canceled_scheduler_job
+
+    reconcile(stale)
+    reconcile(stale)
+
+    disposition = queue.get_scheduler_cancel_disposition(job.job_id, cluster=job.cluster)
+    assert disposition is not None
+    assert disposition.complete is True
+    assert disposition.identity_resolution == "superseded"
+    assert disposition.dispositions == []
+    assert queue.get_scheduler_cancel_pending(job.job_id, cluster=job.cluster) is None

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1612,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.0.7"
+    assert policy.release_version == "1.0.8"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/tests/test_worker_lifetime_lock.py
+++ b/tests/test_worker_lifetime_lock.py
@@ -458,10 +458,10 @@ def test_external_guard_evidence_validates_real_exclusive_handoff(
         return
     core_dir = tmp_path / "core"
     guard = WorkerLifetimeLock(core_dir, mode="exclusive").acquire()
-    owner_descriptor = guard._fd  # noqa: SLF001
+    owner_descriptor = guard._fd  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
     assert owner_descriptor is not None
     inherited_descriptor = os.dup(owner_descriptor)
-    guard._fd = None  # noqa: SLF001
+    guard._fd = None  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
     os.close(owner_descriptor)
     monkeypatch.setenv(WORKER_LIFETIME_GUARD_FD_ENV, str(inherited_descriptor))
     try:

--- a/tests/test_worker_lifetime_lock.py
+++ b/tests/test_worker_lifetime_lock.py
@@ -1,0 +1,594 @@
+"""Cross-process worker lifetime and migration exclusion coverage."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from collections.abc import Generator
+from contextlib import contextmanager
+from io import StringIO
+from pathlib import Path
+from typing import Any, Literal
+
+import pytest
+
+import clio_relay.core_queue as core_queue_module
+import clio_relay.endpoint as endpoint_module
+import clio_relay.storage_runtime as storage_runtime_module
+from clio_relay.config import RelaySettings
+from clio_relay.core_queue import ClioCoreQueue, LegacyQueueStateError
+from clio_relay.errors import ConfigurationError
+from clio_relay.models import EndpointRole, JarvisRunSpec, JobKind, RelayEvent, RelayJob
+from clio_relay.storage_runtime import storage_managed_queue
+from clio_relay.worker_lifetime_lock import (
+    WORKER_LIFETIME_GUARD_FD_ENV,
+    LockedCoreIdentity,
+    WorkerLifetimeLock,
+    WorkerLifetimeLockUnavailable,
+    exclusive_migration_lifetime,
+)
+
+
+def _start_shared_lock_holder(core_dir: Path) -> subprocess.Popen[str]:
+    """Start a real child that owns a shared lifetime lock until stdin closes."""
+    source = """
+from pathlib import Path
+import sys
+from clio_relay.worker_lifetime_lock import WorkerLifetimeLock
+
+lock = WorkerLifetimeLock(Path(sys.argv[1]), mode="shared").acquire()
+print("ready", flush=True)
+sys.stdin.readline()
+lock.release()
+"""
+    process = subprocess.Popen(
+        [sys.executable, "-c", source, str(core_dir)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert process.stdout is not None
+    assert process.stdout.readline().strip() == "ready"
+    return process
+
+
+def _release_lock_holder(process: subprocess.Popen[str]) -> None:
+    """Release and reap a child lock holder with bounded failure reporting."""
+    assert process.stdin is not None
+    process.stdin.write("release\n")
+    process.stdin.flush()
+    stdout, stderr = process.communicate(timeout=10)
+    assert process.returncode == 0, f"stdout={stdout!r} stderr={stderr!r}"
+
+
+def test_shared_workers_exclude_migration_across_processes(tmp_path: Path) -> None:
+    """Multiple workers coexist, while migration waits for every worker to exit."""
+    core_dir = tmp_path / "core"
+    process = _start_shared_lock_holder(core_dir)
+    local_shared = WorkerLifetimeLock(
+        core_dir,
+        mode="shared",
+        timeout_seconds=0,
+    ).acquire()
+    try:
+        with pytest.raises(WorkerLifetimeLockUnavailable):
+            WorkerLifetimeLock(
+                core_dir,
+                mode="exclusive",
+                timeout_seconds=0,
+            ).acquire()
+    finally:
+        local_shared.release()
+        _release_lock_holder(process)
+
+    exclusive = WorkerLifetimeLock(
+        core_dir,
+        mode="exclusive",
+        timeout_seconds=0,
+    ).acquire()
+    try:
+        with pytest.raises(WorkerLifetimeLockUnavailable):
+            WorkerLifetimeLock(
+                core_dir,
+                mode="shared",
+                timeout_seconds=0,
+            ).acquire()
+    finally:
+        exclusive.release()
+
+
+def test_lifetime_locks_are_scoped_to_physical_core(tmp_path: Path) -> None:
+    """An exclusive migration on one core never blocks a different core."""
+    first = WorkerLifetimeLock(tmp_path / "first", mode="exclusive").acquire()
+    second = WorkerLifetimeLock(
+        tmp_path / "second",
+        mode="shared",
+        timeout_seconds=0,
+    ).acquire()
+    second.release()
+    first.release()
+
+
+def test_stable_lexical_core_alias_is_accepted(tmp_path: Path) -> None:
+    """Equivalent lexical paths resolve to one physical lifetime-lock identity."""
+    parent = tmp_path / "physical"
+    core_dir = parent / "core"
+    core_dir.mkdir(parents=True)
+    (parent / "unused").mkdir()
+    alias = parent / "unused" / ".." / "core"
+
+    shared = WorkerLifetimeLock(alias, mode="shared", timeout_seconds=0).acquire()
+    second = WorkerLifetimeLock(core_dir, mode="shared", timeout_seconds=0).acquire()
+    assert shared.core_dir == core_dir.resolve()
+    second.release()
+    shared.release()
+
+    ClioCoreQueue(alias).initialize(migrate_legacy_output=True)
+
+
+def test_retargeted_core_alias_is_rejected_before_worker_write(tmp_path: Path) -> None:
+    """A worker cannot continue after its queue alias changes physical identity."""
+    if os.name == "nt":
+        # Stable lexical aliases are covered portably above. Windows junction
+        # creation is privilege/policy dependent; CI exercises retargeting on
+        # POSIX where managed bootstrap runs.
+        return
+    first_parent = tmp_path / "first"
+    second_parent = tmp_path / "second"
+    first_core = first_parent / "core"
+    second_core = second_parent / "core"
+    first_core.mkdir(parents=True)
+    second_core.mkdir(parents=True)
+    alias_parent = tmp_path / "current"
+    alias_parent.symlink_to(first_parent, target_is_directory=True)
+    aliased_core = alias_parent / "core"
+    queue = ClioCoreQueue(aliased_core)
+    queue.initialize()
+    worker = endpoint_module.EndpointWorker(
+        role=EndpointRole.WORKER,
+        cluster="test",
+        settings=RelaySettings(core_dir=aliased_core, spool_dir=tmp_path / "spool"),
+        queue=queue,
+    )
+    try:
+        alias_parent.unlink()
+        alias_parent.symlink_to(second_parent, target_is_directory=True)
+        with pytest.raises(ConfigurationError, match="identity changed"):
+            worker.register()
+    finally:
+        worker.close()
+
+
+def test_migration_rejects_alias_retarget_after_exclusive_acquisition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A post-lock alias retarget fails before migration writes the new target."""
+    if os.name == "nt":
+        return
+    first_parent = tmp_path / "first-migration"
+    second_parent = tmp_path / "second-migration"
+    first_core = first_parent / "core"
+    second_core = second_parent / "core"
+    first_core.mkdir(parents=True)
+    second_core.mkdir(parents=True)
+    alias_parent = tmp_path / "migration-current"
+    alias_parent.symlink_to(first_parent, target_is_directory=True)
+    queue = ClioCoreQueue(alias_parent / "core")
+    actual_guard = exclusive_migration_lifetime
+
+    @contextmanager
+    def retargeting_guard(
+        root: Path,
+    ) -> Generator[LockedCoreIdentity, None, None]:
+        with actual_guard(root) as locked_core:
+            alias_parent.unlink()
+            alias_parent.symlink_to(second_parent, target_is_directory=True)
+            yield locked_core
+
+    monkeypatch.setattr(
+        core_queue_module,
+        "exclusive_migration_lifetime",
+        retargeting_guard,
+    )
+
+    with pytest.raises(ConfigurationError, match="does not match its core lifetime lock"):
+        queue.initialize(migrate_legacy_output=True)
+
+    assert list(second_core.iterdir()) == []
+
+
+def test_worker_lock_is_acquired_before_default_queue_construction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default worker queue initialization cannot race ahead of shared ownership."""
+    events: list[str] = []
+
+    class RecordingLock:
+        """Minimal acquisition recorder for constructor ordering."""
+
+        def __init__(
+            self,
+            core_dir: Path,
+            *,
+            mode: Literal["shared", "exclusive"],
+            timeout_seconds: float | None = None,
+        ) -> None:
+            del timeout_seconds
+            assert mode == "shared"
+            core_dir.mkdir(parents=True, exist_ok=True)
+            self.core_dir = core_dir.resolve()
+
+        def acquire(self) -> RecordingLock:
+            """Record shared ownership."""
+            events.append("lock")
+            return self
+
+        def release(self) -> None:
+            """Record rollback after queue construction fails."""
+            events.append("release")
+
+    def fail_queue(
+        _settings: RelaySettings,
+        *,
+        writer_lifetime_lock: WorkerLifetimeLock | None = None,
+    ) -> ClioCoreQueue:
+        assert events == ["lock"]
+        assert writer_lifetime_lock is not None
+        events.append("queue")
+        raise RuntimeError("queue construction failed")
+
+    monkeypatch.setattr(endpoint_module, "WorkerLifetimeLock", RecordingLock)
+    monkeypatch.setattr(endpoint_module, "storage_managed_queue", fail_queue)
+
+    with pytest.raises(RuntimeError, match="queue construction failed"):
+        endpoint_module.EndpointWorker(
+            role=EndpointRole.WORKER,
+            cluster="test",
+            settings=RelaySettings(
+                core_dir=tmp_path / "core",
+                spool_dir=tmp_path / "spool",
+            ),
+        )
+
+    assert events == ["lock", "queue", "release"]
+
+
+def test_every_production_queue_holds_shared_writer_lifetime_ownership(
+    tmp_path: Path,
+) -> None:
+    """API, MCP, CLI, and future managed queues all exclude migration until close."""
+    core_dir = tmp_path / "core"
+    queue = storage_managed_queue(RelaySettings(core_dir=core_dir, spool_dir=tmp_path / "spool"))
+    retained_submit = queue.submit_job
+    try:
+        with pytest.raises(WorkerLifetimeLockUnavailable):
+            WorkerLifetimeLock(
+                core_dir,
+                mode="exclusive",
+                timeout_seconds=0,
+            ).acquire()
+    finally:
+        queue.close()
+
+    assert queue.closed is True
+    with pytest.raises(ConfigurationError, match="managed queue is closed"):
+        queue.submit_job(
+            RelayJob(
+                cluster="test",
+                kind=JobKind.JARVIS,
+                spec=JarvisRunSpec(command=["true"]),
+                idempotency_key="closed-queue-submit",
+            )
+        )
+    with pytest.raises(ConfigurationError, match="managed queue is closed"):
+        retained_submit(
+            RelayJob(
+                cluster="test",
+                kind=JobKind.JARVIS,
+                spec=JarvisRunSpec(command=["true"]),
+                idempotency_key="retained-closed-queue-submit",
+            )
+        )
+
+    exclusive = WorkerLifetimeLock(
+        core_dir,
+        mode="exclusive",
+        timeout_seconds=0,
+    ).acquire()
+    exclusive.release()
+
+
+def test_migration_factory_returns_closed_non_writer_queue(tmp_path: Path) -> None:
+    """Explicit migration cannot return an unfenced queue capable of later writes."""
+    core_dir = tmp_path / "core"
+    queue = storage_managed_queue(
+        RelaySettings(core_dir=core_dir, spool_dir=tmp_path / "spool"),
+        migrate_legacy_output=True,
+    )
+
+    assert queue.closed is True
+    with pytest.raises(ConfigurationError, match="managed queue is closed"):
+        queue.get_job("missing")
+    exclusive = WorkerLifetimeLock(
+        core_dir,
+        mode="exclusive",
+        timeout_seconds=0,
+    ).acquire()
+    exclusive.release()
+
+
+def test_managed_queue_reuses_callers_shared_lifetime_without_owning_it(
+    tmp_path: Path,
+) -> None:
+    """Endpoint workers can retain one shared lock across queue construction and close."""
+    core_dir = tmp_path / "core"
+    shared = WorkerLifetimeLock(core_dir, mode="shared").acquire()
+    queue = storage_managed_queue(
+        RelaySettings(core_dir=core_dir, spool_dir=tmp_path / "spool"),
+        writer_lifetime_lock=shared,
+    )
+
+    queue.close()
+    with pytest.raises(WorkerLifetimeLockUnavailable):
+        WorkerLifetimeLock(
+            core_dir,
+            mode="exclusive",
+            timeout_seconds=0,
+        ).acquire()
+    shared.release()
+
+
+def test_desktop_endpoint_close_releases_its_managed_writer_lifetime(
+    tmp_path: Path,
+) -> None:
+    """A non-worker endpoint releases the managed queue lock on explicit close."""
+    core_dir = tmp_path / "core"
+    endpoint = endpoint_module.EndpointWorker(
+        role=EndpointRole.DESKTOP,
+        cluster="desktop",
+        settings=RelaySettings(core_dir=core_dir, spool_dir=tmp_path / "spool"),
+    )
+    with pytest.raises(WorkerLifetimeLockUnavailable):
+        WorkerLifetimeLock(
+            core_dir,
+            mode="exclusive",
+            timeout_seconds=0,
+        ).acquire()
+
+    endpoint.close()
+    exclusive = WorkerLifetimeLock(
+        core_dir,
+        mode="exclusive",
+        timeout_seconds=0,
+    ).acquire()
+    exclusive.release()
+
+
+def test_http_api_shutdown_releases_managed_writer_lifetime(tmp_path: Path) -> None:
+    """The HTTP server retains shared ownership only through its app lifespan."""
+    from fastapi.testclient import TestClient
+
+    from clio_relay.http_api import create_app
+
+    core_dir = tmp_path / "core"
+    settings = RelaySettings(core_dir=core_dir, spool_dir=tmp_path / "spool")
+    app = create_app(settings)
+    with TestClient(app), pytest.raises(WorkerLifetimeLockUnavailable):
+        WorkerLifetimeLock(
+            core_dir,
+            mode="exclusive",
+            timeout_seconds=0,
+        ).acquire()
+
+    exclusive = WorkerLifetimeLock(
+        core_dir,
+        mode="exclusive",
+        timeout_seconds=0,
+    ).acquire()
+    exclusive.release()
+    with (
+        pytest.raises(RuntimeError, match="cannot restart after shutdown"),
+        TestClient(app),
+    ):
+        pass
+
+
+def test_mcp_stdio_exit_releases_managed_writer_lifetime(tmp_path: Path) -> None:
+    """The stdio MCP server releases shared ownership when its input closes."""
+    from clio_relay.mcp_server import serve_stdio
+
+    core_dir = tmp_path / "core"
+    serve_stdio(
+        stdin=StringIO(""),
+        stdout=StringIO(),
+        settings=RelaySettings(core_dir=core_dir, spool_dir=tmp_path / "spool"),
+    )
+
+    exclusive = WorkerLifetimeLock(
+        core_dir,
+        mode="exclusive",
+        timeout_seconds=0,
+    ).acquire()
+    exclusive.release()
+
+
+def test_authoritative_migration_api_enters_exclusive_lifetime_guard(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct Python migration cannot reach its audit without exclusive ownership."""
+    root = tmp_path / "core"
+    root.mkdir()
+    guarded = False
+    original_audit = ClioCoreQueue._audit_legacy_state_before_initialization  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+
+    def guarded_audit(self: ClioCoreQueue) -> Any:
+        nonlocal guarded
+        with pytest.raises(WorkerLifetimeLockUnavailable):
+            WorkerLifetimeLock(
+                root,
+                mode="shared",
+                timeout_seconds=0,
+            ).acquire()
+        guarded = True
+        assert guarded
+        return original_audit(self)
+
+    monkeypatch.setattr(
+        ClioCoreQueue,
+        "_audit_legacy_state_before_initialization",
+        guarded_audit,
+    )
+
+    ClioCoreQueue(root).initialize(migrate_legacy_output=True)
+    assert guarded
+
+
+def test_external_guard_evidence_validates_real_exclusive_handoff(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A child descriptor retains EX after the shell-side descriptor closes."""
+    if os.name != "posix":
+        return
+    core_dir = tmp_path / "core"
+    guard = WorkerLifetimeLock(core_dir, mode="exclusive").acquire()
+    owner_descriptor = guard._fd  # noqa: SLF001
+    assert owner_descriptor is not None
+    inherited_descriptor = os.dup(owner_descriptor)
+    guard._fd = None  # noqa: SLF001
+    os.close(owner_descriptor)
+    monkeypatch.setenv(WORKER_LIFETIME_GUARD_FD_ENV, str(inherited_descriptor))
+    try:
+        with (
+            exclusive_migration_lifetime(core_dir),
+            pytest.raises(WorkerLifetimeLockUnavailable),
+        ):
+            WorkerLifetimeLock(
+                core_dir,
+                mode="shared",
+                timeout_seconds=0,
+            ).acquire()
+    finally:
+        os.close(inherited_descriptor)
+
+
+def _write_oversized_legacy_output(root: Path) -> None:
+    """Write one exact v0.9-style duplicated output event above the normal cap."""
+    path = root / "events" / "legacy_job" / "00000000000000000001.json"
+    path.parent.mkdir(parents=True)
+    text = "legacy-output\n" * 30_000
+    event = RelayEvent(
+        job_id="legacy_job",
+        seq=1,
+        event_type="stdout.delta",
+        message=text.rstrip("\n"),
+        payload={"stream": "stdout", "text": text},
+    )
+    path.write_text(event.model_dump_json(indent=2), encoding="utf-8")
+
+
+def test_normal_storage_startup_refuses_legacy_before_storage_mutation(
+    tmp_path: Path,
+) -> None:
+    """Ordinary init audits legacy output before runtime creates `.storage` or spool."""
+    core_dir = tmp_path / "core"
+    spool_dir = tmp_path / "spool"
+    _write_oversized_legacy_output(core_dir)
+
+    with pytest.raises(LegacyQueueStateError):
+        storage_managed_queue(RelaySettings(core_dir=core_dir, spool_dir=spool_dir))
+
+    assert not (core_dir / ".storage").exists()
+    assert not spool_dir.exists()
+
+
+def test_storage_migration_waits_for_exclusive_before_runtime_mutation(
+    tmp_path: Path,
+) -> None:
+    """A live shared worker prevents `.storage` creation before migration EX."""
+    core_dir = tmp_path / "core"
+    spool_dir = tmp_path / "spool"
+    started = tmp_path / "started"
+    shared = WorkerLifetimeLock(core_dir, mode="shared").acquire()
+    source = """
+from pathlib import Path
+import sys
+from clio_relay.config import RelaySettings
+from clio_relay.storage_runtime import storage_managed_queue
+
+core, spool, started = map(Path, sys.argv[1:])
+started.write_text("started", encoding="utf-8")
+storage_managed_queue(
+    RelaySettings(core_dir=core, spool_dir=spool),
+    migrate_legacy_output=True,
+)
+"""
+    process = subprocess.Popen(
+        [sys.executable, "-c", source, str(core_dir), str(spool_dir), str(started)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    deadline = time.monotonic() + 10
+    while not started.exists() and process.poll() is None and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert started.exists()
+    time.sleep(0.1)
+    assert process.poll() is None
+    assert not (core_dir / ".storage").exists()
+    assert not spool_dir.exists()
+    shared.release()
+    stdout, stderr = process.communicate(timeout=30)
+    assert process.returncode == 0, f"stdout={stdout!r} stderr={stderr!r}"
+    assert (core_dir / ".storage").is_dir()
+
+
+def test_storage_migration_pins_runtime_when_alias_retargets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runtime and policy remain on locked A when an ancestor alias retargets to B."""
+    if os.name == "nt":
+        return
+    first_parent = tmp_path / "storage-first"
+    second_parent = tmp_path / "storage-second"
+    first_core = first_parent / "core"
+    second_core = second_parent / "core"
+    first_core.mkdir(parents=True)
+    second_core.mkdir(parents=True)
+    alias_parent = tmp_path / "storage-current"
+    alias_parent.symlink_to(first_parent, target_is_directory=True)
+    actual_guard = exclusive_migration_lifetime
+
+    @contextmanager
+    def retargeting_guard(
+        root: Path,
+    ) -> Generator[LockedCoreIdentity, None, None]:
+        with actual_guard(root) as locked_core:
+            alias_parent.unlink()
+            alias_parent.symlink_to(second_parent, target_is_directory=True)
+            yield locked_core
+
+    monkeypatch.setattr(
+        storage_runtime_module,
+        "exclusive_migration_lifetime",
+        retargeting_guard,
+    )
+    queue = storage_managed_queue(
+        RelaySettings(
+            core_dir=alias_parent / "core",
+            spool_dir=tmp_path / "spool",
+        ),
+        migrate_legacy_output=True,
+    )
+
+    assert queue.root == first_core.resolve()
+    assert queue.storage_runtime.config.core_root == first_core.resolve()
+    assert (first_core / ".storage").is_dir()
+    assert list(second_core.iterdir()) == []

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.0.7"
+version = "1.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- migrate exact v0.9 oversized output records with durable archives, receipts, bounded recovery, and final source-to-index reconciliation
- fence every managed queue writer across workers, HTTP API, MCP stdio, desktop endpoints, and explicit migration; reject retained same-core legacy CLI processes during bootstrap
- make scheduler cancellation claims atomic, bounded, race-safe, provider-validated, and idempotent
- honor configured remote core/spool paths and safe HOME/systemd expansion across bootstrap, services, doctor, transport, and live acceptance
- keep the v1.0.8 release mutable while tightening the candidate/released artifact chain and 17-report acceptance gate

## Verification

- Ruff lint and formatting: clean across 152 files
- Pyright: 0 errors
- focused legacy migration, writer fence, bootstrap, scheduler cancellation, API, MCP, storage, and release workflow suites: green
- fresh wheel and sdist: built successfully and passed twine check
- independent blocker review reproduced and closed late flat writes, retained API/MCP/CLI writers, returned migration queue reuse, closed-queue reuse, and API lifespan restart

Tracks #3, #4, #5, #6, #7, #8, #9, #10, and #11. Issues remain open until the released-artifact acceptance chain completes.