### PR TITLE
fix: serialize queue snapshot readers

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -786,17 +786,20 @@ jobs:
               json.dumps(claims, indent=2, sort_keys=True) + "\n",
               encoding="utf-8",
           )
-          requirements = "\n".join(
-              f"- `{requirement}`"
-              for requirement in claims["released_artifact_requirements"]
-          )
           notes = (
               f"clio-relay {tag}\n\n"
-              f"Release acceptance passed through one persistent published "
-              f"`uv tool install clio-relay=={version}` path on "
-              f"{', '.join(claims['clusters'])}. Claims are limited to the "
-              "machine-readable requirements and reports in `RELEASE-CLAIMS.json`.\n\n"
-              f"Validated requirements:\n\n{requirements}\n"
+              "Production 1.0 release for durable desktop-to-cluster execution.\n\n"
+              "Highlights:\n\n"
+              "- Generic cluster-aware virtualization of registered remote MCP servers.\n"
+              "- Explicit detach and owned-resource cleanup, with scheduler jobs preserved by default.\n"
+              "- Provider-specific scheduler lifecycle handling and structured JARVIS runtime metadata.\n"
+              "- Machine-readable progress, artifacts, provenance, and live-validation reports.\n\n"
+              f"The exact PyPI artifact was installed with "
+              f"`uv tool install clio-relay=={version}` and validated on "
+              f"{', '.join(claims['clusters'])}. See `RELEASE-CLAIMS.json` and the "
+              "attached candidate/released reports for the complete evidence. "
+              "This 1.0 release is intentionally mutable; GitHub release immutability "
+              "is planned for 1.1.\n"
           )
           (root / "evidence" / "RELEASE-NOTES.md").write_text(notes, encoding="utf-8")
           PY

--- a/.github/workflows/live-validation-attest.yml
+++ b/.github/workflows/live-validation-attest.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing digest-bound candidate draft tag, such as v1.0.8
+        description: Existing digest-bound candidate draft tag, such as v1.0.9
         required: true
         type: string
 

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing draft release tag, such as v1.0.8
+        description: Existing draft release tag, such as v1.0.9
         required: true
         type: string
       reviewed_main_sha:

--- a/.github/workflows/stage-candidate.yml
+++ b/.github/workflows/stage-candidate.yml
@@ -305,7 +305,7 @@ jobs:
               --target "$SOURCE_COMMIT" \
               --draft \
               --title "$TAG_NAME" \
-              --notes "Candidate wheel SHA-256: $wheel_sha. Live validation and PyPI promotion are pending. GitHub release immutability is deferred to 1.1."
+              --notes "Production 1.0 candidate. Exact wheel SHA-256: $wheel_sha. Candidate and released-artifact validation are pending; GitHub release immutability is planned for 1.1."
           fi
           relay_release_resolve_eventually "$TAG_NAME" true \
             "$RUNNER_TEMP/release-after-create.json"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> The current development candidate is `1.0.8`. The `v1.0.0` candidate
+> The current development candidate is `1.0.9`. The `v1.0.0` candidate
 > was abandoned before publication after its acceptance runbook rejected the
 > staged GNU checksum format; `v1.0.1` was also abandoned before publication
 > after protected-main validation exposed a Windows lease-deletion race;
@@ -26,7 +26,9 @@ It is a piece of the federation layer for [`clio-agent`](https://github.com/iowa
 > distribution-source, and receipt verification; `v1.0.7` was abandoned after
 > one failed bootstrap report exposed that the pre-1.0 state audit rejected
 > valid v0.9.22 output events and production-sized event histories before
-> migration. The latest released live evidence is `0.9.22`; `1.0.8` is not
+> migration; `v1.0.8` was abandoned before candidate staging when protected-main
+> validation exposed a concurrent per-job lease-index read/delete race. The
+> latest released live evidence is `0.9.22`; `1.0.9` is not
 > release-complete until its digest-bound
 > candidate reports pass, its exact candidate is published, and the released-artifact
 > runs pass again. The published 1.0 GitHub release is intentionally mutable;

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.0.8"
+$Version = "1.0.9"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.0.8"
+release_version: "1.0.9"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 1fac1e2ecec5f84528285d3a512876c2fe481d9ff7e65a6d166dc588fc810975
+acceptance_matrix_sha256: d23cddf47e67bdfcb3df637800daf37ed9aa4cedf4bb2a1ee66345ae30bd9ab9
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -70,7 +70,7 @@ Commit the release change with a conventional commit, then create and push an
 exact matching tag:
 
 ```powershell
-$Tag = "v1.0.8"
+$Tag = "v1.0.9"
 git fetch origin main
 $ReviewedMainSha = (git rev-parse refs/remotes/origin/main).Trim()
 if ((git rev-parse HEAD).Trim() -ne $ReviewedMainSha) {
@@ -154,7 +154,7 @@ Download the draft wheel and manifest, verify both the digest and the signed
 tag-build provenance, and compute the digest locally:
 
 ```powershell
-$Tag = "v1.0.8"
+$Tag = "v1.0.9"
 New-Item -ItemType Directory -Force .clio-relay\candidate | Out-Null
 gh release download $Tag --pattern "*.whl" --pattern "SHA256SUMS" `
   --dir .clio-relay\candidate

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.0.8",
-  "matrix_sha256": "1fac1e2ecec5f84528285d3a512876c2fe481d9ff7e65a6d166dc588fc810975",
+  "release_version": "1.0.9",
+  "matrix_sha256": "d23cddf47e67bdfcb3df637800daf37ed9aa4cedf4bb2a1ee66345ae30bd9ab9",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.0.8"
+version = "1.0.9"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.0.8"
+__version__ = "1.0.9"

--- a/src/clio_relay/core_queue.py
+++ b/src/clio_relay/core_queue.py
@@ -3218,24 +3218,26 @@ class ClioCoreQueue:
     def list_leases(self, cluster: str | None = None) -> list[Lease]:
         """Return active and expired leases, optionally filtered by job cluster."""
         self.initialize()
-        leases = list(
-            self._read_many(
-                self._storage_root / "leases",
-                Lease,
-                identity_field="lease_id",
+        with self._lock:
+            self._recover_pending_transitions_unlocked()
+            leases = list(
+                self._read_many(
+                    self._storage_root / "leases",
+                    Lease,
+                    identity_field="lease_id",
+                )
             )
-        )
-        if cluster is not None:
-            matched: list[Lease] = []
-            for lease in leases:
-                try:
-                    job = self.get_job(lease.job_id)
-                except NotFoundError:
-                    continue
-                if job.cluster == cluster:
-                    matched.append(lease)
-            leases = matched
-        return sorted(leases, key=lambda lease: lease.acquired_at)
+            if cluster is not None:
+                matched: list[Lease] = []
+                for lease in leases:
+                    try:
+                        job = self.get_job(lease.job_id)
+                    except NotFoundError:
+                        continue
+                    if job.cluster == cluster:
+                        matched.append(lease)
+                leases = matched
+            return sorted(leases, key=lambda lease: lease.acquired_at)
 
     def scan_leases(
         self,
@@ -3244,33 +3246,39 @@ class ClioCoreQueue:
         cluster: str | None = None,
     ) -> tuple[list[Lease], bool]:
         """Read a bounded durable lease snapshot."""
-        leases, truncated = self._scan_many(
-            self._storage_root / "leases",
-            Lease,
-            limit=limit,
-            identity_field="lease_id",
-        )
-        if cluster is not None:
-            matched: list[Lease] = []
-            for lease in leases:
-                try:
-                    job = self.get_job(lease.job_id)
-                except NotFoundError:
-                    continue
-                if job.cluster == cluster:
-                    matched.append(lease)
-            leases = matched
-        return sorted(leases, key=lambda lease: lease.acquired_at), truncated
+        self.initialize()
+        with self._lock:
+            self._recover_pending_transitions_unlocked()
+            leases, truncated = self._scan_many(
+                self._storage_root / "leases",
+                Lease,
+                limit=limit,
+                identity_field="lease_id",
+            )
+            if cluster is not None:
+                matched: list[Lease] = []
+                for lease in leases:
+                    try:
+                        job = self.get_job(lease.job_id)
+                    except NotFoundError:
+                        continue
+                    if job.cluster == cluster:
+                        matched.append(lease)
+                leases = matched
+            return sorted(leases, key=lambda lease: lease.acquired_at), truncated
 
     def scan_job_leases(self, job_id: str, *, limit: int) -> tuple[list[Lease], bool]:
-        """Read bounded leases from the exact per-job index."""
+        """Read bounded leases from the exact per-job index under writer exclusion."""
         job_id = self._require_durable_record_id(job_id, field="job_id")
-        directory = self._storage_root / "leases_by_job" / self._durable_key(job_id)
-        if self._job_index_exists(job_id):
-            leases, truncated = self._scan_many(directory, Lease, limit=limit)
-            return sorted(leases, key=lambda lease: lease.acquired_at), truncated
-        leases, truncated = self._scan_many(self._storage_root / "leases", Lease, limit=limit)
-        return [lease for lease in leases if lease.job_id == job_id], truncated
+        self.initialize()
+        with self._lock:
+            self._recover_pending_transitions_unlocked()
+            directory = self._storage_root / "leases_by_job" / self._durable_key(job_id)
+            if self._job_index_exists(job_id):
+                leases, truncated = self._scan_many(directory, Lease, limit=limit)
+                return sorted(leases, key=lambda lease: lease.acquired_at), truncated
+            leases, truncated = self._scan_many(self._storage_root / "leases", Lease, limit=limit)
+            return [lease for lease in leases if lease.job_id == job_id], truncated
 
     def _lease_index_identity(
         self,
@@ -5467,21 +5475,27 @@ class ClioCoreQueue:
         if job_id is not None:
             job_id = self._require_durable_record_id(job_id, field="job_id")
         self.initialize()
-        if job_id is not None and self._job_index_exists(job_id):
-            tasks = list(
-                self._read_many(
-                    self._storage_root / "tasks_by_job" / self._durable_key(job_id),
-                    RelayTask,
-                    identity_field="task_id",
+        with self._lock:
+            self._recover_pending_transitions_unlocked()
+            if job_id is not None and self._job_index_exists(job_id):
+                tasks = list(
+                    self._read_many(
+                        self._storage_root / "tasks_by_job" / self._durable_key(job_id),
+                        RelayTask,
+                        identity_field="task_id",
+                    )
                 )
-            )
-        else:
-            tasks = list(
-                self._read_many(self._storage_root / "tasks", RelayTask, identity_field="task_id")
-            )
-            if job_id is not None:
-                tasks = [task for task in tasks if task.job_id == job_id]
-        return sorted(tasks, key=lambda task: task.created_at)
+            else:
+                tasks = list(
+                    self._read_many(
+                        self._storage_root / "tasks",
+                        RelayTask,
+                        identity_field="task_id",
+                    )
+                )
+                if job_id is not None:
+                    tasks = [task for task in tasks if task.job_id == job_id]
+            return sorted(tasks, key=lambda task: task.created_at)
 
     def list_tasks_page(
         self,
@@ -5492,32 +5506,39 @@ class ClioCoreQueue:
     ) -> tuple[list[RelayTask], int | None, int]:
         """Read one stable task page from the per-job sequence index."""
         job_id = self._require_durable_record_id(job_id, field="job_id")
-        return self._read_ordered_job_page(
-            job_id,
-            family="task",
-            model=RelayTask,
-            cursor=cursor,
-            limit=limit,
-            count_field="task_count",
-        )
+        self.initialize()
+        with self._lock:
+            self._recover_pending_transitions_unlocked()
+            return self._read_ordered_job_page(
+                job_id,
+                family="task",
+                model=RelayTask,
+                cursor=cursor,
+                limit=limit,
+                count_field="task_count",
+            )
 
     def scan_job_tasks(self, job_id: str, *, limit: int) -> tuple[list[RelayTask], bool]:
         """Read bounded task records from one exact job index."""
         job_id = self._require_durable_record_id(job_id, field="job_id")
-        directory = (
-            self._storage_root / "tasks_by_job" / self._durable_key(job_id)
-            if self._job_index_exists(job_id)
-            else self._storage_root / "tasks"
-        )
-        tasks, truncated = self._scan_many(
-            directory,
-            RelayTask,
-            limit=limit,
-            identity_field="task_id",
-        )
-        if not self._job_index_exists(job_id):
-            tasks = [task for task in tasks if task.job_id == job_id]
-        return sorted(tasks, key=lambda task: task.created_at), truncated
+        self.initialize()
+        with self._lock:
+            self._recover_pending_transitions_unlocked()
+            indexed = self._job_index_exists(job_id)
+            directory = (
+                self._storage_root / "tasks_by_job" / self._durable_key(job_id)
+                if indexed
+                else self._storage_root / "tasks"
+            )
+            tasks, truncated = self._scan_many(
+                directory,
+                RelayTask,
+                limit=limit,
+                identity_field="task_id",
+            )
+            if not indexed:
+                tasks = [task for task in tasks if task.job_id == job_id]
+            return sorted(tasks, key=lambda task: task.created_at), truncated
 
     def append_task_event(self, event: TaskTimelineEvent) -> TaskTimelineEvent:
         """Append a structured task timeline event with a per-task sequence."""

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1330,7 +1330,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "1fac1e2ecec5f84528285d3a512876c2fe481d9ff7e65a6d166dc588fc810975"
+        "d23cddf47e67bdfcb3df637800daf37ed9aa4cedf4bb2a1ee66345ae30bd9ab9"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -251,6 +251,132 @@ def test_release_lease_retries_windows_sharing_violation(
     assert list((queue.root / "transition_intents").glob("*.json")) == []
 
 
+@pytest.mark.parametrize("reader", ["list", "scan", "job-scan"])
+def test_lease_snapshot_readers_serialize_with_concurrent_release(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    reader: str,
+) -> None:
+    """A legitimate worker release cannot invalidate an in-flight lease snapshot."""
+    queue = ClioCoreQueue(tmp_path / "core")
+    job = queue.submit_job(
+        RelayJob(
+            cluster="ares",
+            kind=JobKind.JARVIS,
+            spec=JarvisRunSpec(command=["true"]),
+            idempotency_key="lease-scan-release-race",
+        )
+    )
+    lease = queue.acquire_next_job("lease-scan-worker", cluster="ares")
+    assert lease is not None
+    observed_path = (
+        queue.root / "leases_by_job" / job.job_id / f"{lease.lease_id}.json"
+        if reader == "job-scan"
+        else queue.root / "leases" / f"{lease.lease_id}.json"
+    )
+    scan_reached_record = threading.Event()
+    release_started = threading.Event()
+    release_finished = threading.Event()
+    release_errors: list[BaseException] = []
+    scan_thread_id = threading.get_ident()
+    original_read = core_queue_module._read_bounded_record_bytes  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+
+    def observe_index_read(path: Path) -> bytes:
+        if (
+            logical_filesystem_path(path) == observed_path
+            and threading.get_ident() == scan_thread_id
+        ):
+            assert (
+                queue._lock._owner_thread_id == scan_thread_id  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            )
+            scan_reached_record.set()
+            assert release_started.wait(timeout=5)
+            assert not release_finished.is_set()
+        return original_read(path)
+
+    def release() -> None:
+        try:
+            assert scan_reached_record.wait(timeout=5)
+            release_started.set()
+            queue.release_lease(lease.lease_id)
+        except BaseException as exc:
+            release_errors.append(exc)
+        finally:
+            release_finished.set()
+
+    monkeypatch.setattr(core_queue_module, "_read_bounded_record_bytes", observe_index_read)
+    thread = threading.Thread(target=release, daemon=True)
+    thread.start()
+
+    if reader == "list":
+        leases = queue.list_leases(cluster="ares")
+        truncated = False
+    elif reader == "scan":
+        leases, truncated = queue.scan_leases(limit=10, cluster="ares")
+    else:
+        leases, truncated = queue.scan_job_leases(job.job_id, limit=10)
+    thread.join(timeout=5)
+
+    assert not truncated
+    assert leases == [lease]
+    assert not thread.is_alive()
+    assert release_errors == []
+    assert release_finished.is_set()
+    assert queue.scan_job_leases(job.job_id, limit=10) == ([], False)
+
+
+@pytest.mark.parametrize("reader", ["list", "page", "scan"])
+def test_task_snapshot_readers_hold_queue_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    reader: str,
+) -> None:
+    """Task snapshots cannot race terminal-job GC of their selected record family."""
+    queue = ClioCoreQueue(tmp_path / "core")
+    job = queue.submit_job(
+        RelayJob(
+            cluster="ares",
+            kind=JobKind.JARVIS,
+            spec=JarvisRunSpec(command=["true"]),
+            idempotency_key=f"task-snapshot-lock-{reader}",
+        )
+    )
+    task = queue.append_task(RelayTask(job_id=job.job_id, name="locked-snapshot"))
+    observed = threading.Event()
+    reader_thread_id = threading.get_ident()
+    original_read = core_queue_module._read_bounded_record_bytes  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+
+    def require_lock(path: Path) -> bytes:
+        logical = logical_filesystem_path(path)
+        per_job_family = logical.parent.parent.name
+        selected_task_record = (
+            logical.parent.name == "tasks" and logical.name == f"{task.task_id}.json"
+        ) or (per_job_family == "tasks_by_job" and logical.name == f"{task.task_id}.json")
+        selected_order_record = per_job_family == "task_order_by_job"
+        if (
+            selected_task_record or selected_order_record
+        ) and threading.get_ident() == reader_thread_id:
+            assert (
+                queue._lock._owner_thread_id == reader_thread_id  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            )
+            observed.set()
+        return original_read(path)
+
+    monkeypatch.setattr(core_queue_module, "_read_bounded_record_bytes", require_lock)
+    if reader == "list":
+        tasks = queue.list_tasks(job.job_id)
+    elif reader == "page":
+        tasks, next_cursor, total = queue.list_tasks_page(job.job_id, limit=10)
+        assert next_cursor is None
+        assert total == 1
+    else:
+        tasks, truncated = queue.scan_job_tasks(job.job_id, limit=10)
+        assert not truncated
+
+    assert tasks == [task]
+    assert observed.is_set()
+
+
 def test_release_lease_sharing_violation_exhaustion_replays_on_restart(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -51,7 +51,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
 
 def test_candidate_manifest_parser_accepts_the_exact_gnu_checksum_separator() -> None:
     digest = "a" * 64
-    wheel_name = "clio_relay-1.0.8-py3-none-any.whl"
+    wheel_name = "clio_relay-1.0.9-py3-none-any.whl"
     selector = re.compile(rf"^[0-9A-Fa-f]{{64}} [ *]{re.escape(wheel_name)}$")
     parser = re.compile(r"^([0-9A-Fa-f]{64}) [ *](.+)$")
 

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1612,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.0.8"
+    assert policy.release_version == "1.0.9"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.0.8"
+version = "1.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- serialize lease and task snapshot readers with durable writer transitions
- preserve fail-closed record validation while preventing legitimate release/GC races
- add deterministic real-thread coverage for list, bounded scan, per-job scan, and task page readers
- advance the production candidate to 1.0.9 and replace the public release body with a concise human summary

This carries the complete v1.0.8 production hardening forward. The patch fixes the real lease-index read/delete race exposed by main CI run 29371227243; the protected v1.0.8 tag is preserved and not rewritten.

## Local verification

- 52 focused pytest cases passed, including the original real-worker queue validation and workflow/release contracts
- Ruff check passed on changed Python surfaces
- Pyright passed with 0 errors
- release policy and 17-report matrix identity validated for 1.0.9

Issues #3-#11 remain open until the released PyPI artifact passes the live acceptance matrix.