### PR TITLE
fix: align release matrix digest

### DIFF
--- a/.github/workflows/live-validation-attest.yml
+++ b/.github/workflows/live-validation-attest.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing digest-bound candidate draft tag, such as v1.0.10
+        description: Existing digest-bound candidate draft tag, such as v1.0.11
         required: true
         type: string
 

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing draft release tag, such as v1.0.10
+        description: Existing draft release tag, such as v1.0.11
         required: true
         type: string
       reviewed_main_sha:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> The current development candidate is `1.0.10`. The `v1.0.0` candidate
+> The current development candidate is `1.0.11`. The `v1.0.0` candidate
 > was abandoned before publication after its acceptance runbook rejected the
 > staged GNU checksum format; `v1.0.1` was also abandoned before publication
 > after protected-main validation exposed a Windows lease-deletion race;
@@ -29,8 +29,9 @@ It is a piece of the federation layer for [`clio-agent`](https://github.com/iowa
 > migration; `v1.0.8` was abandoned before candidate staging when protected-main
 > validation exposed a concurrent per-job lease-index read/delete race;
 > `v1.0.9` was abandoned after one failed bootstrap report exposed an escaping
-> defect in the generated Python receipt writer. The latest released live
-> evidence is `0.9.22`; `1.0.10` is not
+> defect in the generated Python receipt writer; `v1.0.10` was abandoned before
+> candidate staging when its tag gate caught a stale exact matrix-digest test
+> constant. The latest released live evidence is `0.9.22`; `1.0.11` is not
 > release-complete until its digest-bound
 > candidate reports pass, its exact candidate is published, and the released-artifact
 > runs pass again. The published 1.0 GitHub release is intentionally mutable;

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.0.10"
+$Version = "1.0.11"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.0.10"
+release_version: "1.0.11"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 79a73322c5efaeee888ae2e447884ed5034f5cbc317937a4020851e24583b7ef
+acceptance_matrix_sha256: 96b9840c68b423053911cd39b5f3b0c694baa1a27d4d94f5f330605531e69ac8
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -70,7 +70,7 @@ Commit the release change with a conventional commit, then create and push an
 exact matching tag:
 
 ```powershell
-$Tag = "v1.0.10"
+$Tag = "v1.0.11"
 git fetch origin main
 $ReviewedMainSha = (git rev-parse refs/remotes/origin/main).Trim()
 if ((git rev-parse HEAD).Trim() -ne $ReviewedMainSha) {
@@ -154,7 +154,7 @@ Download the draft wheel and manifest, verify both the digest and the signed
 tag-build provenance, and compute the digest locally:
 
 ```powershell
-$Tag = "v1.0.10"
+$Tag = "v1.0.11"
 New-Item -ItemType Directory -Force .clio-relay\candidate | Out-Null
 gh release download $Tag --pattern "*.whl" --pattern "SHA256SUMS" `
   --dir .clio-relay\candidate

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.0.10",
-  "matrix_sha256": "79a73322c5efaeee888ae2e447884ed5034f5cbc317937a4020851e24583b7ef",
+  "release_version": "1.0.11",
+  "matrix_sha256": "96b9840c68b423053911cd39b5f3b0c694baa1a27d4d94f5f330605531e69ac8",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.0.10"
+version = "1.0.11"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.0.10"
+__version__ = "1.0.11"

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1330,7 +1330,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "d23cddf47e67bdfcb3df637800daf37ed9aa4cedf4bb2a1ee66345ae30bd9ab9"
+        "96b9840c68b423053911cd39b5f3b0c694baa1a27d4d94f5f330605531e69ac8"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -51,7 +51,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
 
 def test_candidate_manifest_parser_accepts_the_exact_gnu_checksum_separator() -> None:
     digest = "a" * 64
-    wheel_name = "clio_relay-1.0.10-py3-none-any.whl"
+    wheel_name = "clio_relay-1.0.11-py3-none-any.whl"
     selector = re.compile(rf"^[0-9A-Fa-f]{{64}} [ *]{re.escape(wheel_name)}$")
     parser = re.compile(r"^([0-9A-Fa-f]{64}) [ *](.+)$")
 

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1612,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.0.10"
+    assert policy.release_version == "1.0.11"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.0.10"
+version = "1.0.11"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- update the exact acceptance-matrix digest assertion with the release-version-bound 1.0.11 digest
- advance the candidate metadata to 1.0.11

## Root cause

The 1.0.10 matrix self-digest and policy were correct, but one exact test constant still held the 1.0.9 digest.

## Validation

- 155 focused CI-validation, bootstrap, runbook, policy, and workflow tests passed
- Ruff passed