### PR TITLE
feat: harden the 1.1 release provenance chain

### DIFF
--- a/.github/scripts/release-api.sh
+++ b/.github/scripts/release-api.sh
@@ -45,7 +45,8 @@ relay_release_complete_assets() {
     .tag_name == $expected[0].tag_name and
     .target_commitish == $expected[0].target_commitish and
     .draft == $expected[0].draft and
-    .prerelease == $expected[0].prerelease
+    .prerelease == $expected[0].prerelease and
+    .immutable == $expected[0].immutable
   ' "$refreshed" >/dev/null
   gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
     "repos/$REPOSITORY/releases/$release_id/assets?per_page=100&page=1" >"$page_one"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 name: ci
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
     branches: ["main"]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
@@ -13,14 +13,12 @@ jobs:
   workflow-lint:
     name: GitHub Actions syntax and semantics
     runs-on: ubuntu-latest
-    timeout-minutes: 15  # Bound tool download and static workflow analysis.
-
+    timeout-minutes: 15
     steps:
       - name: check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-
       - name: install checksum-pinned actionlint
         shell: bash
         run: |
@@ -31,45 +29,29 @@ jobs:
           echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  $archive" \
             | sha256sum --check --strict
           tar --extract --gzip --file "$archive" actionlint
-
       - name: lint workflows
         run: ./actionlint
 
-  test:
-    name: ${{ matrix.os }} / python ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 60  # The evidence-producing full gate is intentionally comprehensive.
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-        python-version: ["3.12", "3.13", "3.14"]
-
+  build:
+    name: ubuntu-latest / python 3.12
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-
       - name: install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
           version: "0.11.28"
-
       - name: set up python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: ${{ matrix.python-version }}
-
+          python-version: "3.12"
       - name: install dependencies
-        run: uv sync --python "${{ matrix.python-version }}" --locked --all-groups
-
-      - name: verify matrix interpreter
-        run: >-
-          uv run --python "${{ matrix.python-version }}" python -c
-          "import sys; expected = tuple(map(int, '${{ matrix.python-version }}'.split('.'))); assert sys.version_info[:2] == expected, (sys.version, expected)"
-
+        run: uv sync --python "3.12" --locked --all-groups
       - name: stage exact clio-kit release wheel
         shell: bash
         env:
@@ -82,17 +64,116 @@ jobs:
           wheel_dir="$RUNNER_TEMP/clio-kit-v2.3.2"
           mkdir "$wheel_dir"
           wheel="$wheel_dir/$CLIO_KIT_WHEEL_FILENAME"
-          temporary="$wheel.part"
-          trap 'rm -f -- "$temporary"' EXIT
           curl --fail --show-error --silent --location \
             --proto '=https' --proto-redir '=https' --tlsv1.2 \
             --retry 3 --retry-all-errors --retry-delay 2 --retry-max-time 180 \
             --connect-timeout 20 --max-time 180 \
-            --output "$temporary" "$CLIO_KIT_WHEEL_URL"
-          printf '%s  %s\n' "$CLIO_KIT_WHEEL_SHA256" "$temporary" \
+            --output "$wheel" "$CLIO_KIT_WHEEL_URL"
+          printf '%s  %s\n' "$CLIO_KIT_WHEEL_SHA256" "$wheel" \
             | sha256sum --check --strict
-          mv -- "$temporary" "$wheel"
-          trap - EXIT
+          printf 'CLIO_RELAY_CLIO_KIT_WHEEL=%s\n' "$wheel" >> "$GITHUB_ENV"
+          printf 'CLIO_RELAY_CLIO_KIT_WHEEL_SHA256=%s\n' \
+            "$CLIO_KIT_WHEEL_SHA256" >> "$GITHUB_ENV"
+      - name: run the sole artifact-building release gate
+        run: >-
+          uv run --python 3.12 clio-relay release validate-local
+          --project-root .
+          --report dist/reports/validation-local-ubuntu-latest-3.12.json
+          --artifact-dir dist/build-output
+      - name: stage the exact build-once distributions
+        shell: bash
+        run: |
+          mkdir -p dist/candidate
+          mapfile -t wheels < <(find dist/build-output -maxdepth 1 -type f -name '*.whl' -print)
+          mapfile -t sdists < <(find dist/build-output -maxdepth 1 -type f -name '*.tar.gz' -print)
+          test "${#wheels[@]}" -eq 1
+          test "${#sdists[@]}" -eq 1
+          cp -- "${wheels[0]}" "${sdists[0]}" dist/candidate/
+          (
+            cd dist/candidate
+            mapfile -t distributions < <(find . -maxdepth 1 -type f -printf '%f\n' | sort)
+            test "${#distributions[@]}" -eq 2
+            sha256sum --binary "${distributions[@]}" > SHA256SUMS
+            sha256sum --check --strict SHA256SUMS
+          )
+      - name: upload build-once distributions
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: build-once-${{ github.sha }}
+          path: dist/candidate
+          if-no-files-found: error
+          retention-days: 90
+      - name: upload primary matrix report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: matrix-report-ubuntu-latest-3.12
+          path: dist/reports/validation-local-ubuntu-latest-3.12.json
+          if-no-files-found: error
+          retention-days: 90
+
+  validate:
+    name: ${{ matrix.os }} / python ${{ matrix.python-version }}
+    needs: build
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python-version: "3.13"
+          - os: ubuntu-latest
+            python-version: "3.14"
+          - os: windows-latest
+            python-version: "3.12"
+          - os: windows-latest
+            python-version: "3.13"
+          - os: windows-latest
+            python-version: "3.14"
+    steps:
+      - name: check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: download the one build produced by the primary leg
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: build-once-${{ github.sha }}
+          path: dist/prebuilt
+      - name: install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
+          version: "0.11.28"
+      - name: set up python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: install dependencies
+        run: uv sync --python "${{ matrix.python-version }}" --locked --all-groups
+      - name: verify matrix interpreter
+        run: >-
+          uv run --python "${{ matrix.python-version }}" python -c
+          "import sys; expected = tuple(map(int, '${{ matrix.python-version }}'.split('.'))); assert sys.version_info[:2] == expected, (sys.version, expected)"
+      - name: stage exact clio-kit release wheel
+        shell: bash
+        env:
+          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.3.2-py3-none-any.whl
+          CLIO_KIT_WHEEL_SHA256: 6763c500db777428edc57ed2e1157cefdbe54f9504f2374e9fdc8055870b7321
+          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.3.2/clio_kit-2.3.2-py3-none-any.whl
+        run: |
+          set -euo pipefail
+          umask 077
+          wheel_dir="$RUNNER_TEMP/clio-kit-v2.3.2"
+          mkdir "$wheel_dir"
+          wheel="$wheel_dir/$CLIO_KIT_WHEEL_FILENAME"
+          curl --fail --show-error --silent --location \
+            --proto '=https' --proto-redir '=https' --tlsv1.2 \
+            --retry 3 --retry-all-errors --retry-delay 2 --retry-max-time 180 \
+            --connect-timeout 20 --max-time 180 \
+            --output "$wheel" "$CLIO_KIT_WHEEL_URL"
+          printf '%s  %s\n' "$CLIO_KIT_WHEEL_SHA256" "$wheel" \
+            | sha256sum --check --strict
           if [ "$RUNNER_OS" = Windows ]; then
             exported_wheel="$(cygpath --windows --absolute "$wheel")"
           else
@@ -101,21 +182,84 @@ jobs:
           printf 'CLIO_RELAY_CLIO_KIT_WHEEL=%s\n' "$exported_wheel" >> "$GITHUB_ENV"
           printf 'CLIO_RELAY_CLIO_KIT_WHEEL_SHA256=%s\n' \
             "$CLIO_KIT_WHEEL_SHA256" >> "$GITHUB_ENV"
-
-      - name: run evidence-producing local release gate
+      - name: validate without rebuilding the distributions
         run: >-
           uv run --python "${{ matrix.python-version }}"
           clio-relay release validate-local
           --project-root .
-          --report dist/validation-local-${{ runner.os }}-${{ matrix.python-version }}.json
-          --artifact-dir dist
-
-      - name: upload package artifact
+          --report dist/reports/validation-local-${{ matrix.os }}-${{ matrix.python-version }}.json
+          --artifact-dir dist/validation-output
+          --prebuilt-artifact-dir dist/prebuilt
+      - name: upload matrix report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: dist-${{ runner.os }}-${{ matrix.python-version }}
-          path: |
-            dist/*.whl
-            dist/*.tar.gz
-            dist/validation-*.json
+          name: matrix-report-${{ matrix.os }}-${{ matrix.python-version }}
+          path: dist/reports/validation-local-${{ matrix.os }}-${{ matrix.python-version }}.json
           if-no-files-found: error
+          retention-days: 90
+
+  seal:
+    name: seal tested release candidate
+    needs: [workflow-lint, build, validate]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: check out the exact tested commit
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: download the build-once distributions
+        if: github.event_name == 'merge_group'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: build-once-${{ github.sha }}
+          path: dist/candidate
+      - name: download every matrix report
+        if: github.event_name == 'merge_group'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: matrix-report-*
+          path: dist/reports
+          merge-multiple: true
+      - name: bind all six reports to the one candidate tree
+        id: candidate
+        if: github.event_name == 'merge_group'
+        env:
+          BASE_REF: ${{ github.event.merge_group.base_ref }}
+          HEAD_REF: ${{ github.event.merge_group.head_ref }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          tree="$(git rev-parse 'HEAD^{tree}')"
+          python src/clio_relay/ci_validation.py candidate-build-receipt \
+            --candidate-dir dist/candidate \
+            --reports-dir dist/reports \
+            --repository "$REPOSITORY" \
+            --source-commit "$GITHUB_SHA" \
+            --source-tree "$tree" \
+            --event "$GITHUB_EVENT_NAME" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --head-ref "$HEAD_REF" \
+            --base-ref "$BASE_REF" \
+            --output dist/candidate/CANDIDATE-BUILD.json
+          cp dist/reports/validation-local-ubuntu-latest-3.12.json \
+            dist/candidate/validation-local.json
+          (
+            cd dist/candidate
+            mapfile -t subjects < <(
+              find . -maxdepth 1 -type f ! -name SHA256SUMS -printf '%f\n' | sort
+            )
+            test "${#subjects[@]}" -eq 4
+            sha256sum --binary "${subjects[@]}" > SHA256SUMS
+            sha256sum --check --strict SHA256SUMS
+          )
+          echo "tree=$tree" >> "$GITHUB_OUTPUT"
+      - name: upload the sealed merge-queue candidate
+        if: github.event_name == 'merge_group'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-candidate-${{ steps.candidate.outputs.tree }}
+          path: dist/candidate
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -80,6 +80,22 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: mint repository-scoped administration-read token
+        id: admin_read
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.IMMUTABLE_RELEASES_APP_ID }}
+          private-key: ${{ secrets.IMMUTABLE_RELEASES_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-administration: read
+
+      - name: expose administration-read token to governance checks
+        env:
+          ADMIN_READ_TOKEN: ${{ steps.admin_read.outputs.token }}
+        shell: bash
+        run: echo "GH_ADMIN_READ_TOKEN=$ADMIN_READ_TOKEN" >> "$GITHUB_ENV"
+
       - name: require protected-main dispatch and an exact-tag release
         id: release
         env:
@@ -716,7 +732,7 @@ jobs:
           ci_status = json.loads(ci_status_path.read_text(encoding="utf-8"))
           governance = json.loads(governance_path.read_text(encoding="utf-8"))
           claims = {
-              "schema_version": "1.0",
+              "schema_version": "1.1",
               "artifact_stage": "published",
               "tag": tag,
               "source_commit": commit,
@@ -752,10 +768,11 @@ jobs:
                       "environment_reviewers_available"
                   ),
                   "environments": governance.get("environments"),
+                  "immutable_releases": governance.get("immutable_releases"),
               },
               "release_publication": {
-                  "github_release_immutable": False,
-                  "immutability_deferred_to_version": "1.1",
+                  "github_release_immutable": True,
+                  "verification": ["gh release verify", "gh release verify-asset"],
               },
               "local_quality_requirements": local_requirements,
               "released_artifact_requirements": released_requirements,
@@ -788,7 +805,7 @@ jobs:
           )
           notes = (
               f"clio-relay {tag}\n\n"
-              "Production 1.0 release for durable desktop-to-cluster execution.\n\n"
+              "Production release for durable desktop-to-cluster execution.\n\n"
               "Highlights:\n\n"
               "- Generic cluster-aware virtualization of registered remote MCP servers.\n"
               "- Explicit detach and owned-resource cleanup, with scheduler jobs preserved by default.\n"
@@ -798,8 +815,7 @@ jobs:
               f"`uv tool install clio-relay=={version}` and validated on "
               f"{', '.join(claims['clusters'])}. See `RELEASE-CLAIMS.json` and the "
               "attached candidate/released reports for the complete evidence. "
-              "This 1.0 release is intentionally mutable; GitHub release immutability "
-              "is planned for 1.1.\n"
+              "The published GitHub release and every attached asset are immutable.\n"
           )
           (root / "evidence" / "RELEASE-NOTES.md").write_text(notes, encoding="utf-8")
           PY
@@ -908,15 +924,30 @@ jobs:
           relay_release_resolve "$TAG_NAME" any "$RUNNER_TEMP/final-release-current.json"
           is_draft="$(jq -r .draft "$RUNNER_TEMP/final-release-current.json")"
           [[ "$is_draft" == "true" || "$is_draft" == "false" ]]
-          python src/clio_relay/ci_validation.py mutation-authority \
-            --governance-receipt finalization/evidence/REPOSITORY-GOVERNANCE.json \
-            --repository "$REPOSITORY" \
-            --source-commit "$SOURCE_COMMIT" \
-            --tag "$TAG_NAME" \
-            --workflow-ref "$GITHUB_REF" \
-            --workflow-sha "$GITHUB_SHA" \
-            --release-state present \
-            --draft "$is_draft"
+          if test "$is_draft" = "true"; then
+            python src/clio_relay/ci_validation.py mutation-authority \
+              --governance-receipt finalization/evidence/REPOSITORY-GOVERNANCE.json \
+              --repository "$REPOSITORY" \
+              --source-commit "$SOURCE_COMMIT" \
+              --tag "$TAG_NAME" \
+              --workflow-ref "$GITHUB_REF" \
+              --workflow-sha "$GITHUB_SHA" \
+              --release-state present \
+              --draft true
+          else
+            python src/clio_relay/ci_validation.py verify-live-governance \
+              --receipt finalization/evidence/REPOSITORY-GOVERNANCE.json \
+              --repository "$REPOSITORY" \
+              --source-commit "$SOURCE_COMMIT" \
+              --tag "$TAG_NAME"
+            python src/clio_relay/ci_validation.py verify-live-release \
+              --repository "$REPOSITORY" \
+              --tag "$TAG_NAME" \
+              --source-commit "$SOURCE_COMMIT" \
+              --draft false \
+              --prerelease false \
+              --immutable true
+          fi
           final_assets=(
             finalization/packages/*.whl
             finalization/packages/*.tar.gz
@@ -951,6 +982,15 @@ jobs:
             "${asset_args[@]}" \
             --output "$RUNNER_TEMP/EXACT-FINAL-ASSETS.json"
           if test "$is_draft" = "true"; then
+            python src/clio_relay/ci_validation.py mutation-authority \
+              --governance-receipt finalization/evidence/REPOSITORY-GOVERNANCE.json \
+              --repository "$REPOSITORY" \
+              --source-commit "$SOURCE_COMMIT" \
+              --tag "$TAG_NAME" \
+              --workflow-ref "$GITHUB_REF" \
+              --workflow-sha "$GITHUB_SHA" \
+              --release-state present \
+              --draft true
             jq -n --rawfile body "$notes" \
               '{body: $body, draft: false, prerelease: false}' \
               > "$RUNNER_TEMP/publish-release.json"
@@ -961,6 +1001,23 @@ jobs:
             expected="$(cat "$notes")"
             test "$actual" = "$expected"
           fi
+          release_id="$(jq -r .id "$RUNNER_TEMP/final-release-before-publish.json")"
+          release_target="$(jq -r .target_commitish \
+            "$RUNNER_TEMP/final-release-before-publish.json")"
+          for attempt in $(seq 1 20); do
+            relay_release_resolve "$TAG_NAME" false \
+              "$RUNNER_TEMP/final-release-immutable.json"
+            test "$(jq -r .id "$RUNNER_TEMP/final-release-immutable.json")" = "$release_id"
+            test "$(jq -r .tag_name "$RUNNER_TEMP/final-release-immutable.json")" = "$TAG_NAME"
+            test "$(jq -r .target_commitish \
+              "$RUNNER_TEMP/final-release-immutable.json")" = "$release_target"
+            if test "$(jq -r .immutable \
+              "$RUNNER_TEMP/final-release-immutable.json")" = "true"; then
+              break
+            fi
+            test "$attempt" -lt 20
+            sleep 3
+          done
           capture_release_assets published
           python src/clio_relay/ci_validation.py exact-release-assets \
             --release "$RUNNER_TEMP/final-release-assets-published.json" \
@@ -970,4 +1027,14 @@ jobs:
             --verify-existing "$RUNNER_TEMP/EXACT-FINAL-ASSETS.json"
           test "$(jq -r .draft "$RUNNER_TEMP/final-release-published.json")" = "false"
           test "$(jq -r .prerelease "$RUNNER_TEMP/final-release-published.json")" = "false"
-          test "$(jq -r .immutable "$RUNNER_TEMP/final-release-published.json")" = "false"
+          test "$(jq -r .immutable "$RUNNER_TEMP/final-release-published.json")" = "true"
+          for attempt in $(seq 1 20); do
+            if gh release verify "$TAG_NAME" --repo "$REPOSITORY"; then
+              break
+            fi
+            test "$attempt" -lt 20
+            sleep 3
+          done
+          for asset in "${final_assets[@]}"; do
+            gh release verify-asset "$TAG_NAME" "$asset" --repo "$REPOSITORY"
+          done

--- a/.github/workflows/live-validation-attest.yml
+++ b/.github/workflows/live-validation-attest.yml
@@ -69,6 +69,22 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: mint repository-scoped administration-read token
+        id: admin_read
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.IMMUTABLE_RELEASES_APP_ID }}
+          private-key: ${{ secrets.IMMUTABLE_RELEASES_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-administration: read
+
+      - name: expose administration-read token to governance checks
+        env:
+          ADMIN_READ_TOKEN: ${{ steps.admin_read.outputs.token }}
+        shell: bash
+        run: echo "GH_ADMIN_READ_TOKEN=$ADMIN_READ_TOKEN" >> "$GITHUB_ENV"
+
       - name: install protected-main locked dependencies
         run: uv sync --locked --all-groups
 

--- a/.github/workflows/main-provenance.yml
+++ b/.github/workflows/main-provenance.yml
@@ -1,0 +1,25 @@
+name: main provenance
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  provenance:
+    name: record merged-main provenance
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: check out merged main without credentials
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: record the merged commit and tree
+        shell: bash
+        run: |
+          test "$GITHUB_REF" = "refs/heads/main"
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git rev-parse 'HEAD^{tree}'

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -84,6 +84,22 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: mint repository-scoped administration-read token
+        id: admin_read
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.IMMUTABLE_RELEASES_APP_ID }}
+          private-key: ${{ secrets.IMMUTABLE_RELEASES_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-administration: read
+
+      - name: expose administration-read token to governance checks
+        env:
+          ADMIN_READ_TOKEN: ${{ steps.admin_read.outputs.token }}
+        shell: bash
+        run: echo "GH_ADMIN_READ_TOKEN=$ADMIN_READ_TOKEN" >> "$GITHUB_ENV"
+
       - name: install protected-main locked dependencies
         run: uv sync --locked --all-groups
 
@@ -642,6 +658,22 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
+
+      - name: mint repository-scoped administration-read token
+        id: admin_read
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.IMMUTABLE_RELEASES_APP_ID }}
+          private-key: ${{ secrets.IMMUTABLE_RELEASES_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-administration: read
+
+      - name: expose administration-read token to governance checks
+        env:
+          ADMIN_READ_TOKEN: ${{ steps.admin_read.outputs.token }}
+        shell: bash
+        run: echo "GH_ADMIN_READ_TOKEN=$ADMIN_READ_TOKEN" >> "$GITHUB_ENV"
 
       - name: preflight the exact same-run promotion artifact
         id: promotion_artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: build unprivileged release candidate payload
+name: bind release tag to tested merge-queue candidate
 
 on:
   push:
@@ -9,16 +9,15 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: read
   contents: read
+  pull-requests: read
 
 jobs:
-  build:
-    name: build candidate payload without publication authority
+  bind:
+    name: bind tag without rebuilding or executing candidate code
     runs-on: ubuntu-latest
-    timeout-minutes: 60  # Includes the complete local release gate and artifact smoke tests.
-    permissions:
-      contents: read
-
+    timeout-minutes: 15
     steps:
       - name: check out the exact repository tag commit
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -26,8 +25,8 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 1
           persist-credentials: false
-
-      - name: fetch the exact tag with ephemeral read credentials
+      - name: bind tag, main, version, and tree
+        id: source
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ github.ref_name }}
@@ -35,95 +34,107 @@ jobs:
         run: |
           [[ "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]
           source .github/scripts/authenticated-git.sh
-          relay_authenticated_git_fetch --force --no-tags --depth=1 origin \
+          relay_authenticated_git_fetch --force --no-tags origin \
+            refs/heads/main:refs/remotes/origin/main \
             "refs/tags/$TAG_NAME:refs/tags/$TAG_NAME"
+          test "$(git rev-list -n 1 "$TAG_NAME")" = "$GITHUB_SHA"
+          test "$GITHUB_SHA" = "$(git rev-parse refs/remotes/origin/main)"
+          python - "$TAG_NAME" <<'PY'
+          import re
+          import sys
+          import tomllib
+          from pathlib import Path
 
-      - name: install uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
-        with:
-          enable-cache: false
-          version: "0.11.28"
-
-      - name: set up python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: "3.12"
-
-      - name: install locked dependencies
-        run: uv sync --locked --all-groups
-
-      - name: require the tag to match the package version and commit
+          tag = sys.argv[1]
+          project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          version = project["project"]["version"]
+          init_source = Path("src/clio_relay/__init__.py").read_text(encoding="utf-8")
+          match = re.search(r'^__version__ = "([^"]+)"$', init_source, re.MULTILINE)
+          if match is None or match.group(1) != version or tag != f"v{version}":
+              raise SystemExit("tag and package version identities differ")
+          PY
+          tree="$(git rev-parse 'HEAD^{tree}')"
+          {
+            echo "source_commit=$GITHUB_SHA"
+            echo "source_tree=$tree"
+          } >> "$GITHUB_OUTPUT"
+      - name: select the sole sealed candidate for the tested tree
+        id: candidate
         env:
           GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          SOURCE_TREE: ${{ steps.source.outputs.source_tree }}
           TAG_NAME: ${{ github.ref_name }}
-        run: |
-          test "$GITHUB_REF_TYPE" = "tag"
-          source .github/scripts/authenticated-git.sh
-          relay_authenticated_git_fetch --force --no-tags origin \
-            refs/heads/main:refs/remotes/origin/main
-          version="$(uv run --no-sync python -c 'from clio_relay import __version__; print(__version__)')"
-          test "$TAG_NAME" = "v$version"
-          test "$(git rev-list -n 1 "$TAG_NAME")" = "$GITHUB_SHA"
-          test "$(git tag --points-at HEAD --list "$TAG_NAME")" = "$TAG_NAME"
-          test "$GITHUB_SHA" = "$(git rev-parse refs/remotes/origin/main)"
-
-      - name: stage exact clio-kit release wheel
         shell: bash
+        run: |
+          name="release-candidate-$SOURCE_TREE"
+          gh api "repos/$REPOSITORY/actions/artifacts?name=$name&per_page=100" \
+            > "$RUNNER_TEMP/candidate-artifacts.json"
+          test "$(jq -r .total_count "$RUNNER_TEMP/candidate-artifacts.json")" -eq 1
+          run_id="$(jq -r '.artifacts[0].workflow_run.id' \
+            "$RUNNER_TEMP/candidate-artifacts.json")"
+          [[ "$run_id" =~ ^[1-9][0-9]*$ ]]
+          gh api "repos/$REPOSITORY/actions/runs/$run_id" \
+            > "$RUNNER_TEMP/candidate-run.json"
+          run_attempt="$(jq -r .run_attempt "$RUNNER_TEMP/candidate-run.json")"
+          tested_commit="$(jq -r .head_sha "$RUNNER_TEMP/candidate-run.json")"
+          python src/clio_relay/ci_validation.py actions-artifact-manifest \
+            --run "$RUNNER_TEMP/candidate-run.json" \
+            --artifacts "$RUNNER_TEMP/candidate-artifacts.json" \
+            --repository "$REPOSITORY" \
+            --source-commit "$tested_commit" \
+            --source-tree "$SOURCE_TREE" \
+            --tag "$TAG_NAME" \
+            --run-id "$run_id" \
+            --run-attempt "$run_attempt" \
+            --artifact-name "$name" \
+            --artifact-kind candidate \
+            --output "$RUNNER_TEMP/CANDIDATE-ARTIFACT.json"
+          artifact_id="$(jq -r .artifact.id "$RUNNER_TEMP/CANDIDATE-ARTIFACT.json")"
+          {
+            echo "artifact_id=$artifact_id"
+            echo "manifest=$RUNNER_TEMP/CANDIDATE-ARTIFACT.json"
+          } >> "$GITHUB_OUTPUT"
+      - name: download and verify the sealed candidate by numeric artifact id
         env:
-          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.3.2-py3-none-any.whl
-          CLIO_KIT_WHEEL_SHA256: 6763c500db777428edc57ed2e1157cefdbe54f9504f2374e9fdc8055870b7321
-          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.3.2/clio_kit-2.3.2-py3-none-any.whl
-        run: |
-          set -euo pipefail
-          umask 077
-          wheel_dir="$RUNNER_TEMP/clio-kit-v2.3.2"
-          mkdir "$wheel_dir"
-          wheel="$wheel_dir/$CLIO_KIT_WHEEL_FILENAME"
-          temporary="$wheel.part"
-          trap 'rm -f -- "$temporary"' EXIT
-          curl --fail --show-error --silent --location \
-            --proto '=https' --proto-redir '=https' --tlsv1.2 \
-            --retry 3 --retry-all-errors --retry-delay 2 --retry-max-time 180 \
-            --connect-timeout 20 --max-time 180 \
-            --output "$temporary" "$CLIO_KIT_WHEEL_URL"
-          printf '%s  %s\n' "$CLIO_KIT_WHEEL_SHA256" "$temporary" \
-            | sha256sum --check --strict
-          mv -- "$temporary" "$wheel"
-          trap - EXIT
-          printf 'CLIO_RELAY_CLIO_KIT_WHEEL=%s\n' "$wheel" >> "$GITHUB_ENV"
-          printf 'CLIO_RELAY_CLIO_KIT_WHEEL_SHA256=%s\n' \
-            "$CLIO_KIT_WHEEL_SHA256" >> "$GITHUB_ENV"
-
-      - name: run evidence-producing local release gate
-        run: >-
-          uv run --no-sync clio-relay release validate-local
-          --project-root .
-          --report dist/validation-local.json
-          --artifact-dir dist
-
-      - name: create exact SHA-256 manifest
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          ARTIFACT_ID: ${{ steps.candidate.outputs.artifact_id }}
+          ARTIFACT_MANIFEST: ${{ steps.candidate.outputs.manifest }}
         shell: bash
         run: |
-          mapfile -t wheels < <(find dist -maxdepth 1 -type f -name '*.whl' -printf '%f\n' | sort)
-          mapfile -t sdists < <(find dist -maxdepth 1 -type f -name '*.tar.gz' -printf '%f\n' | sort)
-          test "${#wheels[@]}" -eq 1
-          test "${#sdists[@]}" -eq 1
-          test -f dist/validation-local.json
-          (
-            cd dist
-            sha256sum --binary "${wheels[0]}" "${sdists[0]}" \
-              validation-local.json > SHA256SUMS
-            sha256sum --check --strict SHA256SUMS
-          )
-
-      - name: upload staged candidate
+          gh api "repos/$REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip" \
+            > "$RUNNER_TEMP/candidate.zip"
+          python src/clio_relay/ci_validation.py extract-actions-artifact \
+            --manifest "$ARTIFACT_MANIFEST" \
+            --archive "$RUNNER_TEMP/candidate.zip" \
+            --output-dir candidate
+      - name: bind the tested tree to the merged pull request and release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          SOURCE_COMMIT: ${{ steps.source.outputs.source_commit }}
+          SOURCE_TREE: ${{ steps.source.outputs.source_tree }}
+          TAG_NAME: ${{ github.ref_name }}
+          CANDIDATE_ARTIFACT: ${{ steps.candidate.outputs.manifest }}
+        shell: bash
+        run: |
+          gh api -H 'Accept: application/vnd.github+json' \
+            "repos/$REPOSITORY/commits/$SOURCE_COMMIT/pulls?per_page=100" \
+            > "$RUNNER_TEMP/pulls.json"
+          python src/clio_relay/ci_validation.py tag-binding \
+            --candidate-build candidate/CANDIDATE-BUILD.json \
+            --candidate-artifact "$CANDIDATE_ARTIFACT" \
+            --pulls "$RUNNER_TEMP/pulls.json" \
+            --repository "$REPOSITORY" \
+            --source-commit "$SOURCE_COMMIT" \
+            --source-tree "$SOURCE_TREE" \
+            --tag "$TAG_NAME" \
+            --output TAG-BINDING.json
+      - name: upload the lightweight tag binding
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: release-candidate-${{ github.ref_name }}
-          path: |
-            dist/*.whl
-            dist/*.tar.gz
-            dist/validation-local.json
-            dist/SHA256SUMS
+          name: release-binding-${{ github.ref_name }}
+          path: TAG-BINDING.json
           if-no-files-found: error
           retention-days: 90

--- a/.github/workflows/released-validation-attest.yml
+++ b/.github/workflows/released-validation-attest.yml
@@ -76,6 +76,22 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: mint repository-scoped administration-read token
+        id: admin_read
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.IMMUTABLE_RELEASES_APP_ID }}
+          private-key: ${{ secrets.IMMUTABLE_RELEASES_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-administration: read
+
+      - name: expose administration-read token to governance checks
+        env:
+          ADMIN_READ_TOKEN: ${{ steps.admin_read.outputs.token }}
+        shell: bash
+        run: echo "GH_ADMIN_READ_TOKEN=$ADMIN_READ_TOKEN" >> "$GITHUB_ENV"
+
       - name: install protected-main locked dependencies
         run: uv sync --locked --all-groups
 

--- a/.github/workflows/stage-candidate.yml
+++ b/.github/workflows/stage-candidate.yml
@@ -69,8 +69,8 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: bind the tag and unprivileged payload run to reviewed main
-        id: candidate
+      - name: bind the tag workflow to reviewed main
+        id: tag_run
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
@@ -95,11 +95,11 @@ jobs:
           test -n "$policy_version"
           test "$version" = "$policy_version"
           gh api "repos/$REPOSITORY/actions/workflows/release.yml/runs?head_sha=$source_commit&event=push&status=completed&per_page=100" \
-            > "$RUNNER_TEMP/tag-build-runs.json"
-          test "$(jq -r .total_count "$RUNNER_TEMP/tag-build-runs.json")" -lt 100
+            > "$RUNNER_TEMP/tag-binding-runs.json"
+          test "$(jq -r .total_count "$RUNNER_TEMP/tag-binding-runs.json")" -lt 100
           matches="$(jq -c --arg tag "$TAG_NAME" --arg commit "$source_commit" \
             '[.workflow_runs[] | select(.head_branch == $tag and .head_sha == $commit and .event == "push" and .status == "completed" and .conclusion == "success" and .path == ".github/workflows/release.yml")]' \
-            "$RUNNER_TEMP/tag-build-runs.json")"
+            "$RUNNER_TEMP/tag-binding-runs.json")"
           test "$(jq length <<<"$matches")" -eq 1
           run_id="$(jq -r '.[0].id' <<<"$matches")"
           run_attempt="$(jq -r '.[0].run_attempt' <<<"$matches")"
@@ -112,18 +112,18 @@ jobs:
             echo "version=$version"
           } >> "$GITHUB_OUTPUT"
 
-      - name: preflight the exact Actions artifact before download
-        id: artifact
+      - name: preflight the exact tag-binding artifact
+        id: tag_artifact
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
-          RUN_ID: ${{ steps.candidate.outputs.run_id }}
-          RUN_ATTEMPT: ${{ steps.candidate.outputs.run_attempt }}
-          SOURCE_COMMIT: ${{ steps.candidate.outputs.source_commit }}
+          RUN_ID: ${{ steps.tag_run.outputs.run_id }}
+          RUN_ATTEMPT: ${{ steps.tag_run.outputs.run_attempt }}
+          SOURCE_COMMIT: ${{ steps.tag_run.outputs.source_commit }}
           TAG_NAME: ${{ inputs.tag }}
         shell: bash
         run: |
-          preflight="$RUNNER_TEMP/tag-payload-preflight"
+          preflight="$RUNNER_TEMP/tag-binding-preflight"
           rm -rf "$preflight"
           mkdir "$preflight"
           gh api "repos/$REPOSITORY/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT" \
@@ -138,47 +138,105 @@ jobs:
             --tag "$TAG_NAME" \
             --run-id "$RUN_ID" \
             --run-attempt "$RUN_ATTEMPT" \
-            --artifact-name "release-candidate-$TAG_NAME" \
-            --artifact-kind tag-payload \
+            --artifact-name "release-binding-$TAG_NAME" \
+            --artifact-kind tag-binding \
             --output "$preflight/ARTIFACT.json"
           artifact_id="$(jq -r .artifact.id "$preflight/ARTIFACT.json")"
           [[ "$artifact_id" =~ ^[1-9][0-9]*$ ]]
           echo "artifact_id=$artifact_id" >> "$GITHUB_OUTPUT"
           echo "manifest=$preflight/ARTIFACT.json" >> "$GITHUB_OUTPUT"
 
-      - name: download by artifact id and verify API digest before extraction
+      - name: download and verify the tag binding
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
-          ARTIFACT_ID: ${{ steps.artifact.outputs.artifact_id }}
-          ARTIFACT_MANIFEST: ${{ steps.artifact.outputs.manifest }}
+          ARTIFACT_ID: ${{ steps.tag_artifact.outputs.artifact_id }}
+          ARTIFACT_MANIFEST: ${{ steps.tag_artifact.outputs.manifest }}
         shell: bash
         run: |
-          rm -rf dist "$RUNNER_TEMP/tag-payload.zip"
+          rm -rf binding "$RUNNER_TEMP/tag-binding.zip"
           gh api "repos/$REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip" \
-            > "$RUNNER_TEMP/tag-payload.zip"
+            > "$RUNNER_TEMP/tag-binding.zip"
           python src/clio_relay/ci_validation.py extract-actions-artifact \
             --manifest "$ARTIFACT_MANIFEST" \
-            --archive "$RUNNER_TEMP/tag-payload.zip" \
+            --archive "$RUNNER_TEMP/tag-binding.zip" \
+            --output-dir binding
+
+      - name: download the original sealed candidate by bound numeric id
+        id: candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          TAG_NAME: ${{ inputs.tag }}
+        shell: bash
+        run: |
+          run_id="$(jq -r .candidate_run.id binding/TAG-BINDING.json)"
+          run_attempt="$(jq -r .candidate_run.attempt binding/TAG-BINDING.json)"
+          tested_commit="$(jq -r .candidate_run.head_sha binding/TAG-BINDING.json)"
+          source_tree="$(jq -r .source_tree binding/TAG-BINDING.json)"
+          artifact_id="$(jq -r .candidate_artifact.id binding/TAG-BINDING.json)"
+          artifact_name="$(jq -r .candidate_artifact.name binding/TAG-BINDING.json)"
+          gh api "repos/$REPOSITORY/actions/runs/$run_id/attempts/$run_attempt" \
+            > "$RUNNER_TEMP/candidate-run.json"
+          gh api "repos/$REPOSITORY/actions/artifacts/$artifact_id" \
+            > "$RUNNER_TEMP/candidate-artifact.json"
+          jq '{total_count: 1, artifacts: [.]}' "$RUNNER_TEMP/candidate-artifact.json" \
+            > "$RUNNER_TEMP/candidate-artifacts.json"
+          python src/clio_relay/ci_validation.py actions-artifact-manifest \
+            --run "$RUNNER_TEMP/candidate-run.json" \
+            --artifacts "$RUNNER_TEMP/candidate-artifacts.json" \
+            --repository "$REPOSITORY" \
+            --source-commit "$tested_commit" \
+            --source-tree "$source_tree" \
+            --tag "$TAG_NAME" \
+            --run-id "$run_id" \
+            --run-attempt "$run_attempt" \
+            --artifact-name "$artifact_name" \
+            --artifact-kind candidate \
+            --output "$RUNNER_TEMP/CANDIDATE-ARTIFACT.json"
+          rm -rf dist "$RUNNER_TEMP/candidate.zip"
+          gh api "repos/$REPOSITORY/actions/artifacts/$artifact_id/zip" \
+            > "$RUNNER_TEMP/candidate.zip"
+          python src/clio_relay/ci_validation.py extract-actions-artifact \
+            --manifest "$RUNNER_TEMP/CANDIDATE-ARTIFACT.json" \
+            --archive "$RUNNER_TEMP/candidate.zip" \
             --output-dir dist
+          {
+            echo "tested_commit=$tested_commit"
+            echo "source_tree=$source_tree"
+            echo "run_id=$run_id"
+            echo "run_attempt=$run_attempt"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: mint repository-scoped administration-read token
+        id: admin_read
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.IMMUTABLE_RELEASES_APP_ID }}
+          private-key: ${{ secrets.IMMUTABLE_RELEASES_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-administration: read
 
       - name: build trusted CI and live-governance receipts from protected main
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_ADMIN_READ_TOKEN: ${{ steps.admin_read.outputs.token }}
           REPOSITORY: ${{ github.repository }}
-          SOURCE_COMMIT: ${{ steps.candidate.outputs.source_commit }}
+          SOURCE_COMMIT: ${{ steps.tag_run.outputs.source_commit }}
+          TESTED_COMMIT: ${{ steps.candidate.outputs.tested_commit }}
           TAG_NAME: ${{ inputs.tag }}
         shell: bash
         run: |
           inputs="$RUNNER_TEMP/release-prerequisites"
           rm -rf "$inputs"
           mkdir -p "$inputs/branch-rulesets" "$inputs/tag-rulesets" "$inputs/environments"
-          gh api "repos/$REPOSITORY/actions/workflows/ci.yml/runs?head_sha=$SOURCE_COMMIT&event=push&status=completed&per_page=100" \
+          gh api "repos/$REPOSITORY/actions/workflows/ci.yml/runs?head_sha=$TESTED_COMMIT&event=merge_group&status=completed&per_page=100" \
             > "$inputs/ci-runs.json"
           python src/clio_relay/ci_validation.py select-ci-run \
             --runs "$inputs/ci-runs.json" \
             --repository "$REPOSITORY" \
-            --source-commit "$SOURCE_COMMIT" \
+            --source-commit "$TESTED_COMMIT" \
             --output "$inputs/selected-ci-run.json"
           ci_run_id="$(jq -r .run_id "$inputs/selected-ci-run.json")"
           ci_run_attempt="$(jq -r .run_attempt "$inputs/selected-ci-run.json")"
@@ -187,6 +245,9 @@ jobs:
           python src/clio_relay/ci_validation.py build-ci-status \
             --runs "$inputs/ci-runs.json" \
             --jobs "$inputs/ci-jobs.json" \
+            --candidate-build dist/CANDIDATE-BUILD.json \
+            --candidate-artifact "$RUNNER_TEMP/CANDIDATE-ARTIFACT.json" \
+            --tag-binding binding/TAG-BINDING.json \
             --repository "$REPOSITORY" \
             --source-commit "$SOURCE_COMMIT" \
             --output dist/CI-STATUS.json
@@ -223,12 +284,17 @@ jobs:
             gh api "repos/$REPOSITORY/environments/$environment" \
               > "$inputs/environments/$environment.json"
           done
+          GH_TOKEN="$GH_ADMIN_READ_TOKEN" gh api \
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$REPOSITORY/immutable-releases" \
+            > "$inputs/immutable-releases.json"
           python src/clio_relay/ci_validation.py build-governance \
             --main-effective-rules "$inputs/main-effective-rules.json" \
             --protected-branches "$inputs/protected-branches.json" \
             --branch-rulesets "$inputs/branch-rulesets.json" \
             --tag-rulesets "$inputs/tag-rulesets.json" \
             --environments-dir "$inputs/environments" \
+            --immutable-releases "$inputs/immutable-releases.json" \
             --repository "$REPOSITORY" \
             --source-commit "$SOURCE_COMMIT" \
             --tag "$TAG_NAME" \
@@ -237,10 +303,12 @@ jobs:
       - name: normalize and verify the complete candidate payload
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_ADMIN_READ_TOKEN: ${{ steps.admin_read.outputs.token }}
           REPOSITORY: ${{ github.repository }}
-          SOURCE_COMMIT: ${{ steps.candidate.outputs.source_commit }}
+          SOURCE_COMMIT: ${{ steps.tag_run.outputs.source_commit }}
+          TESTED_COMMIT: ${{ steps.candidate.outputs.tested_commit }}
           TAG_NAME: ${{ inputs.tag }}
-          VERSION: ${{ steps.candidate.outputs.version }}
+          VERSION: ${{ steps.tag_run.outputs.version }}
         shell: bash
         run: |
           python src/clio_relay/ci_validation.py verify-ci-status \
@@ -252,20 +320,20 @@ jobs:
             --repository "$REPOSITORY" \
             --source-commit "$SOURCE_COMMIT" \
             --tag "$TAG_NAME"
-          python - dist/validation-local.json "$SOURCE_COMMIT" "$TAG_NAME" "$VERSION" <<'PY'
+          python - dist/validation-local.json "$TESTED_COMMIT" "$VERSION" <<'PY'
           import json
           import sys
           from pathlib import Path
 
           report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-          commit, tag, version = sys.argv[2:]
+          commit, version = sys.argv[2:]
           software = report.get("software", {})
           source = report.get("install_source", {})
           checks = {
               "status": report.get("status") == "passed",
               "cluster": report.get("cluster") == "local",
               "commit": software.get("commit") == commit,
-              "tag": software.get("tag") == tag,
+              "tag": software.get("tag") is None,
               "clean": software.get("dirty") is False,
               "version": source.get("distribution_version") == version,
           }
@@ -273,13 +341,15 @@ jobs:
           if failed:
               raise SystemExit(f"local release report identity failed: {failed}")
           PY
+          rm dist/CANDIDATE-BUILD.json
           python src/clio_relay/ci_validation.py candidate-manifest --candidate-dir dist
 
       - name: create or verify the empty exact-target draft
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_ADMIN_READ_TOKEN: ${{ steps.admin_read.outputs.token }}
           REPOSITORY: ${{ github.repository }}
-          SOURCE_COMMIT: ${{ steps.candidate.outputs.source_commit }}
+          SOURCE_COMMIT: ${{ steps.tag_run.outputs.source_commit }}
           TAG_NAME: ${{ inputs.tag }}
         shell: bash
         run: |
@@ -304,8 +374,8 @@ jobs:
               --verify-tag \
               --target "$SOURCE_COMMIT" \
               --draft \
-              --title "$TAG_NAME" \
-              --notes "Production 1.0 candidate. Exact wheel SHA-256: $wheel_sha. Candidate and released-artifact validation are pending; GitHub release immutability is planned for 1.1."
+              --title "clio-relay ${TAG_NAME#v}" \
+              --notes "Production candidate. Exact wheel SHA-256: $wheel_sha. Candidate and released-artifact validation are pending; publication requires repository-enforced immutable releases."
           fi
           relay_release_resolve_eventually "$TAG_NAME" true \
             "$RUNNER_TEMP/release-after-create.json"
@@ -314,8 +384,9 @@ jobs:
       - name: revalidate protected main immediately before candidate attestation
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_ADMIN_READ_TOKEN: ${{ steps.admin_read.outputs.token }}
           REPOSITORY: ${{ github.repository }}
-          SOURCE_COMMIT: ${{ steps.candidate.outputs.source_commit }}
+          SOURCE_COMMIT: ${{ steps.tag_run.outputs.source_commit }}
           TAG_NAME: ${{ inputs.tag }}
         shell: bash
         run: >-
@@ -337,8 +408,9 @@ jobs:
       - name: attach only missing candidate assets and verify API digests
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_ADMIN_READ_TOKEN: ${{ steps.admin_read.outputs.token }}
           REPOSITORY: ${{ github.repository }}
-          SOURCE_COMMIT: ${{ steps.candidate.outputs.source_commit }}
+          SOURCE_COMMIT: ${{ steps.tag_run.outputs.source_commit }}
           TAG_NAME: ${{ inputs.tag }}
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ It is a piece of the federation layer for [`clio-agent`](https://github.com/iowa
 > constant. The latest released live evidence is `0.9.22`; `1.0.11` is not
 > release-complete until its digest-bound
 > candidate reports pass, its exact candidate is published, and the released-artifact
-> runs pass again. The published 1.0 GitHub release is intentionally mutable;
-> GitHub release immutability is deferred to 1.1. The policy currently selects the `ares` and `homelab`
+> runs pass again. The published 1.0 GitHub release is intentionally mutable.
+> The 1.1 release system requires repository-enforced immutable releases and
+> build-once merge-queue evidence. The policy currently selects the `ares` and `homelab`
 > evidence labels; those labels are release configuration, not hardcoded
 > product targets, and operators can select additional or different clusters.
 > The coordinated JARVIS-CD 1.2.2 and clio-kit 2.3.2 artifacts are exact pins;

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> The current development candidate is `1.0.11`. The `v1.0.0` candidate
+> The current development candidate is `1.1.0`. The `v1.0.0` candidate
 > was abandoned before publication after its acceptance runbook rejected the
 > staged GNU checksum format; `v1.0.1` was also abandoned before publication
 > after protected-main validation exposed a Windows lease-deletion race;
@@ -31,7 +31,7 @@ It is a piece of the federation layer for [`clio-agent`](https://github.com/iowa
 > `v1.0.9` was abandoned after one failed bootstrap report exposed an escaping
 > defect in the generated Python receipt writer; `v1.0.10` was abandoned before
 > candidate staging when its tag gate caught a stale exact matrix-digest test
-> constant. The latest released live evidence is `0.9.22`; `1.0.11` is not
+> constant. The latest released live evidence is `0.9.22`; `1.1.0` is not
 > release-complete until its digest-bound
 > candidate reports pass, its exact candidate is published, and the released-artifact
 > runs pass again. The published 1.0 GitHub release is intentionally mutable.

--- a/docs/ai/testing-context.md
+++ b/docs/ai/testing-context.md
@@ -1,8 +1,8 @@
-# Testing Context
+# testing context
 
 Local tests are necessary but not sufficient for transport or cluster behavior.
 
-## Local Gates
+## local gates
 
 Run:
 
@@ -20,7 +20,23 @@ For CI parity, also verify the built artifacts:
 uvx twine check dist/*
 ```
 
-## Live Acceptance
+## build-once release CI
+
+The trusted release candidate is produced only by the primary Ubuntu/Python
+3.12 leg of a `merge_group` run. The other five matrix legs pass the downloaded
+wheel, source distribution, and canonical checksum file through
+`release validate-local --prebuilt-artifact-dir`; that mode rejects extra,
+missing, or changed files and cannot execute either `uv build` path. The final
+CI seal binds all six machine-readable reports to one distribution digest map,
+tested merge-group commit, Git tree, queued PR, run, and attempt.
+
+A protected-main tag must identify the merged PR commit and the same tested Git
+tree. The tag workflow is a lightweight binding workflow: it performs no sync,
+test, component fetch, artifact build, or candidate execution. Repository rules
+and merge-queue behavior require a live disposable canary before an owner
+enables them; checkout tests alone cannot prove GitHub's eventual merge identity.
+
+## live acceptance
 
 A feature that depends on a cluster, transport, scheduler, agent process, or MCP call is not done until that path has been live-tested.
 
@@ -35,7 +51,7 @@ The expected Ares acceptance includes:
 - verify transport through the configured path when transport behavior is in scope.
 - verify detach and teardown behavior when lifecycle behavior is in scope.
 
-## Recent Live Evidence
+## recent live evidence
 
 Historical release-candidate evidence is retained in
 `release-validation-0.9.17.md`. Use that file only as the authoritative record
@@ -60,7 +76,7 @@ are not current proof for a release candidate.
 
 Refresh this evidence when changing the relevant code. Do not present old live evidence as current proof after transport, lifecycle, worker, or acceptance code changes.
 
-## Machine-readable evidence
+## machine-readable evidence
 
 `clio-relay live-test` writes a versioned JSON report by default under
 `.clio-relay/validation-reports`. The report is canonical; an optional Markdown

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.0.11"
+$Version = "1.1.0"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.0.11"
+release_version: "1.1.0"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 96b9840c68b423053911cd39b5f3b0c694baa1a27d4d94f5f330605531e69ac8
+acceptance_matrix_sha256: f4a4c47353e63dadfecd5118612a4acf11452018efe1c7df9e9b495d066c65c4
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -83,7 +83,7 @@ for the tested Git tree. After the queued PR is merged, create and push an exact
 matching tag at protected `main`:
 
 ```powershell
-$Tag = "v1.0.11"
+$Tag = "v1.1.0"
 git fetch origin main
 $ReviewedMainSha = (git rev-parse refs/remotes/origin/main).Trim()
 if ((git rev-parse HEAD).Trim() -ne $ReviewedMainSha) {
@@ -170,7 +170,7 @@ Download the draft wheel and manifest, verify both the digest and the signed
 protected-main staging provenance, and compute the digest locally:
 
 ```powershell
-$Tag = "v1.0.11"
+$Tag = "v1.1.0"
 New-Item -ItemType Directory -Force .clio-relay\candidate | Out-Null
 gh release download $Tag --pattern "*.whl" --pattern "SHA256SUMS" `
   --dir .clio-relay\candidate

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,13 +1,16 @@
-# Release
+# release
 
-`clio-relay` uses `uv`, hatchling, and a staged GitHub Actions release. A tag
-creates an inert candidate payload in an unprivileged job. Protected-main code
-normalizes and attests that payload, maintainer-sealed operator live evidence
-gates publication to PyPI, released-artifact evidence then exercises the
-published persistent `uv tool` path, and only the final evidence-verifying workflow publishes
-the GitHub release.
+`clio-relay` uses `uv`, hatchling, and a staged GitHub Actions release. The
+merge queue builds one wheel and one source distribution and validates those
+same bytes across the complete operating-system and Python matrix. A later tag
+only binds the protected `main` commit and its Git tree to that sealed candidate;
+it never rebuilds or reruns the full matrix. Protected-main code attests the
+candidate, maintainer-sealed live evidence gates PyPI, and released-artifact
+evidence exercises the public persistent `uv tool` path. Finalization publishes
+the draft once, waits for GitHub release immutability, and verifies the release
+attestation and every asset.
 
-## Local checks
+## local checks
 
 Run the same checks as the release builder before tagging:
 
@@ -27,14 +30,22 @@ validates both with the lock-installed Twine, and installs the exact wheel into
 a clean environment containing only hash-checked production dependencies from
 `uv.lock`. It also builds the exact source distribution back into a wheel and
 installs and launches that result in a second clean, hash-locked runtime
-environment. This executable sdist smoke runs only in the unprivileged local,
-CI, and tag-build gate; no write-, OIDC-, environment-, attestation-, or
+environment. This executable sdist smoke runs only in the unprivileged local
+and primary merge-queue build gate; no write-, OIDC-, environment-, attestation-, or
 promotion-capable job executes candidate distribution code. Its report records
 the distribution paths, sizes, SHA-256 digests,
 backend identity, commands, resolved freeze, and bounded outputs.
 Protected promotion jobs instead inflate the gzip source distribution into a
 private regular temporary file under a hard uncompressed-tar byte ceiling,
 then parse the bounded tar and wheel topology without invoking either archive.
+
+CI's primary Ubuntu/Python 3.12 leg runs this artifact-building path once. The
+other five matrix legs use `--prebuilt-artifact-dir`, which requires exactly one
+wheel, one source distribution, and a canonical `SHA256SUMS`. Any extra,
+missing, or changed byte fails before smoke validation, and those legs never
+run `uv build` or rebuild the source distribution. The seal records all six
+report digests and their common distribution digests in
+`CANDIDATE-BUILD.json`.
 
 The 1.0 policy has an explicit `release_blockers` list. The evaluator fails
 closed even when all acceptance reports pass while any declared blocker
@@ -46,7 +57,7 @@ new blocker immediately if review discovers work that cannot be represented by
 an existing acceptance requirement, and remove it only after implementation
 and evidence are present on the reviewed release commit.
 
-## Bootstrap source
+## bootstrap source
 
 `cluster bootstrap` supports two deployment sources:
 
@@ -59,15 +70,17 @@ Before tagging, verify the wheel contains
 `clio_relay/assets/jarvis-packages/clio_relay/`. Bootstrap uses that packaged
 asset path and must not depend on a local checkout.
 
-## Version and tag
+## version and tag
 
 Update both version declarations:
 
 - `pyproject.toml`: `[project].version`
 - `src/clio_relay/__init__.py`: `__version__`
 
-Commit the release change with a conventional commit, then create and push an
-exact matching tag:
+Merge the release change through the configured merge queue. Its
+`merge_group` run must complete the six-leg matrix and create a sealed candidate
+for the tested Git tree. After the queued PR is merged, create and push an exact
+matching tag at protected `main`:
 
 ```powershell
 $Tag = "v1.0.11"
@@ -90,20 +103,20 @@ particular, advancing `main` after PyPI publication would prevent the immutable
 evidence chain from being finalized, because published package versions cannot
 be replaced.
 
-All six same-tag release workflows use the shared
+All same-tag release workflows use the shared
 `clio-relay-release-<tag>` concurrency group with cancellation disabled. This
-serializes tag build, staging, both evidence seals, PyPI promotion, and final
+serializes tag binding, staging, both evidence seals, PyPI promotion, and final
 publication. It does not replace the freeze: every privileged stage still
 fetches live `origin/main` and fails unless main, the reviewed SHA, the tag, and
 the protected workflow checkout are identical.
 
 The tag-push workflow rejects a tag that does not match the package version,
-checked-out commit, and freshly fetched `origin/main` commit. It runs the
-complete local gate, builds exactly one wheel and one source distribution, and
-creates `SHA256SUMS`, but grants `GITHUB_TOKEN` only read-only repository
-contents access. Checkout credentials are not persisted, and the workflow can
-upload only an Actions artifact. It cannot mint an OIDC identity, attest
-evidence, or create a release.
+checked-out commit, and freshly fetched `origin/main`. It resolves the merged
+pull request, requires its merge commit to equal the tag, requires the tag's Git
+tree to equal the tested merge-group tree, and downloads the original candidate
+by numeric Actions artifact id and API digest. Its only output is
+`TAG-BINDING.json`. It does not install dependencies, fetch clio-kit, execute
+candidate code, run tests, or build distributions.
 
 After that read-only workflow succeeds, stage the payload by dispatching only
 from protected `main`:
@@ -113,16 +126,14 @@ gh workflow run stage-candidate.yml --ref main -f tag=$Tag `
   -f reviewed_main_sha=$ReviewedMainSha
 ```
 
-The `live-validation` environment admits the staging job only from protected
-`main`. The job selects the sole successful tag-push run for the exact tag and
-commit. Before download, it binds the sole nonexpired artifact to the exact run
-id, attempt, head SHA, name, byte count, and API SHA-256 digest; it downloads by
-artifact id, verifies the archive digest, rejects unsafe or extra members, and
-extracts bounded inert files. Protected-main code then builds current CI and
-repository-governance receipts, replaces the tag manifest with a canonical
-manifest, attests the bytes, and creates the draft with an explicit target of
-the reviewed commit. Tag-supplied workflow code never receives release-write or
-OIDC authority.
+The `live-validation` environment admits staging only from protected `main`.
+Staging verifies the tag-binding artifact first, then downloads the original
+sealed candidate directly by its bound numeric run and artifact ids. It verifies
+the API digest, tested merge-group commit and tree, all eight required jobs,
+merged PR, tag, and protected-main commit before creating `CI-STATUS.json`.
+Protected-main code then records current repository governance, attests the
+bytes, and creates the draft. Neither merge-group nor tag-supplied workflow code receives
+release-write or OIDC authority.
 
 GitHub's release list can lag immediately after draft creation. Staging retries
 only a conclusively absent draft through the same numeric-ID resolver, ten times
@@ -133,15 +144,20 @@ An existing draft is reusable only when every staged asset is byte-for-byte
 identical and its complete asset-name set equals the six staged candidate
 assets. The workflow never replaces a candidate distribution.
 
-The 1.0 release line intentionally publishes a normal, mutable GitHub release.
-Finalization still binds the tag to reviewed `main`, verifies the complete
-asset inventory immediately before and after publication, and requires the
-published release to remain non-prerelease and mutable. GitHub immutable
-releases are deferred to the 1.1 release line, where the additional repository
-setting and administration-read preflight can be introduced independently of
-the production 1.0 acceptance path.
+The 1.1 release line requires repository-enforced immutable releases. Drafts
+remain mutable while evidence is attached. Every release mutation immediately
+rechecks `enabled=true` and `enforced_by_owner=true` through a repository-scoped
+GitHub App token with only Administration read permission. Finalization adds
+`RELEASE-CLAIMS.json` before publication, publishes once, waits for the same
+release id, tag, target, and asset inventory to become immutable, then runs
+`gh release verify` and `gh release verify-asset` for every attached file. A
+rerun after publication performs reads and verification only.
 
-## Live validation of the candidate
+Release workflows never call `PUT` or `DELETE` on the immutable-release setting.
+Changing that repository policy is an owner governance action, not release-job
+authority.
+
+## live validation of the candidate
 
 The cluster labels named in `release-gate-1.0.yaml` are the concrete evidence
 instances selected for this release, not an allowlist in the product. Any
@@ -151,7 +167,7 @@ Adding a target or changing the evidence matrix requires configuration and
 policy updates only, with no target-name branch in relay code.
 
 Download the draft wheel and manifest, verify both the digest and the signed
-tag-build provenance, and compute the digest locally:
+protected-main staging provenance, and compute the digest locally:
 
 ```powershell
 $Tag = "v1.0.11"
@@ -300,7 +316,7 @@ cannot authorize a 1.0 claim or publication of the GitHub release.
 Diagnostic checkout runs and wheels from any other build may find defects, but
 they cannot satisfy the release gate.
 
-## Publish the candidate to PyPI
+## publish the candidate to PyPI
 
 Run the `publish validated candidate to PyPI` workflow with the draft tag:
 
@@ -353,7 +369,7 @@ byte-identical to a record regenerated from the current PyPI filename, URL, and
 digest map. These checks run in the gate and again immediately before the PyPI
 state decision.
 
-## Live validation of the released artifact
+## live validation of the released artifact
 
 After `PYPI-PROMOTION.json` is attached, rerun every required Ares and homelab
 scenario through the actual index-resolved package. Do not pass a wheel path or
@@ -420,7 +436,7 @@ published digest. The workflow signs every released
 report, `RELEASED-VALIDATION-BINDING.json`, and
 `released-release-gate-1.0.json`.
 
-## Finalize the GitHub release
+## finalize the GitHub release
 
 Only after released evidence is sealed, dispatch:
 
@@ -449,7 +465,42 @@ path. The workflow attaches and attests
 the claim set before making the GitHub release public. A retry after publication
 succeeds only when the claim asset and generated release notes are unchanged and
 the claim digest has an authorized `finalize-release.yml` attestation from the
-exact protected-main commit.
+exact protected-main commit. It declares immutable publication in the claims
+before publishing. No asset is created, replaced, or attached after the draft
+becomes public. A published rerun requires `immutable=true`, verifies unchanged
+notes and inventory, and executes only release and asset verification reads.
+
+## owner setup for 1.1
+
+The following setup is intentionally outside workflow authority:
+
+1. Create a GitHub App installed only on `iowarp/clio-relay` with repository
+   Administration **read** permission and no write permissions. Store its app id
+   in the repository variable `IMMUTABLE_RELEASES_APP_ID` and its private key in
+   the repository secret `IMMUTABLE_RELEASES_PRIVATE_KEY`.
+2. Enable immutable releases for the repository and require owner enforcement.
+   The read endpoint must return exactly `enabled=true` and
+   `enforced_by_owner=true` with API version `2026-03-10`.
+3. Exercise a disposable merge-queue canary before changing the production
+   ruleset. The canary must prove the observed `merge_group` head/base refs, the
+   merge-group anchor PR number, the final squash-merged PR commit, identical
+   tested/release Git trees, artifact retention, and rerun behavior, including
+   a group containing more than one PR.
+4. After that canary passes, configure the `main` ruleset with the existing
+   review, conversation, deletion, force-push, and exact status-check controls,
+   plus this merge queue contract:
+
+   - `check_response_timeout_minutes: 60`
+   - `grouping_strategy: ALLGREEN`
+   - `max_entries_to_build: 5`
+   - `max_entries_to_merge: 5`
+   - `merge_method: SQUASH`
+   - `min_entries_to_merge: 1`
+   - `min_entries_to_merge_wait_minutes: 0`
+
+The release governance receipt fails closed until all four steps are complete.
+No workflow in this repository creates the app, enables immutable releases, or
+changes repository rules.
 
 ## PyPI trusted publishing
 
@@ -472,7 +523,8 @@ those optional rules are active.
 
 Repository governance is proved from GitHub's effective rules for `main`, not
 from the legacy branch-protection administration endpoint. The effective rule
-set must enforce strict results from the exact seven GitHub Actions CI jobs,
+set must enforce strict results from actionlint, the exact six matrix jobs, and
+the candidate seal; require the exact merge-queue parameters above;
 pull-request-only changes, stale-review dismissal, conversation resolution, no
 force pushes, and no deletion. For 1.0, the receipt records the explicit
 `single-maintainer` review policy: the repository has no second eligible

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.0.11",
-  "matrix_sha256": "96b9840c68b423053911cd39b5f3b0c694baa1a27d4d94f5f330605531e69ac8",
+  "release_version": "1.1.0",
+  "matrix_sha256": "f4a4c47353e63dadfecd5118612a4acf11452018efe1c7df9e9b495d066c65c4",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.0.11"
+version = "1.1.0"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.0.11"
+__version__ = "1.1.0"

--- a/src/clio_relay/ci_validation.py
+++ b/src/clio_relay/ci_validation.py
@@ -23,14 +23,18 @@ from pathlib import Path
 from typing import BinaryIO, NoReturn, Protocol, cast
 from uuid import uuid4
 
-REQUIRED_CI_JOBS: tuple[str, ...] = (
-    "GitHub Actions syntax and semantics",
+REQUIRED_MATRIX_JOBS: tuple[str, ...] = (
     "ubuntu-latest / python 3.12",
     "ubuntu-latest / python 3.13",
     "ubuntu-latest / python 3.14",
     "windows-latest / python 3.12",
     "windows-latest / python 3.13",
     "windows-latest / python 3.14",
+)
+REQUIRED_CI_JOBS: tuple[str, ...] = (
+    "GitHub Actions syntax and semantics",
+    *REQUIRED_MATRIX_JOBS,
+    "seal tested release candidate",
 )
 GITHUB_ACTIONS_APP_ID = 15368
 MAIN_REVIEW_POLICY = "single-maintainer"
@@ -43,6 +47,17 @@ REQUIRED_ENVIRONMENTS: tuple[str, ...] = (
     "released-validation",
 )
 CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
+RELEASE_WORKFLOW_PATH = ".github/workflows/release.yml"
+IMMUTABLE_RELEASES_API_VERSION = "2026-03-10"
+REQUIRED_MERGE_QUEUE_PARAMETERS: dict[str, object] = {
+    "check_response_timeout_minutes": 60,
+    "grouping_strategy": "ALLGREEN",
+    "max_entries_to_build": 5,
+    "max_entries_to_merge": 5,
+    "merge_method": "SQUASH",
+    "min_entries_to_merge": 1,
+    "min_entries_to_merge_wait_minutes": 0,
+}
 RELEASE_TAG_PATTERN = "refs/tags/v*"
 MAX_RELEASE_ASSET_METADATA_RECORDS = 96
 MAX_RELEASE_HISTORY_PAGES = 100
@@ -65,6 +80,9 @@ MAX_MANIFEST_BYTES = 1024 * 1024
 MAX_RELEASE_ASSET_BYTES = 128 * 1024 * 1024
 MAX_RELEASE_ASSET_AGGREGATE_BYTES = 512 * 1024 * 1024
 TAG_PAYLOAD_FIXED_FILES = frozenset({"SHA256SUMS", "validation-local.json"})
+CANDIDATE_PAYLOAD_FIXED_FILES = frozenset(
+    {"SHA256SUMS", "validation-local.json", "CANDIDATE-BUILD.json"}
+)
 RELEASE_ACCEPTANCE_MATRIX_SCHEMA = "clio-relay.release-acceptance-matrix.v1"
 RELEASE_ACCEPTANCE_MATRIX_STAGES = ("candidate", "released")
 
@@ -97,7 +115,7 @@ def select_ci_run(
     repository: str,
     source_commit: str,
 ) -> dict[str, object]:
-    """Select the sole successful completed push run for an exact main commit."""
+    """Select the sole successful merge-queue CI run for an exact tested commit."""
     _validate_repository(repository)
     _validate_commit(source_commit)
     payload = _mapping(document, "workflow-runs document")
@@ -112,12 +130,14 @@ def select_ci_run(
         run = _mapping(raw, "workflow run")
         if (
             run.get("head_sha") == source_commit
-            and run.get("head_branch") == "main"
-            and run.get("event") == "push"
+            and run.get("event") == "merge_group"
             and run.get("status") == "completed"
             and run.get("conclusion") == "success"
             and run.get("path") == CI_WORKFLOW_PATH
         ):
+            head_branch = _nonempty_string(run.get("head_branch"), "workflow head branch")
+            if not head_branch.startswith("gh-readonly-queue/main/"):
+                continue
             matches.append(
                 {
                     "run_id": _positive_integer(run.get("id"), "workflow run id"),
@@ -127,11 +147,13 @@ def select_ci_run(
                     "run_number": _positive_integer(run.get("run_number"), "workflow run number"),
                     "workflow_id": _positive_integer(run.get("workflow_id"), "workflow id"),
                     "url": _https_url(run.get("html_url"), "workflow run URL"),
+                    "event": "merge_group",
+                    "head_branch": head_branch,
                 }
             )
     if len(matches) != 1:
         raise ProvenanceError(
-            "exact release commit must have exactly one successful completed push run of ci.yml; "
+            "tested merge-group commit must have exactly one successful completed run of ci.yml; "
             f"found {len(matches)}"
         )
     return matches[0]
@@ -140,16 +162,40 @@ def select_ci_run(
 def build_ci_status(
     runs_document: object,
     jobs_document: object,
+    candidate_build: object,
+    candidate_artifact: object,
+    tag_binding: object,
     *,
     repository: str,
     source_commit: str,
 ) -> dict[str, object]:
-    """Build a deterministic receipt for the exact successful CI run and jobs."""
+    """Build a receipt binding release main to its one tested merge-queue artifact."""
+    binding = _mapping(tag_binding, "tag binding")
+    verify_tag_binding(binding, repository=repository, source_commit=source_commit)
+    build = _mapping(candidate_build, "candidate build receipt")
+    verify_candidate_build_receipt(build, repository=repository)
+    artifact_manifest = _mapping(candidate_artifact, "candidate artifact manifest")
+    _verify_candidate_artifact_manifest(
+        artifact_manifest,
+        candidate_build=build,
+        repository=repository,
+    )
+    if binding.get("candidate_build_sha256") != _canonical_json_sha256(build):
+        raise ProvenanceError("tag binding does not identify the candidate build receipt")
+    if binding.get("merge_group_anchor_pull_request_number") != build.get("pull_request_number"):
+        raise ProvenanceError("tag binding does not identify the merge-group anchor pull request")
+    if binding.get("candidate_artifact") != artifact_manifest.get("artifact"):
+        raise ProvenanceError("tag binding does not identify the selected candidate artifact")
+    tested_commit = _nonempty_string(build.get("tested_commit"), "tested merge-group commit")
     selected = select_ci_run(
         runs_document,
         repository=repository,
-        source_commit=source_commit,
+        source_commit=tested_commit,
     )
+    if selected["run_id"] != build.get("run_id") or selected["run_attempt"] != build.get(
+        "run_attempt"
+    ):
+        raise ProvenanceError("candidate build receipt does not identify the selected CI run")
     payload = _mapping(jobs_document, "workflow-jobs document")
     jobs = _list(payload.get("jobs"), "jobs")
     total_count = _integer(payload.get("total_count"), "workflow-jobs total_count")
@@ -186,17 +232,28 @@ def build_ci_status(
     if nonpassing:
         raise ProvenanceError(f"CI jobs did not succeed: {sorted(nonpassing)}")
     receipt: dict[str, object] = {
-        "schema_version": "1.0",
+        "schema_version": "1.1",
         "repository": repository,
         "source_commit": source_commit,
+        "source_tree": build["source_tree"],
         "workflow": CI_WORKFLOW_PATH,
-        "event": "push",
-        "head_branch": "main",
+        "event": "merge_group",
+        "head_branch": selected["head_branch"],
         "status": "completed",
         "conclusion": "success",
         **selected,
         "required_jobs": list(REQUIRED_CI_JOBS),
         "jobs": [observed[name] for name in REQUIRED_CI_JOBS],
+        "tested_merge_group": {
+            "commit": tested_commit,
+            "tree": build["source_tree"],
+            "base_ref": build["base_ref"],
+            "head_ref": build["head_ref"],
+            "pull_request_number": build["pull_request_number"],
+        },
+        "candidate_artifact": artifact_manifest["artifact"],
+        "candidate_build_sha256": _canonical_json_sha256(build),
+        "tag_binding_sha256": _canonical_json_sha256(binding),
     }
     verify_ci_status(receipt, repository=repository, source_commit=source_commit)
     return receipt
@@ -213,18 +270,21 @@ def verify_ci_status(
     _validate_commit(source_commit)
     document = _mapping(receipt, "CI status receipt")
     expected_scalars = {
-        "schema_version": "1.0",
+        "schema_version": "1.1",
         "repository": repository,
         "source_commit": source_commit,
         "workflow": CI_WORKFLOW_PATH,
-        "event": "push",
-        "head_branch": "main",
+        "event": "merge_group",
         "status": "completed",
         "conclusion": "success",
     }
     mismatches = [key for key, value in expected_scalars.items() if document.get(key) != value]
     if mismatches:
         raise ProvenanceError(f"CI receipt identity mismatch: {sorted(mismatches)}")
+    _validate_git_tree(_nonempty_string(document.get("source_tree"), "CI source tree"))
+    head_branch = _nonempty_string(document.get("head_branch"), "CI head branch")
+    if not head_branch.startswith("gh-readonly-queue/main/"):
+        raise ProvenanceError("CI receipt is not from the main merge queue")
     for key in ("run_id", "run_attempt", "run_number", "workflow_id"):
         _positive_integer(document.get(key), f"CI receipt {key}")
     _https_url(document.get("url"), "CI receipt URL")
@@ -245,6 +305,376 @@ def verify_ci_status(
             raise ProvenanceError(f"CI receipt contains a nonpassing job: {name}")
     if names != list(REQUIRED_CI_JOBS) or len(set(names)) != len(names):
         raise ProvenanceError("CI receipt jobs are missing, duplicated, or out of canonical order")
+    tested = _mapping(document.get("tested_merge_group"), "tested merge group")
+    _validate_commit(_nonempty_string(tested.get("commit"), "tested merge-group commit"))
+    tree = _nonempty_string(tested.get("tree"), "tested merge-group tree")
+    _validate_git_tree(tree)
+    if tree != document.get("source_tree"):
+        raise ProvenanceError("CI receipt tree identities differ")
+    if tested.get("base_ref") != "refs/heads/main":
+        raise ProvenanceError("CI receipt merge group does not target main")
+    pull_number = _positive_integer(
+        tested.get("pull_request_number"), "CI receipt pull request number"
+    )
+    head_ref = _nonempty_string(tested.get("head_ref"), "CI receipt merge-group head ref")
+    if (
+        re.fullmatch(
+            rf"refs/heads/gh-readonly-queue/main/pr-{pull_number}-[A-Za-z0-9._/-]+",
+            head_ref,
+        )
+        is None
+    ):
+        raise ProvenanceError("CI receipt merge-group head ref does not bind its pull request")
+    artifact = _mapping(document.get("candidate_artifact"), "CI candidate artifact")
+    _positive_integer(artifact.get("id"), "CI candidate artifact id")
+    _positive_integer(artifact.get("size_in_bytes"), "CI candidate artifact size")
+    digest = _nonempty_string(artifact.get("digest"), "CI candidate artifact digest")
+    if re.fullmatch(r"sha256:[0-9a-f]{64}", digest) is None:
+        raise ProvenanceError("CI candidate artifact digest is invalid")
+    for field in ("candidate_build_sha256", "tag_binding_sha256"):
+        value = _nonempty_string(document.get(field), f"CI receipt {field}")
+        if re.fullmatch(r"[0-9a-f]{64}", value) is None:
+            raise ProvenanceError(f"CI receipt {field} is invalid")
+
+
+def build_candidate_build_receipt(
+    candidate_dir: Path,
+    reports_dir: Path,
+    *,
+    repository: str,
+    source_commit: str,
+    source_tree: str,
+    event: str,
+    run_id: int,
+    run_attempt: int,
+    head_ref: str,
+    base_ref: str,
+) -> dict[str, object]:
+    """Seal one build and six matrix validations from a merge-queue commit."""
+    _validate_repository(repository)
+    _validate_commit(source_commit)
+    _validate_git_tree(source_tree)
+    if event != "merge_group" or base_ref != "refs/heads/main":
+        raise ProvenanceError("candidate build must originate from the main merge queue")
+    match = re.fullmatch(
+        r"refs/heads/gh-readonly-queue/main/pr-([1-9][0-9]*)-[A-Za-z0-9._/-]+",
+        head_ref,
+    )
+    if match is None:
+        raise ProvenanceError("candidate build head ref does not identify one queued pull request")
+    pull_request_number = int(match.group(1))
+    observed_run_id = _positive_integer(run_id, "candidate build run id")
+    observed_run_attempt = _positive_integer(run_attempt, "candidate build run attempt")
+    try:
+        candidate_paths = sorted(candidate_dir.iterdir(), key=lambda path: path.name)
+    except OSError as exc:
+        raise ProvenanceError(f"could not inspect build-once candidate directory: {exc}") from exc
+    wheels = [path for path in candidate_paths if path.name.endswith(".whl")]
+    sdists = [path for path in candidate_paths if path.name.endswith(".tar.gz")]
+    expected_candidate_names = {
+        *(path.name for path in wheels),
+        *(path.name for path in sdists),
+        "SHA256SUMS",
+    }
+    if (
+        len(wheels) != 1
+        or len(sdists) != 1
+        or {path.name for path in candidate_paths} != expected_candidate_names
+    ):
+        raise ProvenanceError(
+            "build-once candidate must contain exactly one wheel, one sdist, and SHA256SUMS"
+        )
+    _verify_checksum_manifest(
+        candidate_dir,
+        expected_names={wheels[0].name, sdists[0].name},
+    )
+    distribution_digests = {
+        path.name: _sha256_bounded_file(path, maximum_bytes=MAX_DISTRIBUTION_BYTES)
+        for path in (wheels[0], sdists[0])
+    }
+    expected_reports = {
+        f"validation-local-{job.split(' / python ')[0]}-{job.rsplit(' ', 1)[1]}.json": job
+        for job in REQUIRED_MATRIX_JOBS
+    }
+    try:
+        report_paths = sorted(reports_dir.iterdir(), key=lambda path: path.name)
+    except OSError as exc:
+        raise ProvenanceError(f"could not inspect matrix report directory: {exc}") from exc
+    if {path.name for path in report_paths} != set(expected_reports):
+        raise ProvenanceError("matrix validation report set is missing, extra, or renamed")
+    reports: list[dict[str, object]] = []
+    for path in report_paths:
+        report = _mapping(_load_json(path), f"matrix validation report {path.name}")
+        if (
+            report.get("status") != "passed"
+            or report.get("scenario") != "local-release"
+            or report.get("cluster") != "local"
+        ):
+            raise ProvenanceError(f"matrix validation report did not pass: {path.name}")
+        software = _mapping(report.get("software"), f"matrix report software {path.name}")
+        if software.get("commit") != source_commit or software.get("dirty") is not False:
+            raise ProvenanceError(f"matrix validation report source identity differs: {path.name}")
+        resources = _list(report.get("resources"), f"matrix report resources {path.name}")
+        observed_digests: dict[str, str] = {}
+        for raw in resources:
+            resource = _mapping(raw, f"matrix report resource {path.name}")
+            name = resource.get("resource_id")
+            if name not in distribution_digests:
+                continue
+            metadata = _mapping(resource.get("metadata"), f"matrix report metadata {path.name}")
+            digest = _nonempty_string(
+                metadata.get("sha256"), f"matrix report artifact digest {path.name}"
+            )
+            if name in observed_digests:
+                raise ProvenanceError(f"matrix report duplicates a release artifact: {path.name}")
+            observed_digests[cast(str, name)] = digest
+        if observed_digests != distribution_digests:
+            raise ProvenanceError(f"matrix report artifact digests differ: {path.name}")
+        checks = {
+            _mapping(raw, f"matrix report check {path.name}").get("check_id")
+            for raw in _list(report.get("checks"), f"matrix report checks {path.name}")
+        }
+        job = expected_reports[path.name]
+        primary = job == "ubuntu-latest / python 3.12"
+        if primary:
+            if "local.build" not in checks or "local.sdist-smoke" not in checks:
+                raise ProvenanceError("primary matrix report does not prove the sole build")
+            mode = "build"
+        else:
+            if (
+                "local.prebuilt-artifacts" not in checks
+                or "local.build" in checks
+                or "local.sdist-smoke" in checks
+            ):
+                raise ProvenanceError(
+                    f"matrix report did not use the build-once artifact path: {path.name}"
+                )
+            mode = "prebuilt"
+        reports.append(
+            {
+                "job": job,
+                "filename": path.name,
+                "sha256": _sha256_bounded_file(path, maximum_bytes=MAX_FIXED_JSON_BYTES),
+                "mode": mode,
+                "artifact_sha256": distribution_digests,
+            }
+        )
+    reports.sort(key=lambda item: REQUIRED_MATRIX_JOBS.index(cast(str, item["job"])))
+    receipt: dict[str, object] = {
+        "schema_version": "clio-relay.candidate-build.v1",
+        "repository": repository,
+        "workflow": CI_WORKFLOW_PATH,
+        "event": "merge_group",
+        "tested_commit": source_commit,
+        "source_tree": source_tree,
+        "base_ref": base_ref,
+        "head_ref": head_ref,
+        "pull_request_number": pull_request_number,
+        "run_id": observed_run_id,
+        "run_attempt": observed_run_attempt,
+        "distribution_sha256": distribution_digests,
+        "matrix_reports": reports,
+    }
+    verify_candidate_build_receipt(receipt, repository=repository)
+    return receipt
+
+
+def verify_candidate_build_receipt(receipt: object, *, repository: str) -> None:
+    """Verify the structural identity of a sealed merge-queue candidate build."""
+    _validate_repository(repository)
+    document = _mapping(receipt, "candidate build receipt")
+    expected = {
+        "schema_version": "clio-relay.candidate-build.v1",
+        "repository": repository,
+        "workflow": CI_WORKFLOW_PATH,
+        "event": "merge_group",
+        "base_ref": "refs/heads/main",
+    }
+    mismatches = [key for key, value in expected.items() if document.get(key) != value]
+    if mismatches:
+        raise ProvenanceError(f"candidate build receipt identity mismatch: {mismatches}")
+    _validate_commit(_nonempty_string(document.get("tested_commit"), "tested commit"))
+    _validate_git_tree(_nonempty_string(document.get("source_tree"), "candidate source tree"))
+    pull_number = _positive_integer(
+        document.get("pull_request_number"), "candidate pull request number"
+    )
+    head_ref = _nonempty_string(document.get("head_ref"), "candidate head ref")
+    if (
+        re.fullmatch(
+            rf"refs/heads/gh-readonly-queue/main/pr-{pull_number}-[A-Za-z0-9._/-]+",
+            head_ref,
+        )
+        is None
+    ):
+        raise ProvenanceError("candidate head ref does not match its pull request number")
+    _positive_integer(document.get("run_id"), "candidate run id")
+    _positive_integer(document.get("run_attempt"), "candidate run attempt")
+    digests = _mapping(document.get("distribution_sha256"), "candidate distribution digests")
+    if len(digests) != 2:
+        raise ProvenanceError("candidate receipt must identify exactly two distributions")
+    for name, digest in digests.items():
+        if (
+            not (name.endswith(".whl") or name.endswith(".tar.gz"))
+            or re.fullmatch(r"[0-9a-f]{64}", _nonempty_string(digest, f"candidate digest {name}"))
+            is None
+        ):
+            raise ProvenanceError(f"candidate distribution digest is invalid: {name}")
+    reports = _list(document.get("matrix_reports"), "candidate matrix reports")
+    if len(reports) != len(REQUIRED_MATRIX_JOBS):
+        raise ProvenanceError("candidate receipt matrix report count differs")
+    observed_jobs: list[str] = []
+    for raw in reports:
+        report = _mapping(raw, "candidate matrix report")
+        observed_jobs.append(_nonempty_string(report.get("job"), "candidate matrix job"))
+        filename = _nonempty_string(report.get("filename"), "candidate matrix filename")
+        if re.fullmatch(r"validation-local-[A-Za-z0-9._-]+\.json", filename) is None:
+            raise ProvenanceError("candidate matrix report filename is invalid")
+        digest = _nonempty_string(report.get("sha256"), "candidate matrix report digest")
+        if re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+            raise ProvenanceError("candidate matrix report digest is invalid")
+        expected_mode = "build" if report["job"] == REQUIRED_MATRIX_JOBS[0] else "prebuilt"
+        if report.get("mode") != expected_mode or report.get("artifact_sha256") != digests:
+            raise ProvenanceError("candidate matrix report build mode or artifact digest differs")
+    if observed_jobs != list(REQUIRED_MATRIX_JOBS) or len(set(observed_jobs)) != len(observed_jobs):
+        raise ProvenanceError("candidate matrix jobs are missing, duplicated, or out of order")
+
+
+def build_tag_binding(
+    candidate_build: object,
+    candidate_artifact: object,
+    pulls_document: object,
+    *,
+    repository: str,
+    source_commit: str,
+    source_tree: str,
+    tag: str,
+) -> dict[str, object]:
+    """Bind a protected release tag to the already tested merge-queue tree."""
+    _validate_repository(repository)
+    _validate_commit(source_commit)
+    _validate_git_tree(source_tree)
+    _validate_tag(tag)
+    build = _mapping(candidate_build, "candidate build receipt")
+    verify_candidate_build_receipt(build, repository=repository)
+    if build.get("source_tree") != source_tree:
+        raise ProvenanceError("release tag tree differs from the tested merge-group tree")
+    artifact = _mapping(candidate_artifact, "candidate artifact manifest")
+    _verify_candidate_artifact_manifest(artifact, candidate_build=build, repository=repository)
+    pulls = _list(pulls_document, "release commit pull requests")
+    if len(pulls) >= 100:
+        raise ProvenanceError("release commit pull-request query is not provably complete")
+    merge_group_anchor = _positive_integer(
+        build.get("pull_request_number"), "candidate merge-group anchor pull request"
+    )
+    matches: list[dict[str, object]] = []
+    for raw in pulls:
+        pull = _mapping(raw, "release commit pull request")
+        base = _mapping(pull.get("base"), "release pull request base")
+        if (
+            pull.get("state") == "closed"
+            and pull.get("merged_at") is not None
+            and pull.get("merge_commit_sha") == source_commit
+            and base.get("ref") == "main"
+        ):
+            matches.append(pull)
+    if len(matches) != 1:
+        raise ProvenanceError("release commit does not identify the tested merged pull request")
+    pull = matches[0]
+    merged_pull_number = _positive_integer(pull.get("number"), "release commit pull request number")
+    binding: dict[str, object] = {
+        "schema_version": "clio-relay.tag-candidate-binding.v1",
+        "repository": repository,
+        "tag": tag,
+        "source_commit": source_commit,
+        "source_tree": source_tree,
+        "merge_group_anchor_pull_request_number": merge_group_anchor,
+        "pull_request": {
+            "number": merged_pull_number,
+            "merge_commit_sha": source_commit,
+            "url": _https_url(pull.get("html_url"), "release pull request URL"),
+        },
+        "tested_commit": build["tested_commit"],
+        "candidate_build_sha256": _canonical_json_sha256(build),
+        "candidate_run": {
+            "id": artifact["run_id"],
+            "attempt": artifact["run_attempt"],
+            "head_sha": build["tested_commit"],
+            "head_branch": artifact["head_branch"],
+        },
+        "candidate_artifact": artifact["artifact"],
+    }
+    verify_tag_binding(binding, repository=repository, source_commit=source_commit)
+    return binding
+
+
+def verify_tag_binding(
+    binding: object,
+    *,
+    repository: str,
+    source_commit: str,
+) -> None:
+    """Verify a release tag's tree, PR, and merge-queue candidate binding."""
+    _validate_repository(repository)
+    _validate_commit(source_commit)
+    document = _mapping(binding, "tag binding")
+    if document.get("schema_version") != "clio-relay.tag-candidate-binding.v1":
+        raise ProvenanceError("tag binding schema does not match")
+    if document.get("repository") != repository or document.get("source_commit") != source_commit:
+        raise ProvenanceError("tag binding release identity differs")
+    _validate_tag(_nonempty_string(document.get("tag"), "tag binding release tag"))
+    _validate_git_tree(_nonempty_string(document.get("source_tree"), "tag binding source tree"))
+    _validate_commit(_nonempty_string(document.get("tested_commit"), "tag binding tested commit"))
+    merge_group_anchor = _positive_integer(
+        document.get("merge_group_anchor_pull_request_number"),
+        "tag binding merge-group anchor pull request number",
+    )
+    build_digest = _nonempty_string(
+        document.get("candidate_build_sha256"), "tag binding candidate build digest"
+    )
+    if re.fullmatch(r"[0-9a-f]{64}", build_digest) is None:
+        raise ProvenanceError("tag binding candidate build digest is invalid")
+    pull = _mapping(document.get("pull_request"), "tag binding pull request")
+    _positive_integer(pull.get("number"), "tag binding pull request number")
+    if pull.get("merge_commit_sha") != source_commit:
+        raise ProvenanceError("tag binding pull request does not identify the release commit")
+    _https_url(pull.get("url"), "tag binding pull request URL")
+    artifact = _mapping(document.get("candidate_artifact"), "tag binding candidate artifact")
+    _positive_integer(artifact.get("id"), "tag binding candidate artifact id")
+    digest = _nonempty_string(artifact.get("digest"), "tag binding candidate artifact digest")
+    if re.fullmatch(r"sha256:[0-9a-f]{64}", digest) is None:
+        raise ProvenanceError("tag binding candidate artifact digest is invalid")
+    run = _mapping(document.get("candidate_run"), "tag binding candidate run")
+    _positive_integer(run.get("id"), "tag binding candidate run id")
+    _positive_integer(run.get("attempt"), "tag binding candidate run attempt")
+    if run.get("head_sha") != document.get("tested_commit"):
+        raise ProvenanceError("tag binding candidate run commit differs")
+    head_branch = _nonempty_string(run.get("head_branch"), "tag binding candidate head branch")
+    if not head_branch.startswith(f"gh-readonly-queue/main/pr-{merge_group_anchor}-"):
+        raise ProvenanceError("tag binding candidate run is not from the main merge queue")
+
+
+def _verify_candidate_artifact_manifest(
+    manifest: Mapping[str, object],
+    *,
+    candidate_build: Mapping[str, object],
+    repository: str,
+) -> None:
+    if (
+        manifest.get("schema_version") != "1.1"
+        or manifest.get("repository") != repository
+        or manifest.get("artifact_kind") != "candidate"
+        or manifest.get("source_commit") != candidate_build.get("tested_commit")
+        or manifest.get("source_tree") != candidate_build.get("source_tree")
+        or manifest.get("run_id") != candidate_build.get("run_id")
+        or manifest.get("run_attempt") != candidate_build.get("run_attempt")
+        or manifest.get("head_branch")
+        != str(candidate_build.get("head_ref", "")).removeprefix("refs/heads/")
+    ):
+        raise ProvenanceError("candidate artifact manifest differs from its build receipt")
+    artifact = _mapping(manifest.get("artifact"), "candidate artifact")
+    expected_name = f"release-candidate-{candidate_build['source_tree']}"
+    if artifact.get("name") != expected_name:
+        raise ProvenanceError("candidate artifact name does not bind the tested tree")
 
 
 def build_actions_artifact_manifest(
@@ -258,39 +688,68 @@ def build_actions_artifact_manifest(
     run_attempt: int,
     artifact_name: str,
     artifact_kind: str,
+    source_tree: str | None = None,
 ) -> dict[str, object]:
-    """Bind one nonexpired Actions artifact to an exact successful tag run."""
+    """Bind one nonexpired Actions artifact to its exact trusted workflow run."""
     _validate_repository(repository)
     _validate_commit(source_commit)
     _validate_tag(tag)
     expected_run_id = _positive_integer(run_id, "workflow run id")
     expected_attempt = _positive_integer(run_attempt, "workflow run attempt")
     expected_name = _nonempty_string(artifact_name, "Actions artifact name")
-    if artifact_kind not in {"tag-payload", "promotion"}:
+    if artifact_kind not in {"candidate", "tag-binding", "tag-payload", "promotion"}:
         raise ProvenanceError("Actions artifact kind is invalid")
-    required_name = (
-        f"release-candidate-{tag}" if artifact_kind == "tag-payload" else f"verified-release-{tag}"
-    )
+    if artifact_kind == "candidate":
+        tree = _nonempty_string(source_tree, "candidate source tree")
+        _validate_git_tree(tree)
+        required_name = f"release-candidate-{tree}"
+    elif artifact_kind == "tag-binding":
+        tree = None
+        required_name = f"release-binding-{tag}"
+    elif artifact_kind == "tag-payload":
+        tree = None
+        required_name = f"release-candidate-{tag}"
+    else:
+        tree = None
+        required_name = f"verified-release-{tag}"
     if expected_name != required_name:
         raise ProvenanceError("Actions artifact name does not match the release tag")
     run = _mapping(run_document, "workflow run attempt")
+    if artifact_kind == "candidate":
+        expected_head_branch: str | None = None
+        expected_event = "merge_group"
+        expected_status = "completed"
+        expected_conclusion: str | None = "success"
+        expected_path = CI_WORKFLOW_PATH
+    elif artifact_kind in {"tag-binding", "tag-payload"}:
+        expected_head_branch = tag
+        expected_event = "push"
+        expected_status = "completed"
+        expected_conclusion = "success"
+        expected_path = RELEASE_WORKFLOW_PATH
+    else:
+        expected_head_branch = "main"
+        expected_event = "workflow_dispatch"
+        expected_status = "in_progress"
+        expected_conclusion = None
+        expected_path = ".github/workflows/release-gate.yml"
     run_expected = {
         "id": expected_run_id,
         "run_attempt": expected_attempt,
-        "head_branch": tag if artifact_kind == "tag-payload" else "main",
         "head_sha": source_commit,
-        "event": "push" if artifact_kind == "tag-payload" else "workflow_dispatch",
-        "status": "completed" if artifact_kind == "tag-payload" else "in_progress",
-        "conclusion": "success" if artifact_kind == "tag-payload" else None,
-        "path": (
-            ".github/workflows/release.yml"
-            if artifact_kind == "tag-payload"
-            else ".github/workflows/release-gate.yml"
-        ),
+        "event": expected_event,
+        "status": expected_status,
+        "conclusion": expected_conclusion,
+        "path": expected_path,
     }
+    if expected_head_branch is not None:
+        run_expected["head_branch"] = expected_head_branch
     run_mismatches = [key for key, value in run_expected.items() if run.get(key) != value]
     if run_mismatches:
         raise ProvenanceError(f"tag-build run identity mismatch: {sorted(run_mismatches)}")
+    run_head_branch = _nonempty_string(run.get("head_branch"), "workflow run head branch")
+    if artifact_kind == "candidate" and not run_head_branch.startswith("gh-readonly-queue/main/"):
+        raise ProvenanceError("candidate artifact run is not a main merge-group run")
     run_started_at = _rfc3339_timestamp(run.get("run_started_at"), "workflow run attempt start")
     repository_id = _positive_integer(
         _mapping(run.get("repository"), "workflow run repository").get("id"),
@@ -333,7 +792,7 @@ def build_actions_artifact_manifest(
     artifact_run_expected = {
         "id": expected_run_id,
         "head_sha": source_commit,
-        "head_branch": tag if artifact_kind == "tag-payload" else "main",
+        "head_branch": run_head_branch,
         "repository_id": repository_id,
         "head_repository_id": repository_id,
     }
@@ -349,11 +808,13 @@ def build_actions_artifact_manifest(
     if archive_url != expected_url:
         raise ProvenanceError("Actions artifact archive URL does not match its repository and id")
     return {
-        "schema_version": "1.0",
+        "schema_version": "1.1" if artifact_kind in {"candidate", "tag-binding"} else "1.0",
         "repository": repository,
         "source_commit": source_commit,
+        "source_tree": tree,
         "tag": tag,
         "artifact_kind": artifact_kind,
+        "head_branch": run_head_branch,
         "run_id": expected_run_id,
         "run_attempt": expected_attempt,
         "run_started_at": run_started_at.isoformat(),
@@ -376,13 +837,14 @@ def verify_actions_artifact_archive(
 ) -> None:
     """Verify and safely extract the exact inert tag-build payload archive."""
     document = _mapping(manifest, "Actions artifact manifest")
-    if document.get("schema_version") != "1.0":
+    artifact_kind = _nonempty_string(document.get("artifact_kind"), "Actions artifact kind")
+    expected_schema = "1.1" if artifact_kind in {"candidate", "tag-binding"} else "1.0"
+    if document.get("schema_version") != expected_schema:
         raise ProvenanceError("Actions artifact manifest schema does not match")
     _validate_repository(_nonempty_string(document.get("repository"), "artifact repository"))
     _validate_commit(_nonempty_string(document.get("source_commit"), "artifact source commit"))
     _validate_tag(_nonempty_string(document.get("tag"), "artifact release tag"))
-    artifact_kind = _nonempty_string(document.get("artifact_kind"), "Actions artifact kind")
-    if artifact_kind not in {"tag-payload", "promotion"}:
+    if artifact_kind not in {"candidate", "tag-binding", "tag-payload", "promotion"}:
         raise ProvenanceError("Actions artifact manifest kind is invalid")
     _positive_integer(document.get("run_id"), "artifact workflow run id")
     _positive_integer(document.get("run_attempt"), "artifact workflow run attempt")
@@ -432,17 +894,23 @@ def verify_actions_artifact_archive(
             names = [item.filename for item in members]
             if len(names) != len(set(names)):
                 raise ProvenanceError("Actions artifact archive contains duplicate paths")
-            if artifact_kind == "tag-payload":
+            if artifact_kind == "candidate":
+                _validate_candidate_payload_names(names)
+            elif artifact_kind == "tag-payload":
                 _validate_tag_payload_names(names)
+            elif artifact_kind == "tag-binding":
+                _validate_tag_binding_payload_names(names)
             else:
                 _validate_promotion_payload_names(names)
             aggregate_size = 0
             for member in members:
                 maximum = (
                     _tag_payload_file_limit(member.filename)
-                    if artifact_kind == "tag-payload"
+                    if artifact_kind in {"candidate", "tag-payload"}
                     else _promotion_payload_file_limit(member.filename)
                 )
+                if artifact_kind == "tag-binding":
+                    maximum = MAX_FIXED_JSON_BYTES
                 if member.flag_bits & 0x1:
                     raise ProvenanceError("Actions artifact archive contains encrypted content")
                 mode = member.external_attr >> 16
@@ -487,13 +955,105 @@ def verify_actions_artifact_archive(
                     )
     except (OSError, zipfile.BadZipFile) as exc:
         raise ProvenanceError(f"could not verify Actions artifact archive: {exc}") from exc
-    if artifact_kind == "tag-payload":
+    if artifact_kind in {"candidate", "tag-payload"}:
         _verify_checksum_manifest(
             output_dir,
             expected_names={
                 item.name for item in output_dir.iterdir() if item.name != "SHA256SUMS"
             },
         )
+    if artifact_kind == "candidate":
+        _verify_extracted_candidate_payload(output_dir, document)
+
+
+def _verify_extracted_candidate_payload(
+    directory: Path,
+    artifact_manifest: Mapping[str, object],
+) -> None:
+    """Bind extracted build-once bytes to their tested merge-group receipt."""
+    repository = _nonempty_string(
+        artifact_manifest.get("repository"), "candidate artifact repository"
+    )
+    candidate_build = _mapping(
+        _load_json(directory / "CANDIDATE-BUILD.json"),
+        "extracted candidate build receipt",
+    )
+    verify_candidate_build_receipt(candidate_build, repository=repository)
+    expected_identity = {
+        "tested_commit": artifact_manifest.get("source_commit"),
+        "source_tree": artifact_manifest.get("source_tree"),
+        "run_id": artifact_manifest.get("run_id"),
+        "run_attempt": artifact_manifest.get("run_attempt"),
+    }
+    mismatches = [
+        key for key, value in expected_identity.items() if candidate_build.get(key) != value
+    ]
+    if mismatches:
+        raise ProvenanceError(
+            "extracted candidate build identity differs from its Actions artifact: "
+            f"{sorted(mismatches)}"
+        )
+    distributions = sorted(
+        (
+            path
+            for path in directory.iterdir()
+            if path.name.endswith(".whl") or path.name.endswith(".tar.gz")
+        ),
+        key=lambda path: path.name,
+    )
+    observed_digests = {
+        path.name: _sha256_bounded_file(path, maximum_bytes=MAX_DISTRIBUTION_BYTES)
+        for path in distributions
+    }
+    if observed_digests != candidate_build.get("distribution_sha256"):
+        raise ProvenanceError("extracted candidate distributions differ from the build receipt")
+    report_path = directory / "validation-local.json"
+    primary_reports = [
+        _mapping(raw, "candidate primary matrix report")
+        for raw in _list(candidate_build.get("matrix_reports"), "candidate matrix reports")
+        if _mapping(raw, "candidate matrix report").get("job") == REQUIRED_MATRIX_JOBS[0]
+    ]
+    if len(primary_reports) != 1:
+        raise ProvenanceError("candidate build receipt does not identify one primary report")
+    primary = primary_reports[0]
+    if primary.get("sha256") != _sha256_bounded_file(
+        report_path,
+        maximum_bytes=MAX_FIXED_JSON_BYTES,
+    ):
+        raise ProvenanceError("extracted primary validation report differs from the build receipt")
+    report = _mapping(_load_json(report_path), "extracted primary validation report")
+    if (
+        report.get("status") != "passed"
+        or report.get("scenario") != "local-release"
+        or report.get("cluster") != "local"
+    ):
+        raise ProvenanceError("extracted primary validation report did not pass")
+    software = _mapping(report.get("software"), "extracted primary report software")
+    if (
+        software.get("commit") != candidate_build.get("tested_commit")
+        or software.get("dirty") is not False
+    ):
+        raise ProvenanceError("extracted primary validation report source identity differs")
+    report_digests: dict[str, str] = {}
+    for raw in _list(report.get("resources"), "extracted primary report resources"):
+        resource = _mapping(raw, "extracted primary report resource")
+        name = resource.get("resource_id")
+        if name not in observed_digests:
+            continue
+        metadata = _mapping(resource.get("metadata"), "extracted primary report metadata")
+        if name in report_digests:
+            raise ProvenanceError("extracted primary report duplicates a distribution")
+        report_digests[cast(str, name)] = _nonempty_string(
+            metadata.get("sha256"), "extracted primary report distribution digest"
+        )
+    if report_digests != observed_digests:
+        raise ProvenanceError("extracted primary report distribution digests differ")
+    checks = {
+        _mapping(raw, "extracted primary report check").get("check_id")
+        for raw in _list(report.get("checks"), "extracted primary report checks")
+    }
+    if "local.build" not in checks or "local.sdist-smoke" not in checks:
+        raise ProvenanceError("extracted primary report does not prove the sole build")
 
 
 def build_distribution_archive_receipt(
@@ -1071,6 +1631,7 @@ def build_repository_governance(
     branch_rulesets: object,
     tag_rulesets: object,
     environments: Mapping[str, object],
+    immutable_releases: object,
     *,
     repository: str,
     source_commit: str,
@@ -1084,8 +1645,9 @@ def build_repository_governance(
     protected_branch_names = _protected_branch_names(protected_branches)
     tags = _tag_protection_receipts(tag_rulesets)
     environment_receipts = _environment_receipts(environments)
+    immutable_receipt = _immutable_releases_receipt(immutable_releases)
     receipt: dict[str, object] = {
-        "schema_version": "1.0",
+        "schema_version": "1.1",
         "repository": repository,
         "source_commit": source_commit,
         "tag": tag,
@@ -1096,6 +1658,7 @@ def build_repository_governance(
         "tag_protections": tags,
         "environment_reviewers_available": False,
         "environments": environment_receipts,
+        "immutable_releases": immutable_receipt,
     }
     verify_repository_governance(
         receipt,
@@ -1119,7 +1682,7 @@ def verify_repository_governance(
     _validate_tag(tag)
     document = _mapping(receipt, "repository governance receipt")
     expected = {
-        "schema_version": "1.0",
+        "schema_version": "1.1",
         "repository": repository,
         "source_commit": source_commit,
         "tag": tag,
@@ -1164,6 +1727,13 @@ def verify_repository_governance(
             "custom_branch_policies": False,
         }:
             raise ProvenanceError("environment receipt branch policy does not match")
+    immutable = _mapping(document.get("immutable_releases"), "immutable releases receipt")
+    if immutable != {
+        "api_version": IMMUTABLE_RELEASES_API_VERSION,
+        "enabled": True,
+        "enforced_by_owner": True,
+    }:
+        raise ProvenanceError("repository governance does not enforce immutable releases")
 
 
 def fetch_live_repository_governance(
@@ -1172,6 +1742,7 @@ def fetch_live_repository_governance(
     source_commit: str,
     tag: str,
     fetch_json: GitHubJsonFetcher,
+    fetch_admin_json: GitHubJsonFetcher,
 ) -> dict[str, object]:
     """Query and normalize the current GitHub controls for a release identity."""
     _validate_repository(repository)
@@ -1214,12 +1785,14 @@ def fetch_live_repository_governance(
             f"environment {name}",
         )
         environments[name] = environment
+    immutable_releases = fetch_admin_json(f"repos/{repository}/immutable-releases")
     return build_repository_governance(
         main_effective_rules,
         protected_branches,
         branch_rulesets,
         tag_rulesets,
         environments,
+        immutable_releases,
         repository=repository,
         source_commit=source_commit,
         tag=tag,
@@ -1233,6 +1806,7 @@ def verify_live_repository_governance(
     source_commit: str,
     tag: str,
     fetch_json: GitHubJsonFetcher,
+    fetch_admin_json: GitHubJsonFetcher,
 ) -> None:
     """Require the carried governance receipt to equal current GitHub state."""
     verify_repository_governance(
@@ -1246,6 +1820,7 @@ def verify_live_repository_governance(
         source_commit=source_commit,
         tag=tag,
         fetch_json=fetch_json,
+        fetch_admin_json=fetch_admin_json,
     )
     if current != receipt:
         raise ProvenanceError(
@@ -1262,6 +1837,7 @@ def verify_release_identity(
     resolved_target_commit: str,
     expect_draft: bool | None,
     expect_prerelease: bool,
+    expect_immutable: bool | None = None,
 ) -> None:
     """Require a GitHub release to identify one exact immutable source commit."""
     _validate_tag(tag)
@@ -1276,6 +1852,8 @@ def verify_release_identity(
     }
     if expect_draft is not None:
         expected["draft"] = expect_draft
+    if expect_immutable is not None:
+        expected["immutable"] = expect_immutable
     mismatches = [key for key, value in expected.items() if release.get(key) != value]
     if mismatches:
         raise ProvenanceError(f"GitHub release identity mismatch: {sorted(mismatches)}")
@@ -1296,6 +1874,7 @@ def resolve_live_release(
     expect_draft: bool | None,
     fetch_json: GitHubJsonFetcher,
     allow_absent: bool = False,
+    expect_immutable: bool | None = None,
 ) -> dict[str, object] | None:
     """Resolve one exact release by tag through a bounded list and numeric ID.
 
@@ -1345,7 +1924,7 @@ def resolve_live_release(
         fetch_json(f"repos/{repository}/releases/{release_id}"),
         "GitHub release",
     )
-    compared_fields = ("id", "tag_name", "target_commitish", "draft", "prerelease")
+    compared_fields = ("id", "tag_name", "target_commitish", "draft", "prerelease", "immutable")
     mismatches = [field for field in compared_fields if release.get(field) != summary.get(field)]
     if mismatches:
         raise ProvenanceError(
@@ -1355,6 +1934,10 @@ def resolve_live_release(
         raise ProvenanceError("numeric GitHub release identity does not match the requested tag")
     if expect_draft is not None and release.get("draft") is not expect_draft:
         raise ProvenanceError("GitHub release draft state does not match the required state")
+    if expect_immutable is not None and release.get("immutable") is not expect_immutable:
+        raise ProvenanceError("GitHub release immutable state does not match the required state")
+    if release.get("draft") is True and release.get("immutable") is not False:
+        raise ProvenanceError("a draft GitHub release must remain mutable")
     return release
 
 
@@ -1366,6 +1949,7 @@ def verify_live_release_identity(
     expect_draft: bool | None,
     expect_prerelease: bool,
     fetch_json: GitHubJsonFetcher,
+    expect_immutable: bool | None = None,
 ) -> None:
     """Fetch and verify the live release, tag, and target identities."""
     _validate_repository(repository)
@@ -1376,6 +1960,7 @@ def verify_live_release_identity(
         tag=tag,
         expect_draft=expect_draft,
         fetch_json=fetch_json,
+        expect_immutable=expect_immutable,
     )
     if release is None:  # pragma: no cover - allow_absent is false above.
         raise GitHubNotFound(f"GitHub release was not found for tag: {tag}")
@@ -1400,6 +1985,7 @@ def verify_live_release_identity(
         ),
         expect_draft=expect_draft,
         expect_prerelease=expect_prerelease,
+        expect_immutable=expect_immutable,
     )
 
 
@@ -1414,6 +2000,7 @@ def verify_live_mutation_authority(
     release_state: str,
     expect_draft: bool | None,
     fetch_json: GitHubJsonFetcher,
+    fetch_admin_json: GitHubJsonFetcher,
 ) -> None:
     """Revalidate protected main, tag, governance, and release before mutation."""
     _validate_repository(repository)
@@ -1421,6 +2008,8 @@ def verify_live_mutation_authority(
     _validate_tag(tag)
     if workflow_ref != "refs/heads/main" or workflow_sha != source_commit:
         raise ProvenanceError("persistent mutation is not executing from the exact main commit")
+    if release_state == "present" and expect_draft is not True:
+        raise ProvenanceError("release mutation is permitted only while the release is a draft")
     main_commit = _mapping(
         fetch_json(f"repos/{repository}/commits/main"),
         "live main commit",
@@ -1437,6 +2026,7 @@ def verify_live_mutation_authority(
         source_commit=source_commit,
         tag=tag,
         fetch_json=fetch_json,
+        fetch_admin_json=fetch_admin_json,
     )
     if release_state not in {"absent", "present"}:
         raise ProvenanceError("release state expectation is invalid")
@@ -1454,6 +2044,8 @@ def verify_live_mutation_authority(
     if release_state == "absent":
         raise ProvenanceError("GitHub release appeared before create mutation")
     target = _nonempty_string(release.get("target_commitish"), "release target_commitish")
+    if release.get("immutable") is not False:
+        raise ProvenanceError("a mutable draft is required before every release mutation")
     if re.fullmatch(r"[A-Za-z0-9_./-]+", target) is None or ".." in target:
         raise ProvenanceError("release target_commitish is unsafe")
     target_commit = _mapping(
@@ -1470,6 +2062,7 @@ def verify_live_mutation_authority(
         ),
         expect_draft=expect_draft,
         expect_prerelease=False,
+        expect_immutable=False,
     )
 
 
@@ -2060,7 +2653,13 @@ def _main_ruleset_protection_receipt(
             )
         effective_ruleset_ids.add(ruleset_id)
         by_type.setdefault(rule_type, []).append(rule)
-    required_types = {"deletion", "non_fast_forward", "pull_request", "required_status_checks"}
+    required_types = {
+        "deletion",
+        "merge_queue",
+        "non_fast_forward",
+        "pull_request",
+        "required_status_checks",
+    }
     missing = sorted(required_types - set(by_type))
     if missing:
         raise ProvenanceError(f"effective main branch rules are incomplete: {missing}")
@@ -2088,6 +2687,15 @@ def _main_ruleset_protection_receipt(
         by_type["pull_request"][0].get("parameters"),
         "effective pull request rule parameters",
     )
+    merge_queue = _mapping(
+        by_type["merge_queue"][0].get("parameters"),
+        "effective merge queue rule parameters",
+    )
+    normalized_merge_queue = {key: merge_queue.get(key) for key in REQUIRED_MERGE_QUEUE_PARAMETERS}
+    if normalized_merge_queue != REQUIRED_MERGE_QUEUE_PARAMETERS or set(merge_queue) != set(
+        REQUIRED_MERGE_QUEUE_PARAMETERS
+    ):
+        raise ProvenanceError("effective merge queue parameters differ from the release contract")
     receipt: dict[str, object] = {
         "source": "effective_rulesets",
         "ruleset_ids": sorted(effective_ruleset_ids),
@@ -2102,6 +2710,7 @@ def _main_ruleset_protection_receipt(
         "require_last_push_approval": reviews.get("require_last_push_approval") is True,
         "required_conversation_resolution": reviews.get("required_review_thread_resolution")
         is True,
+        "merge_queue": normalized_merge_queue,
         "prevents_force_pushes": True,
         "prevents_deletions": True,
         "current_workflow_token_can_bypass": False,
@@ -2154,6 +2763,7 @@ def _verify_main_protection(branch: Mapping[str, object]) -> None:
         "require_last_push_approval": type(last_push_approval) is bool
         and last_push_approval == REQUIRE_LAST_PUSH_APPROVAL,
         "required_conversation_resolution": branch.get("required_conversation_resolution") is True,
+        "merge_queue": branch.get("merge_queue") == REQUIRED_MERGE_QUEUE_PARAMETERS,
         "prevents_force_pushes": branch.get("prevents_force_pushes") is True,
         "prevents_deletions": branch.get("prevents_deletions") is True,
         "current_workflow_token_cannot_bypass": branch.get("current_workflow_token_can_bypass")
@@ -2321,6 +2931,22 @@ def _environment_receipts(environments: Mapping[str, object]) -> list[dict[str, 
     return receipts
 
 
+def _immutable_releases_receipt(document: object) -> dict[str, object]:
+    """Normalize the administration-read immutable-release policy response."""
+    policy = _mapping(document, "immutable releases policy")
+    if set(policy) != {"enabled", "enforced_by_owner"}:
+        raise ProvenanceError("immutable releases policy contains an unexpected schema")
+    if policy.get("enabled") is not True or policy.get("enforced_by_owner") is not True:
+        raise ProvenanceError(
+            "immutable releases must be enabled and enforced by the repository owner"
+        )
+    return {
+        "api_version": IMMUTABLE_RELEASES_API_VERSION,
+        "enabled": True,
+        "enforced_by_owner": True,
+    }
+
+
 def _load_json(path: Path) -> object:
     try:
         details = path.lstat()
@@ -2485,10 +3111,41 @@ def _validate_tag_payload_names(names: Sequence[str]) -> None:
         )
 
 
+def _validate_candidate_payload_names(names: Sequence[str]) -> None:
+    _validate_flat_artifact_names(names)
+    wheels = [name for name in names if name.endswith(".whl")]
+    sdists = [name for name in names if name.endswith(".tar.gz")]
+    fixed = set(names) - set(wheels) - set(sdists)
+    if len(wheels) != 1 or len(sdists) != 1 or fixed != set(CANDIDATE_PAYLOAD_FIXED_FILES):
+        raise ProvenanceError(
+            "Actions artifact archive file set does not match the sealed candidate contract"
+        )
+
+
+def _validate_tag_binding_payload_names(names: Sequence[str]) -> None:
+    _validate_flat_artifact_names(names)
+    if list(names) != ["TAG-BINDING.json"]:
+        raise ProvenanceError("tag binding artifact must contain only TAG-BINDING.json")
+
+
+def _validate_flat_artifact_names(names: Sequence[str]) -> None:
+    if any(
+        not name
+        or name != Path(name).name
+        or "/" in name
+        or "\\" in name
+        or re.fullmatch(r"[A-Za-z0-9_.+-]+", name) is None
+        for name in names
+    ):
+        raise ProvenanceError("Actions artifact archive contains an unsafe path")
+
+
 def _tag_payload_file_limit(name: str) -> int:
     if name.endswith((".whl", ".tar.gz")):
         return MAX_DISTRIBUTION_BYTES
     if name == "validation-local.json":
+        return MAX_FIXED_JSON_BYTES
+    if name == "CANDIDATE-BUILD.json":
         return MAX_FIXED_JSON_BYTES
     if name == "SHA256SUMS":
         return MAX_MANIFEST_BYTES
@@ -2613,6 +3270,21 @@ def _validate_commit(commit: str) -> None:
         raise ProvenanceError("source commit must be a lowercase 40-character SHA")
 
 
+def _validate_git_tree(tree: str) -> None:
+    if re.fullmatch(r"[0-9a-f]{40}", tree) is None:
+        raise ProvenanceError("source tree must be a lowercase 40-character Git object id")
+
+
+def _canonical_json_sha256(document: object) -> str:
+    encoded = json.dumps(
+        document,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
 def _validate_tag(tag: str) -> None:
     if re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+(?:[.-][0-9A-Za-z.-]+)?", tag) is None:
         raise ProvenanceError("release tag is invalid")
@@ -2636,6 +3308,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     build_ci = subparsers.add_parser("build-ci-status")
     build_ci.add_argument("--runs", type=Path, required=True)
     build_ci.add_argument("--jobs", type=Path, required=True)
+    build_ci.add_argument("--candidate-build", type=Path, required=True)
+    build_ci.add_argument("--candidate-artifact", type=Path, required=True)
+    build_ci.add_argument("--tag-binding", type=Path, required=True)
     build_ci.add_argument("--repository", required=True)
     build_ci.add_argument("--source-commit", required=True)
     build_ci.add_argument("--output", type=Path, required=True)
@@ -2650,8 +3325,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     artifact_manifest.add_argument("--run-attempt", type=int, required=True)
     artifact_manifest.add_argument("--artifact-name", required=True)
     artifact_manifest.add_argument(
-        "--artifact-kind", choices=("tag-payload", "promotion"), required=True
+        "--artifact-kind",
+        choices=("candidate", "tag-binding", "tag-payload", "promotion"),
+        required=True,
     )
+    artifact_manifest.add_argument("--source-tree")
     artifact_manifest.add_argument("--output", type=Path, required=True)
 
     extract_artifact = subparsers.add_parser("extract-actions-artifact")
@@ -2678,6 +3356,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     build_governance.add_argument("--branch-rulesets", type=Path, required=True)
     build_governance.add_argument("--tag-rulesets", type=Path, required=True)
     build_governance.add_argument("--environments-dir", type=Path, required=True)
+    build_governance.add_argument("--immutable-releases", type=Path, required=True)
     build_governance.add_argument("--repository", required=True)
     build_governance.add_argument("--source-commit", required=True)
     build_governance.add_argument("--tag", required=True)
@@ -2701,12 +3380,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     verify_live_release.add_argument("--source-commit", required=True)
     verify_live_release.add_argument("--draft", choices=("true", "false", "any"), required=True)
     verify_live_release.add_argument("--prerelease", choices=("true", "false"), required=True)
+    verify_live_release.add_argument("--immutable", choices=("true", "false", "any"), default="any")
 
     resolve_release = subparsers.add_parser("resolve-live-release")
     resolve_release.add_argument("--repository", required=True)
     resolve_release.add_argument("--tag", required=True)
     resolve_release.add_argument("--draft", choices=("true", "false", "any"), required=True)
     resolve_release.add_argument("--allow-absent", action="store_true")
+    resolve_release.add_argument("--immutable", choices=("true", "false", "any"), default="any")
     resolve_release.add_argument("--output", type=Path, required=True)
 
     mutation_authority = subparsers.add_parser("mutation-authority")
@@ -2746,6 +3427,29 @@ def main(argv: Sequence[str] | None = None) -> int:
     exact_destination.add_argument("--output", type=Path)
     exact_destination.add_argument("--verify-existing", type=Path)
 
+    candidate_build = subparsers.add_parser("candidate-build-receipt")
+    candidate_build.add_argument("--candidate-dir", type=Path, required=True)
+    candidate_build.add_argument("--reports-dir", type=Path, required=True)
+    candidate_build.add_argument("--repository", required=True)
+    candidate_build.add_argument("--source-commit", required=True)
+    candidate_build.add_argument("--source-tree", required=True)
+    candidate_build.add_argument("--event", required=True)
+    candidate_build.add_argument("--run-id", type=int, required=True)
+    candidate_build.add_argument("--run-attempt", type=int, required=True)
+    candidate_build.add_argument("--head-ref", required=True)
+    candidate_build.add_argument("--base-ref", required=True)
+    candidate_build.add_argument("--output", type=Path, required=True)
+
+    tag_binding = subparsers.add_parser("tag-binding")
+    tag_binding.add_argument("--candidate-build", type=Path, required=True)
+    tag_binding.add_argument("--candidate-artifact", type=Path, required=True)
+    tag_binding.add_argument("--pulls", type=Path, required=True)
+    tag_binding.add_argument("--repository", required=True)
+    tag_binding.add_argument("--source-commit", required=True)
+    tag_binding.add_argument("--source-tree", required=True)
+    tag_binding.add_argument("--tag", required=True)
+    tag_binding.add_argument("--output", type=Path, required=True)
+
     args = parser.parse_args(argv)
     try:
         if args.command == "select-ci-run":
@@ -2759,6 +3463,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             receipt = build_ci_status(
                 _load_json(args.runs),
                 _load_json(args.jobs),
+                _load_json(args.candidate_build),
+                _load_json(args.candidate_artifact),
+                _load_json(args.tag_binding),
                 repository=args.repository,
                 source_commit=args.source_commit,
             )
@@ -2774,6 +3481,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 run_attempt=args.run_attempt,
                 artifact_name=args.artifact_name,
                 artifact_kind=args.artifact_kind,
+                source_tree=args.source_tree,
             )
             _write_json(args.output, manifest)
         elif args.command == "extract-actions-artifact":
@@ -2810,6 +3518,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 _load_json(args.branch_rulesets),
                 _load_json(args.tag_rulesets),
                 environment_documents,
+                _load_json(args.immutable_releases),
                 repository=args.repository,
                 source_commit=args.source_commit,
                 tag=args.tag,
@@ -2829,6 +3538,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 source_commit=args.source_commit,
                 tag=args.tag,
                 fetch_json=_github_fetcher(os.environ.get("GH_TOKEN", "")),
+                fetch_admin_json=_github_fetcher(os.environ.get("GH_ADMIN_READ_TOKEN", "")),
             )
         elif args.command == "verify-live-release":
             verify_live_release_identity(
@@ -2837,6 +3547,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 source_commit=args.source_commit,
                 expect_draft=None if args.draft == "any" else args.draft == "true",
                 expect_prerelease=args.prerelease == "true",
+                expect_immutable=(None if args.immutable == "any" else args.immutable == "true"),
                 fetch_json=_github_fetcher(os.environ.get("GH_TOKEN", "")),
             )
         elif args.command == "resolve-live-release":
@@ -2846,6 +3557,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 expect_draft=None if args.draft == "any" else args.draft == "true",
                 fetch_json=_github_fetcher(os.environ.get("GH_TOKEN", "")),
                 allow_absent=args.allow_absent,
+                expect_immutable=(None if args.immutable == "any" else args.immutable == "true"),
             )
             _write_json(args.output, release)
         elif args.command == "mutation-authority":
@@ -2859,6 +3571,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 release_state=args.release_state,
                 expect_draft=None if args.draft == "any" else args.draft == "true",
                 fetch_json=_github_fetcher(os.environ.get("GH_TOKEN", "")),
+                fetch_admin_json=_github_fetcher(os.environ.get("GH_ADMIN_READ_TOKEN", "")),
             )
         elif args.command == "report-assets":
             manifest = build_validation_report_asset_manifest(
@@ -2895,6 +3608,31 @@ def main(argv: Sequence[str] | None = None) -> int:
                     page_size=args.page_size,
                 )
                 _write_json(args.output, inventory)
+        elif args.command == "candidate-build-receipt":
+            receipt = build_candidate_build_receipt(
+                args.candidate_dir,
+                args.reports_dir,
+                repository=args.repository,
+                source_commit=args.source_commit,
+                source_tree=args.source_tree,
+                event=args.event,
+                run_id=args.run_id,
+                run_attempt=args.run_attempt,
+                head_ref=args.head_ref,
+                base_ref=args.base_ref,
+            )
+            _write_json(args.output, receipt)
+        elif args.command == "tag-binding":
+            binding = build_tag_binding(
+                _load_json(args.candidate_build),
+                _load_json(args.candidate_artifact),
+                _load_json(args.pulls),
+                repository=args.repository,
+                source_commit=args.source_commit,
+                source_tree=args.source_tree,
+                tag=args.tag,
+            )
+            _write_json(args.output, binding)
         else:  # pragma: no cover - argparse owns command validation.
             _error(f"unsupported command: {args.command}")
     except ProvenanceError as exc:

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -322,6 +322,15 @@ def release_validate_local(
         Path | None,
         typer.Option(help="Optional empty output directory for wheel and sdist artifacts."),
     ] = None,
+    prebuilt_artifact_dir: Annotated[
+        Path | None,
+        typer.Option(
+            help=(
+                "Reuse an exact build-once wheel, sdist, and SHA256SUMS directory; "
+                "never build artifacts in this validation run."
+            )
+        ),
+    ] = None,
 ) -> None:
     """Run the complete local release gate and persist evidence on failure."""
     report_path = report or default_report_path("local")
@@ -339,6 +348,7 @@ def release_validate_local(
                     report_path=report_path,
                     markdown_report_path=markdown_report,
                     artifact_dir=artifact_dir,
+                    prebuilt_artifact_dir=prebuilt_artifact_dir,
                     report_id=seed_report.report_id,
                 )
             )

--- a/src/clio_relay/release_validation.py
+++ b/src/clio_relay/release_validation.py
@@ -82,6 +82,7 @@ class LocalReleaseValidationOptions:
     report_path: Path
     markdown_report_path: Path | None = None
     artifact_dir: Path | None = None
+    prebuilt_artifact_dir: Path | None = None
     report_id: DurableRecordId | None = None
 
 
@@ -108,6 +109,18 @@ def run_local_release_validation(
         options.artifact_dir or root / ".clio-relay" / "release-artifacts" / report.report_id
     ).resolve()
     artifact_dir = internal_filesystem_path(logical_artifact_dir, force_extended=True)
+    prebuilt_artifact_dir = (
+        None
+        if options.prebuilt_artifact_dir is None
+        else internal_filesystem_path(
+            logical_filesystem_path(options.prebuilt_artifact_dir).resolve(),
+            force_extended=True,
+        )
+    )
+    if prebuilt_artifact_dir is not None and prebuilt_artifact_dir == artifact_dir:
+        raise ConfigurationError(
+            "prebuilt artifact input and release validation output directories must differ"
+        )
     artifact_dir.mkdir(parents=True, exist_ok=True)
     support_dir = artifact_dir / ".validation-support"
     support_dir.mkdir(parents=True, exist_ok=True)
@@ -232,23 +245,29 @@ def run_local_release_validation(
             root=root,
             runner=command_runner,
         )
-        _run_check(
-            recorder,
-            "local.build",
-            "build wheel and source distribution",
-            [
-                "uv",
-                "build",
-                "--no-build-isolation",
-                "--python",
-                sys.executable,
-                "--out-dir",
-                str(artifact_dir),
-            ],
-            root=root,
-            runner=command_runner,
-        )
-        artifacts = _release_artifacts(artifact_dir)
+        if prebuilt_artifact_dir is None:
+            _run_check(
+                recorder,
+                "local.build",
+                "build wheel and source distribution",
+                [
+                    "uv",
+                    "build",
+                    "--no-build-isolation",
+                    "--python",
+                    sys.executable,
+                    "--out-dir",
+                    str(artifact_dir),
+                ],
+                root=root,
+                runner=command_runner,
+            )
+            artifacts = _release_artifacts(artifact_dir)
+        else:
+            artifacts = _verify_prebuilt_release_artifacts(
+                recorder,
+                prebuilt_artifact_dir,
+            )
         _record_release_artifacts(recorder, artifacts)
         _run_check(
             recorder,
@@ -325,14 +344,15 @@ def run_local_release_validation(
             )
         finally:
             shutil.rmtree(smoke_environment, ignore_errors=True)
-        _run_sdist_smoke(
-            recorder,
-            sdist=sdist,
-            runtime_requirements=runtime_requirements,
-            support_dir=support_dir,
-            root=root,
-            runner=command_runner,
-        )
+        if prebuilt_artifact_dir is None:
+            _run_sdist_smoke(
+                recorder,
+                sdist=sdist,
+                runtime_requirements=runtime_requirements,
+                support_dir=support_dir,
+                root=root,
+                runner=command_runner,
+            )
     except BaseException as exc:
         if not report.checks or report.checks[-1].status.value != "failed":
             recorder.record_failure("local-release.completed", "complete local release gate", exc)
@@ -546,6 +566,71 @@ def _release_artifacts(artifact_dir: Path) -> list[Path]:
             f"found wheels={len(wheels)}, sdists={len(sdists)}"
         )
     return [*wheels, *sdists]
+
+
+def _verify_prebuilt_release_artifacts(
+    recorder: ValidationRecorder,
+    artifact_dir: Path,
+) -> list[Path]:
+    """Verify an exact external wheel/sdist pair without rebuilding either file."""
+    with recorder.check(
+        "local.prebuilt-artifacts",
+        "verify and reuse the exact build-once wheel and source distribution",
+    ) as evidence:
+        try:
+            paths = sorted(artifact_dir.iterdir(), key=lambda path: path.name)
+        except OSError as exc:
+            raise ConfigurationError(
+                f"could not inspect prebuilt artifact directory: {artifact_dir}: {exc}"
+            ) from exc
+        expected_fixed = {"SHA256SUMS"}
+        wheels = [path for path in paths if path.name.endswith(".whl")]
+        sdists = [path for path in paths if path.name.endswith(".tar.gz")]
+        expected_names = {
+            *expected_fixed,
+            *(path.name for path in wheels),
+            *(path.name for path in sdists),
+        }
+        if len(wheels) != 1 or len(sdists) != 1 or {path.name for path in paths} != expected_names:
+            raise ConfigurationError(
+                "prebuilt artifact directory must contain exactly one wheel, one source "
+                "distribution, and SHA256SUMS"
+            )
+        for path in paths:
+            try:
+                details = path.lstat()
+            except OSError as exc:
+                raise ConfigurationError(
+                    f"could not inspect prebuilt artifact: {path}: {exc}"
+                ) from exc
+            if path.is_symlink() or not path.is_file() or details.st_size < 1:
+                raise ConfigurationError(
+                    f"prebuilt artifact is not a nonempty regular file: {path}"
+                )
+        manifest_path = artifact_dir / "SHA256SUMS"
+        try:
+            manifest = manifest_path.read_text(encoding="ascii")
+        except (OSError, UnicodeError) as exc:
+            raise ConfigurationError(f"could not read prebuilt SHA256SUMS: {exc}") from exc
+        artifacts = [wheels[0], sdists[0]]
+        expected_manifest = "".join(
+            f"{sha256_file(path)} *{path.name}\n"
+            for path in sorted(artifacts, key=lambda item: item.name)
+        )
+        if manifest != expected_manifest:
+            raise ConfigurationError(
+                "prebuilt SHA256SUMS is noncanonical or differs from the supplied artifacts"
+            )
+        evidence.extend(
+            EvidenceReference(
+                kind="prebuilt_artifact",
+                reference=str(logical_filesystem_path(path)),
+                sha256=sha256_file(path),
+                metadata={"size_bytes": path.stat().st_size},
+            )
+            for path in artifacts
+        )
+        return artifacts
 
 
 def _record_release_artifacts(

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1696,7 +1696,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "96b9840c68b423053911cd39b5f3b0c694baa1a27d4d94f5f330605531e69ac8"
+        "f4a4c47353e63dadfecd5118612a4acf11452018efe1c7df9e9b495d066c65c4"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -35,13 +35,17 @@ from clio_relay.ci_validation import (
     REQUIRED_APPROVING_REVIEW_COUNT,
     REQUIRED_CI_JOBS,
     REQUIRED_ENVIRONMENTS,
+    REQUIRED_MATRIX_JOBS,
+    REQUIRED_MERGE_QUEUE_PARAMETERS,
     ProvenanceError,
     build_actions_artifact_manifest,
+    build_candidate_build_receipt,
     build_ci_status,
     build_distribution_archive_receipt,
     build_exact_release_asset_inventory,
     build_repository_governance,
     build_staged_release_asset_plan,
+    build_tag_binding,
     build_validation_report_asset_manifest,
     fetch_live_repository_governance,
     resolve_live_release,
@@ -61,6 +65,8 @@ from clio_relay.ci_validation import (
 
 REPOSITORY = "iowarp/clio-relay"
 COMMIT = "a" * 40
+TESTED_COMMIT = "b" * 40
+TREE = "c" * 40
 TAG = "v1.0.0"
 
 
@@ -74,9 +80,9 @@ def _runs() -> dict[str, object]:
                 "run_number": 75,
                 "workflow_id": 99,
                 "html_url": "https://github.com/iowarp/clio-relay/actions/runs/1001",
-                "head_sha": COMMIT,
-                "head_branch": "main",
-                "event": "push",
+                "head_sha": TESTED_COMMIT,
+                "head_branch": "gh-readonly-queue/main/pr-23-deadbeef",
+                "event": "merge_group",
                 "status": "completed",
                 "conclusion": "success",
                 "path": ".github/workflows/ci.yml",
@@ -101,6 +107,96 @@ def _jobs() -> dict[str, object]:
     }
 
 
+def _candidate_build() -> dict[str, object]:
+    distributions = {
+        "clio_relay-1.0.0-py3-none-any.whl": "d" * 64,
+        "clio_relay-1.0.0.tar.gz": "e" * 64,
+    }
+    return {
+        "schema_version": "clio-relay.candidate-build.v1",
+        "repository": REPOSITORY,
+        "workflow": ".github/workflows/ci.yml",
+        "event": "merge_group",
+        "tested_commit": TESTED_COMMIT,
+        "source_tree": TREE,
+        "base_ref": "refs/heads/main",
+        "head_ref": "refs/heads/gh-readonly-queue/main/pr-23-deadbeef",
+        "pull_request_number": 23,
+        "run_id": 1001,
+        "run_attempt": 2,
+        "distribution_sha256": distributions,
+        "matrix_reports": [
+            {
+                "job": job,
+                "filename": (
+                    f"validation-local-{job.split(' / python ')[0]}-{job.rsplit(' ', 1)[1]}.json"
+                ),
+                "sha256": f"{index:x}" * 64,
+                "mode": "build" if index == 1 else "prebuilt",
+                "artifact_sha256": distributions,
+            }
+            for index, job in enumerate(REQUIRED_MATRIX_JOBS, start=1)
+        ],
+    }
+
+
+def _candidate_artifact() -> dict[str, object]:
+    return {
+        "schema_version": "1.1",
+        "repository": REPOSITORY,
+        "source_commit": TESTED_COMMIT,
+        "source_tree": TREE,
+        "tag": TAG,
+        "artifact_kind": "candidate",
+        "head_branch": "gh-readonly-queue/main/pr-23-deadbeef",
+        "run_id": 1001,
+        "run_attempt": 2,
+        "artifact": {
+            "id": 6001,
+            "name": f"release-candidate-{TREE}",
+            "size_in_bytes": 100,
+            "digest": f"sha256:{'f' * 64}",
+            "archive_download_url": (
+                f"https://api.github.com/repos/{REPOSITORY}/actions/artifacts/6001/zip"
+            ),
+            "expired": False,
+            "created_at": "2026-07-11T10:05:00+00:00",
+        },
+    }
+
+
+def _canonical_digest(document: object) -> str:
+    return hashlib.sha256(
+        json.dumps(document, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _tag_binding() -> dict[str, object]:
+    artifact = _candidate_artifact()
+    return {
+        "schema_version": "clio-relay.tag-candidate-binding.v1",
+        "repository": REPOSITORY,
+        "tag": TAG,
+        "source_commit": COMMIT,
+        "source_tree": TREE,
+        "merge_group_anchor_pull_request_number": 23,
+        "pull_request": {
+            "number": 23,
+            "merge_commit_sha": COMMIT,
+            "url": "https://github.com/iowarp/clio-relay/pull/23",
+        },
+        "tested_commit": TESTED_COMMIT,
+        "candidate_build_sha256": _canonical_digest(_candidate_build()),
+        "candidate_run": {
+            "id": 1001,
+            "attempt": 2,
+            "head_sha": TESTED_COMMIT,
+            "head_branch": "gh-readonly-queue/main/pr-23-deadbeef",
+        },
+        "candidate_artifact": artifact["artifact"],
+    }
+
+
 MAIN_RULESET_ID = 18816105
 TAG_RULESET_ID = 18813108
 
@@ -109,6 +205,11 @@ def _main_effective_rules() -> list[dict[str, object]]:
     return [
         {"type": "deletion", "ruleset_id": MAIN_RULESET_ID},
         {"type": "non_fast_forward", "ruleset_id": MAIN_RULESET_ID},
+        {
+            "type": "merge_queue",
+            "ruleset_id": MAIN_RULESET_ID,
+            "parameters": deepcopy(REQUIRED_MERGE_QUEUE_PARAMETERS),
+        },
         {
             "type": "pull_request",
             "ruleset_id": MAIN_RULESET_ID,
@@ -187,6 +288,10 @@ def _environments() -> dict[str, object]:
     }
 
 
+def _immutable_releases() -> dict[str, object]:
+    return {"enabled": True, "enforced_by_owner": True}
+
+
 def _governance_routes() -> dict[str, object]:
     routes: dict[str, object] = {
         f"repos/{REPOSITORY}/rules/branches/main?per_page=100": _main_effective_rules(),
@@ -197,6 +302,7 @@ def _governance_routes() -> dict[str, object]:
         ],
         f"repos/{REPOSITORY}/rulesets/{MAIN_RULESET_ID}": _branch_rulesets()[0],
         f"repos/{REPOSITORY}/rulesets/{TAG_RULESET_ID}": _tag_rulesets()[0],
+        f"repos/{REPOSITORY}/immutable-releases": _immutable_releases(),
     }
     for name, environment in _environments().items():
         routes[f"repos/{REPOSITORY}/environments/{name}"] = environment
@@ -219,10 +325,13 @@ def _release_assets(names_and_sizes: list[tuple[str, int]]) -> dict[str, object]
 
 
 def test_ci_status_requires_exact_successful_push_run_and_job_set() -> None:
-    selected = select_ci_run(_runs(), repository=REPOSITORY, source_commit=COMMIT)
+    selected = select_ci_run(_runs(), repository=REPOSITORY, source_commit=TESTED_COMMIT)
     receipt = build_ci_status(
         _runs(),
         _jobs(),
+        _candidate_build(),
+        _candidate_artifact(),
+        _tag_binding(),
         repository=REPOSITORY,
         source_commit=COMMIT,
     )
@@ -233,6 +342,8 @@ def test_ci_status_requires_exact_successful_push_run_and_job_set() -> None:
         "run_number": 75,
         "workflow_id": 99,
         "url": "https://github.com/iowarp/clio-relay/actions/runs/1001",
+        "event": "merge_group",
+        "head_branch": "gh-readonly-queue/main/pr-23-deadbeef",
     }
     assert receipt["required_jobs"] == list(REQUIRED_CI_JOBS)
     assert [job["name"] for job in cast(list[dict[str, object]], receipt["jobs"])] == list(
@@ -256,7 +367,15 @@ def test_ci_status_rejects_incomplete_or_nonpassing_jobs(mutation: str) -> None:
         jobs["total_count"] = len(typed_jobs) + 1
 
     with pytest.raises(ProvenanceError):
-        build_ci_status(_runs(), jobs, repository=REPOSITORY, source_commit=COMMIT)
+        build_ci_status(
+            _runs(),
+            jobs,
+            _candidate_build(),
+            _candidate_artifact(),
+            _tag_binding(),
+            repository=REPOSITORY,
+            source_commit=COMMIT,
+        )
 
 
 def test_ci_status_rejects_a_caller_supplied_non_push_or_wrong_sha_run() -> None:
@@ -265,15 +384,143 @@ def test_ci_status_rejects_a_caller_supplied_non_push_or_wrong_sha_run() -> None
     run["event"] = "workflow_dispatch"
 
     with pytest.raises(ProvenanceError, match="exactly one"):
-        select_ci_run(runs, repository=REPOSITORY, source_commit=COMMIT)
+        select_ci_run(runs, repository=REPOSITORY, source_commit=TESTED_COMMIT)
 
-    run["event"] = "push"
-    run["head_sha"] = "b" * 40
+    run["event"] = "merge_group"
+    run["head_sha"] = "d" * 40
     with pytest.raises(ProvenanceError, match="exactly one"):
-        select_ci_run(runs, repository=REPOSITORY, source_commit=COMMIT)
+        select_ci_run(runs, repository=REPOSITORY, source_commit=TESTED_COMMIT)
+
+
+def test_candidate_build_receipt_proves_one_build_and_five_exact_reuses(
+    tmp_path: Path,
+) -> None:
+    candidate = tmp_path / "candidate"
+    reports = tmp_path / "reports"
+    candidate.mkdir()
+    reports.mkdir()
+    wheel = candidate / "clio_relay-1.0.0-py3-none-any.whl"
+    sdist = candidate / "clio_relay-1.0.0.tar.gz"
+    wheel.write_bytes(b"wheel")
+    sdist.write_bytes(b"sdist")
+    distribution_digests = {
+        path.name: hashlib.sha256(path.read_bytes()).hexdigest() for path in (wheel, sdist)
+    }
+    (candidate / "SHA256SUMS").write_text(
+        "".join(
+            f"{distribution_digests[path.name]} *{path.name}\n"
+            for path in sorted((wheel, sdist), key=lambda item: item.name)
+        ),
+        encoding="ascii",
+        newline="\n",
+    )
+    for index, job in enumerate(REQUIRED_MATRIX_JOBS):
+        filename = f"validation-local-{job.split(' / python ')[0]}-{job.rsplit(' ', 1)[1]}.json"
+        checks = (
+            ["local.build", "local.sdist-smoke"] if index == 0 else ["local.prebuilt-artifacts"]
+        )
+        document = {
+            "status": "passed",
+            "scenario": "local-release",
+            "cluster": "local",
+            "software": {"commit": TESTED_COMMIT, "dirty": False},
+            "checks": [{"check_id": check_id} for check_id in checks],
+            "resources": [
+                {
+                    "resource_id": name,
+                    "metadata": {"sha256": digest},
+                }
+                for name, digest in distribution_digests.items()
+            ],
+        }
+        (reports / filename).write_text(json.dumps(document), encoding="utf-8")
+
+    receipt = build_candidate_build_receipt(
+        candidate,
+        reports,
+        repository=REPOSITORY,
+        source_commit=TESTED_COMMIT,
+        source_tree=TREE,
+        event="merge_group",
+        run_id=1001,
+        run_attempt=2,
+        head_ref="refs/heads/gh-readonly-queue/main/pr-23-deadbeef",
+        base_ref="refs/heads/main",
+    )
+
+    matrix = cast(list[dict[str, object]], receipt["matrix_reports"])
+    assert [item["mode"] for item in matrix] == ["build", *(["prebuilt"] * 5)]
+    assert all(item["artifact_sha256"] == distribution_digests for item in matrix)
+
+    changed = json.loads((reports / cast(str, matrix[-1]["filename"])).read_text())
+    cast(list[dict[str, object]], changed["resources"])[0]["metadata"] = {"sha256": "0" * 64}
+    (reports / cast(str, matrix[-1]["filename"])).write_text(json.dumps(changed), encoding="utf-8")
+    with pytest.raises(ProvenanceError, match="artifact digests differ"):
+        build_candidate_build_receipt(
+            candidate,
+            reports,
+            repository=REPOSITORY,
+            source_commit=TESTED_COMMIT,
+            source_tree=TREE,
+            event="merge_group",
+            run_id=1001,
+            run_attempt=2,
+            head_ref="refs/heads/gh-readonly-queue/main/pr-23-deadbeef",
+            base_ref="refs/heads/main",
+        )
+
+
+def test_tag_binding_accepts_a_multi_pr_group_final_commit_and_requires_tested_tree() -> None:
+    pulls = [
+        {
+            "number": 47,
+            "state": "closed",
+            "merged_at": "2026-07-14T01:00:00Z",
+            "merge_commit_sha": COMMIT,
+            "html_url": "https://github.com/iowarp/clio-relay/pull/47",
+            "base": {"ref": "main"},
+        }
+    ]
+    binding = build_tag_binding(
+        _candidate_build(),
+        _candidate_artifact(),
+        pulls,
+        repository=REPOSITORY,
+        source_commit=COMMIT,
+        source_tree=TREE,
+        tag=TAG,
+    )
+
+    assert binding["candidate_build_sha256"] == _canonical_digest(_candidate_build())
+    assert binding["merge_group_anchor_pull_request_number"] == 23
+    assert cast(dict[str, object], binding["pull_request"])["number"] == 47
+    with pytest.raises(ProvenanceError, match="tree differs"):
+        build_tag_binding(
+            _candidate_build(),
+            _candidate_artifact(),
+            pulls,
+            repository=REPOSITORY,
+            source_commit=COMMIT,
+            source_tree="9" * 40,
+            tag=TAG,
+        )
 
 
 def _artifact_run(*, kind: str = "tag-payload") -> dict[str, object]:
+    if kind == "candidate":
+        return {
+            "id": 1001,
+            "run_attempt": 2,
+            "head_branch": "gh-readonly-queue/main/pr-23-deadbeef",
+            "head_sha": TESTED_COMMIT,
+            "event": "merge_group",
+            "status": "completed",
+            "conclusion": "success",
+            "run_started_at": "2026-07-11T10:00:00Z",
+            "path": ".github/workflows/ci.yml",
+            "repository": {"id": 100},
+            "head_repository": {"id": 100},
+        }
     is_tag = kind == "tag-payload"
     return {
         "id": 5001,
@@ -293,7 +540,18 @@ def _artifact_run(*, kind: str = "tag-payload") -> dict[str, object]:
 
 
 def _artifact_listing(*, size: int, digest: str, kind: str = "tag-payload") -> dict[str, object]:
-    name = f"release-candidate-{TAG}" if kind == "tag-payload" else f"verified-release-{TAG}"
+    if kind == "candidate":
+        name = f"release-candidate-{TREE}"
+        head_sha = TESTED_COMMIT
+        head_branch = "gh-readonly-queue/main/pr-23-deadbeef"
+    elif kind == "tag-payload":
+        name = f"release-candidate-{TAG}"
+        head_sha = COMMIT
+        head_branch = TAG
+    else:
+        name = f"verified-release-{TAG}"
+        head_sha = COMMIT
+        head_branch = "main"
     return {
         "total_count": 1,
         "artifacts": [
@@ -308,9 +566,9 @@ def _artifact_listing(*, size: int, digest: str, kind: str = "tag-payload") -> d
                     f"https://api.github.com/repos/{REPOSITORY}/actions/artifacts/6001/zip"
                 ),
                 "workflow_run": {
-                    "id": 5001,
-                    "head_sha": COMMIT,
-                    "head_branch": TAG if kind == "tag-payload" else "main",
+                    "id": 1001 if kind == "candidate" else 5001,
+                    "head_sha": head_sha,
+                    "head_branch": head_branch,
                     "repository_id": 100,
                     "head_repository_id": 100,
                 },
@@ -332,6 +590,62 @@ def _write_tag_payload_zip(path: Path, *, extra_name: str | None = None) -> None
     files["SHA256SUMS"] = checksum
     if extra_name is not None:
         files[extra_name] = b"extra"
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for name, payload in files.items():
+            archive.writestr(name, payload)
+
+
+def _write_candidate_zip(path: Path, *, inconsistent_receipt: bool = False) -> None:
+    wheel_name = "clio_relay-1.0.0-py3-none-any.whl"
+    sdist_name = "clio_relay-1.0.0.tar.gz"
+    wheel = b"one tested wheel"
+    sdist = b"one tested sdist"
+    distribution_digests = {
+        wheel_name: hashlib.sha256(wheel).hexdigest(),
+        sdist_name: hashlib.sha256(sdist).hexdigest(),
+    }
+    report = {
+        "status": "passed",
+        "scenario": "local-release",
+        "cluster": "local",
+        "software": {"commit": TESTED_COMMIT, "dirty": False},
+        "resources": [
+            {
+                "resource_id": name,
+                "metadata": {"sha256": digest},
+            }
+            for name, digest in distribution_digests.items()
+        ],
+        "checks": [
+            {"check_id": "local.build"},
+            {"check_id": "local.sdist-smoke"},
+        ],
+    }
+    report_bytes = json.dumps(report, sort_keys=True, separators=(",", ":")).encode()
+    build = _candidate_build()
+    build["distribution_sha256"] = dict(distribution_digests)
+    matrix = cast(list[dict[str, object]], build["matrix_reports"])
+    for item in matrix:
+        item["artifact_sha256"] = dict(distribution_digests)
+    matrix[0]["sha256"] = hashlib.sha256(report_bytes).hexdigest()
+    if inconsistent_receipt:
+        build["distribution_sha256"][wheel_name] = "0" * 64
+        for item in matrix:
+            cast(dict[str, str], item["artifact_sha256"])[wheel_name] = "0" * 64
+    files = {
+        wheel_name: wheel,
+        sdist_name: sdist,
+        "validation-local.json": report_bytes,
+        "CANDIDATE-BUILD.json": json.dumps(
+            build,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode(),
+    }
+    files["SHA256SUMS"] = "".join(
+        f"{hashlib.sha256(payload).hexdigest()} *{name}\n"
+        for name, payload in sorted(files.items())
+    ).encode()
     with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
         for name, payload in files.items():
             archive.writestr(name, payload)
@@ -424,6 +738,38 @@ def test_actions_artifact_manifest_and_archive_bind_exact_api_identity(tmp_path:
         "validation-local.json",
         "SHA256SUMS",
     }
+
+
+@pytest.mark.parametrize("inconsistent_receipt", [False, True])
+def test_candidate_archive_binds_extracted_distributions_to_build_receipt(
+    tmp_path: Path,
+    inconsistent_receipt: bool,
+) -> None:
+    archive = tmp_path / "candidate.zip"
+    _write_candidate_zip(archive, inconsistent_receipt=inconsistent_receipt)
+    digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+    manifest = build_actions_artifact_manifest(
+        _artifact_run(kind="candidate"),
+        _artifact_listing(
+            size=archive.stat().st_size,
+            digest=digest,
+            kind="candidate",
+        ),
+        repository=REPOSITORY,
+        source_commit=TESTED_COMMIT,
+        source_tree=TREE,
+        tag=TAG,
+        run_id=1001,
+        run_attempt=2,
+        artifact_name=f"release-candidate-{TREE}",
+        artifact_kind="candidate",
+    )
+
+    if inconsistent_receipt:
+        with pytest.raises(ProvenanceError, match="distributions differ"):
+            verify_actions_artifact_archive(manifest, archive, tmp_path / "candidate")
+    else:
+        verify_actions_artifact_archive(manifest, archive, tmp_path / "candidate")
 
 
 @pytest.mark.parametrize(
@@ -828,6 +1174,7 @@ def test_repository_governance_receipt_requires_effective_current_token_controls
         _branch_rulesets(),
         _tag_rulesets(),
         _environments(),
+        _immutable_releases(),
         repository=REPOSITORY,
         source_commit=COMMIT,
         tag=TAG,
@@ -866,6 +1213,7 @@ def test_live_governance_requery_must_equal_the_carried_receipt() -> None:
         source_commit=COMMIT,
         tag=TAG,
         fetch_json=fetch,
+        fetch_admin_json=fetch,
     )
     verify_live_repository_governance(
         receipt,
@@ -873,6 +1221,7 @@ def test_live_governance_requery_must_equal_the_carried_receipt() -> None:
         source_commit=COMMIT,
         tag=TAG,
         fetch_json=fetch,
+        fetch_admin_json=fetch,
     )
 
     branch = cast(dict[str, object], routes[f"repos/{REPOSITORY}/rulesets/{MAIN_RULESET_ID}"])
@@ -884,6 +1233,7 @@ def test_live_governance_requery_must_equal_the_carried_receipt() -> None:
             source_commit=COMMIT,
             tag=TAG,
             fetch_json=fetch,
+            fetch_admin_json=fetch,
         )
 
 
@@ -893,6 +1243,7 @@ def test_live_governance_requery_must_equal_the_carried_receipt() -> None:
         ("status_app", "integration id"),
         ("main_bypass", "current workflow token can bypass"),
         ("missing_main_rule", "effective main branch rules are incomplete"),
+        ("merge_queue", "merge queue parameters"),
         ("review_count", "required_approving_review_count"),
         ("last_push_approval", "require_last_push_approval"),
         ("tag_bypass", "current_workflow_token_cannot_bypass"),
@@ -900,6 +1251,7 @@ def test_live_governance_requery_must_equal_the_carried_receipt() -> None:
         ("environment", "protected-branch deployment policy"),
         ("environment_policy", "protected-branch deployment policy"),
         ("environment_admin_bypass", "administrator bypass"),
+        ("immutable_releases", "immutable releases must be enabled"),
     ],
 )
 def test_repository_governance_rejects_weakened_controls(
@@ -910,6 +1262,7 @@ def test_repository_governance_rejects_weakened_controls(
     branch_rulesets = deepcopy(_branch_rulesets())
     tag_rulesets = deepcopy(_tag_rulesets())
     environments = deepcopy(_environments())
+    immutable_releases = deepcopy(_immutable_releases())
     if surface == "status_app":
         status = cast(dict[str, object], effective[-1]["parameters"])
         cast(list[dict[str, object]], status["required_status_checks"])[0]["integration_id"] = None
@@ -917,11 +1270,14 @@ def test_repository_governance_rejects_weakened_controls(
         branch_rulesets[0]["current_user_can_bypass"] = "always"
     elif surface == "missing_main_rule":
         effective.pop(0)
+    elif surface == "merge_queue":
+        queue = cast(dict[str, object], effective[2]["parameters"])
+        queue["max_entries_to_build"] = 6
     elif surface == "review_count":
-        reviews = cast(dict[str, object], effective[2]["parameters"])
+        reviews = cast(dict[str, object], effective[3]["parameters"])
         reviews["required_approving_review_count"] = 1
     elif surface == "last_push_approval":
-        reviews = cast(dict[str, object], effective[2]["parameters"])
+        reviews = cast(dict[str, object], effective[3]["parameters"])
         reviews["require_last_push_approval"] = True
     elif surface == "tag_bypass":
         tag_rulesets[0]["current_user_can_bypass"] = "always"
@@ -936,9 +1292,11 @@ def test_repository_governance_rejects_weakened_controls(
             "protected_branches": False,
             "custom_branch_policies": True,
         }
-    else:
+    elif surface == "environment_admin_bypass":
         environment = cast(dict[str, object], environments["live-validation"])
         environment["can_admins_bypass"] = True
+    else:
+        immutable_releases["enabled"] = False
 
     with pytest.raises(ProvenanceError, match=expected_message):
         build_repository_governance(
@@ -947,6 +1305,7 @@ def test_repository_governance_rejects_weakened_controls(
             branch_rulesets,
             tag_rulesets,
             environments,
+            immutable_releases,
             repository=REPOSITORY,
             source_commit=COMMIT,
             tag=TAG,
@@ -963,6 +1322,7 @@ def test_repository_governance_rejects_another_protected_branch() -> None:
             _branch_rulesets(),
             _tag_rulesets(),
             _environments(),
+            _immutable_releases(),
             repository=REPOSITORY,
             source_commit=COMMIT,
             tag=TAG,
@@ -976,6 +1336,7 @@ def _release_identity() -> dict[str, object]:
         "target_commitish": COMMIT,
         "draft": True,
         "prerelease": False,
+        "immutable": False,
     }
 
 
@@ -1186,6 +1547,7 @@ def _governance_receipt() -> dict[str, object]:
         _branch_rulesets(),
         _tag_rulesets(),
         _environments(),
+        _immutable_releases(),
         repository=REPOSITORY,
         source_commit=COMMIT,
         tag=TAG,
@@ -1215,6 +1577,7 @@ def test_mutation_authority_revalidates_exact_main_tag_governance_and_draft() ->
         release_state="present",
         expect_draft=True,
         fetch_json=lambda path: deepcopy(routes[path]),
+        fetch_admin_json=lambda path: deepcopy(routes[path]),
     )
 
 
@@ -1232,11 +1595,12 @@ def test_mutation_authority_proves_release_absence_before_create() -> None:
         release_state="absent",
         expect_draft=True,
         fetch_json=lambda path: deepcopy(routes[path]),
+        fetch_admin_json=lambda path: deepcopy(routes[path]),
     )
 
 
 def test_mutation_authority_rejects_an_unspecified_present_draft_state() -> None:
-    with pytest.raises(ProvenanceError, match="exact draft state"):
+    with pytest.raises(ProvenanceError, match="only while the release is a draft"):
         verify_live_mutation_authority(
             _governance_receipt(),
             repository=REPOSITORY,
@@ -1247,6 +1611,7 @@ def test_mutation_authority_rejects_an_unspecified_present_draft_state() -> None
             release_state="present",
             expect_draft=None,
             fetch_json=lambda path: deepcopy(_mutation_routes()[path]),
+            fetch_admin_json=lambda path: deepcopy(_mutation_routes()[path]),
         )
 
 
@@ -1278,6 +1643,7 @@ def test_mutation_authority_rejects_stale_or_bypassable_live_state(mutation: str
             release_state="present",
             expect_draft=True,
             fetch_json=lambda path: deepcopy(routes[path]),
+            fetch_admin_json=lambda path: deepcopy(routes[path]),
         )
 
 

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -51,7 +51,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
 
 def test_candidate_manifest_parser_accepts_the_exact_gnu_checksum_separator() -> None:
     digest = "a" * 64
-    wheel_name = "clio_relay-1.0.11-py3-none-any.whl"
+    wheel_name = "clio_relay-1.1.0-py3-none-any.whl"
     selector = re.compile(rf"^[0-9A-Fa-f]{{64}} [ *]{re.escape(wheel_name)}$")
     parser = re.compile(r"^([0-9A-Fa-f]{64}) [ *](.+)$")
 

--- a/tests/test_release_validation.py
+++ b/tests/test_release_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 import subprocess
 import sys
@@ -264,6 +265,96 @@ def test_local_release_validation_runs_all_checks_and_records_artifacts(
         "tests/test_surface_pagination.py::test_sparse_job_filters_return_empty_source_page_with_next_cursor",
     ]
     assert load_validation_report(report_path).status is ValidationStatus.PASSED
+
+
+def test_prebuilt_release_validation_reuses_exact_bytes_without_any_build(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='test'\n", encoding="utf-8")
+    prebuilt = tmp_path / "prebuilt"
+    prebuilt.mkdir()
+    wheel = prebuilt / "clio_relay-1.0.0-py3-none-any.whl"
+    sdist = prebuilt / "clio_relay-1.0.0.tar.gz"
+    wheel.write_bytes(b"one tested wheel")
+    sdist.write_bytes(b"one tested sdist")
+    manifest = "".join(
+        f"{hashlib.sha256(path.read_bytes()).hexdigest()} *{path.name}\n"
+        for path in sorted((wheel, sdist), key=lambda item: item.name)
+    )
+    (prebuilt / "SHA256SUMS").write_text(manifest, encoding="ascii", newline="\n")
+    commands: list[list[str]] = []
+
+    def runner(
+        command: list[str],
+        *,
+        cwd: Path,
+    ) -> subprocess.CompletedProcess[str]:
+        assert cwd == tmp_path.resolve()
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="passed", stderr="")
+
+    report = run_local_release_validation(
+        LocalReleaseValidationOptions(
+            project_root=tmp_path,
+            report_path=tmp_path / "prebuilt-report.json",
+            artifact_dir=tmp_path / "validation-output",
+            prebuilt_artifact_dir=prebuilt,
+        ),
+        runner=runner,
+    )
+
+    check_ids = {check.check_id for check in report.checks}
+    assert report.status is ValidationStatus.PASSED
+    assert "local.prebuilt-artifacts" in check_ids
+    assert "local.build" not in check_ids
+    assert "local.sdist-smoke" not in check_ids
+    assert not any(command[:2] == ["uv", "build"] for command in commands)
+    assert {resource.metadata["sha256"] for resource in report.resources} == {
+        hashlib.sha256(wheel.read_bytes()).hexdigest(),
+        hashlib.sha256(sdist.read_bytes()).hexdigest(),
+    }
+
+
+@pytest.mark.parametrize("mutation", ["extra", "digest"])
+def test_prebuilt_release_validation_rejects_extra_or_changed_files(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='test'\n", encoding="utf-8")
+    prebuilt = tmp_path / "prebuilt"
+    prebuilt.mkdir()
+    wheel = prebuilt / "clio_relay-1.0.0-py3-none-any.whl"
+    sdist = prebuilt / "clio_relay-1.0.0.tar.gz"
+    wheel.write_bytes(b"wheel")
+    sdist.write_bytes(b"sdist")
+    manifest = "".join(
+        f"{hashlib.sha256(path.read_bytes()).hexdigest()} *{path.name}\n"
+        for path in sorted((wheel, sdist), key=lambda item: item.name)
+    )
+    (prebuilt / "SHA256SUMS").write_text(manifest, encoding="ascii", newline="\n")
+    if mutation == "extra":
+        (prebuilt / "unexpected.txt").write_text("no", encoding="utf-8")
+    else:
+        wheel.write_bytes(b"changed")
+
+    def runner(
+        command: list[str],
+        *,
+        cwd: Path,
+    ) -> subprocess.CompletedProcess[str]:
+        del cwd
+        return subprocess.CompletedProcess(command, 0, stdout="passed", stderr="")
+
+    with pytest.raises(ConfigurationError):
+        run_local_release_validation(
+            LocalReleaseValidationOptions(
+                project_root=tmp_path,
+                report_path=tmp_path / "rejected.json",
+                artifact_dir=tmp_path / "validation-output",
+                prebuilt_artifact_dir=prebuilt,
+            ),
+            runner=runner,
+        )
 
 
 def test_local_release_validation_persists_structured_pytest_gate_failure(

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -22,7 +22,7 @@ def _workflow(name: str) -> dict[str, Any]:
     return cast(dict[str, Any], document)
 
 
-def test_tag_workflow_only_builds_an_unprivileged_actions_payload() -> None:
+def test_tag_workflow_only_binds_the_unprivileged_merge_queue_payload() -> None:
     workflow = _workflow("release.yml")
     jobs = cast(dict[str, dict[str, Any]], workflow["jobs"])
     text = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
@@ -33,9 +33,13 @@ def test_tag_workflow_only_builds_an_unprivileged_actions_payload() -> None:
     assert "gh release upload" not in text
     assert "environment:" not in text
     assert "--clobber" not in text
-    assert set(jobs) == {"build"}
-    assert jobs["build"]["permissions"] == {"contents": "read"}
-    steps = cast(list[dict[str, Any]], jobs["build"]["steps"])
+    assert set(jobs) == {"bind"}
+    assert workflow["permissions"] == {
+        "actions": "read",
+        "contents": "read",
+        "pull-requests": "read",
+    }
+    steps = cast(list[dict[str, Any]], jobs["bind"]["steps"])
     checkout = next(step for step in steps if "actions/checkout@" in str(step.get("uses")))
     assert cast(dict[str, str], checkout["with"])["persist-credentials"] == "false"
     assert cast(dict[str, str], checkout["with"])["ref"] == "${{ github.sha }}"
@@ -43,6 +47,10 @@ def test_tag_workflow_only_builds_an_unprivileged_actions_payload() -> None:
     assert "REPOSITORY-GOVERNANCE.json" not in text
     assert "relay_authenticated_git_fetch" in text
     assert "actions/upload-artifact@" in text
+    assert "release validate-local" not in text
+    assert "uv build" not in text
+    assert "TAG-BINDING.json" in text
+    assert "--artifact-kind candidate" in text
 
 
 def test_same_tag_release_stages_share_one_non_canceling_concurrency_group() -> None:
@@ -134,15 +142,22 @@ def test_ci_uses_read_only_permissions_and_nonpersistent_checkout_credentials() 
     workflow = _workflow("ci.yml")
     permissions = cast(dict[str, str], workflow["permissions"])
     jobs = cast(dict[str, dict[str, Any]], workflow["jobs"])
-    steps = cast(list[dict[str, Any]], jobs["test"]["steps"])
+    steps = cast(list[dict[str, Any]], jobs["validate"]["steps"])
     checkout = next(step for step in steps if "actions/checkout@" in str(step.get("uses")))
-    strategy = cast(dict[str, Any], jobs["test"]["strategy"])
-    matrix = cast(dict[str, list[str]], strategy["matrix"])
+    strategy = cast(dict[str, Any], jobs["validate"]["strategy"])
+    matrix = cast(dict[str, list[dict[str, str]]], strategy["matrix"])
 
     assert permissions == {"contents": "read"}
     assert cast(dict[str, str], checkout["with"])["persist-credentials"] == "false"
-    assert matrix["os"] == ["ubuntu-latest", "windows-latest"]
-    assert matrix["python-version"] == ["3.12", "3.13", "3.14"]
+    assert matrix["include"] == [
+        {"os": "ubuntu-latest", "python-version": "3.13"},
+        {"os": "ubuntu-latest", "python-version": "3.14"},
+        {"os": "windows-latest", "python-version": "3.12"},
+        {"os": "windows-latest", "python-version": "3.13"},
+        {"os": "windows-latest", "python-version": "3.14"},
+    ]
+    assert jobs["build"]["name"] == "ubuntu-latest / python 3.12"
+    assert jobs["seal"]["name"] == "seal tested release candidate"
     workflow_lint = str(jobs["workflow-lint"])
     assert "actionlint_1.7.12_linux_amd64.tar.gz" in workflow_lint
     assert "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8" in (workflow_lint)
@@ -154,13 +169,13 @@ def test_ci_uses_read_only_permissions_and_nonpersistent_checkout_credentials() 
 def test_ci_matrix_pins_sync_probe_and_release_gate_to_each_declared_python() -> None:
     workflow = _workflow("ci.yml")
     jobs = cast(dict[str, dict[str, Any]], workflow["jobs"])
-    steps = cast(list[dict[str, Any]], jobs["test"]["steps"])
+    steps = cast(list[dict[str, Any]], jobs["validate"]["steps"])
     by_name = {str(step["name"]): step for step in steps}
     matrix_python = '"${{ matrix.python-version }}"'
 
     sync_command = str(by_name["install dependencies"]["run"])
     probe_command = str(by_name["verify matrix interpreter"]["run"])
-    gate_command = str(by_name["run evidence-producing local release gate"]["run"])
+    gate_command = str(by_name["validate without rebuilding the distributions"]["run"])
 
     assert sync_command == f"uv sync --python {matrix_python} --locked --all-groups"
     assert probe_command.startswith(f"uv run --python {matrix_python} python -c ")
@@ -168,7 +183,55 @@ def test_ci_matrix_pins_sync_probe_and_release_gate_to_each_declared_python() ->
     assert gate_command.startswith(
         f"uv run --python {matrix_python} clio-relay release validate-local "
     )
+    assert "--prebuilt-artifact-dir dist/prebuilt" in gate_command
     assert gate_command.count("${{ matrix.python-version }}") == 2
+    primary = str(jobs["build"])
+    assert "run the sole artifact-building release gate" in primary
+    assert "--prebuilt-artifact-dir" not in primary
+
+
+def test_merge_queue_builds_once_and_main_or_tag_never_repeat_the_full_gate() -> None:
+    ci = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
+    main = (WORKFLOWS / "main-provenance.yml").read_text(encoding="utf-8")
+    tag = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
+
+    assert "merge_group:" in ci
+    assert "push:" not in ci
+    assert "push:" in main
+    assert "record merged-main provenance" in main
+    assert "validate-local" not in main
+    assert ci.count("--artifact-dir dist/build-output") == 1
+    assert ci.count("--prebuilt-artifact-dir dist/prebuilt") == 1
+    assert "--report dist/reports/validation-local" in ci
+    assert "candidate-build-receipt" in ci
+    assert "release-candidate-${{ steps.candidate.outputs.tree }}" in ci
+    assert "release validate-local" not in tag
+    assert "uv sync" not in tag
+    assert "uv build" not in tag
+    assert "stage exact clio-kit" not in tag
+
+
+def test_release_mutations_require_live_admin_read_immutability_governance() -> None:
+    privileged = (
+        "stage-candidate.yml",
+        "live-validation-attest.yml",
+        "release-gate.yml",
+        "released-validation-attest.yml",
+        "finalize-release.yml",
+    )
+    for workflow_name in privileged:
+        text = (WORKFLOWS / workflow_name).read_text(encoding="utf-8")
+        assert "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1" in text
+        assert "permission-administration: read" in text
+        assert "GH_ADMIN_READ_TOKEN" in text
+        assert "mutation-authority" in text
+        assert "--method PUT" not in text
+        assert "--method DELETE" not in text
+
+    source = (ROOT / "src" / "clio_relay" / "ci_validation.py").read_text(encoding="utf-8")
+    assert 'fetch_admin_json(f"repos/{repository}/immutable-releases")' in source
+    assert '"enabled": True' in source
+    assert '"enforced_by_owner": True' in source
 
 
 def test_jarvis_release_requirement_enforces_unified_gray_scott_contract() -> None:
@@ -689,8 +752,8 @@ def test_candidate_staging_binds_live_exact_sha_ci_and_governance() -> None:
     text = (WORKFLOWS / "stage-candidate.yml").read_text(encoding="utf-8")
 
     assert permissions["actions"] == "read"
-    assert "actions/workflows/ci.yml/runs?head_sha=$SOURCE_COMMIT" in text
-    assert "event=push&status=completed&per_page=100" in text
+    assert "actions/workflows/ci.yml/runs?head_sha=$TESTED_COMMIT" in text
+    assert "event=merge_group&status=completed&per_page=100" in text
     assert "actions/runs/$ci_run_id/attempts/$ci_run_attempt/jobs?per_page=100" in text
     assert "ci_validation.py select-ci-run" in text
     assert "ci_validation.py build-ci-status" in text
@@ -708,6 +771,11 @@ def test_candidate_staging_binds_live_exact_sha_ci_and_governance() -> None:
         assert environment in text
     assert "deployment-branch-policies" not in text
     assert "ci_validation.py build-governance" in text
+    assert '--immutable-releases "$inputs/immutable-releases.json"' in text
+    assert "permission-administration: read" in text
+    assert "GH_ADMIN_READ_TOKEN" in text
+    assert "--candidate-build dist/CANDIDATE-BUILD.json" in text
+    assert "--tag-binding binding/TAG-BINDING.json" in text
     assert "ci_validation.py candidate-manifest" in text
 
 
@@ -859,9 +927,11 @@ def test_actions_artifacts_are_preflighted_and_downloaded_by_exact_api_id() -> N
     stage = (WORKFLOWS / "stage-candidate.yml").read_text(encoding="utf-8")
     publish = (WORKFLOWS / "release-gate.yml").read_text(encoding="utf-8")
 
-    assert "--artifact-kind tag-payload" in stage
+    assert "--artifact-kind tag-binding" in stage
+    assert "--artifact-kind candidate" in stage
     assert "actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT" in stage
     assert "actions/artifacts/$ARTIFACT_ID/zip" in stage
+    assert "actions/artifacts/$artifact_id/zip" in stage
     assert "--artifact-kind promotion" in publish
     assert "actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT" in publish
     assert "actions/artifacts/$ARTIFACT_ID/zip" in publish
@@ -970,8 +1040,10 @@ def test_final_publication_rechecks_exact_assets_before_and_after_publication() 
     assert authority < preflight < receipt < publish
     assert publish < postflight < published_receipt < mutable_check
     assert (
-        'test "$(jq -r .immutable "$RUNNER_TEMP/final-release-published.json")" = "false"' in script
+        'test "$(jq -r .immutable "$RUNNER_TEMP/final-release-published.json")" = "true"' in script
     )
+    assert 'gh release verify "$TAG_NAME"' in script
+    assert 'gh release verify-asset "$TAG_NAME" "$asset"' in script
     assert '"${asset_args[@]}"' in script
     assert script.count("relay_release_complete_assets") == 1
     assert script.count("--next-assets-page") == 2
@@ -1004,7 +1076,8 @@ def test_distribution_archives_are_parsed_but_never_executed_in_privileged_jobs(
     assert gate.count("ci_validation.py distribution-archives") == 2
     assert "DISTRIBUTION-ARCHIVES.json" in gate
     assert "local.sdist-smoke" not in gate
-    assert "release validate-local" in release
+    assert "release validate-local" not in release
+    assert "CANDIDATE-BUILD.json" in release
 
 
 def test_privileged_release_jobs_never_execute_candidate_or_pypi_code() -> None:
@@ -1038,18 +1111,17 @@ def test_privileged_release_jobs_never_execute_candidate_or_pypi_code() -> None:
                     assert "uv run --no-sync clio-relay release gate" in script
 
 
-def test_finalization_intentionally_publishes_a_normal_mutable_release() -> None:
+def test_finalization_publishes_once_then_verifies_immutable_release_and_assets() -> None:
     text = (WORKFLOWS / "finalize-release.yml").read_text(encoding="utf-8")
 
     assert 'gh api "repos/$REPOSITORY/immutable-releases"' not in text
-    assert "IMMUTABLE_RELEASES_READ_TOKEN" not in text
-    assert '"github_release_immutable": False' in text
-    assert '"immutability_deferred_to_version": "1.1"' in text
+    assert "permission-administration: read" in text
+    assert '"github_release_immutable": True' in text
     assert '.immutable "$RUNNER_TEMP/final-release-published.json"' in text
-    assert (
-        'test "$(jq -r .immutable "$RUNNER_TEMP/final-release-published.json")" = "false"' in text
-    )
-    assert "gh release verify" not in text
+    assert 'test "$(jq -r .immutable "$RUNNER_TEMP/final-release-published.json")" = "true"' in text
+    assert 'gh release verify "$TAG_NAME"' in text
+    assert 'gh release verify-asset "$TAG_NAME" "$asset"' in text
+    assert text.count("relay_release_patch") == 1
 
 
 def test_final_claims_resolve_all_decision_reports_and_bind_target_policy() -> None:
@@ -1069,6 +1141,7 @@ def test_final_claims_resolve_all_decision_reports_and_bind_target_policy() -> N
 def test_release_workflow_actions_are_commit_pinned() -> None:
     for workflow_name in (
         "ci.yml",
+        "main-provenance.yml",
         "release.yml",
         "stage-candidate.yml",
         "release-gate.yml",

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1612,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.0.11"
+    assert policy.release_version == "1.1.0"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.0.11"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## what changed

- Builds the wheel and source distribution exactly once on the merge-group commit, then validates those same bytes on all six supported OS/Python legs.
- Replaces tag-time rebuilding with a lightweight tree, merged-PR, workflow-run, and numeric artifact binding.
- Adds repository-enforced immutable-release governance, draft-only mutation checks, immutable publication polling, and `gh release verify`/`verify-asset` verification.
- Separates main-push provenance from merge-queue CI, adds exact merge-queue governance receipts, and prepares version 1.1.0.

## why

The 1.0 pipeline repeatedly rebuilt and revalidated equivalent source at PR, main, and tag time. That was slow and did not prove that every matrix leg, release tag, and published asset referred to the same distribution bytes. The 1.1 chain makes that identity explicit and fails closed on dirty checkouts, stale governance, artifact drift, mutable publication, or multi-PR merge-group ambiguity.

## impact

Operators retain configurable cluster acceptance targets. Release owners must install the documented repository-scoped GitHub App with Administration read permission, enable owner-enforced immutable releases, and canary the documented merge-queue parameters before the first finalized 1.1 release.

## validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- 156 focused release-system tests
- 23 focused version, policy, matrix, and runbook tests
- actionlint semantic validation of all workflows