### PR TITLE
fix: publish release artifacts immediately

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: ci
 
 on:
+  push:
+    tags: ["v*"]
   pull_request:
     branches: ["main"]
   merge_group:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
-name: bind release tag to tested merge-queue candidate
+name: validate release tag asynchronously
 
 on:
   push:
     tags: ["v*"]
+  release:
+    types: [published]
 
 concurrency:
   group: clio-relay-release-${{ github.ref_name }}
@@ -15,20 +17,21 @@ permissions:
 
 jobs:
   bind:
-    name: bind tag without rebuilding or executing candidate code
+    name: validate tag identity without blocking publication
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: check out the exact repository tag commit
+      - name: check out the exact tagged commit
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1
           persist-credentials: false
-      - name: bind tag, main, version, and tree
-        id: source
+      - name: validate tag, package version, and current main
         env:
           GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
           TAG_NAME: ${{ github.ref_name }}
         shell: bash
         run: |
@@ -39,7 +42,99 @@ jobs:
             "refs/tags/$TAG_NAME:refs/tags/$TAG_NAME"
           test "$(git rev-list -n 1 "$TAG_NAME")" = "$GITHUB_SHA"
           test "$GITHUB_SHA" = "$(git rev-parse refs/remotes/origin/main)"
-          python - "$TAG_NAME" <<'PY'
+          python - "$TAG_NAME" "$REPOSITORY" "$GITHUB_SHA" <<'PY'
+          import json
+          import re
+          import subprocess
+          import sys
+          import tomllib
+          from pathlib import Path
+
+          tag, repository, source_commit = sys.argv[1:]
+          project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          version = project["project"]["version"]
+          init_source = Path("src/clio_relay/__init__.py").read_text(encoding="utf-8")
+          match = re.search(r'^__version__ = "([^"]+)"$', init_source, re.MULTILINE)
+          if match is None or match.group(1) != version or tag != f"v{version}":
+              raise SystemExit("tag and package version identities differ")
+          source_tree = subprocess.check_output(
+              ["git", "rev-parse", "HEAD^{tree}"], text=True
+          ).strip()
+          Path("TAG-BINDING.json").write_text(
+              json.dumps(
+                  {
+                      "schema_version": "clio-relay.tag-binding.v2",
+                      "repository": repository,
+                      "tag": tag,
+                      "version": version,
+                      "source_commit": source_commit,
+                      "source_tree": source_tree,
+                  },
+                  indent=2,
+                  sort_keys=True,
+              )
+              + "\n",
+              encoding="utf-8",
+          )
+          PY
+      - name: upload the asynchronous tag identity receipt
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-binding-${{ github.ref_name }}
+          path: TAG-BINDING.json
+          if-no-files-found: error
+          retention-days: 90
+
+  publish-pypi:
+    name: publish exact GitHub Release distributions to PyPI
+    if: github.event_name == 'release' && github.repository == 'iowarp/clio-relay'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: pypi
+      url: https://pypi.org/project/clio-relay/${{ steps.identity.outputs.version }}/
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    steps:
+      - name: check out the exact release tag
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 1
+          persist-credentials: false
+      - name: verify the published release identity and download exact assets
+        id: identity
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_DRAFT: ${{ github.event.release.draft }}
+          RELEASE_ID: ${{ github.event.release.id }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+          RELEASE_TARGET: ${{ github.event.release.target_commitish }}
+          REPOSITORY: ${{ github.repository }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_EVENT_ACTION" = "published"
+          test "$RELEASE_DRAFT" = "false"
+          test "$RELEASE_PRERELEASE" = "false"
+          [[ "$RELEASE_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]
+
+          gh api "repos/$REPOSITORY/releases/$RELEASE_ID" > "$RUNNER_TEMP/release.json"
+          test "$(jq -r .id "$RUNNER_TEMP/release.json")" = "$RELEASE_ID"
+          test "$(jq -r .tag_name "$RUNNER_TEMP/release.json")" = "$TAG_NAME"
+          test "$(jq -r .draft "$RUNNER_TEMP/release.json")" = "false"
+          test "$(jq -r .prerelease "$RUNNER_TEMP/release.json")" = "false"
+
+          source_commit="$(gh api "repos/$REPOSITORY/commits/$TAG_NAME" --jq .sha)"
+          test "$source_commit" = "$(git rev-parse HEAD)"
+          test "$RELEASE_TARGET" = "$source_commit"
+          test "$(jq -r .target_commitish "$RUNNER_TEMP/release.json")" = "$source_commit"
+
+          version="$(python - "$TAG_NAME" <<'PY'
           import re
           import sys
           import tomllib
@@ -51,90 +146,45 @@ jobs:
           init_source = Path("src/clio_relay/__init__.py").read_text(encoding="utf-8")
           match = re.search(r'^__version__ = "([^"]+)"$', init_source, re.MULTILINE)
           if match is None or match.group(1) != version or tag != f"v{version}":
-              raise SystemExit("tag and package version identities differ")
+              raise SystemExit("release tag and package version identities differ")
+          print(version)
           PY
-          tree="$(git rev-parse 'HEAD^{tree}')"
-          {
-            echo "source_commit=$GITHUB_SHA"
-            echo "source_tree=$tree"
-          } >> "$GITHUB_OUTPUT"
-      - name: select the sole sealed candidate for the tested tree
-        id: candidate
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPOSITORY: ${{ github.repository }}
-          SOURCE_TREE: ${{ steps.source.outputs.source_tree }}
-          TAG_NAME: ${{ github.ref_name }}
-        shell: bash
-        run: |
-          name="release-candidate-$SOURCE_TREE"
-          gh api "repos/$REPOSITORY/actions/artifacts?name=$name&per_page=100" \
-            > "$RUNNER_TEMP/candidate-artifacts.json"
-          test "$(jq -r .total_count "$RUNNER_TEMP/candidate-artifacts.json")" -eq 1
-          run_id="$(jq -r '.artifacts[0].workflow_run.id' \
-            "$RUNNER_TEMP/candidate-artifacts.json")"
-          [[ "$run_id" =~ ^[1-9][0-9]*$ ]]
-          gh api "repos/$REPOSITORY/actions/runs/$run_id" \
-            > "$RUNNER_TEMP/candidate-run.json"
-          run_attempt="$(jq -r .run_attempt "$RUNNER_TEMP/candidate-run.json")"
-          tested_commit="$(jq -r .head_sha "$RUNNER_TEMP/candidate-run.json")"
-          python src/clio_relay/ci_validation.py actions-artifact-manifest \
-            --run "$RUNNER_TEMP/candidate-run.json" \
-            --artifacts "$RUNNER_TEMP/candidate-artifacts.json" \
-            --repository "$REPOSITORY" \
-            --source-commit "$tested_commit" \
-            --source-tree "$SOURCE_TREE" \
-            --tag "$TAG_NAME" \
-            --run-id "$run_id" \
-            --run-attempt "$run_attempt" \
-            --artifact-name "$name" \
-            --artifact-kind candidate \
-            --output "$RUNNER_TEMP/CANDIDATE-ARTIFACT.json"
-          artifact_id="$(jq -r .artifact.id "$RUNNER_TEMP/CANDIDATE-ARTIFACT.json")"
-          {
-            echo "artifact_id=$artifact_id"
-            echo "manifest=$RUNNER_TEMP/CANDIDATE-ARTIFACT.json"
-          } >> "$GITHUB_OUTPUT"
-      - name: download and verify the sealed candidate by numeric artifact id
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPOSITORY: ${{ github.repository }}
-          ARTIFACT_ID: ${{ steps.candidate.outputs.artifact_id }}
-          ARTIFACT_MANIFEST: ${{ steps.candidate.outputs.manifest }}
-        shell: bash
-        run: |
-          gh api "repos/$REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip" \
-            > "$RUNNER_TEMP/candidate.zip"
-          python src/clio_relay/ci_validation.py extract-actions-artifact \
-            --manifest "$ARTIFACT_MANIFEST" \
-            --archive "$RUNNER_TEMP/candidate.zip" \
-            --output-dir candidate
-      - name: bind the tested tree to the merged pull request and release tag
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPOSITORY: ${{ github.repository }}
-          SOURCE_COMMIT: ${{ steps.source.outputs.source_commit }}
-          SOURCE_TREE: ${{ steps.source.outputs.source_tree }}
-          TAG_NAME: ${{ github.ref_name }}
-          CANDIDATE_ARTIFACT: ${{ steps.candidate.outputs.manifest }}
-        shell: bash
-        run: |
-          gh api -H 'Accept: application/vnd.github+json' \
-            "repos/$REPOSITORY/commits/$SOURCE_COMMIT/pulls?per_page=100" \
-            > "$RUNNER_TEMP/pulls.json"
-          python src/clio_relay/ci_validation.py tag-binding \
-            --candidate-build candidate/CANDIDATE-BUILD.json \
-            --candidate-artifact "$CANDIDATE_ARTIFACT" \
-            --pulls "$RUNNER_TEMP/pulls.json" \
-            --repository "$REPOSITORY" \
-            --source-commit "$SOURCE_COMMIT" \
-            --source-tree "$SOURCE_TREE" \
-            --tag "$TAG_NAME" \
-            --output TAG-BINDING.json
-      - name: upload the lightweight tag binding
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+          )"
+          wheel="clio_relay-${version}-py3-none-any.whl"
+          sdist="clio_relay-${version}.tar.gz"
+
+          gh api "repos/$REPOSITORY/releases/$RELEASE_ID/assets?per_page=100" \
+            > "$RUNNER_TEMP/assets.json"
+          test "$(jq length "$RUNNER_TEMP/assets.json")" -le 100
+          mkdir -p dist
+          for name in "$wheel" "$sdist" SHA256SUMS; do
+            count="$(jq --arg name "$name" '[.[] | select(.name == $name)] | length' \
+              "$RUNNER_TEMP/assets.json")"
+            test "$count" -eq 1
+            asset_id="$(jq -r --arg name "$name" '.[] | select(.name == $name) | .id' \
+              "$RUNNER_TEMP/assets.json")"
+            asset_size="$(jq -r --arg name "$name" '.[] | select(.name == $name) | .size' \
+              "$RUNNER_TEMP/assets.json")"
+            [[ "$asset_id" =~ ^[1-9][0-9]*$ ]]
+            [[ "$asset_size" =~ ^[1-9][0-9]*$ ]]
+            gh api -H 'Accept: application/octet-stream' \
+              "repos/$REPOSITORY/releases/assets/$asset_id" > "dist/$name"
+            test "$(stat --format '%s' "dist/$name")" = "$asset_size"
+          done
+          (
+            cd dist
+            sha256sum --check --strict SHA256SUMS
+          )
+          rm dist/SHA256SUMS
+          python src/clio_relay/ci_validation.py distribution-archives \
+            --wheel "dist/$wheel" \
+            --sdist "dist/$sdist" \
+            --project clio-relay \
+            --version "$version" \
+            --output "$RUNNER_TEMP/DISTRIBUTION-ARCHIVES.json"
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+      - name: publish the exact attached wheel and source distribution
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
-          name: release-binding-${{ github.ref_name }}
-          path: TAG-BINDING.json
-          if-no-files-found: error
-          retention-days: 90
+          packages-dir: dist/
+          skip-existing: true

--- a/README.md
+++ b/README.md
@@ -8,39 +8,15 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> The current development candidate is `1.1.0`. The `v1.0.0` candidate
-> was abandoned before publication after its acceptance runbook rejected the
-> staged GNU checksum format; `v1.0.1` was also abandoned before publication
-> after protected-main validation exposed a Windows lease-deletion race;
-> `v1.0.2` was abandoned before publication when candidate acceptance found a
-> strict-mode Spack JSON-array parsing defect in the reviewed runbook;
-> `v1.0.3` was abandoned before any reports were produced when candidate
-> acceptance found that Windows checkout CRLF bytes had been copied directly
-> into a remote shell fixture; `v1.0.4` was abandoned before any reports were
-> produced when the corrected fixture reached CMake and exposed that the direct
-> Gray-Scott helper did not bind the selected Spack ADIOS2 package's own CMake
-> configuration; `v1.0.5` was abandoned after one failed bootstrap report when
-> Ares exposed a lexical-versus-canonical home-path mismatch in the JARVIS-CD
-> wheel provenance check; `v1.0.6` was abandoned after one failed bootstrap
-> report exposed the same mount-alias boundary in persistent uv-tool provider,
-> distribution-source, and receipt verification; `v1.0.7` was abandoned after
-> one failed bootstrap report exposed that the pre-1.0 state audit rejected
-> valid v0.9.22 output events and production-sized event histories before
-> migration; `v1.0.8` was abandoned before candidate staging when protected-main
-> validation exposed a concurrent per-job lease-index read/delete race;
-> `v1.0.9` was abandoned after one failed bootstrap report exposed an escaping
-> defect in the generated Python receipt writer; `v1.0.10` was abandoned before
-> candidate staging when its tag gate caught a stale exact matrix-digest test
-> constant. The latest released live evidence is `0.9.22`; `1.1.0` is not
-> release-complete until its digest-bound
-> candidate reports pass, its exact candidate is published, and the released-artifact
-> runs pass again. The published 1.0 GitHub release is intentionally mutable.
-> The 1.1 release system requires repository-enforced immutable releases and
-> build-once merge-queue evidence. The policy currently selects the `ares` and `homelab`
-> evidence labels; those labels are release configuration, not hardcoded
-> product targets, and operators can select additional or different clusters.
-> The coordinated JARVIS-CD 1.2.2 and clio-kit 2.3.2 artifacts are exact pins;
-> older component artifacts cannot satisfy the 1.0 gate.
+> Version `1.1.1` uses a release-first patch process. A maintainer builds the
+> wheel and source distribution once, attaches those exact bytes and their
+> checksums to a GitHub Release, and publishes the release immediately. Tag
+> regression jobs and the trusted PyPI upload then run asynchronously; they do
+> not hold the maintainer session open or delay continued live testing. A
+> failure is reproduced with a focused test and corrected in the next patch.
+> The `ares` and `homelab` names in the current acceptance policy are evidence
+> labels for this release, not product allowlists. Operators can register other
+> clusters without changing relay code.
 
 ## How It Works
 

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.1.0"
+$Version = "1.1.1"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.1.0"
+release_version: "1.1.1"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: f4a4c47353e63dadfecd5118612a4acf11452018efe1c7df9e9b495d066c65c4
+acceptance_matrix_sha256: 486080ef7a950d88518dcd3e561c76afef64fd297fca8c114469d02b08e62f1a
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,546 +1,120 @@
-# release
+# Release process
 
-`clio-relay` uses `uv`, hatchling, and a staged GitHub Actions release. The
-merge queue builds one wheel and one source distribution and validates those
-same bytes across the complete operating-system and Python matrix. A later tag
-only binds the protected `main` commit and its Git tree to that sealed candidate;
-it never rebuilds or reruns the full matrix. Protected-main code attests the
-candidate, maintainer-sealed live evidence gates PyPI, and released-artifact
-evidence exercises the public persistent `uv tool` path. Finalization publishes
-the draft once, waits for GitHub release immutability, and verifies the release
-attestation and every asset.
+`clio-relay` uses a release-first patch workflow. Publication is a maintainer
+action, not the final step of a long GitHub Actions pipeline.
 
-## local checks
+## Operating rule
 
-Run the same checks as the release builder before tagging:
+For a bug fix, add a focused test that reproduces the failure, implement the
+fix, and run only that focused test locally. Then push the branch, open and
+merge the pull request, tag the merged commit, and publish the GitHub Release
+immediately. Do not wait for pull-request, `main`, tag, or release workflows.
+
+GitHub runs the full regression matrix on the tag. After the GitHub Release is
+published, `release.yml` downloads its wheel and source distribution by numeric
+release-asset ID, verifies `SHA256SUMS` and archive metadata, and sends those
+exact attached bytes to PyPI through trusted publishing and the `pypi`
+environment. These jobs are asynchronous. Check their state after publication,
+but continue live testing while they run. If an asynchronous check fails,
+reproduce that failure locally and include its fix with the next patch.
+
+The older staged evidence workflows remain available for acceptance reporting.
+They do not authorize or block immediate GitHub publication or the normal PyPI
+path.
+
+## Version
+
+Update the release version in:
+
+- `pyproject.toml`
+- `src/clio_relay/__init__.py`
+- `docs/release-gate-1.0.yaml`
+- `examples/release-gate/report-matrix-1.0.json`
+- the version-specific acceptance examples and assertions
+
+After editing the matrix, replace `acceptance_matrix_sha256` in the policy with
+the SHA-256 of the exact matrix file.
+
+## Focused validation
+
+Run the new test only. For a release-workflow change, for example:
 
 ```powershell
-uv run ruff check --fix
-uv run ruff format
-uv run pyright
-uv run pytest
-uv run clio-relay release validate-local --project-root .
+uv run pytest tests/test_release_workflows.py `
+  -k "tag_workflow_validates_identity or published_release_uploads_exact"
 ```
 
-`release validate-local` writes stable JSON even when a check fails. Skipped
-tests fail the gate. It exports the exact `uv.lock` dependency set with hashes,
-audits that set with the lock-installed `pip-audit`, builds exactly one wheel
-and source distribution with the exact lock-installed Hatchling backend,
-validates both with the lock-installed Twine, and installs the exact wheel into
-a clean environment containing only hash-checked production dependencies from
-`uv.lock`. It also builds the exact source distribution back into a wheel and
-installs and launches that result in a second clean, hash-locked runtime
-environment. This executable sdist smoke runs only in the unprivileged local
-and primary merge-queue build gate; no write-, OIDC-, environment-, attestation-, or
-promotion-capable job executes candidate distribution code. Its report records
-the distribution paths, sizes, SHA-256 digests,
-backend identity, commands, resolved freeze, and bounded outputs.
-Protected promotion jobs instead inflate the gzip source distribution into a
-private regular temporary file under a hard uncompressed-tar byte ceiling,
-then parse the bounded tar and wheel topology without invoking either archive.
+Formatting or package construction required by the changed surface is not a
+substitute for the focused behavioral test. Do not run the full regression
+suite locally as part of the patch release loop.
 
-CI's primary Ubuntu/Python 3.12 leg runs this artifact-building path once. The
-other five matrix legs use `--prebuilt-artifact-dir`, which requires exactly one
-wheel, one source distribution, and a canonical `SHA256SUMS`. Any extra,
-missing, or changed byte fails before smoke validation, and those legs never
-run `uv build` or rebuild the source distribution. The seal records all six
-report digests and their common distribution digests in
-`CANDIDATE-BUILD.json`.
+## Build exact distributions
 
-The 1.0 policy has an explicit `release_blockers` list. The evaluator fails
-closed even when all acceptance reports pass while any declared blocker
-remains. The reviewed 1.0 candidate has no declared implementation blockers:
-the exact JARVIS-CD and clio-kit releases are pinned, while containment,
-retention, cross-platform CI, and live Gray-Scott proof are enforced by named
-checks and target requirements. Missing evidence still fails the gate. Add a
-new blocker immediately if review discovers work that cannot be represented by
-an existing acceptance requirement, and remove it only after implementation
-and evidence are present on the reviewed release commit.
-
-## bootstrap source
-
-`cluster bootstrap` supports two deployment sources:
-
-- A repository checkout deploys the committed `HEAD`. The checkout must be
-  clean so the remote cluster receives the reviewed tree.
-- An installed wheel deploys packaged JARVIS assets and installs that exact
-  wheel on the remote cluster.
-
-Before tagging, verify the wheel contains
-`clio_relay/assets/jarvis-packages/clio_relay/`. Bootstrap uses that packaged
-asset path and must not depend on a local checkout.
-
-## version and tag
-
-Update both version declarations:
-
-- `pyproject.toml`: `[project].version`
-- `src/clio_relay/__init__.py`: `__version__`
-
-Merge the release change through the configured merge queue. Its
-`merge_group` run must complete the six-leg matrix and create a sealed candidate
-for the tested Git tree. After the queued PR is merged, create and push an exact
-matching tag at protected `main`:
+Build once from the merged release commit:
 
 ```powershell
-$Tag = "v1.1.0"
-git fetch origin main
-$ReviewedMainSha = (git rev-parse refs/remotes/origin/main).Trim()
-if ((git rev-parse HEAD).Trim() -ne $ReviewedMainSha) {
-  throw "release commit is not the exact reviewed origin/main commit"
+Remove-Item -Recurse -Force dist -ErrorAction SilentlyContinue
+uv build --out-dir dist
+uv run twine check dist/*
+$files = Get-ChildItem dist -File | Where-Object {
+  $_.Name.EndsWith(".whl") -or $_.Name.EndsWith(".tar.gz")
 }
-git tag $Tag $ReviewedMainSha
+if ($files.Count -ne 2) { throw "expected one wheel and one source distribution" }
+$lines = foreach ($file in $files | Sort-Object Name) {
+  $digest = (Get-FileHash -Algorithm SHA256 $file.FullName).Hash.ToLower()
+  "$digest  $($file.Name)"
+}
+Set-Content -Encoding ascii -Path dist/SHA256SUMS -Value $lines
+```
+
+Do not rebuild between GitHub publication and PyPI publication. PyPI receives
+the distributions downloaded from the published GitHub Release, not a second
+CI build.
+
+## Push, merge, tag, and publish
+
+The normal order is:
+
+```powershell
+git push -u origin HEAD
+gh pr create --title "fix: ..." --body-file PR.md
+gh pr merge --squash --delete-branch
+git switch main
+git pull --ff-only origin main
+$Tag = "v1.1.1"
+$Commit = (git rev-parse HEAD).Trim()
+git tag $Tag $Commit
 git push origin $Tag
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.1.1" `
+  dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
+gh release edit $Tag --draft=false
 ```
 
-From the tag push until `finalize-release.yml` succeeds, keep `main` frozen at
-`$ReviewedMainSha`. Every privileged stage fetches live `origin/main` again and
-requires it, the protected workflow checkout, and the release tag to identify
-that exact commit. If `main` advances before PyPI publication, abandon the
-candidate and cut a new version from the newly reviewed commit; never move or
-replace the protected tag. Do not merge unrelated work during this window. In
-particular, advancing `main` after PyPI publication would prevent the immutable
-evidence chain from being finalized, because published package versions cannot
-be replaced.
+Creating the draft with all assets first avoids a release-event race: the
+`published` event is emitted only after the exact distributions and checksum
+manifest are attached. Draft state is not a validation pause; publication
+follows immediately in the same command sequence.
 
-All same-tag release workflows use the shared
-`clio-relay-release-<tag>` concurrency group with cancellation disabled. This
-serializes tag binding, staging, both evidence seals, PyPI promotion, and final
-publication. It does not replace the freeze: every privileged stage still
-fetches live `origin/main` and fails unless main, the reviewed SHA, the tag, and
-the protected workflow checkout are identical.
+Repository rules may require a temporary maintainer bypass for an immediate
+merge. If used, snapshot the complete ruleset, change only what is necessary,
+merge, and restore the exact prior ruleset before tagging.
 
-The tag-push workflow rejects a tag that does not match the package version,
-checked-out commit, and freshly fetched `origin/main`. It resolves the merged
-pull request, requires its merge commit to equal the tag, requires the tag's Git
-tree to equal the tested merge-group tree, and downloads the original candidate
-by numeric Actions artifact id and API digest. Its only output is
-`TAG-BINDING.json`. It does not install dependencies, fetch clio-kit, execute
-candidate code, run tests, or build distributions.
+## Post-publication check
 
-After that read-only workflow succeeds, stage the payload by dispatching only
-from protected `main`:
+Check once; do not wait:
 
 ```powershell
-gh workflow run stage-candidate.yml --ref main -f tag=$Tag `
-  -f reviewed_main_sha=$ReviewedMainSha
+gh run list --branch $Tag --limit 10
+gh release view $Tag
 ```
 
-The `live-validation` environment admits staging only from protected `main`.
-Staging verifies the tag-binding artifact first, then downloads the original
-sealed candidate directly by its bound numeric run and artifact ids. It verifies
-the API digest, tested merge-group commit and tree, all eight required jobs,
-merged PR, tag, and protected-main commit before creating `CI-STATUS.json`.
-Protected-main code then records current repository governance, attests the
-bytes, and creates the draft. Neither merge-group nor tag-supplied workflow code receives
-release-write or OIDC authority.
+The expected asynchronous work is:
 
-GitHub's release list can lag immediately after draft creation. Staging retries
-only a conclusively absent draft through the same numeric-ID resolver, ten times
-at three-second intervals. API errors, duplicate tag matches, numeric drift, or
-an unexpected draft state remain immediate failures.
+- the tag identity receipt in `release.yml`;
+- the full tagged regression matrix in `ci.yml`;
+- the published-release trusted PyPI upload in `release.yml`.
 
-An existing draft is reusable only when every staged asset is byte-for-byte
-identical and its complete asset-name set equals the six staged candidate
-assets. The workflow never replaces a candidate distribution.
-
-The 1.1 release line requires repository-enforced immutable releases. Drafts
-remain mutable while evidence is attached. Every release mutation immediately
-rechecks `enabled=true` and `enforced_by_owner=true` through a repository-scoped
-GitHub App token with only Administration read permission. Finalization adds
-`RELEASE-CLAIMS.json` before publication, publishes once, waits for the same
-release id, tag, target, and asset inventory to become immutable, then runs
-`gh release verify` and `gh release verify-asset` for every attached file. A
-rerun after publication performs reads and verification only.
-
-Release workflows never call `PUT` or `DELETE` on the immutable-release setting.
-Changing that repository policy is an owner governance action, not release-job
-authority.
-
-## live validation of the candidate
-
-The cluster labels named in `release-gate-1.0.yaml` are the concrete evidence
-instances selected for this release, not an allowlist in the product. Any
-operator can add another physical target through the cluster registry and can
-make it release-blocking by adding requirements for that label to the policy.
-Adding a target or changing the evidence matrix requires configuration and
-policy updates only, with no target-name branch in relay code.
-
-Download the draft wheel and manifest, verify both the digest and the signed
-protected-main staging provenance, and compute the digest locally:
-
-```powershell
-$Tag = "v1.1.0"
-New-Item -ItemType Directory -Force .clio-relay\candidate | Out-Null
-gh release download $Tag --pattern "*.whl" --pattern "SHA256SUMS" `
-  --dir .clio-relay\candidate
-$Wheel = (Get-ChildItem .clio-relay\candidate\*.whl).FullName
-$Expected = ((Get-FileHash -Algorithm SHA256 $Wheel).Hash).ToLowerInvariant()
-$WheelName = Split-Path $Wheel -Leaf
-$ManifestLine = Get-Content .clio-relay\candidate\SHA256SUMS |
-  Where-Object { $_ -match " [ *]$([Regex]::Escape($WheelName))$" }
-if ($ManifestLine -notmatch "^$Expected [ *]") { throw "candidate digest mismatch" }
-$Commit = gh api "repos/iowarp/clio-relay/commits/$Tag" --jq .sha
-gh attestation verify $Wheel `
-  --repo iowarp/clio-relay `
-  --signer-workflow iowarp/clio-relay/.github/workflows/stage-candidate.yml `
-  --source-ref refs/heads/main `
-  --source-digest $Commit `
-  --deny-self-hosted-runners
-```
-
-Every acceptance command for the evidence instances currently named Ares and
-homelab must execute through that local wheel,
-not a checkout or an already published PyPI package. Record its independently
-computed digest in each report:
-
-```powershell
-$env:CLIO_RELAY_VALIDATION_LAUNCHER = "uv-tool"
-$env:CLIO_RELAY_VALIDATION_ARTIFACT_SHA256 = $Expected
-$Source = "wheel:$([Uri]::new($Wheel).AbsoluteUri)"
-$env:UV = (Get-Command uv).Source
-uv tool install --force --python 3.12 --no-config $Wheel
-$Relay = (Get-Command clio-relay).Source
-$env:CLIO_RELAY_VALIDATION_TOOL_EXECUTABLE = $Relay
-
-& $Relay cluster bootstrap `
-  --cluster ares `
-  --relay-wheel $Wheel `
-  --validation-launcher uv-tool `
-  --validation-install-source $Source `
-  --report .clio-relay\validation-reports\validation-ares-bootstrap.json
-
-& $Relay live-test `
-  --cluster ares `
-  --validation-install-source $Source `
-  --jarvis-yaml .\pipeline.yaml `
-  --report .clio-relay\validation-reports\validation-ares-live-test.json
-
-& $Relay jarvis-mcp-validate `
-  --cluster ares `
-  --arguments-json-file .\jarvis-run.json `
-  --validation-launcher uv-tool `
-  --validation-install-source $Source `
-  --report .clio-relay\validation-reports\validation-ares-jarvis-mcp.json
-```
-
-Run every scenario required by the candidate-mode derivation of
-[`release-gate-1.0.yaml`](release-gate-1.0.yaml), including Ares bootstrap,
-JARVIS and non-JARVIS MCP, existing LAMMPS Spack discovery/location plus one
-separate absent-to-fresh-install-to-location transition, explicit SLURM
-phases, a bounded 20-step JARVIS-native Gray-Scott progress and artifact query,
-safe cleanup and explicit owned-job cancellation, homelab transport and
-cleanup, and the gateway runtime.
-Use the executable [1.0 live acceptance runbook](release-acceptance-1.0.md) and
-its tracked policy-defined matrix, which contains 17 reports for 1.0. The matrix
-carries a canonical semantic SHA-256, the candidate and released filename
-prefixes, and the ordered logical report identities. Candidate and released
-preflight reject any missing, extra, renamed, or reordered logical entry; the
-policy evaluator then requires every report declared by that matrix to
-participate in a satisfied requirement. Protected workflows derive their report
-cardinality from the self-digested matrix, so extending the release to another
-target changes policy evidence and its digest, not workflow code. Both seals,
-both decisions, and final claims bind the same matrix digest and order. The
-runbook assigns fresh candidate or released pipeline, session, gateway,
-invocation, report, and output identities and keeps the two evidence stages
-disjoint.
-Upload each unique machine-readable report to the draft without replacing an
-earlier report:
-
-```powershell
-gh release upload $Tag .clio-relay\validation-reports\validation-*.json
-```
-
-An uploaded JSON file is not promotion evidence by itself. These reports are
-generated by an operator-run validation process; they do not contain a TPM,
-target-held signing key, or other independent proof that the target executed
-the recorded commands. After every required report is present, dispatch the
-attestation workflow from protected `main`, passing the candidate tag as verified
-data:
-
-```powershell
-gh workflow run live-validation-attest.yml --ref main -f tag=$Tag
-```
-
-The repository's current GitHub plan does not support environment required-
-reviewer rules. A write-capable repository maintainer must manually dispatch
-sealing from protected `main`; the workflow resolves that actor to a positive
-GitHub identity and requires `write`, `maintain`, or `admin` permission. The
-maintainer may also be the source author, report producer, or report uploader.
-The seal is therefore maintainer authorization and integrity binding, not an
-independent review claim. All privileged environments admit only protected-
-branch dispatches and disable administrator bypass. This is a trust boundary,
-not defense in depth: a tag dispatch would let the tag supply the code that
-validates itself. The workflow requires protected `main`, the tag commit, and
-the checked-out source to be identical, then checks every non-local report's
-passing status, exact tag and commit, clean source identity, detected wheel
-install source, persistent uv-tool launcher and RECORD closure, distribution
-version, and candidate wheel digest.
-It then runs the candidate-mode gate with protected-main code and locked dependencies;
-the candidate wheel remains inert in every write-, OIDC-, and attestation-
-capable job. The operator-produced reports, not execution inside the privileged
-job, prove that the exact wheel ran on each selected target. The workflow signs
-every live JSON report and a deterministic
-`LIVE-VALIDATION-BINDING.json` that lists the exact report filenames, report
-ids, scenarios, clusters, and SHA-256 digests. Re-uploaded, added, or modified
-reports invalidate promotion unless the authorized workflow seals the exact new
-set. The binding labels this trust boundary as
-`maintainer_sealed_operator_evidence`, records the sealer's numeric GitHub
-identity and write-capable permission, and explicitly records
-`producer_execution_verified=false`; neither the GitHub attestation nor the
-release notes may be described as independent target-produced proof.
-
-The release policy also requires every non-local report to contain exactly one
-evidenced, verified physical `cluster_target`. The gate validates its live
-hostname, SSH host key, scheduler provider, and optional scheduler/site markers
-against the operator pins. It records a canonical target-identity SHA-256 for
-each cluster label and fails if any report reuses a label for a different
-physical identity. These labels are evidence keys for this release, not a
-runtime target allowlist. Operators can register arbitrary cluster targets, and
-a later release can add any of them to `policy.targets` and `requirements`
-without changing relay code.
-
-The 1.0 worker and JARVIS requirements also verify two receipt-bound native
-capabilities: JARVIS-CD must expose its execution handle, record, progress, and
-query APIs in its execution interpreter, and the released clio-kit wheel must
-expose the locked JARVIS MCP contract with those exact schemas. Legacy
-`clio_relay.package_progress_adapters` entry points remain compatibility
-diagnostics, but they are neither required nor accepted as native release
-evidence.
-
-These are immutable-candidate reports, not released-artifact reports. Their
-`released_artifact` field remains false because PyPI publication has not yet
-occurred. They can authorize publication of the exact bytes to PyPI, but they
-cannot authorize a 1.0 claim or publication of the GitHub release.
-
-Diagnostic checkout runs and wheels from any other build may find defects, but
-they cannot satisfy the release gate.
-
-## publish the candidate to PyPI
-
-Run the `publish validated candidate to PyPI` workflow with the draft tag:
-
-```powershell
-gh workflow run release-gate.yml --ref main -f tag=$Tag `
-  -f reviewed_main_sha=$ReviewedMainSha
-```
-
-The workflow:
-
-1. resolves the tag to its commit and requires it to equal both the explicitly
-   supplied reviewed main SHA and a freshly fetched `origin/main`;
-2. requires the complete draft asset-name set to contain only the authorized
-   candidate inputs (plus exact idempotent promotion-record names on recovery),
-   then downloads exactly one wheel, one source distribution, the local report,
-   every live validation report, and the authorized binding;
-3. independently checks `SHA256SUMS`; parses every wheel and source-distribution
-   member with strict path, type, count, per-file, compressed, and uncompressed
-   aggregate bounds; verifies both core-metadata identities; and verifies the
-   GitHub attestation identity for protected-main
-   `.github/workflows/stage-candidate.yml` and the reviewed commit;
-4. verifies the binding and every live report were attested by the protected-
-   `main` `.github/workflows/live-validation-attest.yml` at that same commit, then
-   rejects missing, extra, modified, or differently bound reports;
-5. derives a candidate-mode policy from the final policy and runs the
-   protected-main gate over reports bound to the independently computed
-   candidate digest, without importing or executing either downloaded
-   distribution;
-6. publishes only the verified wheel and source distribution to PyPI through
-   the OIDC-scoped `pypi` environment;
-7. verifies PyPI reports the exact candidate filenames and digests; and
-8. attests and attaches `PYPI-PROMOTION.json` while requiring the GitHub
-   release to remain a draft.
-
-Promotion is recovery-safe after a partial run. If the version is absent from
-PyPI, the workflow uploads both distributions. If PyPI already has an exact
-subset of the candidate files, the workflow preserves those bytes and uploads
-only the missing distribution. If the complete filename-to-SHA-256 map already
-matches, it skips the upload and continues. Any additional filename or digest
-mismatch fails closed. `skip-existing` is enabled only after that preflight so
-an interrupted two-file upload is rerunnable; a mandatory postflight then
-requires the complete PyPI map to equal the candidate exactly. The workflow
-does not rebuild distributions, accept a caller-supplied digest, or publish the
-GitHub release. A rerun after successful PyPI publication verifies the existing
-bytes, regenerates the same publication record, and continues without upload.
-If a prior run already attached either recovery asset, the workflow verifies
-its GitHub attestation and requires the candidate decision to be byte-identical
-to a fresh gate result. An existing promotion record must also be
-byte-identical to a record regenerated from the current PyPI filename, URL, and
-digest map. These checks run in the gate and again immediately before the PyPI
-state decision.
-
-## live validation of the released artifact
-
-After `PYPI-PROMOTION.json` is attached, rerun every required Ares and homelab
-scenario through the actual index-resolved package. Do not pass a wheel path or
-override the install source. Preserve the independently verified published
-wheel digest in each report:
-
-```powershell
-$Version = $Tag.TrimStart("v")
-New-Item -ItemType Directory -Force .clio-relay\published | Out-Null
-gh release download $Tag --pattern "PYPI-PROMOTION.json" `
-  --dir .clio-relay\published
-$Promotion = Get-Content .clio-relay\published\PYPI-PROMOTION.json | ConvertFrom-Json
-$env:CLIO_RELAY_VALIDATION_LAUNCHER = "uv-tool"
-$env:CLIO_RELAY_VALIDATION_ARTIFACT_SHA256 = $Promotion.wheel_sha256
-$env:UV = (Get-Command uv).Source
-Remove-Item Env:UV_INDEX, Env:UV_EXTRA_INDEX_URL, Env:UV_INDEX_URL `
-  -ErrorAction SilentlyContinue
-
-uv tool install --force --refresh --no-config `
-  --default-index https://pypi.org/simple `
-  --python 3.12 "clio-relay==$Version"
-$Relay = (Get-Command clio-relay).Source
-$env:CLIO_RELAY_VALIDATION_TOOL_EXECUTABLE = $Relay
-
-& $Relay cluster bootstrap --cluster ares `
-  --validation-launcher uv-tool `
-  --validation-install-source "pypi:clio-relay==$Version" `
-  --report .clio-relay\validation-reports\released-validation-ares-bootstrap.json
-
-& $Relay live-test --cluster ares --jarvis-yaml .\pipeline.yaml `
-  --report .clio-relay\validation-reports\released-validation-ares-live-test.json
-
-& $Relay jarvis-mcp-validate `
-  --cluster ares `
-  --arguments-json-file .\jarvis-run.json `
-  --validation-launcher uv-tool `
-  --report .clio-relay\validation-reports\released-validation-ares-jarvis-mcp.json
-```
-
-The report must detect `pypi` itself as both its effective and detected install
-source, record launcher `uv-tool`, verify its persistent environment and
-installed RECORD closure, set `released_artifact` true, and match the published
-wheel digest. Renaming a candidate report does not satisfy this contract.
-Upload the distinct released reports without replacing assets, then
-seal them from protected `main`:
-
-```powershell
-gh release upload $Tag `
-  .clio-relay\validation-reports\released-validation-*.json
-gh workflow run released-validation-attest.yml --ref main -f tag=$Tag
-```
-
-Released-evidence sealing applies the same write-capable maintainer dispatch
-rule and permits that maintainer to seal evidence they produced or uploaded.
-The workflow verifies
-the signed PyPI promotion record, current PyPI filenames and
-digests, every released report's exact source identity, and the final published
-policy. It evaluates that policy with protected-main code and locked
-dependencies; it does not execute either the draft wheel or the PyPI package in
-the privileged sealing job. Instead, every accepted report must prove that its
-operator installed `clio-relay==<version>` once with `uv tool install` against
-the public PyPI index, reused that persistent executable, and bound the exact
-published digest. The workflow signs every released
-report, `RELEASED-VALIDATION-BINDING.json`, and
-`released-release-gate-1.0.json`.
-
-## finalize the GitHub release
-
-Only after released evidence is sealed, dispatch:
-
-```powershell
-gh workflow run finalize-release.yml --ref main -f tag=$Tag `
-  -f reviewed_main_sha=$ReviewedMainSha
-```
-
-The finalization environment admits only protected branches and cannot be
-bypassed by administrators. The workflow
-reverifies the full build, candidate, PyPI, and released-evidence
-attestation chain; requires the final policy decision to pass with no remaining
-blockers; confirms the current PyPI map still equals the candidate bytes; and
-creates `RELEASE-CLAIMS.json`. Immediately after live mutation-authority
-revalidation and before publication it requires the complete GitHub release
-asset set to equal the attested distributions, reports, bindings, decisions,
-promotion record, manifest, and claims file by exact asset id, name, size, and
-SHA-256 digest, with no additional payloads. Both reads request a 100-record
-first page and an explicit second page; the configured 96-asset ceiling and an
-empty second page are recorded in the inventory, so pagination cannot silently
-truncate the comparison. After publication it requires the captured inventory
-to remain byte-for-byte and id-for-id identical before the
-workflow can succeed. The claims file separates the local quality gate from
-only those live requirements and reports selected through the released-artifact
-path. The workflow attaches and attests
-the claim set before making the GitHub release public. A retry after publication
-succeeds only when the claim asset and generated release notes are unchanged and
-the claim digest has an authorized `finalize-release.yml` attestation from the
-exact protected-main commit. It declares immutable publication in the claims
-before publishing. No asset is created, replaced, or attached after the draft
-becomes public. A published rerun requires `immutable=true`, verifies unchanged
-notes and inventory, and executes only release and asset verification reads.
-
-## owner setup for 1.1
-
-The following setup is intentionally outside workflow authority:
-
-1. Create a GitHub App installed only on `iowarp/clio-relay` with repository
-   Administration **read** permission and no write permissions. Store its app id
-   in the repository variable `IMMUTABLE_RELEASES_APP_ID` and its private key in
-   the repository secret `IMMUTABLE_RELEASES_PRIVATE_KEY`.
-2. Enable immutable releases for the repository and require owner enforcement.
-   The read endpoint must return exactly `enabled=true` and
-   `enforced_by_owner=true` with API version `2026-03-10`.
-3. Exercise a disposable merge-queue canary before changing the production
-   ruleset. The canary must prove the observed `merge_group` head/base refs, the
-   merge-group anchor PR number, the final squash-merged PR commit, identical
-   tested/release Git trees, artifact retention, and rerun behavior, including
-   a group containing more than one PR.
-4. After that canary passes, configure the `main` ruleset with the existing
-   review, conversation, deletion, force-push, and exact status-check controls,
-   plus this merge queue contract:
-
-   - `check_response_timeout_minutes: 60`
-   - `grouping_strategy: ALLGREEN`
-   - `max_entries_to_build: 5`
-   - `max_entries_to_merge: 5`
-   - `merge_method: SQUASH`
-   - `min_entries_to_merge: 1`
-   - `min_entries_to_merge_wait_minutes: 0`
-
-The release governance receipt fails closed until all four steps are complete.
-No workflow in this repository creates the app, enables immutable releases, or
-changes repository rules.
-
-## PyPI trusted publishing
-
-Configure PyPI trusted publishing for:
-
-- project: `clio-relay`
-- owner: `iowarp`
-- repository: `clio-relay`
-- workflow: `release-gate.yml`
-- environment: `pypi`
-
-The publication uses OpenID Connect and needs no PyPI token. Every privileged
-environment must set `protected_branches=true`,
-`custom_branch_policies=false`, and `can_admins_bypass=false`; a `v*` environment
-policy is insufficient because an unreviewed tag can contain a modified workflow
-at the trusted publisher's configured path. If the repository plan supports
-environment required-reviewer rules, enable them for `pypi` and
-`release-finalization` as defense in depth. The release chain does not claim
-those optional rules are active.
-
-Repository governance is proved from GitHub's effective rules for `main`, not
-from the legacy branch-protection administration endpoint. The effective rule
-set must enforce strict results from actionlint, the exact six matrix jobs, and
-the candidate seal; require the exact merge-queue parameters above;
-pull-request-only changes, stale-review dismissal, conversation resolution, no
-force pushes, and no deletion. For 1.0, the receipt records the explicit
-`single-maintainer` review policy: the repository has no second eligible
-collaborator, so the ruleset must require exactly zero approvals and must not
-require an impossible last-pusher approval. Enabling independent review later
-requires a reviewed policy change rather than silently changing the live rule.
-Active tag rules must prevent `v*` update and deletion. Detailed ruleset
-responses must report that the current workflow token can never bypass each
-contributing ruleset.
-GitHub may omit the global `bypass_actors` list for the workflow token; receipts
-record whether that list was visible and never convert an omitted list into a
-false empty-list claim. Global actor policy therefore remains an administrator
-audit, while the automated decision proves the current token's non-bypass
-status.
-
-Do not cut a new artifact for the same version after a partial publication;
-rerun the workflow so its preflight can verify and complete the exact file set.
-Protect release tags so only reviewed release commits can invoke staging and
-attestation workflows.
+Live released-artifact validation can begin as soon as the GitHub Release is
+public. The acceptance procedure and machine-readable report schema remain in
+[`release-acceptance-1.0.md`](release-acceptance-1.0.md) and
+[`release-gate-1.0.yaml`](release-gate-1.0.yaml).

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.1.0",
+  "release_version": "1.1.1",
   "matrix_sha256": "f4a4c47353e63dadfecd5118612a4acf11452018efe1c7df9e9b495d066c65c4",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.1.0"
+version = "1.1.1"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -51,7 +51,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
 
 def test_candidate_manifest_parser_accepts_the_exact_gnu_checksum_separator() -> None:
     digest = "a" * 64
-    wheel_name = "clio_relay-1.1.0-py3-none-any.whl"
+    wheel_name = "clio_relay-1.1.1-py3-none-any.whl"
     selector = re.compile(rf"^[0-9A-Fa-f]{{64}} [ *]{re.escape(wheel_name)}$")
     parser = re.compile(r"^([0-9A-Fa-f]{64}) [ *](.+)$")
 

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -22,23 +22,22 @@ def _workflow(name: str) -> dict[str, Any]:
     return cast(dict[str, Any], document)
 
 
-def test_tag_workflow_only_binds_the_unprivileged_merge_queue_payload() -> None:
+def test_tag_workflow_validates_identity_without_blocking_publication() -> None:
     workflow = _workflow("release.yml")
     jobs = cast(dict[str, dict[str, Any]], workflow["jobs"])
     text = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
 
-    assert "gh-action-pypi-publish" not in text
     assert "actions/attest@" not in text
     assert "gh release create" not in text
     assert "gh release upload" not in text
-    assert "environment:" not in text
     assert "--clobber" not in text
-    assert set(jobs) == {"bind"}
+    assert set(jobs) == {"bind", "publish-pypi"}
     assert workflow["permissions"] == {
         "actions": "read",
         "contents": "read",
         "pull-requests": "read",
     }
+    assert jobs["bind"]["if"] == "github.event_name == 'push'"
     steps = cast(list[dict[str, Any]], jobs["bind"]["steps"])
     checkout = next(step for step in steps if "actions/checkout@" in str(step.get("uses")))
     assert cast(dict[str, str], checkout["with"])["persist-credentials"] == "false"
@@ -50,7 +49,41 @@ def test_tag_workflow_only_binds_the_unprivileged_merge_queue_payload() -> None:
     assert "release validate-local" not in text
     assert "uv build" not in text
     assert "TAG-BINDING.json" in text
-    assert "--artifact-kind candidate" in text
+    assert "merge_queue" not in text
+    assert "release-candidate-" not in text
+
+
+def test_published_release_uploads_exact_attached_distributions_asynchronously() -> None:
+    workflow = _workflow("release.yml")
+    release_trigger = cast(dict[str, Any], cast(dict[str, Any], workflow["on"])["release"])
+    jobs = cast(dict[str, dict[str, Any]], workflow["jobs"])
+    publish = jobs["publish-pypi"]
+    text = str(publish)
+
+    assert release_trigger["types"] == ["published"]
+    assert publish["if"] == (
+        "github.event_name == 'release' && github.repository == 'iowarp/clio-relay'"
+    )
+    assert cast(dict[str, str], publish["environment"])["name"] == "pypi"
+    assert publish["permissions"] == {
+        "actions": "read",
+        "contents": "read",
+        "id-token": "write",
+    }
+    assert "github.event.release.tag_name" in text
+    assert "github.event.release.id" in text
+    assert "releases/assets/$asset_id" in text
+    assert "sha256sum --check --strict SHA256SUMS" in text
+    assert "distribution-archives" in text
+    publish_step = next(
+        step
+        for step in cast(list[dict[str, Any]], publish["steps"])
+        if str(step.get("uses", "")).startswith("pypa/gh-action-pypi-publish@")
+    )
+    assert cast(dict[str, str], publish_step["with"])["packages-dir"] == "dist/"
+    assert "actions/create-github-app-token@" not in text
+    assert "IMMUTABLE_RELEASES" not in text
+    assert "merge_queue" not in text
 
 
 def test_same_tag_release_stages_share_one_non_canceling_concurrency_group() -> None:
@@ -872,9 +905,10 @@ def test_privileged_dispatches_run_only_from_protected_main() -> None:
             )
             assert cast(dict[str, str], checkout["with"])["ref"] == checkout_refs[job_name]
             assert cast(dict[str, str], checkout["with"])["ref"] != "${{ inputs.tag }}"
-    candidate = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
-    assert "environment:" not in candidate
-    assert "gh-action-pypi-publish" not in candidate
+    workflow = _workflow("release.yml")
+    jobs = cast(dict[str, dict[str, Any]], workflow["jobs"])
+    assert "environment" not in jobs["bind"]
+    assert "gh-action-pypi-publish" not in str(jobs["bind"])
 
 
 def test_release_workflows_preflight_bounded_report_assets() -> None:

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1612,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.1.0"
+    assert policy.release_version == "1.1.1"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- makes tag regressions asynchronous instead of a publication prerequisite
- publishes exact GitHub Release wheel/sdist bytes to PyPI through the existing trusted publisher
- removes merge-queue, GitHub App, and immutable-release dependencies from the immediate path
- documents the release-first patch workflow and bumps the package to 1.1.1

## Focused validation

- `uv run pytest tests/test_release_workflows.py -k "tag_workflow_validates_identity_without_blocking_publication or published_release_uploads_exact_attached_distributions_asynchronously"` (2 passed)
