### PR TITLE
fix: publish PyPI from release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ name: validate release tag asynchronously
 on:
   push:
     tags: ["v*"]
-  release:
-    types: [published]
 
 concurrency:
   group: clio-relay-release-${{ github.ref_name }}
@@ -87,7 +85,7 @@ jobs:
 
   publish-pypi:
     name: publish exact GitHub Release distributions to PyPI
-    if: github.event_name == 'release' && github.repository == 'iowarp/clio-relay'
+    if: github.event_name == 'push' && github.repository == 'iowarp/clio-relay'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
@@ -101,37 +99,44 @@ jobs:
       - name: check out the exact release tag
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.sha }}
           fetch-depth: 1
           persist-credentials: false
       - name: verify the published release identity and download exact assets
         id: identity
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_DRAFT: ${{ github.event.release.draft }}
-          RELEASE_ID: ${{ github.event.release.id }}
-          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
-          RELEASE_TARGET: ${{ github.event.release.target_commitish }}
           REPOSITORY: ${{ github.repository }}
-          TAG_NAME: ${{ github.event.release.tag_name }}
+          SOURCE_COMMIT: ${{ github.sha }}
+          TAG_NAME: ${{ github.ref_name }}
         shell: bash
         run: |
           set -euo pipefail
-          test "$GITHUB_EVENT_ACTION" = "published"
-          test "$RELEASE_DRAFT" = "false"
-          test "$RELEASE_PRERELEASE" = "false"
-          [[ "$RELEASE_ID" =~ ^[1-9][0-9]*$ ]]
           [[ "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]
+          [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
 
-          gh api "repos/$REPOSITORY/releases/$RELEASE_ID" > "$RUNNER_TEMP/release.json"
-          test "$(jq -r .id "$RUNNER_TEMP/release.json")" = "$RELEASE_ID"
+          for attempt in $(seq 1 20); do
+            if gh api "repos/$REPOSITORY/releases/tags/$TAG_NAME" \
+              > "$RUNNER_TEMP/release.json" 2>/dev/null \
+              && test "$(jq -r .draft "$RUNNER_TEMP/release.json")" = "false" \
+              && test "$(jq -r .prerelease "$RUNNER_TEMP/release.json")" = "false"; then
+              break
+            fi
+            if test "$attempt" -eq 20; then
+              echo "published GitHub Release did not appear for $TAG_NAME" >&2
+              exit 1
+            fi
+            sleep 3
+          done
+          release_id="$(jq -r .id "$RUNNER_TEMP/release.json")"
+          [[ "$release_id" =~ ^[1-9][0-9]*$ ]]
           test "$(jq -r .tag_name "$RUNNER_TEMP/release.json")" = "$TAG_NAME"
           test "$(jq -r .draft "$RUNNER_TEMP/release.json")" = "false"
           test "$(jq -r .prerelease "$RUNNER_TEMP/release.json")" = "false"
 
           source_commit="$(gh api "repos/$REPOSITORY/commits/$TAG_NAME" --jq .sha)"
+          test "$source_commit" = "$SOURCE_COMMIT"
           test "$source_commit" = "$(git rev-parse HEAD)"
-          test "$RELEASE_TARGET" = "$source_commit"
           test "$(jq -r .target_commitish "$RUNNER_TEMP/release.json")" = "$source_commit"
 
           version="$(python - "$TAG_NAME" <<'PY'
@@ -153,7 +158,7 @@ jobs:
           wheel="clio_relay-${version}-py3-none-any.whl"
           sdist="clio_relay-${version}.tar.gz"
 
-          gh api "repos/$REPOSITORY/releases/$RELEASE_ID/assets?per_page=100" \
+          gh api "repos/$REPOSITORY/releases/$release_id/assets?per_page=100" \
             > "$RUNNER_TEMP/assets.json"
           test "$(jq length "$RUNNER_TEMP/assets.json")" -le 100
           mkdir -p dist

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.1.1` uses a release-first patch process. A maintainer builds the
+> Version `1.1.2` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.1.1"
+$Version = "1.1.2"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.1.1"
+release_version: "1.1.2"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 486080ef7a950d88518dcd3e561c76afef64fd297fca8c114469d02b08e62f1a
+acceptance_matrix_sha256: 1431c9681d661a28e25bb7faa734f4517d41f3b45e617f3d0d518af54bd3bff2
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -81,11 +81,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.1.1"
+$Tag = "v1.1.2"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.1.1" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.1.2" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.1.1",
+  "release_version": "1.1.2",
   "matrix_sha256": "f4a4c47353e63dadfecd5118612a4acf11452018efe1c7df9e9b495d066c65c4",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.1.1"
+version = "1.1.2"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -51,7 +51,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
 
 def test_candidate_manifest_parser_accepts_the_exact_gnu_checksum_separator() -> None:
     digest = "a" * 64
-    wheel_name = "clio_relay-1.1.1-py3-none-any.whl"
+    wheel_name = "clio_relay-1.1.2-py3-none-any.whl"
     selector = re.compile(rf"^[0-9A-Fa-f]{{64}} [ *]{re.escape(wheel_name)}$")
     parser = re.compile(r"^([0-9A-Fa-f]{64}) [ *](.+)$")
 

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -38,6 +38,7 @@ def test_tag_workflow_validates_identity_without_blocking_publication() -> None:
         "pull-requests": "read",
     }
     assert jobs["bind"]["if"] == "github.event_name == 'push'"
+    assert cast(dict[str, Any], workflow["on"]) == {"push": {"tags": ["v*"]}}
     steps = cast(list[dict[str, Any]], jobs["bind"]["steps"])
     checkout = next(step for step in steps if "actions/checkout@" in str(step.get("uses")))
     assert cast(dict[str, str], checkout["with"])["persist-credentials"] == "false"
@@ -53,16 +54,14 @@ def test_tag_workflow_validates_identity_without_blocking_publication() -> None:
     assert "release-candidate-" not in text
 
 
-def test_published_release_uploads_exact_attached_distributions_asynchronously() -> None:
+def test_tag_push_uploads_exact_release_distributions_asynchronously() -> None:
     workflow = _workflow("release.yml")
-    release_trigger = cast(dict[str, Any], cast(dict[str, Any], workflow["on"])["release"])
     jobs = cast(dict[str, dict[str, Any]], workflow["jobs"])
     publish = jobs["publish-pypi"]
     text = str(publish)
 
-    assert release_trigger["types"] == ["published"]
     assert publish["if"] == (
-        "github.event_name == 'release' && github.repository == 'iowarp/clio-relay'"
+        "github.event_name == 'push' && github.repository == 'iowarp/clio-relay'"
     )
     assert cast(dict[str, str], publish["environment"])["name"] == "pypi"
     assert publish["permissions"] == {
@@ -70,8 +69,11 @@ def test_published_release_uploads_exact_attached_distributions_asynchronously()
         "contents": "read",
         "id-token": "write",
     }
-    assert "github.event.release.tag_name" in text
-    assert "github.event.release.id" in text
+    assert "github.ref_name" in text
+    assert "github.sha" in text
+    assert "releases/tags/$TAG_NAME" in text
+    assert "for attempt in $(seq 1 20)" in text
+    assert "sleep 3" in text
     assert "releases/assets/$asset_id" in text
     assert "sha256sum --check --strict SHA256SUMS" in text
     assert "distribution-archives" in text
@@ -84,6 +86,7 @@ def test_published_release_uploads_exact_attached_distributions_asynchronously()
     assert "actions/create-github-app-token@" not in text
     assert "IMMUTABLE_RELEASES" not in text
     assert "merge_queue" not in text
+    assert "github.event.release" not in text
 
 
 def test_same_tag_release_stages_share_one_non_canceling_concurrency_group() -> None:

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1612,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.1.1"
+    assert policy.release_version == "1.1.2"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- restores tag push as the sole trusted-PyPI workflow trigger
- retries the immediately-created GitHub Release by tag without blocking publication
- verifies target commit, package version, checksum manifest, and exact numeric release assets before OIDC upload
- bumps the patch release to 1.1.2

## Focused validation

- `uv run pytest tests/test_release_workflows.py -k "tag_workflow_validates_identity_without_blocking_publication or tag_push_uploads_exact_release_distributions_asynchronously"` (2 passed)
