### PR TITLE
fix: migrate existing Windows relay configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.1.2` uses a release-first patch process. A maintainer builds the
+> Version `1.1.3` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.1.2"
+$Version = "1.1.3"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.1.2"
+release_version: "1.1.3"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 1431c9681d661a28e25bb7faa734f4517d41f3b45e617f3d0d518af54bd3bff2
+acceptance_matrix_sha256: cca4a4d9f354c83ccc7c46344aa8e0a45700903d34d557e8ae16b0d76a5c5536
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -32,8 +32,9 @@ Update the release version in:
 - `examples/release-gate/report-matrix-1.0.json`
 - the version-specific acceptance examples and assertions
 
-After editing the matrix, replace `acceptance_matrix_sha256` in the policy with
-the SHA-256 of the exact matrix file.
+After editing the matrix, recompute its canonical SHA-256 with the
+`matrix_sha256` field omitted, then store that digest in both `matrix_sha256`
+and the policy's `acceptance_matrix_sha256` field.
 
 ## Focused validation
 
@@ -81,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.1.2"
+$Tag = "v1.1.3"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.1.2" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.1.3" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.1.2",
-  "matrix_sha256": "f4a4c47353e63dadfecd5118612a4acf11452018efe1c7df9e9b495d066c65c4",
+  "release_version": "1.1.3",
+  "matrix_sha256": "cca4a4d9f354c83ccc7c46344aa8e0a45700903d34d557e8ae16b0d76a5c5536",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.1.2"
+version = "1.1.3"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"

--- a/src/clio_relay/cluster_config.py
+++ b/src/clio_relay/cluster_config.py
@@ -845,6 +845,7 @@ def ensure_private_configuration_directory(path: Path) -> None:
                 directory,
                 directory=True,
                 kernel32=kernel32,
+                write_owner=True,
             )
             try:
                 _set_private_windows_acl(
@@ -903,6 +904,7 @@ def _open_windows_configuration_handle(
     *,
     directory: bool,
     kernel32: Any,
+    write_owner: bool = False,
 ) -> ctypes.c_void_p:
     create_file = kernel32.CreateFileW
     create_file.argtypes = [
@@ -918,9 +920,12 @@ def _open_windows_configuration_handle(
     flags = _WINDOWS_FILE_FLAG_OPEN_REPARSE_POINT
     if directory:
         flags |= _WINDOWS_FILE_FLAG_BACKUP_SEMANTICS
+    desired_access = _WINDOWS_GENERIC_READ | _WINDOWS_READ_CONTROL | _WINDOWS_WRITE_DAC
+    if write_owner:
+        desired_access |= _WINDOWS_WRITE_OWNER
     raw_handle = create_file(
         str(path),
-        _WINDOWS_GENERIC_READ | _WINDOWS_READ_CONTROL | _WINDOWS_WRITE_DAC | _WINDOWS_WRITE_OWNER,
+        desired_access,
         _WINDOWS_FILE_SHARE_READ,
         None,
         _WINDOWS_OPEN_EXISTING,
@@ -1403,6 +1408,28 @@ def _set_private_windows_acl(
         if descriptor_owner.value is None:
             raise ConfigurationError(f"private Windows configuration owner has no SID: {path}")
         normalize_owner = owner_sid != user_sid
+        if normalize_owner and owns_handle:
+            _close_windows_handle(handle, kernel32=kernel32)
+            handle = None
+            handle = _open_windows_configuration_handle(
+                path,
+                directory=directory,
+                kernel32=kernel32,
+                write_owner=True,
+            )
+            owner_sid = _windows_object_owner_sid(
+                handle,
+                advapi32=advapi32,
+                kernel32=kernel32,
+                path=path,
+            )
+            _require_current_windows_owner(
+                owner_sid=owner_sid,
+                user_sid=user_sid,
+                default_owner_sid=default_owner_sid,
+                path=path,
+            )
+            normalize_owner = owner_sid != user_sid
         set_security = advapi32.SetSecurityInfo
         set_security.argtypes = [
             ctypes.c_void_p,

--- a/tests/test_ci_clio_kit_wheel.py
+++ b/tests/test_ci_clio_kit_wheel.py
@@ -23,81 +23,80 @@ def _ci_workflow() -> dict[str, Any]:
     return cast(dict[str, Any], document)
 
 
-def test_ci_matrix_stages_exact_clio_kit_wheel_before_evidence_gate() -> None:
-    """Every supported runner must bind gate evidence to the released wheel bytes."""
+def test_ci_jobs_stage_exact_clio_kit_wheel_before_evidence_gate() -> None:
+    """Every evidence-producing CI job must bind to the released wheel bytes."""
     workflow = _ci_workflow()
     jobs = cast(dict[str, dict[str, Any]], workflow["jobs"])
-    test_job = jobs["test"]
-    matrix = cast(dict[str, list[str]], test_job["strategy"]["matrix"])
-    steps = cast(list[dict[str, Any]], test_job["steps"])
-    by_name = {str(step.get("name")): step for step in steps}
-    stage = by_name["stage exact clio-kit release wheel"]
-    stage_index = steps.index(stage)
-    gate_index = steps.index(by_name["run evidence-producing local release gate"])
-
-    assert matrix["os"] == ["ubuntu-latest", "windows-latest"]
-    assert stage_index < gate_index
-    assert stage["shell"] == "bash"
-    assert stage["env"] == {
-        "CLIO_KIT_WHEEL_FILENAME": WHEEL_FILENAME,
-        "CLIO_KIT_WHEEL_SHA256": WHEEL_SHA256,
-        "CLIO_KIT_WHEEL_URL": WHEEL_URL,
+    gate_names = {
+        "build": "run the sole artifact-building release gate",
+        "validate": "validate without rebuilding the distributions",
     }
+
+    for job_name, gate_name in gate_names.items():
+        steps = cast(list[dict[str, Any]], jobs[job_name]["steps"])
+        by_name = {str(step.get("name")): step for step in steps}
+        stage = by_name["stage exact clio-kit release wheel"]
+
+        assert steps.index(stage) < steps.index(by_name[gate_name])
+        assert stage["shell"] == "bash"
+        assert stage["env"] == {
+            "CLIO_KIT_WHEEL_FILENAME": WHEEL_FILENAME,
+            "CLIO_KIT_WHEEL_SHA256": WHEEL_SHA256,
+            "CLIO_KIT_WHEEL_URL": WHEEL_URL,
+        }
+
+    assert jobs["validate"]["needs"] == "build"
 
 
 def test_ci_wheel_download_is_bounded_https_only_and_fail_closed() -> None:
     """The staged dependency must never fall back to mutable index resolution."""
     workflow = _ci_workflow()
     jobs = cast(dict[str, dict[str, Any]], workflow["jobs"])
-    steps = cast(list[dict[str, Any]], jobs["test"]["steps"])
-    stage = next(step for step in steps if step.get("name") == "stage exact clio-kit release wheel")
-    script = str(stage["run"])
+    scripts: dict[str, str] = {}
+    for job_name in ("build", "validate"):
+        steps = cast(list[dict[str, Any]], jobs[job_name]["steps"])
+        stage = next(
+            step for step in steps if step.get("name") == "stage exact clio-kit release wheel"
+        )
+        scripts[job_name] = str(stage["run"])
 
-    for required in (
-        "set -euo pipefail",
-        "--fail",
-        "--location",
-        "--proto '=https'",
-        "--proto-redir '=https'",
-        "--tlsv1.2",
-        "--retry 3",
-        "--retry-all-errors",
-        "--retry-max-time 180",
-        "--connect-timeout 20",
-        "--max-time 180",
-        "sha256sum --check --strict",
-        'if [ "$RUNNER_OS" = Windows ]',
-        "cygpath --windows --absolute",
-        "CLIO_RELAY_CLIO_KIT_WHEEL=%s",
-        "CLIO_RELAY_CLIO_KIT_WHEEL_SHA256=%s",
-        '>> "$GITHUB_ENV"',
-    ):
-        assert required in script
+    for script in scripts.values():
+        for required in (
+            "set -euo pipefail",
+            "umask 077",
+            "--fail",
+            "--location",
+            "--proto '=https'",
+            "--proto-redir '=https'",
+            "--tlsv1.2",
+            "--retry 3",
+            "--retry-all-errors",
+            "--retry-max-time 180",
+            "--connect-timeout 20",
+            "--max-time 180",
+            "sha256sum --check --strict",
+            "CLIO_RELAY_CLIO_KIT_WHEEL=%s",
+            "CLIO_RELAY_CLIO_KIT_WHEEL_SHA256=%s",
+            '>> "$GITHUB_ENV"',
+        ):
+            assert required in script
 
-    assert "pypi.org" not in script
-    assert "pip install" not in script
-    assert "uvx" not in script
-    assert "|| true" not in script
+        assert "pypi.org" not in script
+        assert "pip install" not in script
+        assert "uvx" not in script
+        assert "|| true" not in script
+
+    assert 'if [ "$RUNNER_OS" = Windows ]' in scripts["validate"]
+    assert "cygpath --windows --absolute" in scripts["validate"]
 
 
-def test_tag_payload_gate_stages_the_same_exact_clio_kit_wheel() -> None:
-    """The tag payload's full local gate must receive the release-bound dependency."""
+def test_tag_workflow_does_not_repeat_the_clio_kit_release_gate() -> None:
+    """Tag publication must consume prior build output without rerunning the full gate."""
     workflow = cast(dict[str, Any], yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8")))
     jobs = cast(dict[str, dict[str, Any]], workflow["jobs"])
-    steps = cast(list[dict[str, Any]], jobs["build"]["steps"])
-    by_name = {str(step.get("name")): step for step in steps}
-    stage = by_name["stage exact clio-kit release wheel"]
-    gate = by_name["run evidence-producing local release gate"]
+    serialized = str(workflow)
 
-    assert steps.index(stage) < steps.index(gate)
-    assert stage["env"] == {
-        "CLIO_KIT_WHEEL_FILENAME": WHEEL_FILENAME,
-        "CLIO_KIT_WHEEL_SHA256": WHEEL_SHA256,
-        "CLIO_KIT_WHEEL_URL": WHEEL_URL,
-    }
-    script = str(stage["run"])
-    assert "set -euo pipefail" in script
-    assert "sha256sum --check --strict" in script
-    assert "--proto '=https'" in script
-    assert "CLIO_RELAY_CLIO_KIT_WHEEL=%s" in script
-    assert "CLIO_RELAY_CLIO_KIT_WHEEL_SHA256=%s" in script
+    assert set(jobs) == {"bind", "publish-pypi"}
+    assert "stage exact clio-kit release wheel" not in serialized
+    assert "CLIO_RELAY_CLIO_KIT_WHEEL" not in serialized
+    assert "release validate-local" not in serialized

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1696,7 +1696,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "f4a4c47353e63dadfecd5118612a4acf11452018efe1c7df9e9b495d066c65c4"
+        "cca4a4d9f354c83ccc7c46344aa8e0a45700903d34d557e8ae16b0d76a5c5536"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -237,9 +237,11 @@ def test_windows_nested_configuration_creation_retains_hardened_handles(
         *,
         directory: bool,
         kernel32: object,
+        write_owner: bool,
     ) -> Any:
         nonlocal next_handle
         assert directory
+        assert write_owner
         assert kernel32 is not None
         next_handle += 1
         handle = SimpleNamespace(value=next_handle)
@@ -288,6 +290,59 @@ def test_windows_nested_configuration_creation_retains_hardened_handles(
         ("close", 101),
     ]
     assert open_handles == set()
+
+
+def test_windows_configuration_open_only_requests_owner_change_when_needed(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    requested_access: list[int] = []
+
+    class RecordingCreateFile:
+        argtypes: list[object]
+        restype: object
+
+        def __call__(
+            self,
+            _path: str,
+            desired_access: int,
+            *_args: object,
+        ) -> int:
+            requested_access.append(desired_access)
+            return 100 + len(requested_access)
+
+    kernel32 = SimpleNamespace(CreateFileW=RecordingCreateFile())
+
+    def accept_handle(
+        _handle: ctypes.c_void_p,
+        *,
+        directory: bool,
+        kernel32: object,
+        path: Path,
+    ) -> None:
+        del directory, kernel32, path
+
+    monkeypatch.setattr(
+        cluster_config,
+        "_validate_windows_configuration_handle",
+        accept_handle,
+    )
+
+    cluster_config._open_windows_configuration_handle(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        tmp_path,
+        directory=True,
+        kernel32=kernel32,
+    )
+    cluster_config._open_windows_configuration_handle(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        tmp_path,
+        directory=True,
+        kernel32=kernel32,
+        write_owner=True,
+    )
+
+    assert requested_access[0] & cluster_config._WINDOWS_WRITE_DAC  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    assert not requested_access[0] & cluster_config._WINDOWS_WRITE_OWNER  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    assert requested_access[1] & cluster_config._WINDOWS_WRITE_OWNER  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
 
 
 def test_configuration_read_rejects_foreign_or_group_writable_posix_file(

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -16,6 +16,7 @@ ROOT = Path(__file__).parents[1]
 FIXTURES = ROOT / "examples" / "release-gate"
 RUNBOOK = ROOT / "docs" / "release-acceptance-1.0.md"
 POLICY = ROOT / "docs" / "release-gate-1.0.yaml"
+RELEASE_PROCESS = ROOT / "docs" / "release.md"
 
 
 def _render(path: Path, replacements: dict[str, str]) -> str:
@@ -37,21 +38,39 @@ def _matrix_reports() -> list[dict[str, object]]:
 
 def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook() -> None:
     project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    lock = tomllib.loads((ROOT / "uv.lock").read_text(encoding="utf-8"))
     policy = cast(dict[str, object], yaml.safe_load(POLICY.read_text(encoding="utf-8")))
     matrix = cast(
         dict[str, object],
         json.loads((FIXTURES / "report-matrix-1.0.json").read_text(encoding="utf-8")),
     )
     version = cast(dict[str, object], project["project"])["version"]
+    relay_lock = next(
+        package
+        for package in cast(list[dict[str, object]], lock["package"])
+        if package["name"] == "clio-relay"
+    )
+    init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
+    release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
+    assert version == "1.1.3"
+    assert relay_lock["version"] == version
+    assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version
     assert matrix["release_version"] == version
     assert f'$Version = "{version}"' in RUNBOOK.read_text(encoding="utf-8")
+    assert f'$Tag = "v{version}"' in release_process
+    assert f'--title "clio-relay {version}"' in release_process
+    assert f"> Version `{version}` uses a release-first patch process." in (
+        ROOT / "README.md"
+    ).read_text(encoding="utf-8")
 
 
 def test_candidate_manifest_parser_accepts_the_exact_gnu_checksum_separator() -> None:
     digest = "a" * 64
-    wheel_name = "clio_relay-1.1.2-py3-none-any.whl"
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    version = cast(dict[str, object], project["project"])["version"]
+    wheel_name = f"clio_relay-{version}-py3-none-any.whl"
     selector = re.compile(rf"^[0-9A-Fa-f]{{64}} [ *]{re.escape(wheel_name)}$")
     parser = re.compile(r"^([0-9A-Fa-f]{64}) [ *](.+)$")
 

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -226,13 +226,15 @@ def test_ci_matrix_pins_sync_probe_and_release_gate_to_each_declared_python() ->
     assert "--prebuilt-artifact-dir" not in primary
 
 
-def test_merge_queue_builds_once_and_main_or_tag_never_repeat_the_full_gate() -> None:
+def test_merge_queue_builds_once_main_skips_gate_and_tags_run_regression() -> None:
+    workflow = _workflow("ci.yml")
+    triggers = cast(dict[str, Any], workflow["on"])
     ci = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
     main = (WORKFLOWS / "main-provenance.yml").read_text(encoding="utf-8")
     tag = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
 
     assert "merge_group:" in ci
-    assert "push:" not in ci
+    assert cast(dict[str, list[str]], triggers["push"])["tags"] == ["v*"]
     assert "push:" in main
     assert "record merged-main provenance" in main
     assert "validate-local" not in main

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1612,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.1.2"
+    assert policy.release_version == "1.1.3"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.1.2"
+version = "1.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- open existing Windows configuration paths without requiring `WRITE_OWNER` when the current user already owns them
- request owner-changing rights only for the elevated-token normalization path
- add a focused access-mask regression and prove migration against the existing project configuration
- repair stale asynchronous CI assertions and regenerate the 1.1.3 acceptance-matrix binding

## Root cause

Windows owners can rewrite an object's DACL but do not automatically receive `WRITE_OWNER`. Relay requested that unrelated privilege on every existing configuration directory, so a valid owner-controlled directory with inherited ACLs failed before relay could harden it.

## Validation

- 40 focused tests passed
- Ruff formatting and lint passed
- Pyright passed
- live local migration changed the existing `.clio-relay` directory from inherited ACLs to the exact protected private ACL and `cluster list` succeeded