### PR TITLE
fix: accept scientific catalog MCP contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.2.0` uses a release-first patch process. A maintainer builds the
+> Version `1.2.1` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.2.0"
+$Version = "1.2.1"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.2.0"
+release_version: "1.2.1"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 79b811f2abec6a3f490c523171ee4b395fc32f6aa9bf28eece30f02dd6b4d76c
+acceptance_matrix_sha256: 551f184e27e3ef8e89952f2a7fdcbe3c3aa04efd38150e3b44b5419205ceb13f
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.2.0"
+$Tag = "v1.2.1"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.0" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.1" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.2.0",
-  "matrix_sha256": "79b811f2abec6a3f490c523171ee4b395fc32f6aa9bf28eece30f02dd6b4d76c",
+  "release_version": "1.2.1",
+  "matrix_sha256": "551f184e27e3ef8e89952f2a7fdcbe3c3aa04efd38150e3b44b5419205ceb13f",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.2.0"
+version = "1.2.1"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -1425,7 +1425,10 @@ def remote_mcp_register(
     contract: Annotated[
         str | None,
         typer.Option(
-            help=("Optional audited semantic contract. Supported: clio-kit-spack-user-v2.")
+            help=(
+                "Optional audited semantic contract. Supported: clio-kit-spack-user-v2, "
+                "clio-kit-scientific-catalog-user-v1."
+            )
         ),
     ] = None,
     schema_cache_ttl_seconds: Annotated[

--- a/src/clio_relay/cluster_config.py
+++ b/src/clio_relay/cluster_config.py
@@ -256,7 +256,10 @@ class ClusterTargetIdentity(BaseModel):
 
 
 RemoteMcpProfile = Literal["user", "admin", "operator"]
-RemoteMcpContract = Literal["clio-kit-spack-user-v2"]
+RemoteMcpContract = Literal[
+    "clio-kit-spack-user-v2",
+    "clio-kit-scientific-catalog-user-v1",
+]
 
 
 def _validated_cluster_label(value: str, *, field: str) -> str:

--- a/src/clio_relay/remote_mcp.py
+++ b/src/clio_relay/remote_mcp.py
@@ -81,6 +81,10 @@ CLIO_KIT_SPACK_USER_CONTRACT_ID = "clio-kit-spack-user-v2"
 CLIO_KIT_SPACK_USER_CONTRACT_SHA256 = (
     "3c5412148c770f4844e98eb893c4db0d0afdbf13afe967df67bd5f7d25e1f7db"
 )
+CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ID = "clio-kit-scientific-catalog-user-v1"
+CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256 = (
+    "a53006f24f4698f659f0a7c8bf61fc7bd7ad23274b06d2eed2ccfca68b9ecb0a"
+)
 _COMPOSED_SCHEMA_KEYS = {
     "$dynamicRef",
     "$recursiveRef",
@@ -3312,6 +3316,141 @@ def _spack_user_contract_check(
     )
 
 
+def _scientific_catalog_user_contract_check(
+    entry: RemoteMcpSchemaCacheEntry | None,
+    registration: RemoteMcpServerConfig | None,
+) -> RemoteMcpAcceptanceCheck:
+    """Require the exact read-only scientific catalog surface approved for agents."""
+    expected_names = {"scientific_dataset_describe", "scientific_dataset_search"}
+    tools = {tool.name: tool for tool in entry.tools} if entry is not None else {}
+    actual_names = set(tools)
+    allowlisted_names: set[str] = (
+        set(registration.allow_tools) if registration is not None else set()
+    )
+    observed_contract_digest = remote_mcp_schema_digest(list(tools.values()))
+
+    annotation_matches: dict[str, bool] = {}
+    expected_annotations = {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    }
+    for name in expected_names:
+        tool = tools.get(name)
+        annotations = tool.annotations if tool is not None else None
+        annotation_matches[name] = annotations is not None and all(
+            annotations.get(key) is value for key, value in expected_annotations.items()
+        )
+
+    describe = tools.get("scientific_dataset_describe")
+    describe_input = describe.input_schema if describe is not None else {}
+    describe_input_properties = _as_json(describe_input.get("properties")) or {}
+    describe_required = describe_input.get("required")
+    describe_input_matches = (
+        describe_input.get("type") == "object"
+        and describe_input.get("additionalProperties") is False
+        and set(describe_input_properties) == {"dataset_id"}
+        and _as_json(describe_input_properties.get("dataset_id")) == {"type": "string"}
+        and isinstance(describe_required, list)
+        and cast(list[object], describe_required) == ["dataset_id"]
+    )
+
+    search = tools.get("scientific_dataset_search")
+    search_input = search.input_schema if search is not None else {}
+    search_input_properties = _as_json(search_input.get("properties")) or {}
+    page_size = _as_json(search_input_properties.get("page_size")) or {}
+    search_input_matches = (
+        search_input.get("type") == "object"
+        and search_input.get("additionalProperties") is False
+        and set(search_input_properties)
+        == {"query", "tags", "kind", "format", "page_size", "cursor"}
+        and page_size == {"default": 20, "maximum": 100, "minimum": 1, "type": "integer"}
+        and search_input.get("required", []) == []
+    )
+
+    describe_output = describe.output_schema if describe is not None else None
+    describe_output_properties = (
+        _as_json(describe_output.get("properties")) if describe_output is not None else None
+    ) or {}
+    dataset_schema = _as_json(describe_output_properties.get("dataset")) or {}
+    dataset_properties = _as_json(dataset_schema.get("properties")) or {}
+    descriptor_schema = _as_json(dataset_properties.get("descriptor")) or {}
+    descriptor_properties = _as_json(descriptor_schema.get("properties")) or {}
+    describe_output_matches = (
+        describe_output is not None
+        and describe_output.get("type") == "object"
+        and describe_output.get("additionalProperties") is False
+        and _as_json(describe_output_properties.get("schema_version"))
+        == {
+            "const": "clio-kit.scientific-dataset-description.v1",
+            "default": "clio-kit.scientific-dataset-description.v1",
+            "type": "string",
+        }
+        and descriptor_schema.get("type") == "object"
+        and descriptor_schema.get("additionalProperties") is False
+        and _as_json(descriptor_properties.get("schema_version"))
+        == {"const": "jarvis.dataset-descriptor.v1", "type": "string"}
+    )
+
+    search_output = search.output_schema if search is not None else None
+    search_output_properties = (
+        _as_json(search_output.get("properties")) if search_output is not None else None
+    ) or {}
+    datasets_schema = _as_json(search_output_properties.get("datasets")) or {}
+    dataset_item_schema = _as_json(datasets_schema.get("items")) or {}
+    search_output_matches = (
+        search_output is not None
+        and search_output.get("type") == "object"
+        and search_output.get("additionalProperties") is False
+        and _as_json(search_output_properties.get("schema_version"))
+        == {
+            "const": "clio-kit.scientific-dataset-search.v1",
+            "default": "clio-kit.scientific-dataset-search.v1",
+            "type": "string",
+        }
+        and datasets_schema.get("type") == "array"
+        and dataset_item_schema.get("type") == "object"
+        and dataset_item_schema.get("additionalProperties") is False
+    )
+
+    schema_matches = {
+        "scientific_dataset_describe": describe_input_matches and describe_output_matches,
+        "scientific_dataset_search": search_input_matches and search_output_matches,
+    }
+    passed = (
+        actual_names == expected_names
+        and allowlisted_names == expected_names
+        and registration is not None
+        and registration.contract == CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ID
+        and "user" in registration.profiles
+        and all(annotation_matches.values())
+        and all(schema_matches.values())
+        and observed_contract_digest == CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256
+    )
+    return RemoteMcpAcceptanceCheck(
+        name="remote-mcp.scientific-catalog-user-contract",
+        passed=passed,
+        message=(
+            "Scientific catalog exposes only read-only search and exact descriptor lookup"
+            if passed
+            else "Scientific catalog tools, allowlist, schemas, or safety annotations drifted"
+        ),
+        evidence={
+            "expected_tool_names": sorted(expected_names),
+            "remote_tool_names": sorted(actual_names),
+            "allowlisted_tool_names": sorted(allowlisted_names),
+            "profiles": registration.profiles if registration is not None else [],
+            "declared_contract": registration.contract if registration is not None else None,
+            "annotations_match": annotation_matches,
+            "schemas_match": schema_matches,
+            "expected_contract_sha256": CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256,
+            "expected_clio_kit_version": CLIO_KIT_SPACK_USER_WHEEL_VERSION,
+            "observed_contract_sha256": observed_contract_digest,
+        },
+    )
+
+
 def _declared_contract_check(
     entry: RemoteMcpSchemaCacheEntry | None,
     registration: RemoteMcpServerConfig,
@@ -3319,6 +3458,8 @@ def _declared_contract_check(
     """Evaluate the semantic contract explicitly declared by an operator."""
     if registration.contract == CLIO_KIT_SPACK_USER_CONTRACT_ID:
         return _spack_user_contract_check(entry, registration)
+    if registration.contract == CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ID:
+        return _scientific_catalog_user_contract_check(entry, registration)
     raise ValueError(f"unsupported remote MCP semantic contract: {registration.contract}")
 
 

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1696,7 +1696,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "79b811f2abec6a3f490c523171ee4b395fc32f6aa9bf28eece30f02dd6b4d76c"
+        "551f184e27e3ef8e89952f2a7fdcbe3c3aa04efd38150e3b44b5419205ceb13f"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_clio_kit_mcp_contracts.py
+++ b/tests/test_clio_kit_mcp_contracts.py
@@ -34,6 +34,7 @@ from clio_relay.jarvis_mcp import (
     jarvis_user_contract,
 )
 from clio_relay.remote_mcp import (
+    CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256,
     CLIO_KIT_SPACK_USER_CONTRACT_SHA256,
     CLIO_KIT_SPACK_USER_WHEEL_VERSION,
     RemoteMcpToolSchema,
@@ -83,7 +84,7 @@ EXPECTED_CONTRACTS = {
     "clio-kit-scientific-catalog-user-v1": {
         "server_name": "scientific-catalog",
         "artifact": "scientific-catalog-user-v1.json",
-        "contract_sha256": "a53006f24f4698f659f0a7c8bf61fc7bd7ad23274b06d2eed2ccfca68b9ecb0a",
+        "contract_sha256": CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256,
         "tool_names": {
             "scientific_dataset_describe",
             "scientific_dataset_search",

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.2.0"
+    assert version == "1.2.1"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_remote_mcp.py
+++ b/tests/test_remote_mcp.py
@@ -79,6 +79,14 @@ def test_remote_mcp_registration_is_deny_by_default_and_validated() -> None:
     assert registration.call_timeout_seconds == 300
     assert registration.allows_tool("inspect") is False
 
+    catalog_registration = RemoteMcpServerConfig(
+        command="clio-kit",
+        allow_tools=["scientific_dataset_search", "scientific_dataset_describe"],
+        profiles=["user"],
+        contract="clio-kit-scientific-catalog-user-v1",
+    )
+    assert catalog_registration.contract == "clio-kit-scientific-catalog-user-v1"
+
     with pytest.raises(ValidationError, match="exact names or '\\*' only"):
         RemoteMcpServerConfig(command="science-mcp", allow_tools=["inspect*"])
     with pytest.raises(ValidationError, match="must not be empty"):
@@ -121,6 +129,71 @@ def test_remote_mcp_registration_is_deny_by_default_and_validated() -> None:
                 )
             },
         )
+
+
+def test_scientific_catalog_contract_is_read_only_and_exact(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The released catalog contract must be registrable and fail closed on drift."""
+    expected_names = ["scientific_dataset_describe", "scientific_dataset_search"]
+    registration = RemoteMcpServerConfig(
+        command="uvx",
+        args=[
+            "--from",
+            "/opt/clio/clio_kit-2.4.2-py3-none-any.whl",
+            "clio-kit",
+            "mcp-server",
+            "scientific-catalog",
+        ],
+        allow_tools=expected_names,
+        profiles=["user"],
+        contract="clio-kit-scientific-catalog-user-v1",
+    )
+    tools = [_scientific_catalog_tool(name) for name in expected_names]
+    entry = _entry(
+        registration,
+        cluster="alpha",
+        server_name="scientific-catalog",
+        tools=tools,
+    )
+    monkeypatch.setattr(
+        remote_mcp,
+        "CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256",
+        entry.schema_digest,
+    )
+
+    exact = remote_mcp._declared_contract_check(  # pyright: ignore[reportPrivateUsage]
+        entry, registration
+    )
+
+    assert exact.passed is True
+    assert exact.name == "remote-mcp.scientific-catalog-user-contract"
+    assert exact.evidence["remote_tool_names"] == expected_names
+    assert exact.evidence["allowlisted_tool_names"] == expected_names
+
+    drifted_tools = deepcopy(tools)
+    cast(dict[str, object], drifted_tools[1]["annotations"])["openWorldHint"] = True
+    drifted_entry = _entry(
+        registration,
+        cluster="alpha",
+        server_name="scientific-catalog",
+        tools=drifted_tools,
+    )
+    monkeypatch.setattr(
+        remote_mcp,
+        "CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256",
+        drifted_entry.schema_digest,
+    )
+
+    drifted = remote_mcp._declared_contract_check(  # pyright: ignore[reportPrivateUsage]
+        drifted_entry, registration
+    )
+
+    assert drifted.passed is False
+    assert drifted.evidence["annotations_match"] == {
+        "scientific_dataset_describe": True,
+        "scientific_dataset_search": False,
+    }
 
 
 def test_discovery_artifact_creates_fresh_provenance_cache_entry(tmp_path: Path) -> None:
@@ -1838,6 +1911,62 @@ def test_cli_registers_and_submits_durable_tools_list_job(
     assert job.spec.env_from == {}
     assert job.spec.tool is None
     assert job.spec.arguments == {}
+
+
+def test_cli_registers_released_scientific_catalog_contract(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The operator CLI accepts the catalog contract and preserves its shell-free argv."""
+    monkeypatch.chdir(tmp_path)
+    ClusterRegistry(clusters={"alpha": ClusterDefinition(name="alpha", ssh_host="localhost")}).save(
+        tmp_path / ".clio-relay" / "clusters.json"
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "remote-mcp",
+            "register",
+            "--cluster",
+            "alpha",
+            "--name",
+            "scientific-catalog",
+            "--command",
+            "clio-kit",
+            "--arg",
+            "mcp-server",
+            "--arg",
+            "scientific-catalog",
+            "--arg=--",
+            "--arg=--catalog-file",
+            "--arg",
+            "/srv/catalog/scientific-catalog.json",
+            "--allow-tool",
+            "scientific_dataset_search",
+            "--allow-tool",
+            "scientific_dataset_describe",
+            "--profile",
+            "user",
+            "--contract",
+            "clio-kit-scientific-catalog-user-v1",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    registration = (
+        ClusterRegistry.load(tmp_path / ".clio-relay" / "clusters.json")
+        .require("alpha")
+        .remote_mcp_servers["scientific-catalog"]
+    )
+    assert registration.contract == "clio-kit-scientific-catalog-user-v1"
+    assert registration.args == [
+        "mcp-server",
+        "scientific-catalog",
+        "--",
+        "--catalog-file",
+        "/srv/catalog/scientific-catalog.json",
+    ]
 
 
 def test_cli_refresh_ingests_only_terminal_discovery_artifact(
@@ -4369,6 +4498,101 @@ def _spack_result_schema(name: str) -> dict[str, object]:
             "additionalProperties": False,
         }
     raise AssertionError(f"unexpected Spack tool: {name}")
+
+
+def _scientific_catalog_tool(name: str) -> dict[str, object]:
+    """Return the bounded schema shape required by the scientific catalog contract check."""
+    annotations = {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    }
+    if name == "scientific_dataset_describe":
+        return {
+            "name": name,
+            "description": "Return one exact operator catalog record.",
+            "annotations": annotations,
+            "inputSchema": {
+                "type": "object",
+                "properties": {"dataset_id": {"type": "string"}},
+                "required": ["dataset_id"],
+                "additionalProperties": False,
+            },
+            "outputSchema": {
+                "type": "object",
+                "properties": {
+                    "schema_version": {
+                        "const": "clio-kit.scientific-dataset-description.v1",
+                        "default": "clio-kit.scientific-dataset-description.v1",
+                        "type": "string",
+                    },
+                    "dataset": {
+                        "type": "object",
+                        "properties": {
+                            "descriptor": {
+                                "type": "object",
+                                "properties": {
+                                    "schema_version": {
+                                        "const": "jarvis.dataset-descriptor.v1",
+                                        "type": "string",
+                                    }
+                                },
+                                "additionalProperties": False,
+                            }
+                        },
+                        "additionalProperties": False,
+                    },
+                },
+                "additionalProperties": False,
+            },
+        }
+    if name != "scientific_dataset_search":
+        raise AssertionError(f"unsupported scientific catalog test tool: {name}")
+    nullable_string = {"anyOf": [{"type": "string"}, {"type": "null"}], "default": None}
+    return {
+        "name": name,
+        "description": "Search operator-registered scientific datasets.",
+        "annotations": annotations,
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": nullable_string,
+                "tags": {
+                    "anyOf": [
+                        {"items": {"type": "string"}, "type": "array"},
+                        {"type": "null"},
+                    ],
+                    "default": None,
+                },
+                "kind": nullable_string,
+                "format": nullable_string,
+                "page_size": {
+                    "default": 20,
+                    "maximum": 100,
+                    "minimum": 1,
+                    "type": "integer",
+                },
+                "cursor": nullable_string,
+            },
+            "additionalProperties": False,
+        },
+        "outputSchema": {
+            "type": "object",
+            "properties": {
+                "schema_version": {
+                    "const": "clio-kit.scientific-dataset-search.v1",
+                    "default": "clio-kit.scientific-dataset-search.v1",
+                    "type": "string",
+                },
+                "datasets": {
+                    "type": "array",
+                    "items": {"type": "object", "additionalProperties": False},
+                },
+            },
+            "additionalProperties": False,
+        },
+    }
 
 
 def _spack_tool(name: str) -> dict[str, object]:

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1612,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.2.0"
+    assert policy.release_version == "1.2.1"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- accept the released clio-kit scientific-catalog v1 contract in remote MCP registrations
- enforce the exact two-tool read-only agent surface and descriptor/search schema identities
- preserve shell-free catalog-file argv through the operator CLI
- bump clio-relay to 1.2.1

## Validation
- 7 focused tests passed, including the exact clio-kit 2.4.2 wheel contract
- live contract digest matched a53006f24f4698f659f0a7c8bf61fc7bd7ad23274b06d2eed2ccfca68b9ecb0a
- Ruff and targeted Pyright passed