### PR TITLE
fix: embed relay JARVIS package modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.2.1` uses a release-first patch process. A maintainer builds the
+> Version `1.2.2` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.2.1"
+$Version = "1.2.2"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.2.1"
+release_version: "1.2.2"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 551f184e27e3ef8e89952f2a7fdcbe3c3aa04efd38150e3b44b5419205ceb13f
+acceptance_matrix_sha256: 569375cbf7b4fedb7bbdb206b194aa08077339768b51d8b553553647e6c95af2
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.2.1"
+$Tag = "v1.2.2"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.1" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.2" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.2.1",
-  "matrix_sha256": "551f184e27e3ef8e89952f2a7fdcbe3c3aa04efd38150e3b44b5419205ceb13f",
+  "release_version": "1.2.2",
+  "matrix_sha256": "569375cbf7b4fedb7bbdb206b194aa08077339768b51d8b553553647e6c95af2",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.2.1"
+version = "1.2.2"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"
@@ -40,6 +40,10 @@ packages = ["src/clio_relay"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "jarvis-packages" = "clio_relay/assets/jarvis-packages"
+"jarvis-packages/clio_relay/clio_relay/_jarvis_api.py" = "clio_relay/_jarvis_api.py"
+"jarvis-packages/clio_relay/clio_relay/bounded_command" = "clio_relay/bounded_command"
+"jarvis-packages/clio_relay/clio_relay/mcp_call" = "clio_relay/mcp_call"
+"jarvis-packages/clio_relay/clio_relay/remote_agent" = "clio_relay/remote_agent"
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -1344,8 +1344,12 @@ test -x "$RELAY_PROVIDER_PYTHON"
 uv pip install --python "$JARVIS_VENV/bin/python" \\
   --default-index https://pypi.org/simple \\
   --refresh-package clio-relay "$RELAY_INSTALL_TARGET"
-"$RELAY_PROVIDER_PYTHON" -c 'import clio_relay, jarvis_cd'
-"$JARVIS_VENV/bin/python" -c 'import clio_relay, jarvis_cd'
+JARVIS_PACKAGE_PROBE='import clio_relay, jarvis_cd; '
+JARVIS_PACKAGE_PROBE+='import clio_relay.bounded_command.pkg; '
+JARVIS_PACKAGE_PROBE+='import clio_relay.mcp_call.pkg; '
+JARVIS_PACKAGE_PROBE+='import clio_relay.remote_agent.pkg'
+"$RELAY_PROVIDER_PYTHON" -c "$JARVIS_PACKAGE_PROBE"
+"$JARVIS_VENV/bin/python" -c "$JARVIS_PACKAGE_PROBE"
 verify_jarvis_cd_distribution() {{
   local interpreter="$1"
   "$interpreter" - \\

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -4,6 +4,7 @@ import json
 import re
 import subprocess
 import tarfile
+import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -157,7 +158,9 @@ def test_linux_user_bootstrap_script_installs_required_components() -> None:
         "  --default-index https://pypi.org/simple \\\n"
         '  --refresh-package clio-relay "$RELAY_INSTALL_TARGET"'
     ) in script
-    assert "\"$JARVIS_VENV/bin/python\" -c 'import clio_relay, jarvis_cd'" in script
+    assert "import clio_relay.bounded_command.pkg" in script
+    assert "clio_relay.mcp_call.pkg" in script
+    assert "clio_relay.remote_agent.pkg" in script
     assert "write_install_receipt" in script
     assert '"schema_version": "clio-relay.bootstrap-receipt.v1"' in script
     assert "\"invocation_id\": 'manual'" in script
@@ -190,6 +193,21 @@ def test_linux_user_bootstrap_script_installs_required_components() -> None:
     assert "UV_*|PIP_*) unset" in script
     assert "--index-url https://pypi.org/simple --no-deps --only-binary=:all:" in script
     assert "\r" not in script
+
+
+def test_wheel_embeds_jarvis_package_modules_in_the_installed_namespace() -> None:
+    """JARVIS must import relay packages after the relay distribution is installed."""
+    with Path("pyproject.toml").open("rb") as stream:
+        project = tomllib.load(stream)
+    force_include = project["tool"]["hatch"]["build"]["targets"]["wheel"]["force-include"]
+
+    assert force_include == {
+        "jarvis-packages": "clio_relay/assets/jarvis-packages",
+        "jarvis-packages/clio_relay/clio_relay/_jarvis_api.py": "clio_relay/_jarvis_api.py",
+        "jarvis-packages/clio_relay/clio_relay/bounded_command": "clio_relay/bounded_command",
+        "jarvis-packages/clio_relay/clio_relay/mcp_call": "clio_relay/mcp_call",
+        "jarvis-packages/clio_relay/clio_relay/remote_agent": "clio_relay/remote_agent",
+    }
 
 
 def test_linux_user_bootstrap_embedded_python_programs_compile() -> None:

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1696,7 +1696,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "551f184e27e3ef8e89952f2a7fdcbe3c3aa04efd38150e3b44b5419205ceb13f"
+        "569375cbf7b4fedb7bbdb206b194aa08077339768b51d8b553553647e6c95af2"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5600,7 +5600,12 @@ def test_cli_remote_gateway_passthrough_uses_cluster_core(
         commands.append(command)
         assert capture_output is True
         assert check is False
-        return subprocess.CompletedProcess(command, 0, b'{"session_id":"gateway_remote"}\n', b"")
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            (b'{"session_id":"gateway_remote","cluster":"ares","name":"live-service-example"}\n'),
+            b"",
+        )
 
     monkeypatch.setattr("clio_relay.remote_cli.subprocess.run", fake_run)
 

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.2.1"
+    assert version == "1.2.2"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1612,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.2.1"
+    assert policy.release_version == "1.2.2"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.2.1"
+version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- Embed the relay-owned JARVIS package modules in the installed `clio-relay` namespace.
- Verify those modules are importable from both bootstrap Python environments.
- Preserve the existing JARVIS package IDs and queued-pipeline compatibility.
- Refresh the complete remote-gateway fixture exposed by the asynchronous v1.2.1 checks.

## Why

A released relay installation shadowed the staged JARVIS repository namespace, preventing generic remote-MCP jobs from importing their package implementations.

## Validation

- Focused bootstrap, installed-wheel import, gateway passthrough, release identity, policy, and matrix tests pass.
- The exact JARVIS 1.3.1 in-process discovery path loads all three package IDs.
- Ruff and strict Pyright checks pass.