### PR TITLE
fix: support MCP sessions in JARVIS workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.2.3` uses a release-first patch process. A maintainer builds the
+> Version `1.2.4` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.2.3"
+$Version = "1.2.4"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.2.3"
+release_version: "1.2.4"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: a51ff021a59ab6971bb75d6818948e279cec0e0c96427f4c680384b7e2c9a90d
+acceptance_matrix_sha256: 10a1ec05da56076ad008dbaf7a4624167452cb39e0a6c0c618c57de7476fad48
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.2.3"
+$Tag = "v1.2.4"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.3" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.4" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.2.3",
-  "matrix_sha256": "a51ff021a59ab6971bb75d6818948e279cec0e0c96427f4c680384b7e2c9a90d",
+  "release_version": "1.2.4",
+  "matrix_sha256": "10a1ec05da56076ad008dbaf7a4624167452cb39e0a6c0c618c57de7476fad48",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/jarvis-packages/clio_relay/clio_relay/mcp_call/runner.py
+++ b/jarvis-packages/clio_relay/clio_relay/mcp_call/runner.py
@@ -4398,6 +4398,12 @@ def _install_parent_termination_handlers(
     process: subprocess.Popen[str],
 ) -> dict[int, _SignalHandler]:
     """Ensure outer JARVIS termination cleans the separately-owned MCP group."""
+    # Python signal handlers are process-global and may only be installed by the
+    # main interpreter thread. Durable JARVIS executions invoke package start
+    # hooks from a worker thread, where the session's ``finally`` block and the
+    # relay containment boundary own child cleanup instead.
+    if threading.current_thread() is not threading.main_thread():
+        return {}
     previous: dict[int, _SignalHandler] = {}
     terminating = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.2.3"
+version = "1.2.4"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.2.3"
+__version__ = "1.2.4"

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1696,7 +1696,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "a51ff021a59ab6971bb75d6818948e279cec0e0c96427f4c680384b7e2c9a90d"
+        "10a1ec05da56076ad008dbaf7a4624167452cb39e0a6c0c618c57de7476fad48"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_mcp_call_runner.py
+++ b/tests/test_mcp_call_runner.py
@@ -229,6 +229,56 @@ for line in sys.stdin:
     assert "distribution RECORD closure" in result["server_artifact"]["identity_error"]
 
 
+def test_mcp_session_runs_inside_jarvis_worker_thread(tmp_path: Path) -> None:
+    """A durable JARVIS package may execute the MCP session off the main thread."""
+    runner = _load_runner()
+    server_path = tmp_path / "threaded_stdio_server.py"
+    server_path.write_text(
+        """import json
+import sys
+
+for line in sys.stdin:
+    message = json.loads(line)
+    method = message.get("method")
+    if method == "initialize":
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "threaded-test-server", "version": "1.0"},
+            },
+        }), flush=True)
+    elif method == "tools/list":
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "result": {"tools": []},
+        }), flush=True)
+        break
+""",
+        encoding="utf-8",
+    )
+
+    def run_in_worker() -> subprocess.CompletedProcess[str]:
+        return cast(Any, runner)._run_mcp_session(
+            [sys.executable, str(server_path)],
+            tool=None,
+            arguments={},
+            timeout=10,
+            operation="tools/list",
+            env_from={},
+        )
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        result = executor.submit(run_in_worker).result(timeout=20)
+
+    assert result.returncode == 0
+    assert "threaded-test-server" in result.stdout
+    assert result.stderr == ""
+
+
 def test_direct_console_launcher_binds_real_distribution_record_and_detects_mutation(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.2.3"
+    assert version == "1.2.4"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1612,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.2.3"
+    assert policy.release_version == "1.2.4"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.2.3"
+version = "1.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- avoid installing process-global signal handlers when a durable JARVIS package runs an MCP session off the main thread
- retain child cleanup through the session `finally` block and relay containment boundary
- add a real stdio subprocess regression test for the JARVIS worker-thread execution path
- advance release identity and acceptance bindings to 1.2.4

## Focused validation
- new worker-thread reproducer passes
- related real stdio discovery test passes
- release identity/matrix tests pass
- Ruff and Pyright pass