### PR TITLE
fix: bind symlinked uv tool runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.2.4` uses a release-first patch process. A maintainer builds the
+> Version `1.2.5` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.2.4"
+$Version = "1.2.5"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.2.4"
+release_version: "1.2.5"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 10a1ec05da56076ad008dbaf7a4624167452cb39e0a6c0c618c57de7476fad48
+acceptance_matrix_sha256: 49dc1315c674fa387ef658a3f203171e6f259f6edb789f0056ec040998409bea
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.2.4"
+$Tag = "v1.2.5"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.4" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.5" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.2.4",
-  "matrix_sha256": "10a1ec05da56076ad008dbaf7a4624167452cb39e0a6c0c618c57de7476fad48",
+  "release_version": "1.2.5",
+  "matrix_sha256": "49dc1315c674fa387ef658a3f203171e6f259f6edb789f0056ec040998409bea",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/jarvis-packages/clio_relay/clio_relay/mcp_call/runner.py
+++ b/jarvis-packages/clio_relay/clio_relay/mcp_call/runner.py
@@ -3134,8 +3134,13 @@ def _external_python_console_distribution_identity(
     if not shebang.startswith("#!") or not shebang[2:]:
         evidence["error"] = "persistent tool launcher has no direct Python interpreter shebang"
         return evidence
+    provider_launcher = Path(shebang[2:]).expanduser()
+    if not provider_launcher.is_absolute():
+        evidence["error"] = "persistent tool provider interpreter path is not absolute"
+        return evidence
     try:
-        provider = Path(shebang[2:]).expanduser().resolve(strict=True)
+        provider_launcher_identity = _file_descriptor_identity(provider_launcher.lstat())
+        provider = provider_launcher.resolve(strict=True)
     except OSError as exc:
         evidence["error"] = f"persistent tool provider interpreter is unavailable: {exc}"
         return evidence
@@ -3200,7 +3205,7 @@ print(json.dumps({"matches": matches}, sort_keys=True))
 """
     try:
         completed = subprocess.run(
-            [str(provider), "-I", "-c", probe, command_name, str(executable)],
+            [str(provider_launcher), "-I", "-c", probe, command_name, str(executable)],
             check=False,
             capture_output=True,
             text=True,
@@ -3208,6 +3213,19 @@ print(json.dumps({"matches": matches}, sort_keys=True))
         )
     except (OSError, subprocess.SubprocessError, UnicodeError) as exc:
         evidence["error"] = f"persistent tool distribution probe failed: {exc}"
+        return evidence
+    try:
+        launcher_after = _file_descriptor_identity(provider_launcher.lstat())
+        provider_after = provider_launcher.resolve(strict=True)
+    except OSError as exc:
+        evidence["error"] = f"persistent tool provider interpreter changed: {exc}"
+        return evidence
+    if (
+        launcher_after != provider_launcher_identity
+        or provider_after != provider
+        or _file_identity(provider) != provider_identity
+    ):
+        evidence["error"] = "persistent tool provider interpreter changed during inspection"
         return evidence
     stdout_bytes = completed.stdout.encode("utf-8")
     if (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.2.4"
+version = "1.2.5"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.2.4"
+__version__ = "1.2.5"

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1696,7 +1696,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "10a1ec05da56076ad008dbaf7a4624167452cb39e0a6c0c618c57de7476fad48"
+        "49dc1315c674fa387ef658a3f203171e6f259f6edb789f0056ec040998409bea"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_mcp_call_runner.py
+++ b/tests/test_mcp_call_runner.py
@@ -398,6 +398,47 @@ def test_persistent_uv_tool_clio_kit_runtime_is_receipt_bindable(
     assert identity["verified"] is True
 
 
+def test_external_console_probe_preserves_logical_provider_path(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A symlink-style tool interpreter path must retain its venv context."""
+    runner = _load_runner()
+    provider = tmp_path / "tool" / "bin" / "python"
+    provider.parent.mkdir(parents=True)
+    provider.write_bytes(b"provider")
+    logical_provider = provider.parent / ".." / "bin" / provider.name
+    launcher = tmp_path / "science-mcp"
+    launcher.write_text(f"#!{logical_provider}\n", encoding="utf-8")
+    captured: dict[str, list[str]] = {}
+
+    def run_probe(
+        command: list[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        captured["command"] = command
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps({"matches": []}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(cast(Any, runner).subprocess, "run", run_probe)
+
+    evidence = cast(Any, runner)._external_python_console_distribution_identity(
+        launcher,
+        command_name="science-mcp",
+    )
+
+    assert captured["command"][0] == str(logical_provider)
+    assert captured["command"][0] != str(logical_provider.resolve())
+    assert (
+        evidence["error"]
+        == "persistent tool launcher has no unique installed console-script distribution"
+    )
+
+
 def test_mcp_call_runner_supports_server_arguments(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.2.4"
+    assert version == "1.2.5"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1612,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.2.4"
+    assert policy.release_version == "1.2.5"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.2.4"
+version = "1.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- preserve the logical Python shebang path when inspecting isolated persistent `uv tool` environments
- bind and recheck both the launcher entry and canonical provider interpreter around the external metadata probe
- add a regression test proving symlink-style provider paths retain virtual-environment context
- advance release identity and acceptance bindings to 1.2.5

## Focused validation
- new logical-provider-path test passes
- real distribution RECORD closure/mutation test passes
- release identity/matrix tests pass
- Ruff and Pyright pass