### PR TITLE
fix: isolate worker service environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.2.5` uses a release-first patch process. A maintainer builds the
+> Version `1.2.6` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.2.5"
+$Version = "1.2.6"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.2.5"
+release_version: "1.2.6"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 49dc1315c674fa387ef658a3f203171e6f259f6edb789f0056ec040998409bea
+acceptance_matrix_sha256: 98f27666c3aa858ec37e27945230f5892ad8fc95485eb391c6c427f68d6a3b01
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.2.5"
+$Tag = "v1.2.6"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.5" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.6" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.2.5",
-  "matrix_sha256": "49dc1315c674fa387ef658a3f203171e6f259f6edb789f0056ec040998409bea",
+  "release_version": "1.2.6",
+  "matrix_sha256": "98f27666c3aa858ec37e27945230f5892ad8fc95485eb391c6c427f68d6a3b01",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.2.5"
+version = "1.2.6"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"

--- a/src/clio_relay/deployment.py
+++ b/src/clio_relay/deployment.py
@@ -59,6 +59,7 @@ def render_endpoint_user_service(
         JARVIS_MCP_COMMAND_ENV,
         os.environ.get(JARVIS_MCP_COMMAND_ENV),
     )
+    jarvis_mcp_unset_line = "" if jarvis_mcp_line else f"UnsetEnvironment={JARVIS_MCP_COMMAND_ENV}"
     jarvis_mcp_spack_line = _optional_environment_line(
         JARVIS_MCP_SPACK_COMMAND_ENV,
         (
@@ -70,6 +71,9 @@ def render_endpoint_user_service(
             else None
         ),
         allow_home_specifier=(spack_source is not None and remote_value_expands_home(spack_source)),
+    )
+    jarvis_mcp_spack_unset_line = (
+        "" if jarvis_mcp_spack_line else f"UnsetEnvironment={JARVIS_MCP_SPACK_COMMAND_ENV}"
     )
     exec_start_arguments = [
         relay_bin,
@@ -138,6 +142,8 @@ Environment="PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin"
 Environment="{INSTALL_RECEIPT_PATH_ENV}=%h/.local/share/clio-relay/install-receipt.json"
 {jarvis_mcp_line}
 {jarvis_mcp_spack_line}
+{jarvis_mcp_unset_line}
+{jarvis_mcp_spack_unset_line}
 ExecStartPre={exec_start_pre}
 ExecStart={exec_start}
 Restart=on-failure

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1696,7 +1696,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "49dc1315c674fa387ef658a3f203171e6f259f6edb789f0056ec040998409bea"
+        "98f27666c3aa858ec37e27945230f5892ad8fc95485eb391c6c427f68d6a3b01"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_doctor_and_relay_host.py
+++ b/tests/test_doctor_and_relay_host.py
@@ -214,6 +214,22 @@ def test_endpoint_user_service_uses_cluster_executable_overrides() -> None:
     assert 'Environment="JARVIS_MCP_SPACK_COMMAND=/opt/site/spack/bin/spack"' in rendered
     assert 'Environment="CLIO_RELAY_FRPC_BIN=/opt/frp/frpc"' in rendered
     assert 'Environment="CLIO_RELAY_AGENT_BIN=/opt/agents/clio"' in rendered
+    assert "UnsetEnvironment=JARVIS_MCP_SPACK_COMMAND" not in rendered
+
+
+def test_endpoint_user_service_unsets_absent_optional_manager_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stale systemd-manager overrides cannot leak into a generated worker unit."""
+    monkeypatch.delenv("CLIO_RELAY_JARVIS_MCP_COMMAND", raising=False)
+
+    rendered = render_endpoint_user_service(
+        cluster="test-cluster",
+        definition=ClusterDefinition(name="test-cluster", ssh_host="test-host"),
+    )
+
+    assert "UnsetEnvironment=CLIO_RELAY_JARVIS_MCP_COMMAND" in rendered
+    assert "UnsetEnvironment=JARVIS_MCP_SPACK_COMMAND" in rendered
 
 
 def test_endpoint_user_service_passes_optional_jarvis_mcp_command(
@@ -233,6 +249,7 @@ def test_endpoint_user_service_passes_optional_jarvis_mcp_command(
         'Environment="CLIO_RELAY_JARVIS_MCP_COMMAND=[\\"uvx\\",\\"--from\\",'
         '\\"git+https://github.com/iowarp/clio-kit.git@branch\\",\\"clio-kit\\"]"'
     ) in rendered
+    assert "UnsetEnvironment=CLIO_RELAY_JARVIS_MCP_COMMAND" not in rendered
 
 
 def test_endpoint_user_service_escapes_arbitrary_labels_and_values() -> None:

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.2.5"
+    assert version == "1.2.6"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1612,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.2.5"
+    assert policy.release_version == "1.2.6"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.2.5"
+version = "1.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- make generated worker services explicitly remove absent optional JARVIS MCP and Spack variables inherited from the user systemd manager
- preserve explicit operator overrides when configured
- add focused coverage for stale-manager isolation
- advance release identity and acceptance bindings to 1.2.6

## Focused validation
- new absent-override service test passes
- explicit override rendering test passes
- release identity/matrix tests pass
- Ruff and Pyright pass