### PR TITLE
fix: validate persistent remote MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.2.6` uses a release-first patch process. A maintainer builds the
+> Version `1.2.7` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.2.6"
+$Version = "1.2.7"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.2.6"
+release_version: "1.2.7"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 98f27666c3aa858ec37e27945230f5892ad8fc95485eb391c6c427f68d6a3b01
+acceptance_matrix_sha256: 201b38bb93941d8d80bc1518b5cf27de7f2bc269af7aefa33e66de7a4d0aaf1f
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.2.6"
+$Tag = "v1.2.7"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.6" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.7" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.2.6",
-  "matrix_sha256": "98f27666c3aa858ec37e27945230f5892ad8fc95485eb391c6c427f68d6a3b01",
+  "release_version": "1.2.7",
+  "matrix_sha256": "201b38bb93941d8d80bc1518b5cf27de7f2bc269af7aefa33e66de7a4d0aaf1f",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.2.6"
+version = "1.2.7"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.2.6"
+__version__ = "1.2.7"

--- a/src/clio_relay/remote_mcp.py
+++ b/src/clio_relay/remote_mcp.py
@@ -1776,6 +1776,9 @@ def build_remote_mcp_acceptance_report(
     stdio_call_passed = mcp_stdio_evidence is None or (
         stdio_initialize_passed and stdio_call_job_id == call_job_id
     )
+    expected_server_artifact_digest = (
+        selected_route.expected_server_artifact_digest if selected_route is not None else None
+    )
     call_passed = (
         job.get("job_id") == call_job_id
         and job.get("cluster") == cluster
@@ -1786,6 +1789,8 @@ def build_remote_mcp_acceptance_report(
         and spec.get("env_from", {}) == registration.env_from
         and spec.get("operation") == "tools/call"
         and spec.get("tool") == remote_tool_name
+        and _is_sha256(expected_server_artifact_digest)
+        and spec.get("expected_server_artifact_digest") == expected_server_artifact_digest
         and stdio_call_passed
     )
     checks.append(
@@ -1802,6 +1807,7 @@ def build_remote_mcp_acceptance_report(
                 "cluster": job.get("cluster"),
                 "kind": job.get("kind"),
                 "spec": spec,
+                "selected_route_server_artifact_digest": expected_server_artifact_digest,
                 "stdio_call_job_id": stdio_call_job_id,
                 "packaged_stdio": mcp_stdio_evidence or {},
             },
@@ -1814,14 +1820,23 @@ def build_remote_mcp_acceptance_report(
         else None
     )
     discovery_server_artifact = entry.provenance.server_artifact if entry is not None else None
+    computed_server_artifact_digest = (
+        remote_mcp_server_artifact_digest(call_server_artifact)
+        if call_server_artifact is not None
+        else None
+    )
     server_artifact_passed = (
         call_server_artifact is not None
         and call_server_artifact.get("verified") is True
         and call_server_artifact.get("server_process_artifact_verified") is True
         and bool(call_server_artifact.get("executable"))
-        and call_server_artifact.get("install_source") == "wheel"
+        and _immutable_remote_mcp_install_verified(call_server_artifact)
         and _is_sha256(call_server_artifact.get("install_artifact_sha256"))
         and call_server_artifact == discovery_server_artifact
+        and computed_server_artifact_digest == expected_server_artifact_digest
+        and mcp_result is not None
+        and mcp_result.get("expected_server_artifact_digest") == expected_server_artifact_digest
+        and mcp_result.get("observed_server_artifact_digest") == expected_server_artifact_digest
     )
     checks.append(
         RemoteMcpAcceptanceCheck(
@@ -1835,6 +1850,18 @@ def build_remote_mcp_acceptance_report(
             evidence={
                 "discovery_server_artifact": discovery_server_artifact or {},
                 "call_server_artifact": call_server_artifact or {},
+                "selected_route_server_artifact_digest": expected_server_artifact_digest,
+                "computed_server_artifact_digest": computed_server_artifact_digest,
+                "result_expected_server_artifact_digest": (
+                    mcp_result.get("expected_server_artifact_digest")
+                    if mcp_result is not None
+                    else None
+                ),
+                "result_observed_server_artifact_digest": (
+                    mcp_result.get("observed_server_artifact_digest")
+                    if mcp_result is not None
+                    else None
+                ),
             },
         )
     )
@@ -3902,6 +3929,32 @@ def _server_artifact_verified(server_artifact: JSON) -> bool:
         server_artifact.get("verified") is True
         and server_artifact.get("server_process_artifact_verified") is True
         and isinstance(server_artifact.get("executable"), dict)
+    )
+
+
+def _immutable_remote_mcp_install_verified(server_artifact: JSON) -> bool:
+    """Accept immutable wheel launches and wheel-backed persistent uv tools."""
+    install_source = server_artifact.get("install_source")
+    if install_source == "wheel":
+        return True
+    if install_source != "uv-tool":
+        return False
+    install_spec = server_artifact.get("install_spec")
+    python_runtime = server_artifact.get("python_distribution_runtime")
+    if (
+        not isinstance(install_spec, str)
+        or not install_spec.lower().endswith(".whl")
+        or not isinstance(python_runtime, dict)
+        or cast(JSON, python_runtime).get("runtime_closure_verified") is not True
+    ):
+        return False
+    if server_artifact.get("nested_launcher") is not True:
+        return True
+    nested_runtime = server_artifact.get("nested_runtime")
+    return (
+        isinstance(nested_runtime, dict)
+        and cast(JSON, nested_runtime).get("persistent_tool") is True
+        and cast(JSON, nested_runtime).get("locked_runtime_verified") is True
     )
 
 

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1696,7 +1696,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "98f27666c3aa858ec37e27945230f5892ad8fc95485eb391c6c427f68d6a3b01"
+        "201b38bb93941d8d80bc1518b5cf27de7f2bc269af7aefa33e66de7a4d0aaf1f"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.2.6"
+    assert version == "1.2.7"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_remote_mcp.py
+++ b/tests/test_remote_mcp.py
@@ -2031,6 +2031,8 @@ def test_cli_refresh_ingests_only_terminal_discovery_artifact(
 
 def test_acceptance_report_has_canonical_checks_and_durable_provenance() -> None:
     registration = _registration(namespace="science", profiles=["user"])
+    server_artifact = _server_artifact(registration)
+    server_artifact_digest = remote_mcp_server_artifact_digest(server_artifact)
     registry = ClusterRegistry(clusters={"alpha": _cluster("alpha", {"spack": registration})})
     cache = RemoteMcpSchemaCache(
         entries=[_entry(registration, cluster="alpha", server_name="spack")]
@@ -2047,6 +2049,7 @@ def test_acceptance_report_has_canonical_checks_and_durable_provenance() -> None
             "operation": "tools/call",
             "tool": "inspect",
             "arguments": {"path": "/data/run"},
+            "expected_server_artifact_digest": server_artifact_digest,
         },
     }
     artifacts = [
@@ -2072,7 +2075,9 @@ def test_acceptance_report_has_canonical_checks_and_durable_provenance() -> None
             "arguments": {"path": "/data/run"},
             "returncode": 0,
             "protocol_result": {"content": [{"type": "text", "text": "ok"}]},
-            "server_artifact": _server_artifact(registration),
+            "server_artifact": server_artifact,
+            "expected_server_artifact_digest": server_artifact_digest,
+            "observed_server_artifact_digest": server_artifact_digest,
             "protocol_error": None,
         },
         provenance={"job": job},
@@ -2105,6 +2110,139 @@ def test_acceptance_report_has_canonical_checks_and_durable_provenance() -> None
     assert server_resource.metadata["install_source"] == "wheel"
 
 
+@pytest.mark.parametrize(
+    (
+        "runtime_closure_verified",
+        "locked_runtime_verified",
+        "artifact_digest_bound",
+        "expected",
+    ),
+    [
+        (True, True, True, True),
+        (False, True, True, False),
+        (True, False, True, False),
+        (True, True, False, False),
+    ],
+)
+def test_acceptance_report_requires_verified_persistent_uv_tool_runtime(
+    runtime_closure_verified: bool,
+    locked_runtime_verified: bool,
+    artifact_digest_bound: bool,
+    expected: bool,
+) -> None:
+    registration = RemoteMcpServerConfig(
+        command="clio-kit",
+        args=["mcp-server", "scientific-catalog"],
+        allow_tools=["scientific_dataset_search"],
+        profiles=["user"],
+        namespace="scientific_catalog",
+    )
+    server_artifact: dict[str, object] = {
+        "requested_command": "clio-kit",
+        "resolved_executable": "/opt/clio-kit/bin/clio-kit",
+        "executable": {
+            "path": "/opt/clio-kit/bin/clio-kit",
+            "filename": "clio-kit",
+            "sha256": "a" * 64,
+            "size_bytes": 256,
+        },
+        "install_spec": "/opt/wheels/clio_kit-2.4.2-py3-none-any.whl",
+        "install_source": "uv-tool",
+        "install_artifact_sha256": "b" * 64,
+        "python_distribution_runtime": {
+            "runtime_closure_verified": runtime_closure_verified,
+        },
+        "nested_launcher": True,
+        "nested_runtime": {
+            "persistent_tool": True,
+            "locked_runtime_verified": locked_runtime_verified,
+        },
+        "launcher_artifact_verified": True,
+        "server_process_artifact_verified": True,
+        "identity_error": None,
+        "verified": True,
+    }
+    server_artifact_digest = remote_mcp_server_artifact_digest(server_artifact)
+    result_server_artifact_digest = server_artifact_digest if artifact_digest_bound else "c" * 64
+    discovery_payload = _discovery_artifact(
+        registration,
+        tools=[_tool("scientific_dataset_search")],
+        server_artifact=server_artifact,
+    )
+    entry = cache_entry_from_discovery_artifact(
+        cluster="alpha",
+        server_name="scientific-catalog",
+        registration=registration,
+        discovery_job_id="job_discovery",
+        artifact_id="artifact_discovery",
+        artifact_sha256=hashlib.sha256(discovery_payload).hexdigest(),
+        artifact_payload=discovery_payload,
+        discovered_at=NOW,
+    )
+    job_id = "job_catalog_search"
+    job: dict[str, object] = {
+        "job_id": job_id,
+        "cluster": "alpha",
+        "kind": "mcp_call",
+        "state": "succeeded",
+        "spec": {
+            "server": registration.command,
+            "server_args": registration.args,
+            "operation": "tools/call",
+            "tool": "scientific_dataset_search",
+            "arguments": {},
+            "expected_server_artifact_digest": server_artifact_digest,
+        },
+    }
+    report = build_remote_mcp_acceptance_report(
+        registry=ClusterRegistry(
+            clusters={
+                "alpha": _cluster(
+                    "alpha",
+                    {"scientific-catalog": registration},
+                )
+            }
+        ),
+        cache=RemoteMcpSchemaCache(entries=[entry]),
+        cluster="alpha",
+        server_name="scientific-catalog",
+        remote_tool_name="scientific_dataset_search",
+        profile="user",
+        call_job_id=job_id,
+        call_status={"job": job, "terminal": True},
+        artifacts=[
+            {
+                "artifact_id": f"artifact_{kind}",
+                "job_id": job_id,
+                "kind": kind,
+                "sha256": kind,
+            }
+            for kind in ("stdout", "stderr", "mcp_result", "provenance")
+        ],
+        mcp_result={
+            "server": registration.command,
+            "server_args": registration.args,
+            "operation": "tools/call",
+            "tool": "scientific_dataset_search",
+            "arguments": {},
+            "returncode": 0,
+            "protocol_result": {"content": [{"type": "text", "text": "ok"}]},
+            "server_artifact": server_artifact,
+            "expected_server_artifact_digest": result_server_artifact_digest,
+            "observed_server_artifact_digest": result_server_artifact_digest,
+            "protocol_error": None,
+        },
+        provenance={"job": job},
+        now=NOW,
+    )
+
+    server_check = next(
+        check for check in report.checks if check.name == "remote-mcp.server-artifact"
+    )
+    assert server_check.passed is expected
+    assert report.passed is expected
+
+
 def test_spack_acceptance_enforces_exact_stateless_user_contract(
     monkeypatch: MonkeyPatch,
 ) -> None:
@@ -2125,6 +2263,8 @@ def test_spack_acceptance_enforces_exact_stateless_user_contract(
     registry = ClusterRegistry(
         clusters={"alpha": _cluster("alpha", {"site-software": registration})}
     )
+    server_artifact = _server_artifact(registration)
+    server_artifact_digest = remote_mcp_server_artifact_digest(server_artifact)
     job_id = "job_spack_find"
     job: dict[str, object] = {
         "job_id": job_id,
@@ -2138,6 +2278,7 @@ def test_spack_acceptance_enforces_exact_stateless_user_contract(
             "operation": "tools/call",
             "tool": "spack_find",
             "arguments": {},
+            "expected_server_artifact_digest": server_artifact_digest,
         },
     }
     artifacts = [
@@ -2181,7 +2322,9 @@ def test_spack_acceptance_enforces_exact_stateless_user_contract(
                 "arguments": {},
                 "returncode": 0,
                 "protocol_result": protocol_result or {"content": [{"type": "text", "text": "ok"}]},
-                "server_artifact": _server_artifact(registration),
+                "server_artifact": server_artifact,
+                "expected_server_artifact_digest": server_artifact_digest,
+                "observed_server_artifact_digest": server_artifact_digest,
                 "protocol_error": None,
             },
             provenance={"job": job},
@@ -4627,6 +4770,7 @@ def _discovery_artifact(
     registration: RemoteMcpServerConfig,
     *,
     tools: list[dict[str, object]],
+    server_artifact: dict[str, object] | None = None,
 ) -> bytes:
     return json.dumps(
         {
@@ -4640,7 +4784,9 @@ def _discovery_artifact(
             "structured_result": None,
             "protocol_version": "2024-11-05",
             "server_info": {"name": "science", "version": "1.2.3"},
-            "server_artifact": _server_artifact(registration),
+            "server_artifact": (
+                server_artifact if server_artifact is not None else _server_artifact(registration)
+            ),
             "returncode": 0,
             "stdout": "",
             "stderr": "",

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1612,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.2.6"
+    assert policy.release_version == "1.2.7"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.2.6"
+version = "1.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed
- accept verified persistent `uv tool` MCP servers backed by an exact retained wheel
- require the installed distribution RECORD closure and locked clio-kit child runtime
- bind acceptance evidence to the discovery route, call spec, and expected/observed server artifact digests
- bump the release identity to 1.2.7

## Why
The live Ares scientific-catalog call succeeded through the production persistent clio-kit tool, but the generic acceptance validator still required the legacy `wheel` launch label. This caused a false release-gate failure despite identical verified discovery and call artifacts.

## Validation
- focused remote MCP acceptance tests: 6 passed
- focused release identity/matrix tests: 3 passed
- Pyright: 0 errors
- Ruff and diff checks: clean