### PR TITLE
fix: preserve exact JARVIS discovery artifact bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.2.7` uses a release-first patch process. A maintainer builds the
+> Version `1.2.8` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.2.7"
+$Version = "1.2.8"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.2.7"
+release_version: "1.2.8"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 201b38bb93941d8d80bc1518b5cf27de7f2bc269af7aefa33e66de7a4d0aaf1f
+acceptance_matrix_sha256: cbbc68c6a3b1c2c039d1e51ba08d406496ba847d64f7bfd3187fe154ed76869c
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.2.7"
+$Tag = "v1.2.8"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.7" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.8" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.2.7",
-  "matrix_sha256": "201b38bb93941d8d80bc1518b5cf27de7f2bc269af7aefa33e66de7a4d0aaf1f",
+  "release_version": "1.2.8",
+  "matrix_sha256": "cbbc68c6a3b1c2c039d1e51ba08d406496ba847d64f7bfd3187fe154ed76869c",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.2.7"
+version = "1.2.8"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.2.7"
+__version__ = "1.2.8"

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -7429,7 +7429,7 @@ def jarvis_mcp_refresh(
     def action() -> None:
         queue = _managed_queue_from_env()
         queue.initialize()
-        job_id, result, artifacts = _run_jarvis_remote_contract_discovery(
+        job_id, result, artifacts, artifact_payload = _run_jarvis_remote_contract_discovery(
             cluster=cluster,
             definition=definition,
             queue=queue,
@@ -7441,6 +7441,7 @@ def jarvis_mcp_refresh(
             discovery_job_id=job_id,
             result=result,
             artifacts=artifacts,
+            artifact_payload=artifact_payload,
         )
         typer.echo(
             json.dumps(
@@ -7550,6 +7551,7 @@ def jarvis_mcp_validate(
             remote_discovery_job_id,
             remote_tools_list_result,
             remote_discovery_artifacts,
+            remote_discovery_payload,
         ) = _run_jarvis_remote_contract_discovery(
             cluster=cluster,
             definition=definition,
@@ -7562,6 +7564,7 @@ def jarvis_mcp_validate(
             discovery_job_id=remote_discovery_job_id,
             result=remote_tools_list_result,
             artifacts=remote_discovery_artifacts,
+            artifact_payload=remote_discovery_payload,
         )
         stdio_session = run_packaged_mcp_stdio_session(
             profile=profile,
@@ -10283,7 +10286,7 @@ def _run_jarvis_remote_contract_discovery(
     queue: ClioCoreQueue,
     wait_timeout_seconds: float,
     poll_seconds: float,
-) -> tuple[str, dict[str, Any], list[dict[str, Any]]]:
+) -> tuple[str, dict[str, Any], list[dict[str, Any]], bytes]:
     """Discover the actual cluster-side JARVIS MCP before accepting its virtual route."""
     idempotency_key = f"mcp:jarvis-contract:{cluster}:{uuid4().hex}"
     if should_execute_on_cluster(definition):
@@ -10314,7 +10317,7 @@ def _run_jarvis_remote_contract_discovery(
         )
         _require_discovery_success(terminal, job_id)
         artifacts = _remote_artifact_records(definition, job_id)
-        result = _read_remote_json_artifact_kind(
+        artifact_payload = _read_remote_artifact_kind_bytes(
             definition,
             artifacts,
             kind="mcp_result",
@@ -10345,10 +10348,15 @@ def _run_jarvis_remote_contract_discovery(
         )
         _require_discovery_success(terminal_job.model_dump(mode="json"), job_id)
         artifacts = _complete_local_artifact_records(queue, job_id)
-        result = _read_local_json_artifact_kind(queue, artifacts, kind="mcp_result")
-    if result is None:
+        artifact_payload = _read_local_artifact_kind_bytes(
+            queue,
+            artifacts,
+            kind="mcp_result",
+        )
+    if artifact_payload is None:
         raise RelayError("JARVIS MCP discovery did not produce an mcp_result artifact")
-    return job_id, result, artifacts
+    result = _decode_json_artifact(artifact_payload, kind="mcp_result")
+    return job_id, result, artifacts, artifact_payload
 
 
 def _persist_jarvis_remote_contract_discovery(
@@ -10357,6 +10365,7 @@ def _persist_jarvis_remote_contract_discovery(
     discovery_job_id: str,
     result: dict[str, Any],
     artifacts: list[dict[str, Any]],
+    artifact_payload: bytes,
 ) -> tuple[RemoteMcpSchemaCacheEntry, str]:
     """Persist and verify the exact discovery identity used by built-in JARVIS calls."""
     server = result.get("server")
@@ -10403,7 +10412,7 @@ def _persist_jarvis_remote_contract_discovery(
         discovery_job_id=discovery_job_id,
         artifact_id=artifact_id,
         artifact_sha256=artifact_sha256,
-        artifact_payload=json.dumps(result, sort_keys=True, separators=(",", ":")).encode("utf-8"),
+        artifact_payload=artifact_payload,
     )
     if entry.schema_digest != CLIO_KIT_JARVIS_USER_CONTRACT_SHA256:
         raise RelayError(
@@ -10462,6 +10471,17 @@ def _read_remote_json_artifact_kind(
     *,
     kind: str,
 ) -> dict[str, Any] | None:
+    payload = _read_remote_artifact_kind_bytes(definition, artifacts, kind=kind)
+    return _decode_json_artifact(payload, kind=kind) if payload is not None else None
+
+
+def _read_remote_artifact_kind_bytes(
+    definition: ClusterDefinition,
+    artifacts: list[dict[str, Any]],
+    *,
+    kind: str,
+) -> bytes | None:
+    """Read the exact remote artifact bytes recorded by the durable queue."""
     artifact = _artifact_record(artifacts, kind=kind)
     if artifact is None:
         return None
@@ -10472,7 +10492,7 @@ def _read_remote_json_artifact_kind(
         run_remote_clio(definition, ["job", "read-artifact", artifact_id]),
         f"remote {kind} artifact payload",
     )
-    return _decode_json_artifact(_decode_artifact_envelope(envelope), kind=kind)
+    return _decode_artifact_envelope(envelope)
 
 
 def _read_local_json_artifact_kind(
@@ -10481,6 +10501,17 @@ def _read_local_json_artifact_kind(
     *,
     kind: str,
 ) -> dict[str, Any] | None:
+    payload = _read_local_artifact_kind_bytes(queue, artifacts, kind=kind)
+    return _decode_json_artifact(payload, kind=kind) if payload is not None else None
+
+
+def _read_local_artifact_kind_bytes(
+    queue: ClioCoreQueue,
+    artifacts: list[dict[str, Any]],
+    *,
+    kind: str,
+) -> bytes | None:
+    """Read the exact local artifact bytes recorded by the durable queue."""
     artifact = _artifact_record(artifacts, kind=kind)
     if artifact is None:
         return None
@@ -10488,7 +10519,7 @@ def _read_local_json_artifact_kind(
     if not isinstance(artifact_id, str) or not artifact_id:
         raise RelayError(f"local {kind} artifact has no artifact_id")
     envelope = read_artifact_bytes(queue, artifact_id)
-    return _decode_json_artifact(_decode_artifact_envelope(envelope), kind=kind)
+    return _decode_artifact_envelope(envelope)
 
 
 def _decode_json_artifact(payload: bytes, *, kind: str) -> dict[str, Any]:

--- a/tests/test_acceptance_report_defaults.py
+++ b/tests/test_acceptance_report_defaults.py
@@ -757,8 +757,8 @@ def _stop_gateway(
 
 def _jarvis_contract_discovery(
     **_kwargs: object,
-) -> tuple[str, dict[str, object], list[dict[str, object]]]:
-    return "discovery-job", {}, []
+) -> tuple[str, dict[str, object], list[dict[str, object]], bytes]:
+    return "discovery-job", {}, [], b"{}"
 
 
 def _persist_jarvis_contract(**_kwargs: object) -> None:

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1696,7 +1696,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "201b38bb93941d8d80bc1518b5cf27de7f2bc269af7aefa33e66de7a4d0aaf1f"
+        "cbbc68c6a3b1c2c039d1e51ba08d406496ba847d64f7bfd3187fe154ed76869c"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,10 @@ from clio_relay.cluster_config import (
 )
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.errors import ConfigurationError, QueueConflictError, RelayError
+from clio_relay.jarvis_mcp import (
+    CLIO_KIT_JARVIS_USER_CONTRACT_SHA256,
+    jarvis_user_contract,
+)
 from clio_relay.models import (
     ArtifactRef,
     Cursor,
@@ -5164,6 +5168,75 @@ def test_cli_jarvis_mcp_call_uses_builtin_cluster_command(
     assert job.spec.env_from == {"JARVIS_MCP_SPACK_COMMAND": "JARVIS_MCP_SPACK_COMMAND"}
     assert job.spec.tool == "jarvis_describe"
     assert job.spec.arguments == {"target": "packages"}
+
+
+def test_jarvis_discovery_persists_exact_durable_artifact_bytes(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Keep the discovery hash bound to stored bytes, not a JSON reserialization."""
+    monkeypatch.chdir(tmp_path)
+    contract = jarvis_user_contract()
+    server_artifact: dict[str, object] = {
+        "verified": True,
+        "server_process_artifact_verified": True,
+        "executable": {
+            "path": "/opt/clio-kit/bin/clio-kit",
+            "sha256": "a" * 64,
+        },
+    }
+    result: dict[str, object] = {
+        "server": "clio-kit",
+        "server_args": ["mcp-server", "jarvis"],
+        "env_from": {},
+        "operation": "tools/list",
+        "tool": None,
+        "arguments": {},
+        "protocol_result": {
+            "tools": [
+                {
+                    "name": name,
+                    "description": definition["description"],
+                    "inputSchema": definition["inputSchema"],
+                    "outputSchema": definition["outputSchema"],
+                    "annotations": definition["annotations"],
+                }
+                for name, definition in contract.items()
+            ]
+        },
+        "structured_result": None,
+        "protocol_version": "2024-11-05",
+        "server_info": {"name": "clio-kit", "version": "2.4.2"},
+        "server_artifact": server_artifact,
+        "returncode": 0,
+        "stdout": "",
+        "stderr": "",
+        "timed_out": False,
+        "protocol_error": None,
+    }
+    artifact_payload = (json.dumps(result, indent=2) + "\n").encode()
+    compact_payload = json.dumps(result, sort_keys=True, separators=(",", ":")).encode()
+    artifact_sha256 = hashlib.sha256(artifact_payload).hexdigest()
+
+    assert artifact_payload != compact_payload
+
+    entry, binding = cli._persist_jarvis_remote_contract_discovery(  # pyright: ignore[reportPrivateUsage]
+        cluster="ares",
+        discovery_job_id="job_discovery",
+        result=result,
+        artifacts=[
+            {
+                "artifact_id": "artifact_discovery",
+                "kind": "mcp_result",
+                "sha256": artifact_sha256,
+            }
+        ],
+        artifact_payload=artifact_payload,
+    )
+
+    assert entry.schema_digest == CLIO_KIT_JARVIS_USER_CONTRACT_SHA256
+    assert entry.provenance.artifact_sha256 == artifact_sha256
+    assert binding
 
 
 def test_cli_remote_jarvis_call_defers_artifact_selection_to_target(

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.2.7"
+    assert version == "1.2.8"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1612,7 +1612,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.2.7"
+    assert policy.release_version == "1.2.8"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.2.7"
+version = "1.2.8"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- retain the exact durable MCP result bytes through JARVIS contract discovery
- verify and cache the stored artifact SHA against those bytes instead of a JSON reserialization
- add a regression using non-canonical pretty-printed JSON
- prepare the v1.2.8 patch release identity and acceptance matrix

## Focused verification
- 7 focused pytest cases covering discovery, acceptance reporting, release identity, matrix, and policy
- Ruff on affected Python files
- Pyright on affected production and test modules
- uv lock --check

The broader Windows-only shell tests were not rerun; the focused release tests use D: temp because C: is full.