### PR TITLE
fix: verify released uv tool installations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,13 @@ jobs:
       - name: stage exact clio-kit release wheel
         shell: bash
         env:
-          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.4.2-py3-none-any.whl
-          CLIO_KIT_WHEEL_SHA256: 655db7d63a64d0220f3fdfe70eaf7d6a654ce06918b04c4b4e0f7db608116363
-          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.4.2/clio_kit-2.4.2-py3-none-any.whl
+          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.4.5-py3-none-any.whl
+          CLIO_KIT_WHEEL_SHA256: 327186527b16e7ce33be9d3d27a1e09dc564d2bca5ffa6beedfadf25738deb81
+          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.4.5/clio_kit-2.4.5-py3-none-any.whl
         run: |
           set -euo pipefail
           umask 077
-          wheel_dir="$RUNNER_TEMP/clio-kit-v2.4.2"
+          wheel_dir="$RUNNER_TEMP/clio-kit-v2.4.5"
           mkdir "$wheel_dir"
           wheel="$wheel_dir/$CLIO_KIT_WHEEL_FILENAME"
           curl --fail --show-error --silent --location \
@@ -160,13 +160,13 @@ jobs:
       - name: stage exact clio-kit release wheel
         shell: bash
         env:
-          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.4.2-py3-none-any.whl
-          CLIO_KIT_WHEEL_SHA256: 655db7d63a64d0220f3fdfe70eaf7d6a654ce06918b04c4b4e0f7db608116363
-          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.4.2/clio_kit-2.4.2-py3-none-any.whl
+          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.4.5-py3-none-any.whl
+          CLIO_KIT_WHEEL_SHA256: 327186527b16e7ce33be9d3d27a1e09dc564d2bca5ffa6beedfadf25738deb81
+          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.4.5/clio_kit-2.4.5-py3-none-any.whl
         run: |
           set -euo pipefail
           umask 077
-          wheel_dir="$RUNNER_TEMP/clio-kit-v2.4.2"
+          wheel_dir="$RUNNER_TEMP/clio-kit-v2.4.5"
           mkdir "$wheel_dir"
           wheel="$wheel_dir/$CLIO_KIT_WHEEL_FILENAME"
           curl --fail --show-error --silent --location \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.2.8` uses a release-first patch process. A maintainer builds the
+> Version `1.2.9` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -214,7 +214,7 @@ For the legacy clio-kit 2.2.6 compatibility path, a successful synchronous
 `jarvis_run` MCP return is normalized to a terminal `completed` record even
 though that release labels the result `status=running`; the original status and
 completion basis remain in `details.completion_normalization` for auditability.
-The pinned clio-kit 2.4.2 production path removes that ambiguity upstream and
+The pinned clio-kit 2.4.5 production path removes that ambiguity upstream and
 returns a structured completed result directly. The legacy normalization is
 diagnostic compatibility evidence and cannot satisfy the 1.0 gate. Scheduler
 submissions remain non-terminal unless JARVIS was asked to wait.
@@ -445,7 +445,8 @@ Use timeline events for UI-visible agent work such as repository scans, dataset 
 Install the cluster-side server once, then launch its persistent executable:
 
 ```bash
-uv tool install --python 3.12 --no-config clio-kit==2.4.2
+uv tool install --python 3.12 --no-config \
+  https://github.com/iowarp/clio-kit/releases/download/v2.4.5/clio_kit-2.4.5-py3-none-any.whl
 clio-kit mcp-server jarvis
 ```
 

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.2.8"
+$Version = "1.2.9"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.2.8"
+release_version: "1.2.9"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: cbbc68c6a3b1c2c039d1e51ba08d406496ba847d64f7bfd3187fe154ed76869c
+acceptance_matrix_sha256: d0d2bd529c8f544d3f87b38c15225b240561b04e04714c7700afd8a00d3b4006
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true
@@ -108,16 +108,16 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.4.2"
+            clio-kit: "2.4.5"
             jarvis-cd: "1.3.2"
             jarvis-util: c91bfdc9bba802e4b03bfb1babe614ffa3e09644
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.4.2"
-              install_spec: clio-kit==2.4.2
-              requested_source: pypi
-              artifact_sha256: 655db7d63a64d0220f3fdfe70eaf7d6a654ce06918b04c4b4e0f7db608116363
+              distribution_version: "2.4.5"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.4.5/clio_kit-2.4.5-py3-none-any.whl
+              requested_source: github_release
+              artifact_sha256: 327186527b16e7ce33be9d3d27a1e09dc564d2bca5ffa6beedfadf25738deb81
               native_execution:
                 schema_version: clio-relay.jarvis-native-execution-capability.v1
                 handle_schema: jarvis.execution.handle.v1
@@ -218,14 +218,14 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.4.2"
+            clio-kit: "2.4.5"
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.4.2"
-              install_spec: clio-kit==2.4.2
-              requested_source: pypi
-              artifact_sha256: 655db7d63a64d0220f3fdfe70eaf7d6a654ce06918b04c4b4e0f7db608116363
+              distribution_version: "2.4.5"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.4.5/clio_kit-2.4.5-py3-none-any.whl
+              requested_source: github_release
+              artifact_sha256: 327186527b16e7ce33be9d3d27a1e09dc564d2bca5ffa6beedfadf25738deb81
       - kind: scheduler_job
         roles: [queue-preservation-fixture]
         states: [completed]
@@ -285,24 +285,24 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.4.2"
+            clio-kit: "2.4.5"
             jarvis-cd: "1.3.2"
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.4.2"
-              install_spec: clio-kit==2.4.2
-              requested_source: pypi
-              artifact_filename: clio_kit-2.4.2-py3-none-any.whl
-              artifact_sha256: 655db7d63a64d0220f3fdfe70eaf7d6a654ce06918b04c4b4e0f7db608116363
+              distribution_version: "2.4.5"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.4.5/clio_kit-2.4.5-py3-none-any.whl
+              requested_source: github_release
+              artifact_filename: clio_kit-2.4.5-py3-none-any.whl
+              artifact_sha256: 327186527b16e7ce33be9d3d27a1e09dc564d2bca5ffa6beedfadf25738deb81
               persistent_tool:
                 manager: uv
                 uv_version: "0.11.28"
                 pyvenv_uv_version: "0.11.28"
                 distribution: clio-kit
-                distribution_version: "2.4.2"
+                distribution_version: "2.4.5"
                 entry_point: clio-kit
-                source_artifact_sha256: 655db7d63a64d0220f3fdfe70eaf7d6a654ce06918b04c4b4e0f7db608116363
+                source_artifact_sha256: 327186527b16e7ce33be9d3d27a1e09dc564d2bca5ffa6beedfadf25738deb81
               native_execution:
                 schema_version: clio-relay.jarvis-native-execution-capability.v1
                 handle_schema: jarvis.execution.handle.v1
@@ -360,10 +360,10 @@ requirements:
         states: [verified]
         metadata_equals:
           install_source: uv-tool
-          install_artifact_sha256: 655db7d63a64d0220f3fdfe70eaf7d6a654ce06918b04c4b4e0f7db608116363
+          install_artifact_sha256: 327186527b16e7ce33be9d3d27a1e09dc564d2bca5ffa6beedfadf25738deb81
           python_distribution_runtime:
             distribution: clio-kit
-            distribution_version: "2.4.2"
+            distribution_version: "2.4.5"
             entry_point: clio-kit
             runtime_closure_verified: true
           nested_runtime:
@@ -619,7 +619,7 @@ requirements:
         states: [verified]
         metadata_equals:
           install_source: wheel
-          install_artifact_sha256: 655db7d63a64d0220f3fdfe70eaf7d6a654ce06918b04c4b4e0f7db608116363
+          install_artifact_sha256: 327186527b16e7ce33be9d3d27a1e09dc564d2bca5ffa6beedfadf25738deb81
           server_process_artifact_verified: true
           verified: true
 
@@ -718,7 +718,7 @@ requirements:
           remote_tool_names: [spack_find, spack_install, spack_locate]
           allowlisted_tool_names: [spack_find, spack_install, spack_locate]
           install_source: wheel
-          install_artifact_sha256: 655db7d63a64d0220f3fdfe70eaf7d6a654ce06918b04c4b4e0f7db608116363
+          install_artifact_sha256: 327186527b16e7ce33be9d3d27a1e09dc564d2bca5ffa6beedfadf25738deb81
           contract_id: clio-kit-spack-user-v2
           contract_sha256: 3c5412148c770f4844e98eb893c4db0d0afdbf13afe967df67bd5f7d25e1f7db
           server_process_artifact_verified: true
@@ -823,7 +823,7 @@ requirements:
           remote_tool_names: [spack_find, spack_install, spack_locate]
           allowlisted_tool_names: [spack_find, spack_install, spack_locate]
           install_source: wheel
-          install_artifact_sha256: 655db7d63a64d0220f3fdfe70eaf7d6a654ce06918b04c4b4e0f7db608116363
+          install_artifact_sha256: 327186527b16e7ce33be9d3d27a1e09dc564d2bca5ffa6beedfadf25738deb81
           contract_id: clio-kit-spack-user-v2
           contract_sha256: 3c5412148c770f4844e98eb893c4db0d0afdbf13afe967df67bd5f7d25e1f7db
           server_process_artifact_verified: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.2.8"
+$Tag = "v1.2.9"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.8" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.9" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/docs/remote-mcp-federation.md
+++ b/docs/remote-mcp-federation.md
@@ -252,7 +252,7 @@ Virtual JARVIS mutations and runs receive a fresh relay job by default. Supply
 an explicit `idempotency_key` only when retry de-duplication is intentional; an
 identical second `jarvis_run` is otherwise a new execution.
 
-The released clio-kit 2.4.2 artifact is the pinned six-tool JARVIS v3.1 contract.
+The released clio-kit 2.4.5 artifact is the pinned six-tool JARVIS v3.1 contract.
 Bootstrap
 downloads and hashes the exact coordinated wheel, installs it once with
 `uv tool install`, and persists the wheel plus the direct JARVIS command in the
@@ -263,7 +263,7 @@ that persistent executable directly. clio-kit's child launcher still uses its
 wheel-owned server source and lock with `uv run --frozen --no-editable`, so the
 live MCP response binds both the installed outer tool and the locked child
 server rather than trusting an unobserved nested resolution. The release gate
-requires that exact 2.4.2 artifact to be rerun on every target selected by the
+requires that exact 2.4.5 artifact to be rerun on every target selected by the
 release policy. Other servers use the operator registry and generated
 `remote_...` aliases.
 
@@ -280,7 +280,7 @@ operator-defined and do not select behavior.
 
 ## Register the scientific catalog MCP
 
-clio-kit 2.4.2 also ships the two-tool
+clio-kit 2.4.5 also ships the two-tool
 `clio-kit-scientific-catalog-user-v1` contract. It separates dataset discovery
 from visualization control: `scientific_dataset_search` finds operator catalog
 records and `scientific_dataset_describe` returns one exact

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.2.8",
-  "matrix_sha256": "cbbc68c6a3b1c2c039d1e51ba08d406496ba847d64f7bfd3187fe154ed76869c",
+  "release_version": "1.2.9",
+  "matrix_sha256": "d0d2bd529c8f544d3f87b38c15225b240561b04e04714c7700afd8a00d3b4006",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.2.8"
+version = "1.2.9"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.2.8"
+__version__ = "1.2.9"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -22,7 +22,12 @@ from uuid import uuid4
 from clio_relay import __version__
 from clio_relay.deployment import endpoint_user_service_name
 from clio_relay.errors import ConfigurationError, RelayError
-from clio_relay.jarvis_mcp import CLIO_KIT_JARVIS_MCP_VERSION
+from clio_relay.jarvis_mcp import (
+    CLIO_KIT_JARVIS_MCP_VERSION,
+    CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME,
+    CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
+    CLIO_KIT_JARVIS_MCP_WHEEL_URL,
+)
 from clio_relay.remote_values import render_remote_shell_path
 from clio_relay.worker_lifetime_lock import (
     WORKER_LIFETIME_GUARD_FD_ENV,
@@ -46,9 +51,6 @@ JARVIS_CD_WHEEL_URL = (
     f"v{JARVIS_CD_VERSION}/{JARVIS_CD_WHEEL_FILENAME}"
 )
 JARVIS_CD_WHEEL_SHA256 = "2e5c994b1b21caf44eecb62c1d631c5ce3886d9282549589520c1d9b49961277"
-CLIO_KIT_JARVIS_MCP_WHEEL_SHA256 = (
-    "655db7d63a64d0220f3fdfe70eaf7d6a654ce06918b04c4b4e0f7db608116363"
-)
 DEFAULT_REMOTE_CORE_DIR = "$HOME/.local/share/clio-relay/core"
 DEFAULT_REMOTE_SPOOL_DIR = "$HOME/.local/share/clio-relay/spool"
 
@@ -1072,14 +1074,14 @@ def render_linux_user_bootstrap_script(
         raise ConfigurationError(f"no pinned Linux checksum is registered for frp {frp_version}")
     resolved_jarvis_mcp_install_spec = jarvis_mcp_install_spec or os.environ.get(
         "CLIO_RELAY_JARVIS_MCP_INSTALL_SPEC",
-        f"clio-kit=={CLIO_KIT_JARVIS_MCP_VERSION}",
+        CLIO_KIT_JARVIS_MCP_WHEEL_URL,
     )
     resolved_jarvis_mcp_artifact_sha256 = (
         jarvis_mcp_artifact_sha256
         or os.environ.get("CLIO_RELAY_JARVIS_MCP_ARTIFACT_SHA256")
         or (
             CLIO_KIT_JARVIS_MCP_WHEEL_SHA256
-            if resolved_jarvis_mcp_install_spec == f"clio-kit=={CLIO_KIT_JARVIS_MCP_VERSION}"
+            if resolved_jarvis_mcp_install_spec == CLIO_KIT_JARVIS_MCP_WHEEL_URL
             else None
         )
     )
@@ -1200,6 +1202,23 @@ JARVIS_MCP_ARTIFACT_PATH=""
 JARVIS_MCP_REQUESTED_SOURCE="checkout"
 JARVIS_MCP_VERSION=""
 case "$JARVIS_MCP_INSTALL_SPEC" in
+  "{CLIO_KIT_JARVIS_MCP_WHEEL_URL}")
+    JARVIS_MCP_VERSION="{CLIO_KIT_JARVIS_MCP_VERSION}"
+    COMPONENT_DOWNLOAD_DIR="$HOME/.local/share/clio-relay/component-wheels/clio-kit"
+    rm -rf "$COMPONENT_DOWNLOAD_DIR"
+    mkdir -p "$COMPONENT_DOWNLOAD_DIR"
+    JARVIS_MCP_ARTIFACT_PATH="$COMPONENT_DOWNLOAD_DIR/{CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME}"
+    COMPONENT_STAGING="$(mktemp "${{JARVIS_MCP_ARTIFACT_PATH}}.XXXXXX")"
+    curl --fail --location --proto '=https' --proto-redir '=https' --tlsv1.2 \
+      --retry 3 --retry-all-errors --retry-max-time 180 \
+      --connect-timeout 20 --max-time 180 \
+      --output "$COMPONENT_STAGING" "$JARVIS_MCP_INSTALL_SPEC"
+    echo "$JARVIS_MCP_ARTIFACT_SHA256 *$COMPONENT_STAGING" | \
+      sha256sum --check --strict -
+    mv "$COMPONENT_STAGING" "$JARVIS_MCP_ARTIFACT_PATH"
+    JARVIS_MCP_INSTALL_TARGET="$JARVIS_MCP_ARTIFACT_PATH"
+    JARVIS_MCP_REQUESTED_SOURCE="github_release"
+    ;;
   clio-kit==*)
     JARVIS_MCP_VERSION="${{JARVIS_MCP_INSTALL_SPEC#clio-kit==}}"
     COMPONENT_DOWNLOAD_DIR="$HOME/.local/share/clio-relay/component-wheels/clio-kit"
@@ -1233,7 +1252,7 @@ case "$JARVIS_MCP_INSTALL_SPEC" in
     JARVIS_MCP_REQUESTED_SOURCE="wheel"
     ;;
   *)
-    echo "clio-kit bootstrap source must be an exact version or wheel" >&2
+    echo "clio-kit source must be the pinned URL, an exact version, or a local wheel" >&2
     exit 1
     ;;
 esac

--- a/src/clio_relay/installation.py
+++ b/src/clio_relay/installation.py
@@ -20,11 +20,14 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_valida
 from clio_relay.errors import ConfigurationError
 from clio_relay.validation_report import (
     EvidenceReference,
+    InstallSource,
+    InstallSourceKind,
     LiveValidationReport,
     SoftwareIdentity,
     ValidationCheck,
     ValidationResource,
     ValidationStatus,
+    detect_install_source,
     detect_software_identity,
     sha256_file,
 )
@@ -811,7 +814,14 @@ def _path_within(path: Path, root: Path) -> bool:
 
 def installation_info(path: Path | None = None) -> dict[str, object]:
     """Return current package identity together with its durable install receipt."""
-    receipt = load_install_receipt(path)
+    receipt_path = path or default_install_receipt_path()
+    receipt_origin = "bootstrap"
+    install_source: InstallSource | None = None
+    if receipt_path.exists() or path is not None or os.environ.get(INSTALL_RECEIPT_PATH_ENV):
+        receipt = load_install_receipt(receipt_path)
+    else:
+        receipt, install_source = _persistent_uv_tool_install_receipt()
+        receipt_origin = "uv-tool"
     current_software = detect_software_identity()
     current_version = metadata.version("clio-relay")
     component_runtime = _component_runtime_identity(receipt)
@@ -820,11 +830,58 @@ def installation_info(path: Path | None = None) -> dict[str, object]:
         "distribution_version": current_version,
         "software": current_software.model_dump(mode="json"),
         "receipt": receipt.model_dump(mode="json"),
+        "receipt_origin": receipt_origin,
+        "install_source": (
+            install_source.model_dump(mode="json") if install_source is not None else None
+        ),
         "receipt_matches_install": (
             receipt.distribution_version == current_version and receipt.software == current_software
         ),
         "component_runtime": component_runtime,
     }
+
+
+def _persistent_uv_tool_install_receipt() -> tuple[InstallReceipt, InstallSource]:
+    """Derive a compatible receipt from uv's exact persistent-tool identity."""
+    source = detect_install_source(
+        launcher="uv-tool",
+        infer_artifact_sha256=True,
+    )
+    if source.kind not in {InstallSourceKind.WHEEL, InstallSourceKind.PYPI}:
+        raise ConfigurationError("running clio-relay is not installed as a persistent uv tool")
+    if not source.launcher_verified:
+        raise ConfigurationError("persistent uv tool launcher identity could not be verified")
+    if not source.artifact_identity_verified or source.artifact_sha256 is None:
+        raise ConfigurationError("persistent uv tool wheel identity could not be verified")
+    raw_uv_receipt = source.launcher_receipt.get("uv_tool_receipt")
+    if not isinstance(raw_uv_receipt, dict):
+        raise ConfigurationError("persistent uv tool receipt could not be verified")
+    uv_receipt = cast(dict[str, object], raw_uv_receipt)
+    if uv_receipt.get("verified") is not True:
+        raise ConfigurationError("persistent uv tool receipt could not be verified")
+    receipt_path_value = uv_receipt.get("path")
+    if not isinstance(receipt_path_value, str):
+        raise ConfigurationError("persistent uv tool receipt path is missing")
+    try:
+        installed_at = datetime.fromtimestamp(Path(receipt_path_value).stat().st_mtime, tz=UTC)
+    except OSError as exc:
+        raise ConfigurationError("persistent uv tool receipt path is unavailable") from exc
+    reference = source.reference
+    artifact_filename: str | None = None
+    if reference is not None:
+        parsed = urlsplit(reference)
+        if parsed.path:
+            artifact_filename = Path(unquote(parsed.path)).name or None
+    receipt = InstallReceipt(
+        installed_at=installed_at,
+        install_spec=reference or f"clio-relay=={source.distribution_version}",
+        requested_source=source.kind.value,
+        artifact_filename=artifact_filename,
+        artifact_sha256=source.artifact_sha256,
+        distribution_version=source.distribution_version,
+        software=detect_software_identity(),
+    )
+    return receipt, source
 
 
 def worker_runtime_info(

--- a/src/clio_relay/jarvis_mcp.py
+++ b/src/clio_relay/jarvis_mcp.py
@@ -22,7 +22,15 @@ from clio_relay.remote_mcp import (
 if TYPE_CHECKING:
     from clio_relay.installation import ComponentArtifactIdentity, InstallReceipt
 
-CLIO_KIT_JARVIS_MCP_VERSION = "2.4.2"
+CLIO_KIT_JARVIS_MCP_VERSION = "2.4.5"
+CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME = f"clio_kit-{CLIO_KIT_JARVIS_MCP_VERSION}-py3-none-any.whl"
+CLIO_KIT_JARVIS_MCP_WHEEL_URL = (
+    "https://github.com/iowarp/clio-kit/releases/download/"
+    f"v{CLIO_KIT_JARVIS_MCP_VERSION}/{CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME}"
+)
+CLIO_KIT_JARVIS_MCP_WHEEL_SHA256 = (
+    "327186527b16e7ce33be9d3d27a1e09dc564d2bca5ffa6beedfadf25738deb81"
+)
 CLIO_KIT_JARVIS_USER_CONTRACT_ID = "clio-kit-jarvis-user-v3.1"
 DEFAULT_JARVIS_MCP_COMMAND = [
     "clio-kit",

--- a/src/clio_relay/remote_mcp.py
+++ b/src/clio_relay/remote_mcp.py
@@ -73,7 +73,7 @@ MAX_REMOTE_MCP_CATALOG_ISSUES = 10_000
 MAX_VIRTUAL_REMOTE_MCP_ALIAS_LENGTH = 64
 REMOTE_MCP_REPLACE_ATTEMPTS = 25
 REMOTE_MCP_REPLACE_RETRY_SECONDS = 0.02
-CLIO_KIT_SPACK_USER_WHEEL_VERSION = "2.4.2"
+CLIO_KIT_SPACK_USER_WHEEL_VERSION = "2.4.5"
 CLIO_KIT_SPACK_USER_CONTRACT_ID = "clio-kit-spack-user-v2"
 # Digest the MCP wire ``tools/list`` result. FastMCP's in-process FunctionTool
 # schemas retain ``$defs`` that its protocol serializer dereferences, so their

--- a/src/clio_relay/validation_report.py
+++ b/src/clio_relay/validation_report.py
@@ -8,14 +8,18 @@ import csv
 import ctypes
 import hashlib
 import io
+import ipaddress
 import json
 import math
 import os
 import re
 import shutil
+import socket
 import stat
 import subprocess
 import sys
+import tomllib
+import urllib.error
 import urllib.parse
 import urllib.request
 import zipfile
@@ -49,6 +53,12 @@ MAX_TRANSPORT_PROBE_JSON_DEPTH = 16
 MAX_TRANSPORT_PROBE_JSON_NODES = 4096
 MAX_LAUNCHER_PROCESS_ANCESTORS = 64
 MAX_PYVENV_CONFIG_BYTES = 64 * 1024
+MAX_UV_TOOL_RECEIPT_BYTES = 256 * 1024
+MAX_DISTRIBUTION_WHEEL_BYTES = 128 * 1024 * 1024
+_OFFICIAL_RELEASE_WHEEL_PATH = re.compile(
+    r"/iowarp/clio-relay/releases/download/v(?P<version>[0-9A-Za-z][0-9A-Za-z.+-]*)/"
+    r"clio_relay-(?P=version)-py3-none-any\.whl"
+)
 SPACK_FRESH_INSTALL_TRANSITION_CHECK_IDS = (
     "remote-mcp.spack-preinstall-absent",
     "remote-mcp.spack-fresh-install",
@@ -205,17 +215,21 @@ class InstallSource(BaseModel):
     launcher_receipt: dict[str, Any] = Field(default_factory=dict[str, Any])
 
     @model_validator(mode="after")
-    def released_source_requires_verified_pypi_identity(self) -> InstallSource:
+    def released_source_requires_verified_artifact_identity(self) -> InstallSource:
         """Reject internally inconsistent released-artifact claims."""
+        released_source = self.kind is InstallSourceKind.PYPI or (
+            self.kind is InstallSourceKind.WHEEL
+            and _is_official_github_release_wheel(self.direct_url, self.distribution_version)
+        )
         if self.released_artifact and not (
-            self.kind is InstallSourceKind.PYPI
-            and self.detected_kind is InstallSourceKind.PYPI
+            self.kind is self.detected_kind
+            and released_source
             and self.launcher == "uv-tool"
             and self.artifact_sha256 is not None
             and self.artifact_identity_verified
             and self.launcher_verified
         ):
-            raise ValueError("released artifact requires verified PyPI uv-tool artifact identity")
+            raise ValueError("released artifact requires verified uv-tool artifact identity")
         return self
 
 
@@ -1119,8 +1133,14 @@ def detect_install_source(
     launcher: str | None = None,
     source_override: str | None = None,
     artifact_sha256: str | None = None,
+    infer_artifact_sha256: bool = False,
 ) -> InstallSource:
-    """Inspect PEP 610 metadata and explicit acceptance provenance overrides."""
+    """Inspect PEP 610 metadata and explicit acceptance provenance overrides.
+
+    Validation callers should supply an independently computed artifact digest.
+    ``infer_artifact_sha256`` exists for installation inspection, where the
+    exact wheel URL is already bound by uv's persistent-tool receipt.
+    """
     distribution = metadata.distribution("clio-relay")
     package_path = str(resources.files("clio_relay"))
     direct_url = _distribution_direct_url(distribution)
@@ -1130,13 +1150,21 @@ def detect_install_source(
         kind, reference = _parse_source_override(source_override)
     resolved_launcher = launcher or os.environ.get("CLIO_RELAY_VALIDATION_LAUNCHER", "unknown")
     resolved_hash = artifact_sha256 or os.environ.get("CLIO_RELAY_VALIDATION_ARTIFACT_SHA256")
-    artifact_identity_verified = _verify_running_artifact_identity(
-        distribution,
-        detected_kind=detected_kind,
-        direct_url=direct_url,
-        artifact_sha256=resolved_hash,
-        launcher=resolved_launcher,
-    )
+    if resolved_hash is None and infer_artifact_sha256:
+        resolved_hash, artifact_identity_verified = _infer_running_artifact_identity(
+            distribution,
+            detected_kind=detected_kind,
+            direct_url=direct_url,
+            launcher=resolved_launcher,
+        )
+    else:
+        artifact_identity_verified = _verify_running_artifact_identity(
+            distribution,
+            detected_kind=detected_kind,
+            direct_url=direct_url,
+            artifact_sha256=resolved_hash,
+            launcher=resolved_launcher,
+        )
     launcher_verified, launcher_receipt = _detect_launcher_receipt(
         resolved_launcher,
         detected_kind=detected_kind,
@@ -1144,8 +1172,14 @@ def detect_install_source(
         distribution=distribution,
     )
     released = (
-        kind is InstallSourceKind.PYPI
-        and detected_kind is InstallSourceKind.PYPI
+        kind is detected_kind
+        and (
+            kind is InstallSourceKind.PYPI
+            or (
+                kind is InstallSourceKind.WHEEL
+                and _is_official_github_release_wheel(direct_url, distribution.version)
+            )
+        )
         and resolved_launcher == "uv-tool"
         and artifact_identity_verified
         and launcher_verified
@@ -1265,7 +1299,7 @@ def _detect_persistent_uv_tool_receipt(
     distribution: metadata.Distribution,
 ) -> tuple[bool, dict[str, Any]]:
     """Capture structural evidence for an install-once uv tool invocation."""
-    uv_executable = os.environ.get("UV")
+    uv_executable = os.environ.get("UV") or shutil.which("uv")
     uv_path = Path(uv_executable) if uv_executable is not None else None
     uv_identity_before = _regular_file_identity(uv_path) if uv_path is not None else None
     uv_path_verified, uv_version, uv_executable_sha256 = _uv_executable_identity(uv_executable)
@@ -1316,6 +1350,11 @@ def _detect_persistent_uv_tool_receipt(
     )
     project_environment = (Path.cwd() / ".venv").resolve()
     isolated_environment = prefix != base_prefix and prefix != project_environment
+    uv_receipt_identity = _persistent_uv_tool_receipt_identity(
+        environment_prefix=prefix,
+        tool_executable=tool_path_absolute,
+        distribution=distribution,
+    )
     verified = (
         detected_kind in {InstallSourceKind.WHEEL, InstallSourceKind.PYPI}
         and uv_path_verified
@@ -1329,6 +1368,7 @@ def _detect_persistent_uv_tool_receipt(
         and tool_bin_bound
         and tool_target_bound
         and record_identity.get("verified") is True
+        and uv_receipt_identity.get("verified") is True
         and isolated_environment
     )
     return verified, {
@@ -1360,9 +1400,149 @@ def _detect_persistent_uv_tool_receipt(
         "pyvenv_matches_uv": pyvenv_matches_uv,
         "isolated_environment": isolated_environment,
         "distribution_record": record_identity,
+        "uv_tool_receipt": uv_receipt_identity,
         "detected_install_source": detected_kind.value,
         "verified": verified,
     }
+
+
+def _persistent_uv_tool_receipt_identity(
+    *,
+    environment_prefix: Path,
+    tool_executable: Path | None,
+    distribution: metadata.Distribution,
+) -> dict[str, Any]:
+    """Bind uv's launcher and requirement records to the running distribution."""
+    receipt_path = environment_prefix / "uv-receipt.toml"
+    identity = _regular_file_identity(receipt_path)
+    if identity is None or not 1 <= identity[2] <= MAX_UV_TOOL_RECEIPT_BYTES:
+        return {"verified": False, "error": "uv tool receipt is missing or invalid"}
+    payload = _read_open_regular_file(
+        receipt_path,
+        identity,
+        maximum_bytes=MAX_UV_TOOL_RECEIPT_BYTES,
+    )
+    if payload is None:
+        return {"verified": False, "error": "uv tool receipt changed while reading"}
+    try:
+        document = tomllib.loads(payload.decode("utf-8"))
+    except (UnicodeError, tomllib.TOMLDecodeError):
+        return {"verified": False, "error": "uv tool receipt is not valid TOML"}
+    tool = document.get("tool")
+    if not isinstance(tool, dict):
+        return {"verified": False, "error": "uv tool receipt omitted its tool record"}
+    tool_record = cast(dict[str, object], tool)
+    entrypoints = tool_record.get("entrypoints")
+    requirements = tool_record.get("requirements")
+    if not isinstance(entrypoints, list) or not isinstance(requirements, list):
+        return {"verified": False, "error": "uv tool receipt omitted its mappings"}
+
+    launcher_matches: list[dict[str, object]] = []
+    for raw_entrypoint in cast(list[object], entrypoints):
+        if not isinstance(raw_entrypoint, dict):
+            return {"verified": False, "error": "uv tool receipt entry point is invalid"}
+        entrypoint = cast(dict[str, object], raw_entrypoint)
+        source = entrypoint.get("from")
+        if isinstance(source, str) and _normalized_distribution_name(source) == "clio-relay":
+            launcher_matches.append(entrypoint)
+    launcher_bound = False
+    if len(launcher_matches) == 1 and tool_executable is not None:
+        install_path = launcher_matches[0].get("install-path")
+        install_location = (
+            Path(install_path).expanduser() if isinstance(install_path, str) else None
+        )
+        launcher_bound = (
+            install_location is not None
+            and install_location.is_absolute()
+            and _lexical_path_key(install_location) == _lexical_path_key(tool_executable)
+        )
+
+    requirement_matches: list[dict[str, object]] = []
+    for raw_requirement in cast(list[object], requirements):
+        if not isinstance(raw_requirement, dict):
+            return {"verified": False, "error": "uv tool receipt requirement is invalid"}
+        requirement = cast(dict[str, object], raw_requirement)
+        name = requirement.get("name")
+        if isinstance(name, str) and _normalized_distribution_name(name) == "clio-relay":
+            requirement_matches.append(requirement)
+    direct_url = _distribution_direct_url(distribution)
+    source_bound = len(requirement_matches) == 1 and _uv_requirement_matches_distribution_source(
+        requirement_matches[0] if requirement_matches else {},
+        direct_url=direct_url,
+        distribution_version=distribution.version,
+    )
+    requirement = requirement_matches[0] if len(requirement_matches) == 1 else {}
+    source_url = requirement.get("url")
+    source_path = requirement.get("path")
+    source_specifier = requirement.get("specifier")
+    verified = launcher_bound and source_bound
+    return {
+        "schema_version": "clio-relay.uv-tool-receipt.v1",
+        "path": str(receipt_path.resolve()),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "launcher_bound": launcher_bound,
+        "requirement_name": requirement.get("name"),
+        "requirement_url": _redact_url(source_url) if isinstance(source_url, str) else None,
+        "requirement_path": source_path if isinstance(source_path, str) else None,
+        "requirement_specifier": source_specifier if isinstance(source_specifier, str) else None,
+        "distribution_url": direct_url.get("url") if direct_url is not None else None,
+        "source_bound": source_bound,
+        "verified": verified,
+    }
+
+
+def _uv_requirement_matches_distribution_source(
+    requirement: dict[str, object],
+    *,
+    direct_url: dict[str, Any] | None,
+    distribution_version: str,
+) -> bool:
+    """Match one uv requirement to the exact PEP 610 installation source."""
+    source_url = requirement.get("url")
+    source_path = requirement.get("path")
+    source_specifier = requirement.get("specifier")
+    if direct_url is None:
+        return (
+            source_url is None
+            and source_path is None
+            and source_specifier in {None, f"=={distribution_version}"}
+        )
+    distribution_url = direct_url.get("url")
+    if not isinstance(distribution_url, str):
+        return False
+    parsed = urllib.parse.urlsplit(distribution_url)
+    if parsed.scheme.casefold() == "file":
+        if not isinstance(source_path, str):
+            return False
+        direct_path = _local_wheel_archive_path(direct_url)
+        if direct_path is None:
+            return False
+        try:
+            return Path(source_path).expanduser().resolve(strict=True) == direct_path.resolve(
+                strict=True
+            )
+        except (OSError, RuntimeError, ValueError):
+            return False
+    return (
+        parsed.scheme.casefold() == "https"
+        and not parsed.username
+        and not parsed.password
+        and not parsed.query
+        and not parsed.fragment
+        and isinstance(source_url, str)
+        and source_url == distribution_url
+        and _redact_url(source_url) == source_url
+    )
+
+
+def _normalized_distribution_name(value: str) -> str:
+    """Return the canonical comparison key for one Python distribution name."""
+    return re.sub(r"[-_.]+", "-", value).casefold()
+
+
+def _lexical_path_key(path: Path) -> str:
+    """Return a platform-normalized lexical path key."""
+    return os.path.normcase(os.path.normpath(str(path)))
 
 
 def _uv_tool_dir(executable: Path | None, *, bin_directory: bool) -> Path | None:
@@ -3510,10 +3690,182 @@ def _verify_running_artifact_identity(
     if launcher not in {"uv-tool", "uvx"}:
         return False
     if detected_kind is InstallSourceKind.WHEEL:
-        return _local_wheel_matches_install(distribution, direct_url, expected)
+        if _local_wheel_archive_path(direct_url) is not None:
+            return _local_wheel_matches_install(distribution, direct_url, expected)
+        return _wheel_url_matches_install(distribution, direct_url, expected)
     if detected_kind is InstallSourceKind.PYPI:
         return _pypi_wheel_matches_install(distribution, expected)
     return False
+
+
+def _infer_running_artifact_identity(
+    distribution: metadata.Distribution,
+    *,
+    detected_kind: InstallSourceKind,
+    direct_url: dict[str, Any] | None,
+    launcher: str,
+) -> tuple[str | None, bool]:
+    """Inspect one exact direct wheel for human-facing installation information."""
+    if launcher != "uv-tool" or detected_kind is not InstallSourceKind.WHEEL:
+        return None, False
+    wheel_bytes = _direct_wheel_bytes(direct_url)
+    if wheel_bytes is None:
+        return None, False
+    digest = hashlib.sha256(wheel_bytes).hexdigest()
+    direct_hashes = _direct_url_sha256_hashes(direct_url)
+    if direct_hashes and digest not in direct_hashes:
+        return digest, False
+    try:
+        return digest, _installed_files_match_wheel(distribution, wheel_bytes)
+    except (OSError, ValueError, zipfile.BadZipFile):
+        return digest, False
+
+
+def _wheel_url_matches_install(
+    distribution: metadata.Distribution,
+    direct_url: dict[str, Any] | None,
+    expected_sha256: str,
+) -> bool:
+    """Verify exact local or HTTPS wheel bytes and their installed RECORD closure."""
+    wheel_bytes = _direct_wheel_bytes(direct_url)
+    if wheel_bytes is None:
+        return False
+    direct_hashes = _direct_url_sha256_hashes(direct_url)
+    if direct_hashes and expected_sha256 not in direct_hashes:
+        return False
+    if hashlib.sha256(wheel_bytes).hexdigest() != expected_sha256:
+        return False
+    try:
+        return _installed_files_match_wheel(distribution, wheel_bytes)
+    except (OSError, ValueError, zipfile.BadZipFile):
+        return False
+
+
+def _direct_wheel_bytes(direct_url: dict[str, Any] | None) -> bytes | None:
+    """Read one bounded wheel from its exact local-file or clean HTTPS URL."""
+    if direct_url is None:
+        return None
+    raw_url = direct_url.get("url")
+    if not isinstance(raw_url, str):
+        return None
+    parsed = urllib.parse.urlsplit(raw_url)
+    if not parsed.path.casefold().endswith(".whl"):
+        return None
+    if parsed.scheme.casefold() == "file":
+        path = _local_wheel_archive_path(direct_url)
+        if path is None:
+            return None
+        identity = _regular_file_identity(path)
+        if identity is None or identity[2] > MAX_DISTRIBUTION_WHEEL_BYTES:
+            return None
+        return _read_open_regular_file(
+            path,
+            identity,
+            maximum_bytes=MAX_DISTRIBUTION_WHEEL_BYTES,
+        )
+    if not _is_official_release_wheel_url(raw_url) or not _url_host_resolves_publicly(raw_url):
+        return None
+    try:
+        opener = urllib.request.build_opener(_ReleaseWheelRedirectHandler())
+        with opener.open(raw_url, timeout=60) as response:  # noqa: S310
+            final_url = urllib.parse.urlsplit(str(response.geturl()))
+            final_url_text = urllib.parse.urlunsplit(final_url)
+            if not (
+                _is_official_release_wheel_url(final_url_text)
+                or _is_github_release_asset_url(final_url_text)
+            ):
+                return None
+            content = response.read(MAX_DISTRIBUTION_WHEEL_BYTES + 1)
+    except (OSError, ValueError, urllib.error.HTTPError):
+        return None
+    return content if len(content) <= MAX_DISTRIBUTION_WHEEL_BYTES else None
+
+
+class _ReleaseWheelRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Reject a release download redirect before it can reach an unsafe host."""
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> urllib.request.Request | None:
+        if not _is_github_release_asset_url(newurl) or not _url_host_resolves_publicly(newurl):
+            raise urllib.error.HTTPError(
+                newurl,
+                403,
+                "unsafe wheel download redirect",
+                headers,
+                fp,
+            )
+        return super().redirect_request(
+            req,
+            fp,
+            code,
+            msg,
+            headers,
+            newurl,
+        )
+
+
+def _is_official_release_wheel_url(value: str) -> bool:
+    """Allow only one credential-free canonical clio-relay GitHub release URL."""
+    try:
+        parsed = urllib.parse.urlsplit(value)
+        port = parsed.port
+    except ValueError:
+        return False
+    return (
+        parsed.scheme.casefold() == "https"
+        and parsed.hostname == "github.com"
+        and port in {None, 443}
+        and parsed.username is None
+        and parsed.password is None
+        and not parsed.query
+        and not parsed.fragment
+        and _OFFICIAL_RELEASE_WHEEL_PATH.fullmatch(parsed.path) is not None
+    )
+
+
+def _is_github_release_asset_url(value: str) -> bool:
+    """Allow only GitHub's credential-free HTTPS release-asset redirect target."""
+    try:
+        parsed = urllib.parse.urlsplit(value)
+        port = parsed.port
+    except ValueError:
+        return False
+    return (
+        parsed.scheme.casefold() == "https"
+        and parsed.hostname == "release-assets.githubusercontent.com"
+        and port in {None, 443}
+        and parsed.username is None
+        and parsed.password is None
+        and not parsed.fragment
+        and parsed.path.startswith("/github-production-release-asset/")
+    )
+
+
+def _url_host_resolves_publicly(value: str) -> bool:
+    """Fail closed unless every resolved address for one HTTPS URL is globally routable."""
+    try:
+        parsed = urllib.parse.urlsplit(value)
+        hostname = parsed.hostname
+        if parsed.scheme.casefold() != "https" or hostname is None:
+            return False
+        answers = socket.getaddrinfo(hostname, parsed.port or 443, type=socket.SOCK_STREAM)
+        addresses = {
+            str(answer[4][0]).split("%", maxsplit=1)[0]
+            for answer in answers
+            if answer[0] in {socket.AF_INET, socket.AF_INET6}
+        }
+        return bool(addresses) and all(
+            ipaddress.ip_address(address).is_global for address in addresses
+        )
+    except (OSError, ValueError):
+        return False
 
 
 def _local_wheel_matches_install(
@@ -3522,28 +3874,9 @@ def _local_wheel_matches_install(
     expected_sha256: str,
 ) -> bool:
     """Verify a local wheel archive and the installed files derived from its RECORD."""
-    path = _local_wheel_archive_path(direct_url)
-    if path is None:
+    if _local_wheel_archive_path(direct_url) is None:
         return False
-    direct_hashes = _direct_url_sha256_hashes(direct_url)
-    if direct_hashes and expected_sha256 not in direct_hashes:
-        return False
-    try:
-        if path.suffix.casefold() != ".whl":
-            return False
-        identity = _regular_file_identity(path)
-        if identity is None or identity[2] > 128 * 1024 * 1024:
-            return False
-        wheel_bytes = _read_open_regular_file(
-            path,
-            identity,
-            maximum_bytes=128 * 1024 * 1024,
-        )
-        if wheel_bytes is None or hashlib.sha256(wheel_bytes).hexdigest() != expected_sha256:
-            return False
-        return _installed_files_match_wheel(distribution, wheel_bytes)
-    except (OSError, ValueError, zipfile.BadZipFile):
-        return False
+    return _wheel_url_matches_install(distribution, direct_url, expected_sha256)
 
 
 def _local_wheel_archive_path(direct_url: dict[str, Any] | None) -> Path | None:
@@ -3722,6 +4055,23 @@ def _classify_install_source(
     if url is not None and url.startswith("file:"):
         return InstallSourceKind.CHECKOUT, url
     return InstallSourceKind.UNKNOWN, url
+
+
+def _is_official_github_release_wheel(
+    direct_url: dict[str, Any] | None,
+    distribution_version: str,
+) -> bool:
+    """Recognize the canonical clio-relay wheel URL for one GitHub release."""
+    if direct_url is None:
+        return False
+    value = direct_url.get("url")
+    if not isinstance(value, str):
+        return False
+    expected = (
+        "https://github.com/iowarp/clio-relay/releases/download/"
+        f"v{distribution_version}/clio_relay-{distribution_version}-py3-none-any.whl"
+    )
+    return value == expected
 
 
 def _parse_source_override(value: str) -> tuple[InstallSourceKind, str | None]:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -18,7 +18,10 @@ from clio_relay.application_profiles import (
     render_cluster_app_install_script,
 )
 from clio_relay.bootstrap import (
+    CLIO_KIT_JARVIS_MCP_VERSION,
+    CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME,
     CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
+    CLIO_KIT_JARVIS_MCP_WHEEL_URL,
     FRP_LINUX_AMD64_SHA256,
     FRPC_LINUX_AMD64_SHA256,
     FRPS_LINUX_AMD64_SHA256,
@@ -101,10 +104,16 @@ def test_linux_user_bootstrap_script_installs_required_components() -> None:
     ) in script
     assert "pull --ff-only" not in script
     assert 'python -m pip install -e "$HOME/.local/src/jarvis' not in script
-    assert "JARVIS_MCP_INSTALL_SPEC=clio-kit==2.4.2" in script
+    assert f"JARVIS_MCP_INSTALL_SPEC={CLIO_KIT_JARVIS_MCP_WHEEL_URL}" in script
     assert f"JARVIS_MCP_ARTIFACT_SHA256={CLIO_KIT_JARVIS_MCP_WHEEL_SHA256}" in script
-    assert "python -m pip download --isolated --disable-pip-version-check --no-cache-dir" in script
-    assert '"$JARVIS_VENV/bin/python" -m pip download' in script
+    assert f'"{CLIO_KIT_JARVIS_MCP_WHEEL_URL}")' in script
+    assert f'JARVIS_MCP_VERSION="{CLIO_KIT_JARVIS_MCP_VERSION}"' in script
+    assert (
+        f'JARVIS_MCP_ARTIFACT_PATH="$COMPONENT_DOWNLOAD_DIR/{CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME}"'
+    ) in script
+    assert "--proto '=https' --proto-redir '=https' --tlsv1.2" in script
+    assert "--retry 3 --retry-all-errors --retry-max-time 180" in script
+    assert 'JARVIS_MCP_REQUESTED_SOURCE="github_release"' in script
     assert "uv tool install --force --python 3.12 --no-config \\" in script
     assert '--default-index https://pypi.org/simple "$JARVIS_MCP_INSTALL_TARGET"' in script
     digest_check = (
@@ -247,6 +256,13 @@ def test_custom_clio_kit_bootstrap_wheel_requires_preinstall_digest() -> None:
     assert script.index("JARVIS_MCP_ARTIFACT_SHA256 *$JARVIS_MCP_ARTIFACT_PATH") < (
         script.index("uv tool install --force")
     )
+
+
+def test_clio_kit_exact_version_override_requires_its_own_digest() -> None:
+    with pytest.raises(ConfigurationError, match="requires its expected wheel SHA-256"):
+        render_linux_user_bootstrap_script(
+            jarvis_mcp_install_spec=f"clio-kit=={CLIO_KIT_JARVIS_MCP_VERSION}"
+        )
 
 
 def test_bootstrap_uv_pin_matches_release_policy() -> None:

--- a/tests/test_ci_clio_kit_wheel.py
+++ b/tests/test_ci_clio_kit_wheel.py
@@ -7,12 +7,27 @@ from typing import Any, cast
 
 import yaml
 
+from clio_relay.jarvis_mcp import (
+    CLIO_KIT_JARVIS_MCP_VERSION,
+    CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME,
+    CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
+    CLIO_KIT_JARVIS_MCP_WHEEL_URL,
+)
+
 ROOT = Path(__file__).resolve().parents[1]
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
-WHEEL_FILENAME = "clio_kit-2.4.2-py3-none-any.whl"
-WHEEL_SHA256 = "655db7d63a64d0220f3fdfe70eaf7d6a654ce06918b04c4b4e0f7db608116363"
-WHEEL_URL = f"https://github.com/iowarp/clio-kit/releases/download/v2.4.2/{WHEEL_FILENAME}"
+WHEEL_FILENAME = "clio_kit-2.4.5-py3-none-any.whl"
+WHEEL_SHA256 = "327186527b16e7ce33be9d3d27a1e09dc564d2bca5ffa6beedfadf25738deb81"
+WHEEL_URL = f"https://github.com/iowarp/clio-kit/releases/download/v2.4.5/{WHEEL_FILENAME}"
+
+
+def test_runtime_and_ci_share_one_exact_clio_kit_release_pin() -> None:
+    """Keep bootstrap, JARVIS MCP, and CI on the same exact release wheel bytes."""
+    assert CLIO_KIT_JARVIS_MCP_VERSION == "2.4.5"
+    assert CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME == WHEEL_FILENAME
+    assert CLIO_KIT_JARVIS_MCP_WHEEL_SHA256 == WHEEL_SHA256
+    assert CLIO_KIT_JARVIS_MCP_WHEEL_URL == WHEEL_URL
 
 
 def _ci_workflow() -> dict[str, Any]:

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1696,7 +1696,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "cbbc68c6a3b1c2c039d1e51ba08d406496ba847d64f7bfd3187fe154ed76869c"
+        "d0d2bd529c8f544d3f87b38c15225b240561b04e04714c7700afd8a00d3b4006"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5206,7 +5206,7 @@ def test_jarvis_discovery_persists_exact_durable_artifact_bytes(
         },
         "structured_result": None,
         "protocol_version": "2024-11-05",
-        "server_info": {"name": "clio-kit", "version": "2.4.2"},
+        "server_info": {"name": "clio-kit", "version": "2.4.5"},
         "server_artifact": server_artifact,
         "returncode": 0,
         "stdout": "",

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -37,7 +37,7 @@ from clio_relay.jarvis_mcp import (
     jarvis_mcp_command,
     jarvis_user_contract,
 )
-from clio_relay.validation_report import SoftwareIdentity
+from clio_relay.validation_report import InstallSource, InstallSourceKind, SoftwareIdentity
 
 
 def test_distribution_file_source_accepts_a_canonical_filesystem_alias(
@@ -334,6 +334,71 @@ def test_install_receipt_labels_exact_version_spec_as_pypi(tmp_path: Path) -> No
     )
 
     assert receipt.requested_source == "pypi"
+
+
+def test_installation_info_uses_verified_uv_tool_receipt_without_bootstrap_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    missing_bootstrap = tmp_path / "missing-install-receipt.json"
+    uv_receipt = tmp_path / "tools" / "clio-relay" / "uv-receipt.toml"
+    uv_receipt.parent.mkdir(parents=True)
+    uv_receipt.write_text("[tool]\n", encoding="utf-8")
+    version = metadata.version("clio-relay")
+    source_url = (
+        "https://github.com/iowarp/clio-relay/releases/download/"
+        f"v{version}/clio_relay-{version}-py3-none-any.whl"
+    )
+    source = InstallSource(
+        kind=InstallSourceKind.WHEEL,
+        detected_kind=InstallSourceKind.WHEEL,
+        reference=source_url,
+        launcher="uv-tool",
+        package_path=str(tmp_path / "site-packages" / "clio_relay"),
+        distribution_version=version,
+        artifact_sha256="a" * 64,
+        direct_url={"url": source_url, "archive_info": {}},
+        artifact_identity_verified=True,
+        released_artifact=True,
+        launcher_verified=True,
+        launcher_receipt={
+            "verified": True,
+            "uv_tool_receipt": {
+                "path": str(uv_receipt),
+                "verified": True,
+            },
+        },
+    )
+
+    monkeypatch.delenv(INSTALL_RECEIPT_PATH_ENV, raising=False)
+    monkeypatch.setattr(
+        installation_module,
+        "default_install_receipt_path",
+        lambda: missing_bootstrap,
+    )
+
+    def detect_source(**_kwargs: object) -> InstallSource:
+        return source
+
+    monkeypatch.setattr(
+        installation_module,
+        "detect_install_source",
+        detect_source,
+    )
+
+    info = installation_info()
+    receipt = cast(dict[str, object], info["receipt"])
+    install_source = cast(dict[str, object], info["install_source"])
+
+    assert info["receipt_origin"] == "uv-tool"
+    assert info["receipt_matches_install"] is True
+    assert receipt["install_spec"] == source_url
+    assert receipt["requested_source"] == "wheel"
+    assert receipt["artifact_sha256"] == "a" * 64
+    assert install_source["artifact_identity_verified"] is True
+    assert install_source["launcher_verified"] is True
+    assert install_source["released_artifact"] is True
+    assert info["component_runtime"] == {}
 
 
 def test_remote_native_jarvis_component_requires_runtime_capability_provenance(

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.2.8"
+    assert version == "1.2.9"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -303,11 +303,11 @@ def test_jarvis_release_requirement_enforces_unified_gray_scott_contract() -> No
         if resource["kind"] == "relay_worker"
     )
     clio_kit_component = worker["metadata_equals"]["component_artifacts"]["clio-kit"]
-    assert clio_kit_component["distribution_version"] == "2.4.2"
+    assert clio_kit_component["distribution_version"] == "2.4.5"
     assert clio_kit_component["persistent_tool"]["manager"] == "uv"
     assert clio_kit_component["persistent_tool"]["uv_version"] == "0.11.28"
     assert clio_kit_component["persistent_tool"]["source_artifact_sha256"] == (
-        "655db7d63a64d0220f3fdfe70eaf7d6a654ce06918b04c4b4e0f7db608116363"
+        "327186527b16e7ce33be9d3d27a1e09dc564d2bca5ffa6beedfadf25738deb81"
     )
     jarvis_component = worker["metadata_equals"]["component_artifacts"]["jarvis-cd"]
     assert jarvis_component["distribution_version"] == "1.3.2"
@@ -470,7 +470,7 @@ def test_spack_release_requirements_split_existing_resolution_from_fresh_install
     )
     assert fresh_server["metadata_equals"]["server_name"] == "spack-fresh"
     assert fresh_server["metadata_equals"]["install_artifact_sha256"] == (
-        "655db7d63a64d0220f3fdfe70eaf7d6a654ce06918b04c4b4e0f7db608116363"
+        "327186527b16e7ce33be9d3d27a1e09dc564d2bca5ffa6beedfadf25738deb81"
     )
     assert fresh_server["metadata_equals"]["contract_id"] == "clio-kit-spack-user-v2"
     assert fresh_server["metadata_equals"]["contract_sha256"] == (

--- a/tests/test_remote_mcp.py
+++ b/tests/test_remote_mcp.py
@@ -140,7 +140,7 @@ def test_scientific_catalog_contract_is_read_only_and_exact(
         command="uvx",
         args=[
             "--from",
-            "/opt/clio/clio_kit-2.4.2-py3-none-any.whl",
+            "/opt/clio/clio_kit-2.4.5-py3-none-any.whl",
             "clio-kit",
             "mcp-server",
             "scientific-catalog",
@@ -2146,7 +2146,7 @@ def test_acceptance_report_requires_verified_persistent_uv_tool_runtime(
             "sha256": "a" * 64,
             "size_bytes": 256,
         },
-        "install_spec": "/opt/wheels/clio_kit-2.4.2-py3-none-any.whl",
+        "install_spec": "/opt/wheels/clio_kit-2.4.5-py3-none-any.whl",
         "install_source": "uv-tool",
         "install_artifact_sha256": "b" * 64,
         "python_distribution_runtime": {

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import io
 import json
 import os
 import shutil
+import socket
 import subprocess
 import sys
 import zipfile
@@ -209,6 +211,332 @@ def test_local_wheel_identity_rejects_forged_direct_url_hash(tmp_path: Path) -> 
         artifact_sha256=forged_digest,
         launcher="uvx",
     )
+
+
+def test_released_https_wheel_binds_url_sha_record_and_uv_tool(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    wheel, _, digest, installed = _test_wheel(tmp_path)
+    wheel_bytes = wheel.read_bytes()
+    source_url = (
+        "https://github.com/iowarp/clio-relay/releases/download/"
+        "v1.0.0/clio_relay-1.0.0-py3-none-any.whl"
+    )
+
+    class RemoteDistribution(_FakeWheelDistribution):
+        version = "1.0.0"
+
+        def read_text(self, filename: str) -> str | None:
+            if filename == "direct_url.json":
+                return json.dumps({"url": source_url, "archive_info": {}})
+            return None
+
+    class WheelResponse(io.BytesIO):
+        def __enter__(self) -> WheelResponse:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            self.close()
+
+        def geturl(self) -> str:
+            return (
+                "https://release-assets.githubusercontent.com/"
+                "github-production-release-asset/exact-wheel?token=test"
+            )
+
+    class WheelOpener:
+        def open(self, *_args: object, **_kwargs: object) -> WheelResponse:
+            return WheelResponse(wheel_bytes)
+
+    installed_root = cast(_FakeWheelDistribution, installed).root
+    distribution = cast(metadata.Distribution, RemoteDistribution(installed_root))
+
+    def find_distribution(_name: str) -> metadata.Distribution:
+        return distribution
+
+    def package_files(_name: str) -> Path:
+        return tmp_path
+
+    def verified_launcher(
+        *_args: object,
+        **_kwargs: object,
+    ) -> tuple[bool, dict[str, object]]:
+        return True, {"verified": True}
+
+    def build_opener(*_args: object, **_kwargs: object) -> WheelOpener:
+        return WheelOpener()
+
+    def publicly_resolved(_url: str) -> bool:
+        return True
+
+    monkeypatch.setattr(
+        validation_report_module.metadata,
+        "distribution",
+        find_distribution,
+    )
+    monkeypatch.setattr(validation_report_module.resources, "files", package_files)
+    monkeypatch.setattr(
+        validation_report_module,
+        "_detect_launcher_receipt",
+        verified_launcher,
+    )
+    monkeypatch.setattr(
+        validation_report_module.urllib.request,
+        "build_opener",
+        build_opener,
+    )
+    monkeypatch.setattr(
+        validation_report_module,
+        "_url_host_resolves_publicly",
+        publicly_resolved,
+    )
+
+    source = validation_report_module.detect_install_source(
+        launcher="uv-tool",
+        artifact_sha256=digest,
+    )
+
+    assert source.kind is InstallSourceKind.WHEEL
+    assert source.reference == source_url
+    assert source.artifact_identity_verified is True
+    assert source.launcher_verified is True
+    assert source.released_artifact is True
+
+    rejected = validation_report_module.detect_install_source(
+        launcher="uv-tool",
+        artifact_sha256="f" * 64,
+    )
+    assert rejected.artifact_identity_verified is False
+    assert rejected.released_artifact is False
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://user@github.com/iowarp/clio-relay/releases/download/v1.0.0/"
+        "clio_relay-1.0.0-py3-none-any.whl",
+        "https://github.com/iowarp/clio-relay/releases/download/v1.0.0/"
+        "clio_relay-1.0.0-py3-none-any.whl?redirect=https://127.0.0.1",
+        "https://github.com/other/clio-relay/releases/download/v1.0.0/"
+        "clio_relay-1.0.0-py3-none-any.whl",
+        "https://github.com/iowarp/clio-relay/releases/download/v1.0.0/"
+        "clio_relay-1.0.1-py3-none-any.whl",
+        "https://127.0.0.1/clio_relay-1.0.0-py3-none-any.whl",
+        "https://github.com:invalid/iowarp/clio-relay/releases/download/v1.0.0/"
+        "clio_relay-1.0.0-py3-none-any.whl",
+    ],
+)
+def test_remote_wheel_fetch_rejects_noncanonical_sources(url: str) -> None:
+    assert validation_report_module._is_official_release_wheel_url(url) is False  # pyright: ignore[reportPrivateUsage]
+    assert (
+        validation_report_module._direct_wheel_bytes(  # pyright: ignore[reportPrivateUsage]
+            {"url": url, "archive_info": {}}
+        )
+        is None
+    )
+
+
+def test_release_wheel_fetch_rejects_private_dns_and_unsafe_redirects(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    source_url = (
+        "https://github.com/iowarp/clio-relay/releases/download/"
+        "v1.0.0/clio_relay-1.0.0-py3-none-any.whl"
+    )
+
+    def private_dns(
+        _host: str,
+        _port: int,
+        *,
+        type: socket.SocketKind,
+    ) -> list[tuple[socket.AddressFamily, socket.SocketKind, int, str, tuple[str, int]]]:
+        assert type is socket.SOCK_STREAM
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 443))]
+
+    monkeypatch.setattr(validation_report_module.socket, "getaddrinfo", private_dns)
+
+    assert validation_report_module._is_official_release_wheel_url(source_url) is True  # pyright: ignore[reportPrivateUsage]
+    assert validation_report_module._url_host_resolves_publicly(source_url) is False  # pyright: ignore[reportPrivateUsage]
+    handler = validation_report_module._ReleaseWheelRedirectHandler()  # pyright: ignore[reportPrivateUsage]
+    request = validation_report_module.urllib.request.Request(source_url)
+    with pytest.raises(validation_report_module.urllib.error.HTTPError):
+        handler.redirect_request(
+            request,
+            None,
+            302,
+            "Found",
+            {},
+            "https://127.0.0.1/private-wheel.whl",
+        )
+
+
+def test_uv_tool_receipt_binds_exact_remote_url_and_launcher(tmp_path: Path) -> None:
+    environment = tmp_path / "tools" / "clio-relay"
+    environment.mkdir(parents=True)
+    launcher = tmp_path / "bin" / "clio-relay.exe"
+    launcher.parent.mkdir()
+    launcher.write_bytes(b"launcher")
+    source_url = "https://example.invalid/releases/clio_relay-1.0.0-py3-none-any.whl"
+    (environment / "uv-receipt.toml").write_text(
+        "\n".join(
+            [
+                "[tool]",
+                f'requirements = [{{ name = "clio-relay", url = "{source_url}" }}]',
+                "entrypoints = [",
+                (
+                    '  { name = "clio-relay", '
+                    f'install-path = "{launcher.as_posix()}", from = "clio-relay" }},'
+                ),
+                "]",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    class Distribution:
+        version = "1.0.0"
+
+        def read_text(self, filename: str) -> str | None:
+            if filename == "direct_url.json":
+                return json.dumps({"url": source_url, "archive_info": {}})
+            return None
+
+    identity = validation_report_module._persistent_uv_tool_receipt_identity(  # pyright: ignore[reportPrivateUsage]
+        environment_prefix=environment,
+        tool_executable=launcher.absolute(),
+        distribution=cast(metadata.Distribution, Distribution()),
+    )
+
+    assert identity["launcher_bound"] is True
+    assert identity["source_bound"] is True
+    assert identity["requirement_url"] == source_url
+    assert identity["verified"] is True
+
+    changed = (
+        (environment / "uv-receipt.toml")
+        .read_text(encoding="utf-8")
+        .replace(
+            source_url,
+            f"{source_url}.changed",
+        )
+    )
+    (environment / "uv-receipt.toml").write_text(changed, encoding="utf-8")
+    rejected = validation_report_module._persistent_uv_tool_receipt_identity(  # pyright: ignore[reportPrivateUsage]
+        environment_prefix=environment,
+        tool_executable=launcher.absolute(),
+        distribution=cast(metadata.Distribution, Distribution()),
+    )
+    assert rejected["source_bound"] is False
+    assert rejected["verified"] is False
+
+
+def test_persistent_uv_tool_discovers_uv_from_path_and_requires_receipt(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    tool_directory = tmp_path / "uv" / "tools"
+    environment = tool_directory / "clio-relay"
+    tool_bin = tmp_path / "uv" / "bin"
+    package = environment / "Lib" / "site-packages" / "clio_relay"
+    interpreter = environment / "Scripts" / "python.exe"
+    launcher = tool_bin / "clio-relay.exe"
+    uv = tmp_path / "bin" / "uv.exe"
+    base_prefix = tmp_path / "python"
+    for directory in (package, interpreter.parent, tool_bin, uv.parent, base_prefix):
+        directory.mkdir(parents=True, exist_ok=True)
+    interpreter.write_bytes(b"python")
+    launcher.write_bytes(b"launcher")
+    uv.write_bytes(b"uv")
+    source_url = (
+        "https://github.com/iowarp/clio-relay/releases/download/"
+        "v1.0.0/clio_relay-1.0.0-py3-none-any.whl"
+    )
+    (environment / "uv-receipt.toml").write_text(
+        "\n".join(
+            [
+                "[tool]",
+                f'requirements = [{{ name = "clio-relay", url = "{source_url}" }}]',
+                "entrypoints = [",
+                (
+                    '  { name = "clio-relay", '
+                    f'install-path = "{launcher.as_posix()}", from = "clio-relay" }},'
+                ),
+                "]",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    class Distribution:
+        version = "1.0.0"
+
+        def read_text(self, filename: str) -> str | None:
+            if filename == "direct_url.json":
+                return json.dumps({"url": source_url, "archive_info": {}})
+            return None
+
+    launcher_digest = hashlib.sha256(launcher.read_bytes()).hexdigest()
+
+    def find_executable(name: str) -> str:
+        return str(uv) if name == "uv" else str(launcher)
+
+    def uv_identity(_path: str | None) -> tuple[bool, str | None, str | None]:
+        return True, "0.11.28", hashlib.sha256(uv.read_bytes()).hexdigest()
+
+    def uv_tool_directory(_path: Path | None, *, bin_directory: bool) -> Path:
+        return tool_bin if bin_directory else tool_directory
+
+    def pyvenv_version(_prefix: Path) -> str:
+        return "0.11.28"
+
+    def record_identity(_distribution: metadata.Distribution) -> dict[str, object]:
+        return {
+            "verified": True,
+            "console_script_sha256": [launcher_digest],
+            "record_sha256": "a" * 64,
+        }
+
+    monkeypatch.delenv("UV", raising=False)
+    monkeypatch.setattr(
+        validation_report_module.shutil,
+        "which",
+        find_executable,
+    )
+    monkeypatch.setattr(validation_report_module.sys, "prefix", str(environment))
+    monkeypatch.setattr(validation_report_module.sys, "base_prefix", str(base_prefix))
+    monkeypatch.setattr(validation_report_module.sys, "executable", str(interpreter))
+    monkeypatch.setattr(
+        validation_report_module,
+        "_uv_executable_identity",
+        uv_identity,
+    )
+    monkeypatch.setattr(
+        validation_report_module,
+        "_uv_tool_dir",
+        uv_tool_directory,
+    )
+    monkeypatch.setattr(
+        validation_report_module,
+        "_pyvenv_uv_version",
+        pyvenv_version,
+    )
+    monkeypatch.setattr(
+        validation_report_module,
+        "_installed_record_identity",
+        record_identity,
+    )
+
+    verified, receipt = validation_report_module._detect_persistent_uv_tool_receipt(  # pyright: ignore[reportPrivateUsage]
+        detected_kind=InstallSourceKind.WHEEL,
+        package_path=str(package),
+        distribution=cast(metadata.Distribution, Distribution()),
+    )
+
+    assert verified is True
+    assert receipt["uv_executable"] == str(uv)
+    assert receipt["uv_tool_receipt"]["verified"] is True
+    assert receipt["verified"] is True
 
 
 def test_uv_launcher_identity_hashes_exact_regular_executable(
@@ -1612,7 +1940,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.2.8"
+    assert policy.release_version == "1.2.9"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256
@@ -2768,7 +3096,7 @@ def _fresh_spack_transition_report(
             ),
             ValidationResource(
                 kind="mcp_server",
-                resource_id="spack-fresh:clio-kit-2.4.2",
+                resource_id="spack-fresh:clio-kit-2.4.5",
                 role="remote_mcp_server",
                 cluster="ares",
                 state="verified",

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.2.8"
+version = "1.2.9"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- make installation-info verify direct persistent uv tool installs on Windows without requiring a relay bootstrap receipt
- bind the uv launcher/receipt, PEP 610 source, exact wheel SHA, and installed RECORD closure; reject unsafe wheel URLs, private DNS, and redirect targets
- pin bootstrap, JARVIS, Spack, CI, and release policy to the immutable clio-kit 2.4.5 GitHub wheel
- release as clio-relay 1.2.9 with recomputed acceptance-matrix digest

## Focused verification
- Ruff check/format
- strict Pyright: 0 errors
- 21 focused pytest cases
- uv lock --check
- downloaded clio-kit 2.4.5 wheel SHA and embedded contract-index verification
- git diff --check

No broad regression suite was rerun locally; tag CI remains asynchronous per the repository release workflow.