### PR TITLE
fix: harden remote session teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.2.11` uses a release-first patch process. A maintainer builds the
+> Version `1.2.12` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.2.11"
+$Version = "1.2.12"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.2.11"
+release_version: "1.2.12"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 02122ec69f25ae9ee9190db3b1e94a7824e4ae0e8252495331d052409715c4d4
+acceptance_matrix_sha256: 9d722812077d0120f60d305d29b7776d21c7d83fad54cf7ee59f248c6f428bb4
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.2.11"
+$Tag = "v1.2.12"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.11" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.12" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.2.11",
-  "matrix_sha256": "02122ec69f25ae9ee9190db3b1e94a7824e4ae0e8252495331d052409715c4d4",
+  "release_version": "1.2.12",
+  "matrix_sha256": "9d722812077d0120f60d305d29b7776d21c7d83fad54cf7ee59f248c6f428bb4",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.2.11"
+version = "1.2.12"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.2.11"
+__version__ = "1.2.12"

--- a/src/clio_relay/session_lifecycle.py
+++ b/src/clio_relay/session_lifecycle.py
@@ -693,6 +693,7 @@ def teardown_remote_session(
     output = _ssh_script(
         definition,
         _owned_teardown_script(
+            definition=definition,
             session_id=session_id,
             expected_session_generation_id=expected_session_generation_id,
             stop_worker=stop_worker,
@@ -1301,6 +1302,7 @@ __CLIO_RELAY_OWNED_STATUS__
 
 def _owned_teardown_script(
     *,
+    definition: ClusterDefinition,
     session_id: str,
     expected_session_generation_id: str,
     stop_worker: bool,
@@ -1320,6 +1322,7 @@ def _owned_teardown_script(
     if cancel_scheduler_jobs:
         cleanup_policy_flags += " --cleanup-cancel-scheduler-jobs"
     return f"""set -euo pipefail
+{remote_env(definition)}
 session_id={shlex.quote(session_id)}
 session_dir="$HOME/.local/share/clio-relay/sessions/$session_id"
 mkdir -p "$session_dir"
@@ -1408,11 +1411,32 @@ def token_group_processes():
         try:
             if proc.stat().st_uid != os.geteuid():
                 continue
-            environment = (proc / "environ").read_bytes().split(bytes([0]))
-            state = (proc / "stat").read_text(encoding="utf-8").rsplit(")", 1)[1].split()[0]
+            fields = (proc / "stat").read_text(encoding="utf-8").rsplit(")", 1)[1].split()
+            state = fields[0]
         except (FileNotFoundError, ProcessLookupError):
             continue
         except (OSError, IndexError, ValueError) as exc:
+            raise RuntimeError(
+                f"cannot verify owned session process {{proc.name}}: {{exc}}"
+            ) from exc
+        try:
+            environment = (proc / "environ").read_bytes().split(bytes([0]))
+        except (FileNotFoundError, ProcessLookupError):
+            continue
+        except PermissionError as exc:
+            recorded_pgid = metadata.get("api_pgid")
+            try:
+                observed_pgid = int(fields[2])
+            except (IndexError, ValueError) as parse_exc:
+                raise RuntimeError(
+                    f"cannot verify protected session process {{proc.name}}: {{parse_exc}}"
+                ) from parse_exc
+            if isinstance(recorded_pgid, int) and observed_pgid != recorded_pgid:
+                continue
+            raise RuntimeError(
+                f"cannot verify protected session process {{proc.name}}: {{exc}}"
+            ) from exc
+        except OSError as exc:
             raise RuntimeError(
                 f"cannot verify owned session process {{proc.name}}: {{exc}}"
             ) from exc

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.2.11"
+    assert version == "1.2.12"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -628,9 +628,15 @@ def test_teardown_remote_session_kills_owned_pid_and_optional_worker(
     assert "process_start_ticks" in scripts[0]
     assert "ownership proof failed" in scripts[0]
     assert "token_group_processes" in scripts[0]
-    token_scan = scripts[0].split("def token_group_processes():", 1)[1].split("pid =", 1)[0]
+    token_scan = (
+        scripts[0].split("def token_group_processes():", 1)[1].split("\npid = metadata.get", 1)[0]
+    )
     assert "process_group ==" not in token_scan
     assert "proc.stat().st_uid != os.geteuid()" in token_scan
+    assert 'export PATH="$HOME/.local/bin:$PATH"' in scripts[0]
+    assert "observed_pgid = int(fields[2])" in token_scan
+    assert "observed_pgid != recorded_pgid" in token_scan
+    assert "cannot verify protected session process" in token_scan
     assert "os.pidfd_open(owned_pid, 0)" in scripts[0]
     assert "signal.pidfd_send_signal(process_fd, sig, None, 0)" in scripts[0]
     assert "signal_token_processes(signal.SIGTERM)" in scripts[0]
@@ -662,6 +668,7 @@ def test_teardown_remote_session_kills_owned_pid_and_optional_worker(
 
 def test_owned_teardown_revalidates_exact_pidfd_identity_after_leader_pid_reuse() -> None:
     script = session_lifecycle._owned_teardown_script(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        definition=ClusterDefinition(name="ares", ssh_host="ares"),
         session_id="session-1",
         expected_session_generation_id="generation-1",
         stop_worker=False,

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1940,7 +1940,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.2.11"
+    assert policy.release_version == "1.2.12"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.2.11"
+version = "1.2.12"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Production bug

Owned remote relay teardown could fail on a live cluster even when the durable session identity was correct. The generated teardown program did not apply the cluster's configured remote environment, so cleanup helpers installed under the operator PATH could be unavailable. On Linux systems with protected or dump-disabled processes, reading `/proc/<pid>/environ` can also return `PermissionError`; the scanner treated every such process as a fatal ambiguity and aborted cleanup before reaching the recorded owned process.

## Reproduction

1. Bootstrap an owned remote session on a cluster whose relay tooling depends on the configured remote environment.
2. Leave a same-user process whose `/proc/<pid>/environ` is protected, as happens with dump-disabled services.
3. Run explicit owned-session teardown.
4. Observe teardown fail during the ownership scan instead of distinguishing an unrelated process group and continuing safely.

## Fix

- Apply the cluster's remote environment at the start of the owned teardown script.
- Parse the process group from `/proc/<pid>/stat` before attempting the protected environment read.
- Ignore an unreadable process only when its observed process group differs from the session's recorded API process group.
- Fail closed with a precise error when a protected process could still be the owned group.
- Bump the release contract and dependency lock to 1.2.12.

This preserves the ownership safety boundary: cleanup never signals an unverifiable process that could belong to another session.

## Validation

Focused lifecycle and release-contract tests passed on the branch, including assertions for the remote PATH, protected-process group discrimination, and fail-closed behavior.