### PR TITLE
fix: validate canonical released component artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.2.12` uses a release-first patch process. A maintainer builds the
+> Version `1.2.13` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.2.12"
+$Version = "1.2.13"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.2.12"
+release_version: "1.2.13"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 9d722812077d0120f60d305d29b7776d21c7d83fad54cf7ee59f248c6f428bb4
+acceptance_matrix_sha256: 7575160c0c0e1fda6f33708e5bc8ef26eeb85bbe8d7a2c8e9726a119980f5dc2
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.2.12"
+$Tag = "v1.2.13"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.12" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.13" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.2.12",
-  "matrix_sha256": "9d722812077d0120f60d305d29b7776d21c7d83fad54cf7ee59f248c6f428bb4",
+  "release_version": "1.2.13",
+  "matrix_sha256": "7575160c0c0e1fda6f33708e5bc8ef26eeb85bbe8d7a2c8e9726a119980f5dc2",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.2.12"
+version = "1.2.13"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.2.12"
+__version__ = "1.2.13"

--- a/src/clio_relay/installation.py
+++ b/src/clio_relay/installation.py
@@ -51,6 +51,10 @@ CLIO_KIT_NATIVE_OPERATIONS = (
     "jarvis_get_execution",
     "jarvis_run",
 )
+OFFICIAL_COMPONENT_RELEASE_REPOSITORIES = {
+    "clio-kit": ("iowarp", "clio-kit"),
+    "jarvis-cd": ("grc-iit", "jarvis-cd"),
+}
 JARVIS_CD_NATIVE_OPERATIONS = (
     "execution_handle.progress",
     "pipeline.get_execution",
@@ -1144,7 +1148,10 @@ def attach_verified_worker_identity(
                     excerpt=(
                         "clio-kit component artifact is exact and released"
                         if component_valid
-                        else "clio-kit component artifact is missing or not a hashed PyPI wheel"
+                        else (
+                            "clio-kit component artifact is missing or not an exact "
+                            "hashed released wheel"
+                        )
                     ),
                     metadata={
                         "component": (
@@ -1157,7 +1164,7 @@ def attach_verified_worker_identity(
             error=(
                 None
                 if component_valid
-                else "worker clio-kit component is not bound to an exact hashed PyPI artifact"
+                else "worker clio-kit component is not bound to an exact hashed released artifact"
             ),
         )
     )
@@ -1165,7 +1172,7 @@ def attach_verified_worker_identity(
         report.status = ValidationStatus.FAILED
         report.error = "worker component artifact verification failed"
         raise ConfigurationError(
-            "worker clio-kit component is not bound to an exact hashed PyPI artifact"
+            "worker clio-kit component is not bound to an exact hashed released artifact"
         )
     clio_kit_native_runtime = runtime_identity
     try:
@@ -2091,16 +2098,8 @@ def verify_remote_package_progress_component(
         raise ConfigurationError(
             f"worker installation omitted package progress component {component_name}"
         )
-    version = component.distribution_version
-    digest = component.artifact_sha256
     if (
-        component.requested_source != "github_release"
-        or version is None
-        or not component.install_spec.startswith("https://github.com/")
-        or "/releases/download/" not in component.install_spec
-        or digest is None
-        or len(digest) != 64
-        or any(character not in "0123456789abcdef" for character in digest.lower())
+        not _is_official_github_release_component(component, component_name="jarvis-cd")
         or component.runtime_artifact_path is None
         or set(component.runtime_interpreters) != {"provider", "execution"}
         or set(component.runtime_executables) != {"jarvis"}
@@ -2180,14 +2179,11 @@ def verify_remote_native_jarvis_component(
         raise ConfigurationError(
             f"worker installation omitted native JARVIS component {component_name}"
         )
-    version = component.distribution_version
-    digest = component.artifact_sha256
     if (
-        component.requested_source != "github_release"
-        or version is None
-        or not component.install_spec.startswith("https://github.com/")
-        or "/releases/download/" not in component.install_spec
-        or not _is_sha256_text(digest)
+        not _is_official_github_release_component(
+            component,
+            component_name=component_name,
+        )
         or component.runtime_artifact_path is None
         or "execution" not in component.runtime_interpreters
         or set(component.runtime_executables) != {"jarvis"}
@@ -2222,17 +2218,46 @@ def verify_remote_native_jarvis_component(
 
 def _is_released_component(component: ComponentArtifactIdentity) -> bool:
     version = component.distribution_version
-    digest = component.artifact_sha256
-    return (
-        component.requested_source == "pypi"
-        and version is not None
-        and component.install_spec == f"{component.distribution}=={version}"
-        and digest is not None
-        and len(digest) == 64
-        and all(character in "0123456789abcdef" for character in digest.lower())
-        and component.runtime_artifact_path is not None
-        and bool(component.runtime_command)
+    if (
+        version is None
+        or not _is_sha256_text(component.artifact_sha256)
+        or component.runtime_artifact_path is None
+        or not component.runtime_command
+    ):
+        return False
+    if component.requested_source == "pypi":
+        return component.install_spec == f"{component.distribution}=={version}"
+    return _is_official_github_release_component(
+        component,
+        component_name="clio-kit",
     )
+
+
+def _is_official_github_release_component(
+    component: ComponentArtifactIdentity,
+    *,
+    component_name: str,
+) -> bool:
+    """Return whether provenance names one canonical, hash-bound release wheel."""
+    normalized_name = _normalized_distribution_name(component_name)
+    repository = OFFICIAL_COMPONENT_RELEASE_REPOSITORIES.get(normalized_name)
+    version = component.distribution_version
+    if (
+        repository is None
+        or version is None
+        or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", version) is None
+        or _normalized_distribution_name(component.distribution) != normalized_name
+        or component.requested_source != "github_release"
+        or not _is_sha256_text(component.artifact_sha256)
+    ):
+        return False
+    owner, repository_name = repository
+    wheel_distribution = normalized_name.replace("-", "_")
+    filename = f"{wheel_distribution}-{version}-py3-none-any.whl"
+    expected_url = (
+        f"https://github.com/{owner}/{repository_name}/releases/download/v{version}/{filename}"
+    )
+    return component.artifact_filename == filename and component.install_spec == expected_url
 
 
 def _worker_process_matches(pid: int) -> bool:

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -336,6 +336,101 @@ def test_install_receipt_labels_exact_version_spec_as_pypi(tmp_path: Path) -> No
     assert receipt.requested_source == "pypi"
 
 
+def test_released_component_accepts_canonical_hashed_github_release() -> None:
+    component = ComponentArtifactIdentity(
+        distribution="clio-kit",
+        distribution_version="2.4.7",
+        install_spec=(
+            "https://github.com/iowarp/clio-kit/releases/download/"
+            "v2.4.7/clio_kit-2.4.7-py3-none-any.whl"
+        ),
+        requested_source="github_release",
+        artifact_filename="clio_kit-2.4.7-py3-none-any.whl",
+        artifact_sha256="a" * 64,
+        runtime_artifact_path="/opt/clio/clio_kit-2.4.7-py3-none-any.whl",
+        runtime_command=["/home/operator/.local/bin/clio-kit", "mcp-server", "jarvis"],
+    )
+    matcher = cast(
+        Callable[[ComponentArtifactIdentity], bool],
+        installation_module._is_released_component,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    assert matcher(component)
+
+
+def test_released_component_preserves_exact_hashed_pypi_release() -> None:
+    component = ComponentArtifactIdentity(
+        distribution="clio-kit",
+        distribution_version="2.4.7",
+        install_spec="clio-kit==2.4.7",
+        requested_source="pypi",
+        artifact_filename="clio_kit-2.4.7-py3-none-any.whl",
+        artifact_sha256="a" * 64,
+        runtime_artifact_path="/opt/clio/clio_kit-2.4.7-py3-none-any.whl",
+        runtime_command=["/home/operator/.local/bin/clio-kit", "mcp-server", "jarvis"],
+    )
+    matcher = cast(
+        Callable[[ComponentArtifactIdentity], bool],
+        installation_module._is_released_component,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    assert matcher(component)
+
+
+@pytest.mark.parametrize(
+    ("override", "value"),
+    [
+        (
+            "install_spec",
+            "https://github.com/iowarp/clio-kit/releases/latest/download/"
+            "clio_kit-2.4.7-py3-none-any.whl",
+        ),
+        (
+            "install_spec",
+            "https://github.com/other/clio-kit/releases/download/"
+            "v2.4.7/clio_kit-2.4.7-py3-none-any.whl",
+        ),
+        (
+            "install_spec",
+            "https://github.com/iowarp/clio-kit/releases/download/"
+            "v2.4.8/clio_kit-2.4.7-py3-none-any.whl",
+        ),
+        (
+            "install_spec",
+            "https://github.com/iowarp/clio-kit/releases/download/"
+            "v2.4.7/clio_kit-2.4.7-py3-none-any.whl?download=1",
+        ),
+        ("artifact_filename", "clio_kit-latest-py3-none-any.whl"),
+        ("artifact_sha256", "A" * 64),
+        ("artifact_sha256", "a" * 63),
+    ],
+)
+def test_released_component_rejects_unbound_github_release(
+    override: str,
+    value: str,
+) -> None:
+    payload: dict[str, object] = {
+        "distribution": "clio-kit",
+        "distribution_version": "2.4.7",
+        "install_spec": (
+            "https://github.com/iowarp/clio-kit/releases/download/"
+            "v2.4.7/clio_kit-2.4.7-py3-none-any.whl"
+        ),
+        "requested_source": "github_release",
+        "artifact_filename": "clio_kit-2.4.7-py3-none-any.whl",
+        "artifact_sha256": "a" * 64,
+        "runtime_artifact_path": "/opt/clio/clio_kit-2.4.7-py3-none-any.whl",
+        "runtime_command": ["/home/operator/.local/bin/clio-kit", "mcp-server", "jarvis"],
+    }
+    payload[override] = value
+    matcher = cast(
+        Callable[[ComponentArtifactIdentity], bool],
+        installation_module._is_released_component,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    assert not matcher(ComponentArtifactIdentity.model_validate(payload))
+
+
 def test_installation_info_uses_verified_uv_tool_receipt_without_bootstrap_receipt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.2.12"
+    assert version == "1.2.13"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1940,7 +1940,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.2.12"
+    assert policy.release_version == "1.2.13"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.2.12"
+version = "1.2.13"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Production bug

The released 1.2.12 Ares cleanup run successfully proved relay-session cleanup, worker identity, and exact component bytes, but the acceptance validator rejected clio-kit 2.4.7 because it classified only a `clio-kit==version` PyPI request as a released component. Bootstrap intentionally installs clio-kit and JARVIS-CD from immutable, versioned GitHub Release wheel URLs with pinned SHA-256 digests, so the policy contradicted the production bootstrap contract.

Live reproduction report:
`demos/acceptance/vigil-gact/phase1_asteroid-20260716T021052Z-8d076ff9/relay-operator-cleanup-v1.2.12-post-worker.json`

## Fix

- Accept exact hash-bound clio-kit artifacts from either an exact PyPI version pin or its canonical `iowarp/clio-kit` GitHub Release wheel URL.
- Bind canonical GitHub provenance to the fixed owner/repository, exact `v<version>` tag, exact normalized wheel filename, receipt filename, and canonical lowercase SHA-256.
- Apply the same canonical URL boundary to JARVIS-CD provenance.
- Reject mutable `releases/latest` links, alternate owners, mismatched tags, query-bearing URLs, mismatched filenames, and malformed hashes.
- Use source-neutral “released artifact” wording in the machine-readable validation report.
- Advance the package, release runbook, policy, matrix digest, and lock to 1.2.13.

## Validation

- `10 passed` in the focused released-component and native-JARVIS tests.
- `2 passed` for the exact release identity and machine-readable policy/matrix tests.
- Ruff passed and formatted changed Python files.
- Pyright reported 0 errors for the changed implementation and tests.