### PR TITLE
test: fix full-suite type checking

### DIFF
--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -638,22 +638,35 @@ def test_http_generic_gateway_update_cannot_replace_relay_managed_runtime_state(
 
 
 def test_owned_session_api_fails_closed_without_cluster_or_owner_token(tmp_path: Path) -> None:
-    common = {
-        "core_dir": tmp_path / "core",
-        "spool_dir": tmp_path / "spool",
-        "api_token": "session-api-token",
-        "owner_session_id": "desktop-session-1",
-        "owner_session_generation_id": "generation-1",
-    }
-
     with pytest.raises(ConfigurationError, match="REMOTE_CLUSTER"):
-        create_app(RelaySettings(**common))
+        create_app(
+            RelaySettings(
+                core_dir=tmp_path / "core",
+                spool_dir=tmp_path / "spool",
+                api_token="session-api-token",
+                owner_session_id="desktop-session-1",
+                owner_session_generation_id="generation-1",
+            )
+        )
     with pytest.raises(ConfigurationError, match="SESSION_OWNER_TOKEN"):
-        create_app(RelaySettings(**common, remote_cluster="test-cluster"))
+        create_app(
+            RelaySettings(
+                core_dir=tmp_path / "core",
+                spool_dir=tmp_path / "spool",
+                api_token="session-api-token",
+                owner_session_id="desktop-session-1",
+                owner_session_generation_id="generation-1",
+                remote_cluster="test-cluster",
+            )
+        )
     with pytest.raises(ConfigurationError, match="at least 32 bytes"):
         create_app(
             RelaySettings(
-                **common,
+                core_dir=tmp_path / "core",
+                spool_dir=tmp_path / "spool",
+                api_token="session-api-token",
+                owner_session_id="desktop-session-1",
+                owner_session_generation_id="generation-1",
                 remote_cluster="test-cluster",
                 session_owner_token="weak-token",
             )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1935,7 +1935,7 @@ def test_owned_remote_followups_use_session_api_and_never_direct_ssh(
     assert all(response is not None and "error" not in response for response in responses)
     assert stale is not None and "error" in stale
     assert "global queue visibility" in stale["error"]["message"]
-    cancel_request = next(item for item in requests if item["path"].endswith("/cancel"))
+    cancel_request = next(item for item in requests if cast(str, item["path"]).endswith("/cancel"))
     assert cancel_request["body"] == {
         "cluster": "ares",
         "cancel_scheduler_job": False,

--- a/tests/test_session_api.py
+++ b/tests/test_session_api.py
@@ -154,7 +154,7 @@ def _install_transport(
     )
 
     def challenge(**_kwargs: object) -> dict[str, object]:
-        return expected_identity
+        return dict(expected_identity)
 
     captured: list[dict[str, object]] = []
     connections: list[_Connection] = []
@@ -172,10 +172,16 @@ def _install_transport(
     def forward(**_kwargs: Any) -> Generator[int, None, None]:
         yield 18_766
 
+    def token_hex(_size: int) -> str:
+        return nonce
+
+    def readiness_client(**_kwargs: object) -> _ReadinessClient:
+        return _ReadinessClient()
+
     monkeypatch.setattr("clio_relay.session_api.status_remote_session", status)
     monkeypatch.setattr("clio_relay.session_api.challenge_remote_session_identity", challenge)
-    monkeypatch.setattr("clio_relay.session_api.secrets.token_hex", lambda _size: nonce)
-    monkeypatch.setattr("clio_relay.session_api.httpx.Client", lambda **_kwargs: _ReadinessClient())
+    monkeypatch.setattr("clio_relay.session_api.secrets.token_hex", token_hex)
+    monkeypatch.setattr("clio_relay.session_api.httpx.Client", readiness_client)
     monkeypatch.setattr("clio_relay.session_api.http.client.HTTPConnection", connection_factory)
     monkeypatch.setattr("clio_relay.session_api._ssh_forward", forward)
     return captured, connections


### PR DESCRIPTION
## Summary
- replace ambiguous unpacked test settings with explicit typed construction
- type fake HTTP clients and string paths precisely
- preserve the ownership/session behavior added in 1.2.15

## Verification
- full-project Pyright: 0 errors
- Ruff: passed
- 14 focused ownership/session tests: passed