### PR TITLE
fix: support cached MCP aliases across sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.2.15` uses a release-first patch process. A maintainer builds the
+> Version `1.2.16` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.2.15"
+$Version = "1.2.16"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.2.15"
+release_version: "1.2.16"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 7ff57cb6bb016af7d8fcd8d833639776dfca8a4321292ea79ab75be40857ff8d
+acceptance_matrix_sha256: 23de95bb3bac4618530115eba09a41e7b5cbe3223cdb85b266030eca74625e34
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.2.15"
+$Tag = "v1.2.16"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.15" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.16" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.2.15",
-  "matrix_sha256": "7ff57cb6bb016af7d8fcd8d833639776dfca8a4321292ea79ab75be40857ff8d",
+  "release_version": "1.2.16",
+  "matrix_sha256": "23de95bb3bac4618530115eba09a41e7b5cbe3223cdb85b266030eca74625e34",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.2.15"
+version = "1.2.16"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.2.15"
+__version__ = "1.2.16"

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -1249,7 +1249,7 @@ def _call_tool(
             raise ValueError(f"tool is not available in MCP profile {profile!r}: {name}")
     else:
         catalog = _remote_mcp_catalog(profile=profile, reserved_names=static_names)
-        _require_observed_remote_mcp_catalog(
+        _require_compatible_remote_mcp_catalog(
             profile=profile,
             observed_revision=observed_remote_mcp_catalog_revision,
             current_revision=catalog.revision,
@@ -1259,7 +1259,7 @@ def _call_tool(
     if is_virtual_jarvis_tool(name):
         catalog = _remote_mcp_catalog(profile=profile, reserved_names=static_names)
         if require_advertised_remote_mcp_catalog:
-            _require_observed_remote_mcp_catalog(
+            _require_compatible_remote_mcp_catalog(
                 profile=profile,
                 observed_revision=observed_remote_mcp_catalog_revision,
                 current_revision=catalog.revision,
@@ -1574,18 +1574,22 @@ def _call_tool(
     }
 
 
-def _require_observed_remote_mcp_catalog(
+def _require_compatible_remote_mcp_catalog(
     *,
     profile: str,
     observed_revision: str | None,
     current_revision: str,
 ) -> None:
-    """Reject virtual calls that are not bound to the current listed catalog."""
+    """Reject catalog churn on a connection that advertised an older revision.
+
+    MCP clients may cache a prior ``tools/list`` result and open a fresh stdio
+    connection only when they execute a tool.  In that case there is no
+    connection-local revision to compare, so dispatch uses the current durable,
+    profile-filtered catalog as the authority.  The caller still requires the
+    alias to exist in that catalog before selecting its immutable route.
+    """
     if observed_revision is None:
-        raise ValueError(
-            "virtual remote MCP tools must be discovered with tools/list in this "
-            f"MCP session for profile {profile!r} before they can be called"
-        )
+        return
     if observed_revision != current_revision:
         raise ValueError(
             "remote MCP catalog changed after tools/list for profile "

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.2.15"
+    assert version == "1.2.16"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_remote_mcp.py
+++ b/tests/test_remote_mcp.py
@@ -8,6 +8,7 @@ import shlex
 import stat
 from copy import deepcopy
 from datetime import UTC, datetime, timedelta
+from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Protocol, cast
@@ -27,7 +28,9 @@ from clio_relay.cluster_config import (
     ClusterRegistry,
     FrpTransportConfig,
     RemoteMcpServerConfig,
+    cluster_route_revision,
 )
+from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.errors import ConfigurationError, RelayError
 from clio_relay.jarvis_mcp import (
@@ -35,7 +38,7 @@ from clio_relay.jarvis_mcp import (
     JARVIS_MCP_CACHE_SERVER_NAME,
     jarvis_user_contract,
 )
-from clio_relay.mcp_server import McpSessionState, handle_request
+from clio_relay.mcp_server import McpSessionState, handle_request, serve_stdio
 from clio_relay.models import JobKind, JobState, McpCallSpec, McpOperation, RelayJob
 from clio_relay.remote_mcp import (
     MAX_REMOTE_MCP_CACHE_BYTES,
@@ -1040,6 +1043,149 @@ def test_mcp_server_reloads_catalog_and_routes_without_forwarding_cluster(
     )
 
 
+def test_mcp_server_executes_cached_alias_on_fresh_session(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A lazy MCP client may execute a cached tool without listing on its new connection."""
+    monkeypatch.chdir(tmp_path)
+    registration = _registration(profiles=["user"])
+    ClusterRegistry(clusters={"alpha": _cluster("alpha", {"science": registration})}).save(
+        tmp_path / ".clio-relay" / "clusters.json"
+    )
+    discovered_at = datetime.now(UTC)
+    entry = _entry(registration, cluster="alpha", server_name="science").model_copy(
+        update={
+            "discovered_at": discovered_at,
+            "expires_at": discovered_at + timedelta(hours=1),
+        }
+    )
+    RemoteMcpSchemaCache.update_entry(
+        tmp_path / ".clio-relay" / "remote-mcp-cache.json",
+        entry,
+    )
+    discovery_queue = ClioCoreQueue(tmp_path / "discovery-core")
+    discovery_queue.initialize()
+
+    discovery_session = McpSessionState()
+    listed = handle_request(
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        queue=discovery_queue,
+        profile="user",
+        session=discovery_session,
+    )
+    assert listed is not None
+    assert "remote_science_inspect" in {tool["name"] for tool in listed["result"]["tools"]}
+    cached_revision = listed["result"]["_meta"]["clio-relay/remote-mcp-catalog-revision"]
+
+    stdout = StringIO()
+    requests = [
+        {"jsonrpc": "2.0", "id": 2, "method": "initialize"},
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "remote_science_inspect",
+                "arguments": {"cluster": "alpha", "path": "/data/run"},
+            },
+        },
+    ]
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    serve_stdio(
+        stdin=StringIO("".join(f"{json.dumps(request)}\n" for request in requests)),
+        stdout=stdout,
+        settings=settings,
+        profile="user",
+    )
+
+    responses = [json.loads(line) for line in stdout.getvalue().splitlines()]
+    assert [response["id"] for response in responses] == [2, 3]
+    response = responses[1]
+    structured = response["result"]["structuredContent"]
+    assert structured["catalog_revision"] == cached_revision
+    assert structured["route_revision"] == cluster_route_revision(
+        _cluster("alpha", {"science": registration})
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+    queue.initialize()
+    job = queue.get_job(structured["job_id"])
+    assert isinstance(job.spec, McpCallSpec)
+    assert job.spec.expected_server_artifact_digest == remote_mcp_server_artifact_digest(
+        _server_artifact(registration)
+    )
+    assert job.spec.arguments == {"path": "/data/run"}
+
+
+def test_mcp_server_fresh_session_rejects_alias_removed_from_current_catalog(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A cached alias fails closed when its registration no longer matches discovery."""
+    monkeypatch.chdir(tmp_path)
+    registration = _registration(profiles=["user"])
+    registry_path = tmp_path / ".clio-relay" / "clusters.json"
+    ClusterRegistry(clusters={"alpha": _cluster("alpha", {"science": registration})}).save(
+        registry_path
+    )
+    discovered_at = datetime.now(UTC)
+    entry = _entry(registration, cluster="alpha", server_name="science").model_copy(
+        update={
+            "discovered_at": discovered_at,
+            "expires_at": discovered_at + timedelta(hours=1),
+        }
+    )
+    RemoteMcpSchemaCache.update_entry(
+        tmp_path / ".clio-relay" / "remote-mcp-cache.json",
+        entry,
+    )
+    queue = ClioCoreQueue(tmp_path / "core")
+    queue.initialize()
+
+    discovery_session = McpSessionState()
+    listed = handle_request(
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        queue=queue,
+        profile="user",
+        session=discovery_session,
+    )
+    assert listed is not None
+    assert "remote_science_inspect" in {tool["name"] for tool in listed["result"]["tools"]}
+
+    changed_registration = _registration(command="science-mcp-v2", profiles=["user"])
+    ClusterRegistry(clusters={"alpha": _cluster("alpha", {"science": changed_registration})}).save(
+        registry_path
+    )
+    execution_session = McpSessionState()
+    initialized = handle_request(
+        {"jsonrpc": "2.0", "id": 2, "method": "initialize"},
+        queue=queue,
+        profile="user",
+        session=execution_session,
+    )
+    assert initialized is not None
+
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "remote_science_inspect",
+                "arguments": {"cluster": "alpha", "path": "/data/run"},
+            },
+        },
+        queue=queue,
+        profile="user",
+        session=execution_session,
+    )
+
+    assert response is not None
+    assert "tool is not available in MCP profile 'user'" in response["error"]["message"]
+    assert queue.list_jobs() == []
+
+
 def test_mcp_server_rejects_stable_alias_after_schema_revision_changes(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -1631,10 +1777,29 @@ def test_mcp_session_binds_user_and_operator_catalogs_independently(
         if tool["name"].startswith("remote_user_science_")
     )
 
-    unlisted_operator_call = handle_request(
+    cross_profile_call = handle_request(
         {
             "jsonrpc": "2.0",
             "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": user_alias,
+                "arguments": {"cluster": "alpha", "path": "/user"},
+            },
+        },
+        queue=queue,
+        profile="operator",
+        session=session,
+    )
+    assert cross_profile_call is not None
+    assert (
+        "tool is not available in MCP profile 'operator'" in cross_profile_call["error"]["message"]
+    )
+
+    cached_operator_call = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
             "method": "tools/call",
             "params": {
                 "name": "remote_operator_science_inspect",
@@ -1645,11 +1810,11 @@ def test_mcp_session_binds_user_and_operator_catalogs_independently(
         profile="operator",
         session=session,
     )
-    assert unlisted_operator_call is not None
-    assert "must be discovered with tools/list" in unlisted_operator_call["error"]["message"]
+    assert cached_operator_call is not None
+    assert "result" in cached_operator_call
 
     operator_list = handle_request(
-        {"jsonrpc": "2.0", "id": 3, "method": "tools/list"},
+        {"jsonrpc": "2.0", "id": 4, "method": "tools/list"},
         queue=queue,
         profile="operator",
         session=session,
@@ -1681,7 +1846,7 @@ def test_mcp_session_binds_user_and_operator_catalogs_independently(
     user_call = handle_request(
         {
             "jsonrpc": "2.0",
-            "id": 4,
+            "id": 5,
             "method": "tools/call",
             "params": {
                 "name": user_alias,
@@ -1698,7 +1863,7 @@ def test_mcp_session_binds_user_and_operator_catalogs_independently(
     stale_operator_call = handle_request(
         {
             "jsonrpc": "2.0",
-            "id": 5,
+            "id": 6,
             "method": "tools/call",
             "params": {
                 "name": operator_alias,

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1940,7 +1940,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.2.15"
+    assert policy.release_version == "1.2.16"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.2.15"
+version = "1.2.16"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- Allow a fresh MCP execution session to invoke virtual aliases from the current durable, profile-filtered catalog without requiring a same-session `tools/list`.
- Preserve same-session catalog revision mismatch rejection and current route, registration, artifact, collision, and profile authorization checks.
- Add a real stdio regression for `initialize -> tools/call` plus stale-registration and cross-profile failure coverage.
- Prepare the required 1.2.16 package, release-policy, and acceptance-matrix identities.

## Root cause

Lazy MCP clients such as clio-agent intentionally cache a transient discovery result and open a fresh namespace process only when a tool is called. Relay incorrectly required discovery and execution to share process-local session state, even though invocation is independently valid against the current catalog.

## Validation

- Ruff check and format check
- Pyright: 0 errors
- 8 focused relay contract tests
- 2 focused release identity/policy tests
- Independent combined run of 6 directly changed tests