### PR TITLE
fix: separate owner session cluster routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.2.16` uses a release-first patch process. A maintainer builds the
+> Version `1.2.17` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -836,6 +836,11 @@ unbounded shutdown.
 `session start` requires `CLIO_RELAY_API_TOKEN` by default and fails before opening
 the remote API when it is absent. An unauthenticated API requires the explicit
 `--no-require-token` operator choice and must not be used for release acceptance.
+Owner-bound desktop clients set `CLIO_RELAY_OWNER_SESSION_CLUSTER` to the selected
+cluster. `CLIO_RELAY_REMOTE_CLUSTER` identifies the cluster where the current
+process is running and must not be set on the desktop merely to select an owned
+session route. When both variables are present, they must identify the same
+cluster; a mismatch is rejected before admission.
 
 To clean up the persistent worker too:
 

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.2.16"
+$Version = "1.2.17"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.2.16"
+release_version: "1.2.17"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 23de95bb3bac4618530115eba09a41e7b5cbe3223cdb85b266030eca74625e34
+acceptance_matrix_sha256: 0b7e1c98ab0d016a15a2d63a0b6ff7c63b3ec5bead8263e53fe274ea4b875e1b
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.2.16"
+$Tag = "v1.2.17"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.16" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.17" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.2.16",
-  "matrix_sha256": "23de95bb3bac4618530115eba09a41e7b5cbe3223cdb85b266030eca74625e34",
+  "release_version": "1.2.17",
+  "matrix_sha256": "0b7e1c98ab0d016a15a2d63a0b6ff7c63b3ec5bead8263e53fe274ea4b875e1b",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.2.16"
+version = "1.2.17"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.2.16"
+__version__ = "1.2.17"

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -3046,7 +3046,7 @@ def session_submit_jarvis(
         update={
             "owner_session_id": session_id,
             "owner_session_generation_id": session_generation_id,
-            "remote_cluster": cluster,
+            "owner_session_cluster": cluster,
         }
     )
     definition = _require_cluster(cluster)

--- a/src/clio_relay/config.py
+++ b/src/clio_relay/config.py
@@ -106,6 +106,7 @@ class RelaySettings(BaseModel):
     api_token: str | None = None
     owner_session_id: str | None = None
     owner_session_generation_id: DurableRecordId | None = None
+    owner_session_cluster: str | None = None
     remote_cluster: str | None = None
     session_owner_token: str | None = None
     agent_bin: str = "agent"
@@ -119,7 +120,23 @@ class RelaySettings(BaseModel):
             raise ValueError(
                 "owner_session_id and owner_session_generation_id must be configured together"
             )
+        if self.owner_session_cluster is not None and self.owner_session_id is None:
+            raise ValueError(
+                "owner_session_cluster requires owner_session_id and owner_session_generation_id"
+            )
+        if (
+            self.owner_session_cluster is not None
+            and self.remote_cluster is not None
+            and self.owner_session_cluster != self.remote_cluster
+        ):
+            raise ValueError(
+                "owner_session_cluster and remote_cluster must match when both are configured"
+            )
         return self
+
+    def resolved_owner_session_cluster(self) -> str | None:
+        """Return the explicit owner destination or a safe legacy locality binding."""
+        return self.owner_session_cluster or self.remote_cluster
 
     @model_validator(mode="after")
     def validate_storage_policy(self) -> Self:
@@ -237,6 +254,7 @@ class RelaySettings(BaseModel):
             api_token=os.getenv("CLIO_RELAY_API_TOKEN"),
             owner_session_id=os.getenv("CLIO_RELAY_OWNER_SESSION_ID"),
             owner_session_generation_id=os.getenv("CLIO_RELAY_SESSION_GENERATION_ID"),
+            owner_session_cluster=os.getenv("CLIO_RELAY_OWNER_SESSION_CLUSTER"),
             remote_cluster=os.getenv("CLIO_RELAY_REMOTE_CLUSTER"),
             session_owner_token=os.getenv("CLIO_RELAY_SESSION_OWNER_TOKEN"),
             agent_bin=os.getenv(

--- a/src/clio_relay/http_api.py
+++ b/src/clio_relay/http_api.py
@@ -551,9 +551,12 @@ class GatewaySessionUpdateRequest(BaseModel):
 def create_app(settings: RelaySettings | None = None) -> FastAPI:
     """Create the FastAPI relay surface."""
     resolved = settings or RelaySettings.from_env()
+    owner_session_cluster = resolved.resolved_owner_session_cluster()
     if resolved.owner_session_id is not None:
-        if not resolved.remote_cluster:
-            raise ConfigurationError("owned relay session API requires CLIO_RELAY_REMOTE_CLUSTER")
+        if not owner_session_cluster:
+            raise ConfigurationError(
+                "owned relay session API requires CLIO_RELAY_OWNER_SESSION_CLUSTER"
+            )
         if not resolved.session_owner_token:
             raise ConfigurationError(
                 "owned relay session API requires CLIO_RELAY_SESSION_OWNER_TOKEN"
@@ -626,7 +629,7 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
 
     def submit_owned(job: RelayJob) -> RelayJob:
         ensure_intake_open()
-        if resolved.remote_cluster is not None and job.cluster != resolved.remote_cluster:
+        if owner_session_cluster is not None and job.cluster != owner_session_cluster:
             raise HTTPException(
                 status_code=409,
                 detail="job cluster does not match this owned relay session",
@@ -690,13 +693,13 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
         if (
             resolved.owner_session_id is None
             or resolved.owner_session_generation_id is None
-            or resolved.remote_cluster is None
+            or owner_session_cluster is None
             or resolved.session_owner_token is None
         ):
             raise HTTPException(status_code=404, detail="owned session identity is unavailable")
         return session_identity_document(
             owner_token=resolved.session_owner_token,
-            cluster=resolved.remote_cluster,
+            cluster=owner_session_cluster,
             session_id=resolved.owner_session_id,
             generation_id=resolved.owner_session_generation_id,
             nonce=nonce,
@@ -1179,7 +1182,7 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
     )
     def create_gateway_session(request: GatewaySessionCreateRequest) -> GatewaySession:
         ensure_intake_open()
-        if resolved.remote_cluster is not None and request.cluster != resolved.remote_cluster:
+        if owner_session_cluster is not None and request.cluster != owner_session_cluster:
             raise HTTPException(
                 status_code=409,
                 detail="gateway cluster does not match this owned relay session",

--- a/src/clio_relay/session_api.py
+++ b/src/clio_relay/session_api.py
@@ -353,9 +353,10 @@ def _owned_session_credentials(
             "owned remote request requires CLIO_RELAY_OWNER_SESSION_ID and "
             "CLIO_RELAY_SESSION_GENERATION_ID"
         )
-    if settings.remote_cluster != definition.name:
+    if settings.resolved_owner_session_cluster() != definition.name:
         raise ConfigurationError(
-            "owned remote request requires CLIO_RELAY_REMOTE_CLUSTER to match the selected route"
+            "owned remote request requires CLIO_RELAY_OWNER_SESSION_CLUSTER to match the "
+            "selected route"
         )
     if not api_token:
         raise ConfigurationError(

--- a/src/clio_relay/session_lifecycle.py
+++ b/src/clio_relay/session_lifecycle.py
@@ -1054,6 +1054,7 @@ nohup setsid env \\
   "CLIO_RELAY_SESSION_OWNER_TOKEN=$owner_token" \\
   "CLIO_RELAY_SESSION_GENERATION_ID=$session_generation_id" \\
   "CLIO_RELAY_OWNER_SESSION_ID=$session_id" \\
+  "CLIO_RELAY_OWNER_SESSION_CLUSTER={shlex.quote(cluster)}" \\
   "${{api_command[@]}}" \\
   >"$log_file" 2>&1 9>&- &
 api_pid="$!"
@@ -1364,6 +1365,11 @@ command = (proc / "cmdline").read_bytes().replace(bytes([0]), b" ").decode(
     "utf-8", errors="replace"
 )
 environment = (proc / "environ").read_bytes().split(bytes([0]))
+owner_cluster_marker = f"CLIO_RELAY_OWNER_SESSION_CLUSTER={{cluster}}".encode()
+owner_cluster_entries = [
+    item for item in environment if item.startswith(b"CLIO_RELAY_OWNER_SESSION_CLUSTER=")
+]
+owner_cluster_verified = owner_cluster_marker in environment or not owner_cluster_entries
 if (
     stat_fields[0] == "Z"
     or os.getpgid(pid) != pid
@@ -1373,6 +1379,7 @@ if (
     or f"CLIO_RELAY_SESSION_GENERATION_ID={{generation_id}}".encode() not in environment
     or f"CLIO_RELAY_OWNER_SESSION_ID={{session_id}}".encode() not in environment
     or f"CLIO_RELAY_REMOTE_CLUSTER={{cluster}}".encode() not in environment
+    or not owner_cluster_verified
     or "clio-relay" not in command
     or " api " not in f" {{command}} "
     or " start" not in command

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1540,7 +1540,8 @@ def test_cli_session_submit_jarvis_uses_identity_proven_client(
     assert document["metadata"]["owner_session_generation_id"] == "generation-1"
     settings = cast(cli.RelaySettings, captured["settings"])
     assert settings.api_token == "api-token"
-    assert settings.remote_cluster == "ares"
+    assert settings.owner_session_cluster == "ares"
+    assert settings.remote_cluster is None
     assert settings.owner_session_id == "session-1"
     assert settings.owner_session_generation_id == "generation-1"
     assert cast(dict[str, object], captured["payload"])["pipeline_yaml"] == (
@@ -2144,7 +2145,11 @@ def test_cli_remote_teardown_writes_closure_only_in_remote_authoritative_core(
     _write_test_cluster(tmp_path)
     local_core_dir = tmp_path / "desktop-core"
     monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(local_core_dir))
-    monkeypatch.setenv("CLIO_RELAY_CLI_MODE", "ssh")
+    monkeypatch.setenv("CLIO_RELAY_OWNER_SESSION_ID", "session-1")
+    monkeypatch.setenv("CLIO_RELAY_SESSION_GENERATION_ID", "generation-1")
+    monkeypatch.setenv("CLIO_RELAY_OWNER_SESSION_CLUSTER", "ares")
+    monkeypatch.delenv("CLIO_RELAY_REMOTE_CLUSTER", raising=False)
+    monkeypatch.delenv("CLIO_RELAY_CLI_MODE", raising=False)
     remote_calls: list[list[str]] = []
     monkeypatch.setattr(
         cli,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -70,11 +70,25 @@ def test_relay_settings_load_owner_session_generation_from_environment(
 ) -> None:
     monkeypatch.setenv("CLIO_RELAY_OWNER_SESSION_ID", "desktop-session")
     monkeypatch.setenv("CLIO_RELAY_SESSION_GENERATION_ID", "generation-1")
+    monkeypatch.setenv("CLIO_RELAY_OWNER_SESSION_CLUSTER", "ares")
 
     settings = RelaySettings.from_env()
 
     assert settings.owner_session_id == "desktop-session"
     assert settings.owner_session_generation_id == "generation-1"
+    assert settings.owner_session_cluster == "ares"
+    assert settings.resolved_owner_session_cluster() == "ares"
+    assert settings.remote_cluster is None
+
+
+def test_relay_settings_reject_mismatched_owner_and_process_clusters() -> None:
+    with pytest.raises(ValueError, match="must match"):
+        RelaySettings(
+            owner_session_id="desktop-session",
+            owner_session_generation_id="generation-1",
+            owner_session_cluster="ares",
+            remote_cluster="homelab",
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -638,7 +638,7 @@ def test_http_generic_gateway_update_cannot_replace_relay_managed_runtime_state(
 
 
 def test_owned_session_api_fails_closed_without_cluster_or_owner_token(tmp_path: Path) -> None:
-    with pytest.raises(ConfigurationError, match="REMOTE_CLUSTER"):
+    with pytest.raises(ConfigurationError, match="OWNER_SESSION_CLUSTER"):
         create_app(
             RelaySettings(
                 core_dir=tmp_path / "core",
@@ -656,7 +656,7 @@ def test_owned_session_api_fails_closed_without_cluster_or_owner_token(tmp_path:
                 api_token="session-api-token",
                 owner_session_id="desktop-session-1",
                 owner_session_generation_id="generation-1",
-                remote_cluster="test-cluster",
+                owner_session_cluster="test-cluster",
             )
         )
     with pytest.raises(ConfigurationError, match="at least 32 bytes"):
@@ -667,7 +667,7 @@ def test_owned_session_api_fails_closed_without_cluster_or_owner_token(tmp_path:
                 api_token="session-api-token",
                 owner_session_id="desktop-session-1",
                 owner_session_generation_id="generation-1",
-                remote_cluster="test-cluster",
+                owner_session_cluster="test-cluster",
                 session_owner_token="weak-token",
             )
         )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1602,6 +1602,14 @@ def test_owned_registered_remote_mcp_call_uses_authenticated_session_api(
     registry_path = tmp_path / "clusters.json"
     ClusterRegistry(clusters={"ares": definition}).save(registry_path)
     monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+    monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(tmp_path / "core"))
+    monkeypatch.setenv("CLIO_RELAY_SPOOL_DIR", str(tmp_path / "spool"))
+    monkeypatch.setenv("CLIO_RELAY_API_TOKEN", "session-api-token")
+    monkeypatch.setenv("CLIO_RELAY_OWNER_SESSION_ID", "desktop-session-1")
+    monkeypatch.setenv("CLIO_RELAY_SESSION_GENERATION_ID", "generation-1")
+    monkeypatch.setenv("CLIO_RELAY_OWNER_SESSION_CLUSTER", "ares")
+    monkeypatch.delenv("CLIO_RELAY_REMOTE_CLUSTER", raising=False)
+    monkeypatch.delenv("CLIO_RELAY_CLI_MODE", raising=False)
     route = RemoteMcpRoute(
         cluster="ares",
         server_name="science",
@@ -1670,13 +1678,9 @@ def test_owned_registered_remote_mcp_call_uses_authenticated_session_api(
         )
 
     monkeypatch.setattr("clio_relay.mcp_server.submit_owned_session_job", submit_owned)
-    settings = RelaySettings(
-        core_dir=tmp_path / "core",
-        spool_dir=tmp_path / "spool",
-        api_token="session-api-token",
-        owner_session_id="desktop-session-1",
-        owner_session_generation_id="generation-1",
-    )
+    settings = RelaySettings.from_env()
+    assert settings.owner_session_cluster == "ares"
+    assert settings.remote_cluster is None
     queue = ClioCoreQueue(settings.core_dir)
     session = McpSessionState()
     assert (

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.2.16"
+    assert version == "1.2.17"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_session_api.py
+++ b/tests/test_session_api.py
@@ -100,7 +100,7 @@ def _settings(tmp_path: Path) -> RelaySettings:
         api_token="session-api-token",
         owner_session_id="desktop-session-1",
         owner_session_generation_id="generation-1",
-        remote_cluster="ares",
+        owner_session_cluster="ares",
     )
 
 

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -248,6 +248,7 @@ def test_start_remote_session_writes_owned_pid_and_metadata(monkeypatch: MonkeyP
     assert "/proc/{pid}/cmdline" in script
     assert "CLIO_RELAY_SESSION_OWNER_TOKEN" in script
     assert "CLIO_RELAY_OWNER_SESSION_ID=$session_id" in script
+    assert "CLIO_RELAY_OWNER_SESSION_CLUSTER=ares" in script
     assert "process_start_ticks" in script
     assert "nohup setsid" in script
     assert '>"$log_file" 2>&1 9>&- &' in script
@@ -343,6 +344,8 @@ def test_remote_session_identity_challenge_binds_process_cluster_and_nonce(
     script = scripts[0]
     assert "metadata_path, cluster, session_id, generation_id, nonce" in script
     assert "CLIO_RELAY_REMOTE_CLUSTER={cluster}" in script
+    assert "CLIO_RELAY_OWNER_SESSION_CLUSTER={cluster}" in script
+    assert "owner_cluster_verified" in script
     assert "os.getpgid(pid) != pid" in script
     assert "hmac.new(token.encode" in script
     assert "clio-relay.session-identity.v1" in script

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1940,7 +1940,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.2.16"
+    assert policy.release_version == "1.2.17"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.2.16"
+version = "1.2.17"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- Added `CLIO_RELAY_OWNER_SESSION_CLUSTER` as the explicit destination binding for desktop-owned relay sessions.
- Kept `CLIO_RELAY_REMOTE_CLUSTER` as process-locality only.
- Routed owned MCP submissions, HTTP ownership checks, session submission, and teardown through the separated contract.
- Preserved safe compatibility for existing live remote session processes and rejected conflicting cluster identities.
- Prepared the patch as clio-relay 1.2.17.

## Root cause and impact

Desktop clients needed `CLIO_RELAY_REMOTE_CLUSTER` to select an owned Ares session, but relay also interpreted that value as proof the client process was already running on Ares. Registered remote MCP calls and teardown therefore consulted the desktop queue instead of the authenticated remote session API. Separating destination from locality makes automatic routing unambiguous without weakening exact-generation ownership checks.

## Validation

- Ruff check and format: passed
- Pyright on changed Python files: 0 errors
- 12 focused configuration, MCP, API, lifecycle, teardown, and release-policy tests: passed
- `git diff --check`: passed