### PR TITLE
fix: forward owned JARVIS artifact bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.2.17` uses a release-first patch process. A maintainer builds the
+> Version `1.2.18` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.2.17"
+$Version = "1.2.18"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.2.17"
+release_version: "1.2.18"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 0b7e1c98ab0d016a15a2d63a0b6ff7c63b3ec5bead8263e53fe274ea4b875e1b
+acceptance_matrix_sha256: c53ca9db5efcb776fcabe86fc3d358d71362e3bea519e3caab423781d45cc6cd
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.2.17"
+$Tag = "v1.2.18"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.17" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.18" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.2.17",
-  "matrix_sha256": "0b7e1c98ab0d016a15a2d63a0b6ff7c63b3ec5bead8263e53fe274ea4b875e1b",
+  "release_version": "1.2.18",
+  "matrix_sha256": "c53ca9db5efcb776fcabe86fc3d358d71362e3bea519e3caab423781d45cc6cd",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.2.17"
+version = "1.2.18"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.2.17"
+__version__ = "1.2.18"

--- a/src/clio_relay/http_api.py
+++ b/src/clio_relay/http_api.py
@@ -804,7 +804,13 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
                 status_code=422,
                 detail=("owned JARVIS MCP submission requires expected_server_artifact_digest"),
             )
-        if expected_digest is not None:
+        # An owned cluster-side API receives the discovery binding from its
+        # authenticated desktop owner. Its operator cache is intentionally
+        # process-local and may not contain the desktop's discovery entry. Do
+        # not substitute a second, unrelated cache as authority here: preserve
+        # the supplied digest in the durable spec and let the MCP runner compare
+        # it with the server artifact observed immediately before launch.
+        if expected_digest is not None and resolved.owner_session_id is None:
             try:
                 observed_digest = jarvis_mcp_artifact_binding(request.cluster)
             except ValueError as exc:

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -875,7 +875,7 @@ def test_session_job_submission_rejects_missing_stale_and_unbound_identity(
     assert "not bound" in unbound.json()["detail"]
 
 
-def test_owned_jarvis_mcp_submission_binds_digest_membership_and_exact_cancel(
+def test_owned_jarvis_mcp_submission_forwards_desktop_binding_without_remote_cache(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -904,12 +904,12 @@ def test_owned_jarvis_mcp_submission_binds_digest_membership_and_exact_cancel(
         )
     )
 
-    def artifact_binding(_cluster: str) -> str:
-        return expected_digest
+    def fail_on_cluster_cache(_cluster: str) -> str:
+        pytest.fail("owned API must not consult its cluster-local cache")
 
     monkeypatch.setattr(
         "clio_relay.http_api.jarvis_mcp_artifact_binding",
-        artifact_binding,
+        fail_on_cluster_cache,
     )
     client = cast(
         Any,
@@ -934,17 +934,12 @@ def test_owned_jarvis_mcp_submission_binds_digest_membership_and_exact_cancel(
     }
 
     omitted = client.post("/jobs/jarvis-mcp-call", json=payload)
-    mismatched = client.post(
-        "/jobs/jarvis-mcp-call",
-        json={**payload, "expected_server_artifact_digest": "b" * 64},
-    )
     accepted = client.post(
         "/jobs/jarvis-mcp-call",
         json={**payload, "expected_server_artifact_digest": expected_digest},
     )
 
     assert omitted.status_code == 422
-    assert mismatched.status_code == 409
     assert accepted.status_code == 200
     job = queue.get_job(accepted.json()["job_id"])
     assert isinstance(job.spec, McpCallSpec)
@@ -971,6 +966,54 @@ def test_owned_jarvis_mcp_submission_binds_digest_membership_and_exact_cancel(
     assert canceled.status_code == 200
     assert canceled.json()["state"] == "canceled"
     assert queue.get_job(unrelated.job_id).state is JobState.QUEUED
+
+
+def test_unowned_jarvis_mcp_submission_still_validates_operator_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-owned API continues to enforce its own operator discovery cache."""
+
+    expected_digest = "a" * 64
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+
+    def artifact_binding(_cluster: str) -> str:
+        return expected_digest
+
+    monkeypatch.setattr(
+        "clio_relay.http_api.jarvis_mcp_artifact_binding",
+        artifact_binding,
+    )
+    client = cast(Any, TestClient(create_app(settings)))
+    payload = {
+        "cluster": "test-cluster",
+        "tool": "jarvis_describe",
+        "arguments": {"target": "packages"},
+    }
+
+    mismatched = client.post(
+        "/jobs/jarvis-mcp-call",
+        json={
+            **payload,
+            "idempotency_key": "unowned-mismatched-binding",
+            "expected_server_artifact_digest": "b" * 64,
+        },
+    )
+    accepted = client.post(
+        "/jobs/jarvis-mcp-call",
+        json={
+            **payload,
+            "idempotency_key": "unowned-exact-binding",
+            "expected_server_artifact_digest": expected_digest,
+        },
+    )
+
+    assert mismatched.status_code == 409
+    assert accepted.status_code == 200
+    job = queue.get_job(accepted.json()["job_id"])
+    assert isinstance(job.spec, McpCallSpec)
+    assert job.spec.expected_server_artifact_digest == expected_digest
 
 
 def test_owned_session_submission_race_with_quiesce_returns_conflict(

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.2.17"
+    assert version == "1.2.18"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1940,7 +1940,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.2.17"
+    assert policy.release_version == "1.2.18"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.2.17"
+version = "1.2.18"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- treat the authenticated desktop discovery digest as the owned-session submission binding
- avoid consulting an unrelated cluster-local operator cache
- retain fail-closed server-artifact verification immediately before MCP launch
- prepare release 1.2.18

## Focused validation
- owned and unowned JARVIS HTTP binding tests passed
- MCP runner artifact-mutation tests passed
- Ruff and Pyright passed
- release metadata and matrix digest checks passed