### PR TITLE
feat: support bounded JARVIS package discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,13 @@ jobs:
       - name: stage exact clio-kit release wheel
         shell: bash
         env:
-          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.4.9-py3-none-any.whl
-          CLIO_KIT_WHEEL_SHA256: a9d771bcd40ec98de2626ac2a8706fcc614a2eaac462defb10f8d7bec13693e3
-          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.4.9/clio_kit-2.4.9-py3-none-any.whl
+          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.5.0-py3-none-any.whl
+          CLIO_KIT_WHEEL_SHA256: acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f
+          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.5.0/clio_kit-2.5.0-py3-none-any.whl
         run: |
           set -euo pipefail
           umask 077
-          wheel_dir="$RUNNER_TEMP/clio-kit-v2.4.9"
+          wheel_dir="$RUNNER_TEMP/clio-kit-v2.5.0"
           mkdir "$wheel_dir"
           wheel="$wheel_dir/$CLIO_KIT_WHEEL_FILENAME"
           curl --fail --show-error --silent --location \
@@ -160,13 +160,13 @@ jobs:
       - name: stage exact clio-kit release wheel
         shell: bash
         env:
-          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.4.9-py3-none-any.whl
-          CLIO_KIT_WHEEL_SHA256: a9d771bcd40ec98de2626ac2a8706fcc614a2eaac462defb10f8d7bec13693e3
-          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.4.9/clio_kit-2.4.9-py3-none-any.whl
+          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.5.0-py3-none-any.whl
+          CLIO_KIT_WHEEL_SHA256: acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f
+          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.5.0/clio_kit-2.5.0-py3-none-any.whl
         run: |
           set -euo pipefail
           umask 077
-          wheel_dir="$RUNNER_TEMP/clio-kit-v2.4.9"
+          wheel_dir="$RUNNER_TEMP/clio-kit-v2.5.0"
           mkdir "$wheel_dir"
           wheel="$wheel_dir/$CLIO_KIT_WHEEL_FILENAME"
           curl --fail --show-error --silent --location \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.2.18` uses a release-first patch process. A maintainer builds the
+> Version `1.3.0` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -214,7 +214,7 @@ For the legacy clio-kit 2.2.6 compatibility path, a successful synchronous
 `jarvis_run` MCP return is normalized to a terminal `completed` record even
 though that release labels the result `status=running`; the original status and
 completion basis remain in `details.completion_normalization` for auditability.
-The pinned clio-kit 2.4.9 production path removes that ambiguity upstream and
+The pinned clio-kit 2.5.0 production path removes that ambiguity upstream and
 returns a structured completed result directly. The legacy normalization is
 diagnostic compatibility evidence and cannot satisfy the 1.0 gate. Scheduler
 submissions remain non-terminal unless JARVIS was asked to wait.
@@ -225,10 +225,13 @@ result, and non-legacy runtime artifact in one canonical acceptance run:
 ```powershell
 clio-relay jarvis-mcp-validate `
   --cluster my-cluster `
+  --package-search-query lammps `
   --arguments-json-file .\jarvis-run.json `
   --report .\validation\jarvis-mcp.json
 ```
 
+The package-search query must identify at least one installed application; its
+bounded summary page is retained in the same machine-readable report.
 `jarvis-run.json` must contain the remote `pipeline_id` and any `execution`,
 `submit`, or `wait` fields accepted by the cluster-local JARVIS MCP. The local
 `cluster` selector is injected by clio-relay and is never forwarded to JARVIS.
@@ -446,7 +449,7 @@ Install the cluster-side server once, then launch its persistent executable:
 
 ```bash
 uv tool install --python 3.12 --no-config \
-  https://github.com/iowarp/clio-kit/releases/download/v2.4.9/clio_kit-2.4.9-py3-none-any.whl
+  https://github.com/iowarp/clio-kit/releases/download/v2.5.0/clio_kit-2.5.0-py3-none-any.whl
 clio-kit mcp-server jarvis
 ```
 
@@ -482,8 +485,19 @@ environment inside JARVIS rather than relying on a process-local load command.
 The expected workflow is to create or load a pipeline through those JARVIS
 tools, use `jarvis_describe` for package and pipeline inspection, and call
 `jarvis_run` to submit the configured pipeline through the cluster-local JARVIS
-environment. `relay_observe` and `relay_wait` are the agent-facing monitor loop
-for progress, stdout, stderr, and terminal output.
+environment. Discover an application with
+`jarvis_describe(target="package_search", query="visualization", page_size=10)`.
+The query is required and limited to 256 characters; `page_size` defaults to 10
+and is bounded from 1 through 25. Results contain lightweight package summaries
+rather than package settings and never exceed 64 KiB. When `next_cursor` is
+present, repeat the same query with that opaque cursor to read the next page.
+The cursor is limited to 1,024 characters and is bound to both the query and the
+current package inventory, so a different query or a changed inventory fails
+closed. After selecting a result, use `target="package"` with its canonical
+`name` as `package_name` to retrieve the package-owned settings. The exhaustive
+`target="packages"` inventory remains available for explicit legacy use, but it
+is not the normal discovery path. `relay_observe` and `relay_wait` are the
+agent-facing monitor loop for progress, stdout, stderr, and terminal output.
 After submission, `jarvis_get_execution` is the single durable query. It always
 returns the execution handle, lifecycle record, and runtime metadata; progress
 is included by default and can be disabled with `include_progress=false`.

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -22,8 +22,8 @@ machine-readable inventory.
 | 1 | `ares-bootstrap` | `cluster bootstrap` | exact artifact deployment |
 | 2 | `ares-cluster-bootstrap-live-test` | `live-test` | separate worker execution proof |
 | 3 | `ares-queue-management` | `queue validate` | must precede lifecycle fixtures |
-| 4 | `ares-jarvis-gray-scott` | `jarvis-mcp-validate` | Gray-Scott run, progress, query, and artifacts |
-| 5 | `ares-jarvis-lammps` | `jarvis-mcp-validate` | separate LAMMPS progress run |
+| 4 | `ares-jarvis-gray-scott` | `jarvis-mcp-validate` | bounded package search, Gray-Scott run, progress, query, and artifacts |
+| 5 | `ares-jarvis-lammps` | `jarvis-mcp-validate` | bounded package search and separate LAMMPS progress run |
 | 6 | `ares-spack-find` | `remote-mcp validate` | `spack_find` |
 | 7 | `ares-spack-locate` | `remote-mcp validate` | `spack_locate` |
 | 8 | `ares-spack-install` | `remote-mcp validate` | absent -> fresh install -> exact locate transition |
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.2.18"
+$Version = "1.3.0"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }
@@ -767,6 +767,7 @@ $GrayRun = Write-JsonFile "gray-run.json" @{
 }
 Invoke-RelayReport -Id "ares-jarvis-gray-scott" -ReportOption "--report" -Command @(
   "jarvis-mcp-validate", "--cluster", $AresCluster, "--arguments-json-file", $GrayRun,
+  "--package-search-query", "gray scott",
   "--wait-timeout-seconds", "900", "--poll-seconds", "0.05"
 )
 
@@ -804,6 +805,7 @@ $LammpsRun = Write-JsonFile "lammps-run.json" @{
 }
 Invoke-RelayReport -Id "ares-jarvis-lammps" -ReportOption "--report" -Command @(
   "jarvis-mcp-validate", "--cluster", $AresCluster, "--arguments-json-file", $LammpsRun,
+  "--package-search-query", "lammps",
   "--wait-timeout-seconds", "900", "--poll-seconds", "0.05"
 )
 ```

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.2.18"
+release_version: "1.3.0"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: c53ca9db5efcb776fcabe86fc3d358d71362e3bea519e3caab423781d45cc6cd
+acceptance_matrix_sha256: 8dd3064562bf72b20283435b0d1e87bb5f3b38da6dea222dabc661a4b4f2436b
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true
@@ -108,25 +108,25 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.4.9"
+            clio-kit: "2.5.0"
             jarvis-cd: "1.3.6"
             jarvis-util: c91bfdc9bba802e4b03bfb1babe614ffa3e09644
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.4.9"
-              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.4.9/clio_kit-2.4.9-py3-none-any.whl
+              distribution_version: "2.5.0"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.0/clio_kit-2.5.0-py3-none-any.whl
               requested_source: github_release
-              artifact_sha256: a9d771bcd40ec98de2626ac2a8706fcc614a2eaac462defb10f8d7bec13693e3
+              artifact_sha256: acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f
               native_execution:
                 schema_version: clio-relay.jarvis-native-execution-capability.v1
                 handle_schema: jarvis.execution.handle.v1
                 record_schema: jarvis.execution.record.v1
                 progress_schema: jarvis.execution.progress.v1
                 operations: [jarvis_get_execution, jarvis_run]
-                contract_id: clio-kit-jarvis-user-v3.1
+                contract_id: clio-kit-jarvis-user-v3.2
                 contract_schema_version: clio-kit.mcp-user-contract.v1
-                contract_sha256: adc7756025fbcc90b0695bd4eaac00bda5c6cff4eb2f248fd7be263bd90b9b8b
+                contract_sha256: 12f6d349c9d44d8ce3594943dcd4018ec9b6e01ebb0e59d468bb1bb783a1ad5d
             jarvis-cd:
               distribution: jarvis_cd
               distribution_version: "1.3.6"
@@ -218,14 +218,14 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.4.9"
+            clio-kit: "2.5.0"
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.4.9"
-              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.4.9/clio_kit-2.4.9-py3-none-any.whl
+              distribution_version: "2.5.0"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.0/clio_kit-2.5.0-py3-none-any.whl
               requested_source: github_release
-              artifact_sha256: a9d771bcd40ec98de2626ac2a8706fcc614a2eaac462defb10f8d7bec13693e3
+              artifact_sha256: acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f
       - kind: scheduler_job
         roles: [queue-preservation-fixture]
         states: [completed]
@@ -249,6 +249,7 @@ requirements:
     required_checks:
       - remote-mcp.jarvis-discovery
       - remote-mcp.jarvis-remote-contract
+      - remote-mcp.jarvis-package-search
       - remote-mcp.jarvis-call
       - remote-mcp.server-artifact
       - remote-mcp.durable-result
@@ -285,24 +286,24 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.4.9"
+            clio-kit: "2.5.0"
             jarvis-cd: "1.3.6"
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.4.9"
-              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.4.9/clio_kit-2.4.9-py3-none-any.whl
+              distribution_version: "2.5.0"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.0/clio_kit-2.5.0-py3-none-any.whl
               requested_source: github_release
-              artifact_filename: clio_kit-2.4.9-py3-none-any.whl
-              artifact_sha256: a9d771bcd40ec98de2626ac2a8706fcc614a2eaac462defb10f8d7bec13693e3
+              artifact_filename: clio_kit-2.5.0-py3-none-any.whl
+              artifact_sha256: acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f
               persistent_tool:
                 manager: uv
                 uv_version: "0.11.28"
                 pyvenv_uv_version: "0.11.28"
                 distribution: clio-kit
-                distribution_version: "2.4.9"
+                distribution_version: "2.5.0"
                 entry_point: clio-kit
-                source_artifact_sha256: a9d771bcd40ec98de2626ac2a8706fcc614a2eaac462defb10f8d7bec13693e3
+                source_artifact_sha256: acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f
               native_execution:
                 schema_version: clio-relay.jarvis-native-execution-capability.v1
                 handle_schema: jarvis.execution.handle.v1
@@ -311,9 +312,9 @@ requirements:
                 operations:
                   - jarvis_get_execution
                   - jarvis_run
-                contract_id: clio-kit-jarvis-user-v3.1
+                contract_id: clio-kit-jarvis-user-v3.2
                 contract_schema_version: clio-kit.mcp-user-contract.v1
-                contract_sha256: adc7756025fbcc90b0695bd4eaac00bda5c6cff4eb2f248fd7be263bd90b9b8b
+                contract_sha256: 12f6d349c9d44d8ce3594943dcd4018ec9b6e01ebb0e59d468bb1bb783a1ad5d
             jarvis-cd:
               distribution: jarvis_cd
               distribution_version: "1.3.6"
@@ -360,10 +361,10 @@ requirements:
         states: [verified]
         metadata_equals:
           install_source: uv-tool
-          install_artifact_sha256: a9d771bcd40ec98de2626ac2a8706fcc614a2eaac462defb10f8d7bec13693e3
+          install_artifact_sha256: acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f
           python_distribution_runtime:
             distribution: clio-kit
-            distribution_version: "2.4.9"
+            distribution_version: "2.5.0"
             entry_point: clio-kit
             runtime_closure_verified: true
           nested_runtime:
@@ -417,6 +418,7 @@ requirements:
     scenarios:
       - remote-mcp
     required_checks:
+      - remote-mcp.jarvis-package-search
       - remote-mcp.jarvis-live-progress
       - remote-mcp.jarvis-execution-query
       - jarvis.structured-runtime-metadata
@@ -516,6 +518,7 @@ requirements:
     scenarios:
       - remote-mcp
     required_checks:
+      - remote-mcp.jarvis-package-search
       - remote-mcp.jarvis-live-progress
       - remote-mcp.jarvis-execution-query
       - jarvis.structured-runtime-metadata
@@ -619,7 +622,7 @@ requirements:
         states: [verified]
         metadata_equals:
           install_source: wheel
-          install_artifact_sha256: a9d771bcd40ec98de2626ac2a8706fcc614a2eaac462defb10f8d7bec13693e3
+          install_artifact_sha256: acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f
           server_process_artifact_verified: true
           verified: true
 
@@ -718,7 +721,7 @@ requirements:
           remote_tool_names: [spack_find, spack_install, spack_locate]
           allowlisted_tool_names: [spack_find, spack_install, spack_locate]
           install_source: wheel
-          install_artifact_sha256: a9d771bcd40ec98de2626ac2a8706fcc614a2eaac462defb10f8d7bec13693e3
+          install_artifact_sha256: acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f
           contract_id: clio-kit-spack-user-v2
           contract_sha256: 3c5412148c770f4844e98eb893c4db0d0afdbf13afe967df67bd5f7d25e1f7db
           server_process_artifact_verified: true
@@ -823,7 +826,7 @@ requirements:
           remote_tool_names: [spack_find, spack_install, spack_locate]
           allowlisted_tool_names: [spack_find, spack_install, spack_locate]
           install_source: wheel
-          install_artifact_sha256: a9d771bcd40ec98de2626ac2a8706fcc614a2eaac462defb10f8d7bec13693e3
+          install_artifact_sha256: acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f
           contract_id: clio-kit-spack-user-v2
           contract_sha256: 3c5412148c770f4844e98eb893c4db0d0afdbf13afe967df67bd5f7d25e1f7db
           server_process_artifact_verified: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.2.18"
+$Tag = "v1.3.0"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.2.18" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.0" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/docs/remote-mcp-federation.md
+++ b/docs/remote-mcp-federation.md
@@ -248,11 +248,23 @@ when needed. The relay
 removes only local routing controls before submitting the durable remote call;
 all JARVIS query and cursor fields pass through unchanged.
 
+Application discovery stays inside the same compact tool. Call
+`jarvis_describe(target="package_search", query="visualization")` for a ranked,
+summary-only page, then call `target="package"` with the selected canonical
+`name` as `package_name` for its settings. `query` is required and bounded to 256 characters;
+`page_size` defaults to 10 and is limited to 25. Each page is capped at 64 KiB
+and reports `total_matches`, `returned_count`, and an opaque `next_cursor`.
+Continue with the identical query and cursor. Cursors are limited to 1,024
+characters and bind both the normalized query and package-inventory revision,
+so using one with another query or after the inventory changes fails closed.
+The legacy `target="packages"` response remains exhaustive and potentially
+large; agents should not use it for ordinary discovery.
+
 Virtual JARVIS mutations and runs receive a fresh relay job by default. Supply
 an explicit `idempotency_key` only when retry de-duplication is intentional; an
 identical second `jarvis_run` is otherwise a new execution.
 
-The released clio-kit 2.4.9 artifact is the pinned six-tool JARVIS v3.1 contract.
+The released clio-kit 2.5.0 artifact is the pinned six-tool JARVIS v3.2 contract.
 Bootstrap
 downloads and hashes the exact coordinated wheel, installs it once with
 `uv tool install`, and persists the wheel plus the direct JARVIS command in the
@@ -263,9 +275,17 @@ that persistent executable directly. clio-kit's child launcher still uses its
 wheel-owned server source and lock with `uv run --frozen --no-editable`, so the
 live MCP response binds both the installed outer tool and the locked child
 server rather than trusting an unobserved nested resolution. The release gate
-requires that exact 2.4.9 artifact to be rerun on every target selected by the
+requires that exact 2.5.0 artifact to be rerun on every target selected by the
 release policy. Other servers use the operator registry and generated
 `remote_...` aliases.
+
+The exact release wheel is
+`clio_kit-2.5.0-py3-none-any.whl` with SHA-256
+`acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f`.
+Its canonical contract is `clio-kit-jarvis-user-v3.2`, with contract SHA-256
+`12f6d349c9d44d8ce3594943dcd4018ec9b6e01ebb0e59d468bb1bb783a1ad5d`
+and canonical tools-wire SHA-256
+`bda0abe2b57d5e52ef639bf530e967c3b65072ebc4761d25cd9cbbcf0cd934e9`.
 
 ## Register the Spack MCP
 
@@ -280,7 +300,7 @@ operator-defined and do not select behavior.
 
 ## Register the scientific catalog MCP
 
-clio-kit 2.4.9 also ships the two-tool
+clio-kit 2.5.0 also ships the two-tool
 `clio-kit-scientific-catalog-user-v1` contract. It separates dataset discovery
 from visualization control: `scientific_dataset_search` finds operator catalog
 records and `scientific_dataset_describe` returns one exact

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.2.18",
-  "matrix_sha256": "c53ca9db5efcb776fcabe86fc3d358d71362e3bea519e3caab423781d45cc6cd",
+  "release_version": "1.3.0",
+  "matrix_sha256": "8dd3064562bf72b20283435b0d1e87bb5f3b38da6dea222dabc661a4b4f2436b",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.2.18"
+version = "1.3.0"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.2.18"
+__version__ = "1.3.0"

--- a/src/clio_relay/_contracts/jarvis-user-v3.2.json
+++ b/src/clio_relay/_contracts/jarvis-user-v3.2.json
@@ -1,0 +1,2407 @@
+{
+  "canonicalization": "json-sort-keys-compact-utf8-v1",
+  "contract_id": "clio-kit-jarvis-user-v3.2",
+  "contract_sha256": "12f6d349c9d44d8ce3594943dcd4018ec9b6e01ebb0e59d468bb1bb783a1ad5d",
+  "profile": "user",
+  "projection": "mcp-agent-tool-schema-v1",
+  "schema_version": "clio-kit.mcp-user-contract.v1",
+  "server_name": "jarvis",
+  "source": {
+    "method": "tools/list",
+    "protocol_version": "2024-11-05",
+    "transport": "stdio"
+  },
+  "tool_names": [
+    "jarvis_add_step",
+    "jarvis_create_pipeline",
+    "jarvis_describe",
+    "jarvis_edit_step",
+    "jarvis_get_execution",
+    "jarvis_run"
+  ],
+  "tools": [
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Add a package-backed step to a JARVIS pipeline and optionally configure that step with package-owned settings.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "do_configure": {
+            "default": true,
+            "type": "boolean"
+          },
+          "package_name": {
+            "type": "string"
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
+        },
+        "required": [
+          "pipeline_id",
+          "package_name"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_add_step",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      }
+    },
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Create a JARVIS pipeline. Optionally pass execution intent such as local, cluster, or hostfile mode; backend details are resolved where the MCP server runs.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "execution": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Validated, backend-neutral execution request for a JARVIS pipeline.",
+                "properties": {
+                  "account": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "cpus_per_task": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "error": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "exclusive": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "gpus": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "gpus_per_node": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "hostfile": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "hosts": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "job_name": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "mode": {
+                    "default": "auto",
+                    "enum": [
+                      "auto",
+                      "local",
+                      "direct",
+                      "cluster",
+                      "scheduler",
+                      "hostfile"
+                    ],
+                    "type": "string"
+                  },
+                  "nodes": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "output": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "partition": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "qos": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tasks": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tasks_per_node": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "walltime": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "pipeline_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_create_pipeline",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      }
+    },
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "readOnlyHint": true
+      },
+      "description": "Describe JARVIS packages, one package, a pipeline, or one pipeline step. For a named application, first use target='package' with its unique short name or fully qualified package name. Use target='package_search' for bounded discovery, then describe the selected canonical name. target='packages' is an exhaustive legacy inventory with every package's settings and can be large; use it only when the complete installed catalog is explicitly required.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "cursor": {
+            "anyOf": [
+              {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Opaque next-page cursor returned by an earlier package_search with the identical query."
+          },
+          "include_yaml": {
+            "default": true,
+            "description": "Include stored pipeline YAML only for target='pipeline'; ignored for package and package discovery targets.",
+            "type": "boolean"
+          },
+          "package_name": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Case-insensitive unique short name or fully qualified package name for target='package', for example paraview or builtin.paraview. Ambiguous short names fail with canonical candidates."
+          },
+          "page_size": {
+            "default": 10,
+            "description": "Maximum summary matches returned by target='package_search'; bounded to 25.",
+            "maximum": 25,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "pipeline_id": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Pipeline identifier for target='pipeline' or target='step'."
+          },
+          "query": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Natural-language or package-name query required for target='package_search'."
+          },
+          "step_id": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Pipeline step identifier for target='step'."
+          },
+          "target": {
+            "description": "Object to describe. Prefer package for a named application and package_search for discovery; packages is exhaustive and unbounded.",
+            "enum": [
+              "packages",
+              "package_search",
+              "package",
+              "pipeline",
+              "step"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "target"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_describe",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      }
+    },
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Edit or remove a step in a JARVIS pipeline. Use operation='edit' with config, or operation='remove' without config.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "operation": {
+            "default": "edit",
+            "enum": [
+              "edit",
+              "remove"
+            ],
+            "type": "string"
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id",
+          "step_id"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_edit_step",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      }
+    },
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "execution",
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "readOnlyHint": true
+      },
+      "description": "Query one JARVIS execution handle, durable lifecycle record, and runtime metadata. Progress is included by default and can be omitted. Set include_service_runtimes=true to include execution-owned network services such as an interactive ParaView runtime. Set artifacts to {} or filters to include one bounded artifact page; omit artifacts to avoid querying the artifact manifest.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "artifacts": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Optional filters for one bounded page of execution artifacts.",
+                "properties": {
+                  "artifact_id": {
+                    "anyOf": [
+                      {
+                        "maxLength": 90,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Exact opaque JARVIS artifact ID filter."
+                  },
+                  "cursor": {
+                    "anyOf": [
+                      {
+                        "maxLength": 1024,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Opaque next-page cursor."
+                  },
+                  "package_id": {
+                    "anyOf": [
+                      {
+                        "maxLength": 256,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Exact JARVIS package alias filter."
+                  },
+                  "page_size": {
+                    "default": 50,
+                    "description": "Maximum artifacts to return in this page.",
+                    "maximum": 100,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "role": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "intermediate",
+                          "output",
+                          "log",
+                          "checkpoint",
+                          "provenance",
+                          "validation"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "state": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "producing",
+                          "available",
+                          "finalized",
+                          "incomplete",
+                          "failed"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "execution_id": {
+            "type": "string"
+          },
+          "include_progress": {
+            "default": true,
+            "type": "boolean"
+          },
+          "include_service_runtimes": {
+            "default": false,
+            "type": "boolean"
+          },
+          "pipeline_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id",
+          "execution_id"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_get_execution",
+      "outputSchema": {
+        "additionalProperties": false,
+        "description": "Frozen top-level result envelope for a selectable execution query.",
+        "properties": {
+          "artifact_page": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Bounded artifact page nested in a unified execution query.",
+                "properties": {
+                  "artifacts": {
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Current JARVIS-owned lifecycle observation for one generated artifact.",
+                      "properties": {
+                        "artifact_id": {
+                          "type": "string"
+                        },
+                        "checksum": {
+                          "type": "string"
+                        },
+                        "execution_id": {
+                          "type": "string"
+                        },
+                        "format": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string"
+                        },
+                        "location": {
+                          "additionalProperties": false,
+                          "description": "Transport-neutral location in a JARVIS artifact manifest.",
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "execution_path",
+                                "cluster_path",
+                                "external_uri"
+                              ],
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        "logical_name": {
+                          "type": "string"
+                        },
+                        "media_type": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "metadata": {
+                          "additionalProperties": true,
+                          "type": "object"
+                        },
+                        "observed_at_epoch": {
+                          "type": "number"
+                        },
+                        "ownership": {
+                          "enum": [
+                            "execution",
+                            "external",
+                            "shared"
+                          ],
+                          "type": "string"
+                        },
+                        "package_id": {
+                          "type": "string"
+                        },
+                        "package_name": {
+                          "type": "string"
+                        },
+                        "revision": {
+                          "type": "integer"
+                        },
+                        "role": {
+                          "enum": [
+                            "intermediate",
+                            "output",
+                            "log",
+                            "checkpoint",
+                            "provenance",
+                            "validation"
+                          ],
+                          "type": "string"
+                        },
+                        "schema_version": {
+                          "const": "jarvis.artifact.v1",
+                          "type": "string"
+                        },
+                        "sequence": {
+                          "type": "integer"
+                        },
+                        "size_bytes": {
+                          "type": "integer"
+                        },
+                        "state": {
+                          "enum": [
+                            "producing",
+                            "available",
+                            "finalized",
+                            "incomplete",
+                            "failed"
+                          ],
+                          "type": "string"
+                        },
+                        "structure": {
+                          "enum": [
+                            "file",
+                            "directory",
+                            "collection",
+                            "stream"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "schema_version",
+                        "package_name",
+                        "package_id",
+                        "execution_id",
+                        "artifact_id",
+                        "logical_name",
+                        "kind",
+                        "role",
+                        "structure",
+                        "ownership",
+                        "state",
+                        "revision",
+                        "sequence",
+                        "observed_at_epoch",
+                        "metadata"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "execution_id": {
+                    "type": "string"
+                  },
+                  "execution_state": {
+                    "enum": [
+                      "preparing",
+                      "scripted",
+                      "submitting",
+                      "submitted",
+                      "running",
+                      "completed",
+                      "failed",
+                      "canceled",
+                      "unknown"
+                    ],
+                    "type": "string"
+                  },
+                  "matching_artifact_count": {
+                    "type": "integer"
+                  },
+                  "next_cursor": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "pipeline_id": {
+                    "type": "string"
+                  },
+                  "producer_schema_version": {
+                    "const": "jarvis.execution.artifacts.v1",
+                    "type": "string"
+                  },
+                  "returned_artifact_count": {
+                    "type": "integer"
+                  },
+                  "terminal": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "producer_schema_version",
+                  "pipeline_id",
+                  "execution_id",
+                  "execution_state",
+                  "terminal",
+                  "artifacts",
+                  "matching_artifact_count",
+                  "returned_artifact_count",
+                  "next_cursor"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "execution_handle": {
+            "additionalProperties": false,
+            "description": "Stable JARVIS-CD execution-handle document.",
+            "properties": {
+              "cluster": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "execution_id": {
+                "type": "string"
+              },
+              "mode": {
+                "enum": [
+                  "direct",
+                  "scheduler"
+                ],
+                "type": "string"
+              },
+              "pipeline_id": {
+                "type": "string"
+              },
+              "scheduler_native_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_provider": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema_version": {
+                "const": "jarvis.execution.handle.v1",
+                "type": "string"
+              }
+            },
+            "required": [
+              "schema_version",
+              "execution_id",
+              "pipeline_id",
+              "mode",
+              "scheduler_provider",
+              "scheduler_native_id",
+              "cluster"
+            ],
+            "type": "object"
+          },
+          "execution_id": {
+            "type": "string"
+          },
+          "execution_record": {
+            "additionalProperties": false,
+            "description": "Stable JARVIS-CD durable execution-record document.",
+            "properties": {
+              "cluster": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "error": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "execution_id": {
+                "type": "string"
+              },
+              "metadata": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "mode": {
+                "enum": [
+                  "direct",
+                  "scheduler"
+                ],
+                "type": "string"
+              },
+              "pipeline_id": {
+                "type": "string"
+              },
+              "pipeline_name": {
+                "type": "string"
+              },
+              "return_code": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_native_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_provider": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema_version": {
+                "const": "jarvis.execution.record.v1",
+                "type": "string"
+              },
+              "state": {
+                "enum": [
+                  "preparing",
+                  "scripted",
+                  "submitting",
+                  "submitted",
+                  "running",
+                  "completed",
+                  "failed",
+                  "canceled",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "submitted": {
+                "type": "boolean"
+              },
+              "terminal": {
+                "type": "boolean"
+              },
+              "updated_at": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "schema_version",
+              "execution_id",
+              "pipeline_id",
+              "pipeline_name",
+              "mode",
+              "scheduler_provider",
+              "scheduler_native_id",
+              "cluster",
+              "state",
+              "submitted",
+              "terminal",
+              "created_at",
+              "updated_at",
+              "return_code",
+              "error",
+              "metadata"
+            ],
+            "type": "object"
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "progress": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Stable aggregate returned by JARVIS-CD's execution progress API.",
+                "properties": {
+                  "execution_id": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "execution_state": {
+                    "enum": [
+                      "preparing",
+                      "scripted",
+                      "submitting",
+                      "submitted",
+                      "running",
+                      "completed",
+                      "failed",
+                      "canceled",
+                      "unknown"
+                    ],
+                    "type": "string"
+                  },
+                  "packages": {
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Latest stable progress observation for one package alias.",
+                      "properties": {
+                        "event_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "latest": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "description": "One closed, JARVIS-owned package progress observation.",
+                              "properties": {
+                                "current": {
+                                  "anyOf": [
+                                    {
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "determinate": {
+                                  "type": "boolean"
+                                },
+                                "execution_id": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "label": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "anyOf": [
+                                    {
+                                      "maxLength": 4096,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "metadata": {
+                                  "additionalProperties": true,
+                                  "type": "object"
+                                },
+                                "observed_at_epoch": {
+                                  "minimum": 0,
+                                  "type": "number"
+                                },
+                                "package_id": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "package_name": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "schema_version": {
+                                  "const": "jarvis.progress.v1",
+                                  "type": "string"
+                                },
+                                "sequence": {
+                                  "minimum": 0,
+                                  "type": "integer"
+                                },
+                                "state": {
+                                  "enum": [
+                                    "pending",
+                                    "starting",
+                                    "running",
+                                    "ready",
+                                    "completed",
+                                    "failed",
+                                    "canceled"
+                                  ],
+                                  "type": "string"
+                                },
+                                "total": {
+                                  "anyOf": [
+                                    {
+                                      "exclusiveMinimum": 0,
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "unit": {
+                                  "anyOf": [
+                                    {
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                }
+                              },
+                              "required": [
+                                "schema_version",
+                                "package_name",
+                                "package_id",
+                                "execution_id",
+                                "label",
+                                "state",
+                                "sequence",
+                                "observed_at_epoch",
+                                "determinate",
+                                "metadata"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "package_id": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "package_name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "package_id",
+                        "package_name",
+                        "event_count",
+                        "latest"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 4096,
+                    "type": "array"
+                  },
+                  "pipeline_id": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "schema_version": {
+                    "const": "jarvis.execution.progress.v1",
+                    "type": "string"
+                  },
+                  "terminal": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "schema_version",
+                  "execution_id",
+                  "pipeline_id",
+                  "execution_state",
+                  "terminal",
+                  "packages"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "runtime_metadata": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "schema_version": {
+            "const": "clio-kit.jarvis-execution.v2",
+            "type": "string"
+          },
+          "service_runtimes": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Execution-bound current service runtimes returned by JARVIS.",
+                "properties": {
+                  "execution_id": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "execution_state": {
+                    "enum": [
+                      "preparing",
+                      "scripted",
+                      "submitting",
+                      "submitted",
+                      "running",
+                      "completed",
+                      "failed",
+                      "canceled",
+                      "unknown"
+                    ],
+                    "type": "string"
+                  },
+                  "pipeline_id": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "schema_version": {
+                    "const": "jarvis.execution.service-runtimes.v1",
+                    "type": "string"
+                  },
+                  "service_runtimes": {
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Latest durable observation of one execution-owned service.",
+                      "properties": {
+                        "command_path": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "dataset_descriptor": {
+                          "additionalProperties": false,
+                          "description": "Intrinsic, recipe-free dataset identity owned by JARVIS.",
+                          "properties": {
+                            "arrays": {
+                              "items": {
+                                "additionalProperties": false,
+                                "description": "One intrinsic array exposed by a JARVIS-owned service.",
+                                "properties": {
+                                  "association": {
+                                    "enum": [
+                                      "point",
+                                      "cell",
+                                      "field"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "components": {
+                                    "maximum": 64,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  },
+                                  "name": {
+                                    "maxLength": 512,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "units": {
+                                    "anyOf": [
+                                      {
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "default": null
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "association",
+                                  "components"
+                                ],
+                                "type": "object"
+                              },
+                              "maxItems": 256,
+                              "type": "array"
+                            },
+                            "bounds": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "type": "number"
+                                  },
+                                  "maxItems": 6,
+                                  "minItems": 6,
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "dataset_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "fingerprint": {
+                              "additionalProperties": false,
+                              "description": "Canonical identity digest for one bounded dataset descriptor.",
+                              "properties": {
+                                "algorithm": {
+                                  "const": "sha256",
+                                  "type": "string"
+                                },
+                                "digest": {
+                                  "pattern": "^[0-9a-f]{64}$",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "algorithm",
+                                "digest"
+                              ],
+                              "type": "object"
+                            },
+                            "format": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "kind": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "members": {
+                              "items": {
+                                "additionalProperties": false,
+                                "description": "One ordered member in a JARVIS service dataset descriptor.",
+                                "properties": {
+                                  "index": {
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  },
+                                  "location": {
+                                    "maxLength": 4096,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "timestep": {
+                                    "anyOf": [
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "default": null
+                                  }
+                                },
+                                "required": [
+                                  "index",
+                                  "location"
+                                ],
+                                "type": "object"
+                              },
+                              "maxItems": 512,
+                              "minItems": 1,
+                              "type": "array"
+                            },
+                            "schema_version": {
+                              "const": "jarvis.dataset-descriptor.v1",
+                              "type": "string"
+                            },
+                            "source_artifact": {
+                              "anyOf": [
+                                {
+                                  "additionalProperties": false,
+                                  "description": "Optional content identity of a JARVIS-generated source artifact.",
+                                  "properties": {
+                                    "artifact_id": {
+                                      "pattern": "^art_[A-Za-z0-9_-]{22,86}$",
+                                      "type": "string"
+                                    },
+                                    "sha256": {
+                                      "pattern": "^[0-9a-f]{64}$",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "artifact_id",
+                                    "sha256"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "schema_version",
+                            "dataset_id",
+                            "kind",
+                            "format",
+                            "members",
+                            "arrays",
+                            "fingerprint",
+                            "source_artifact"
+                          ],
+                          "type": "object"
+                        },
+                        "delivery_mode": {
+                          "const": "push",
+                          "type": "string"
+                        },
+                        "events_path": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "execution_id": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "health_path": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "host": {
+                          "maxLength": 255,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "lifecycle": {
+                          "enum": [
+                            "starting",
+                            "ready",
+                            "degraded",
+                            "stopping",
+                            "stopped",
+                            "failed"
+                          ],
+                          "type": "string"
+                        },
+                        "live_data_path": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "message": {
+                          "anyOf": [
+                            {
+                              "maxLength": 4096,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "observed_at_epoch": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "package_id": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "package_name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "port": {
+                          "maximum": 65535,
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "protocol": {
+                          "enum": [
+                            "http",
+                            "https"
+                          ],
+                          "type": "string"
+                        },
+                        "revision": {
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "schema_version": {
+                          "const": "jarvis.service-runtime.v1",
+                          "type": "string"
+                        },
+                        "service_instance_id": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "state_path": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "schema_version",
+                        "execution_id",
+                        "package_name",
+                        "package_id",
+                        "service_instance_id",
+                        "revision",
+                        "lifecycle",
+                        "host",
+                        "port",
+                        "protocol",
+                        "health_path",
+                        "live_data_path",
+                        "events_path",
+                        "state_path",
+                        "command_path",
+                        "delivery_mode",
+                        "dataset_descriptor",
+                        "observed_at_epoch"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 4096,
+                    "type": "array"
+                  },
+                  "terminal": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "schema_version",
+                  "execution_id",
+                  "pipeline_id",
+                  "execution_state",
+                  "terminal",
+                  "service_runtimes"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "schema_version",
+          "pipeline_id",
+          "execution_id",
+          "execution_handle",
+          "execution_record",
+          "runtime_metadata",
+          "progress",
+          "artifact_page",
+          "service_runtimes"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Run a configured JARVIS pipeline. Optional execution intent selects local, cluster, or hostfile mode without exposing scheduler internals. Optional spack_specs are resolved into a filtered environment that JARVIS persists before direct or scheduler execution.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "execution": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Validated, backend-neutral execution request for a JARVIS pipeline.",
+                "properties": {
+                  "account": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "cpus_per_task": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "error": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "exclusive": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "gpus": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "gpus_per_node": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "hostfile": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "hosts": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "job_name": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "mode": {
+                    "default": "auto",
+                    "enum": [
+                      "auto",
+                      "local",
+                      "direct",
+                      "cluster",
+                      "scheduler",
+                      "hostfile"
+                    ],
+                    "type": "string"
+                  },
+                  "nodes": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "output": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "partition": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "qos": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tasks": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tasks_per_node": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "walltime": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "execution_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "spack_specs": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "submit": {
+            "default": true,
+            "type": "boolean"
+          },
+          "wait": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "pipeline_id"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_run",
+      "outputSchema": {
+        "description": "Frozen top-level result envelope for ``jarvis_run``.",
+        "properties": {
+          "execution_handle": {
+            "description": "Stable JARVIS-CD execution-handle document.",
+            "properties": {
+              "cluster": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "execution_id": {
+                "type": "string"
+              },
+              "mode": {
+                "enum": [
+                  "direct",
+                  "scheduler"
+                ],
+                "type": "string"
+              },
+              "pipeline_id": {
+                "type": "string"
+              },
+              "scheduler_native_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_provider": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema_version": {
+                "const": "jarvis.execution.handle.v1",
+                "type": "string"
+              }
+            },
+            "required": [
+              "schema_version",
+              "execution_id",
+              "pipeline_id",
+              "mode",
+              "scheduler_provider",
+              "scheduler_native_id",
+              "cluster"
+            ],
+            "type": "object"
+          },
+          "execution_id": {
+            "type": "string"
+          },
+          "execution_record": {
+            "description": "Stable JARVIS-CD durable execution-record document.",
+            "properties": {
+              "cluster": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "error": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "execution_id": {
+                "type": "string"
+              },
+              "metadata": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "mode": {
+                "enum": [
+                  "direct",
+                  "scheduler"
+                ],
+                "type": "string"
+              },
+              "pipeline_id": {
+                "type": "string"
+              },
+              "pipeline_name": {
+                "type": "string"
+              },
+              "return_code": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_native_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_provider": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema_version": {
+                "const": "jarvis.execution.record.v1",
+                "type": "string"
+              },
+              "state": {
+                "enum": [
+                  "preparing",
+                  "scripted",
+                  "submitting",
+                  "submitted",
+                  "running",
+                  "completed",
+                  "failed",
+                  "canceled",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "submitted": {
+                "type": "boolean"
+              },
+              "terminal": {
+                "type": "boolean"
+              },
+              "updated_at": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "schema_version",
+              "execution_id",
+              "pipeline_id",
+              "pipeline_name",
+              "mode",
+              "scheduler_provider",
+              "scheduler_native_id",
+              "cluster",
+              "state",
+              "submitted",
+              "terminal",
+              "created_at",
+              "updated_at",
+              "return_code",
+              "error",
+              "metadata"
+            ],
+            "type": "object"
+          },
+          "mode": {
+            "enum": [
+              "direct",
+              "scheduler"
+            ],
+            "type": "string"
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "progress": {
+            "additionalProperties": false,
+            "description": "Stable aggregate returned by JARVIS-CD's execution progress API.",
+            "properties": {
+              "execution_id": {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "execution_state": {
+                "enum": [
+                  "preparing",
+                  "scripted",
+                  "submitting",
+                  "submitted",
+                  "running",
+                  "completed",
+                  "failed",
+                  "canceled",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "packages": {
+                "items": {
+                  "additionalProperties": false,
+                  "description": "Latest stable progress observation for one package alias.",
+                  "properties": {
+                    "event_count": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "latest": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "description": "One closed, JARVIS-owned package progress observation.",
+                          "properties": {
+                            "current": {
+                              "anyOf": [
+                                {
+                                  "minimum": 0,
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "determinate": {
+                              "type": "boolean"
+                            },
+                            "execution_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "label": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "message": {
+                              "anyOf": [
+                                {
+                                  "maxLength": 4096,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "metadata": {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            "observed_at_epoch": {
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "package_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "package_name": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "schema_version": {
+                              "const": "jarvis.progress.v1",
+                              "type": "string"
+                            },
+                            "sequence": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "state": {
+                              "enum": [
+                                "pending",
+                                "starting",
+                                "running",
+                                "ready",
+                                "completed",
+                                "failed",
+                                "canceled"
+                              ],
+                              "type": "string"
+                            },
+                            "total": {
+                              "anyOf": [
+                                {
+                                  "exclusiveMinimum": 0,
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "unit": {
+                              "anyOf": [
+                                {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            }
+                          },
+                          "required": [
+                            "schema_version",
+                            "package_name",
+                            "package_id",
+                            "execution_id",
+                            "label",
+                            "state",
+                            "sequence",
+                            "observed_at_epoch",
+                            "determinate",
+                            "metadata"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "package_id": {
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "package_name": {
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "package_id",
+                    "package_name",
+                    "event_count",
+                    "latest"
+                  ],
+                  "type": "object"
+                },
+                "maxItems": 4096,
+                "type": "array"
+              },
+              "pipeline_id": {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "schema_version": {
+                "const": "jarvis.execution.progress.v1",
+                "type": "string"
+              },
+              "terminal": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "schema_version",
+              "execution_id",
+              "pipeline_id",
+              "execution_state",
+              "terminal",
+              "packages"
+            ],
+            "type": "object"
+          },
+          "runtime_metadata": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "scheduler": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema_version": {
+            "const": "clio-kit.jarvis-run.v1",
+            "type": "string"
+          },
+          "script_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "status": {
+            "enum": [
+              "preparing",
+              "scripted",
+              "submitting",
+              "submitted",
+              "running",
+              "completed",
+              "failed",
+              "canceled",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "wait": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "schema_version",
+          "pipeline_id",
+          "execution_id",
+          "status",
+          "mode",
+          "scheduler",
+          "script_path",
+          "wait",
+          "execution_handle",
+          "execution_record",
+          "progress",
+          "runtime_metadata"
+        ],
+        "type": "object"
+      }
+    }
+  ],
+  "wire_sha256": "bda0abe2b57d5e52ef639bf530e967c3b65072ebc4761d25cd9cbbcf0cd934e9"
+}

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -7521,6 +7521,12 @@ def jarvis_mcp_refresh(
 @_acceptance_report_command
 def jarvis_mcp_validate(
     cluster: Annotated[str, typer.Option(help="Configured cluster name.")],
+    package_search_query: Annotated[
+        str,
+        typer.Option(
+            help=("Non-blank application query used to prove bounded JARVIS package discovery."),
+        ),
+    ] = "",
     arguments_json: Annotated[
         str,
         typer.Option(help="JSON object arguments for the virtual jarvis_run tool."),
@@ -7566,9 +7572,14 @@ def jarvis_mcp_validate(
     report_path = report or default_report_path(cluster)
     report_written = [False]
 
-    def preflight() -> tuple[dict[str, Any], ClusterDefinition]:
+    def preflight() -> tuple[dict[str, Any], ClusterDefinition, str]:
         if profile not in {"user", "admin", "operator", "all"}:
             raise typer.BadParameter("--profile must be user, admin, operator, or all")
+        normalized_package_search_query = " ".join(package_search_query.split())
+        if not normalized_package_search_query:
+            raise typer.BadParameter("--package-search-query must not be blank")
+        if len(normalized_package_search_query) > 256:
+            raise typer.BadParameter("--package-search-query must not exceed 256 characters")
         arguments_source = _json_text_from_option(arguments_json, arguments_json_file)
         arguments = _json_object(arguments_source)
         if "cluster" in arguments:
@@ -7577,10 +7588,10 @@ def jarvis_mcp_validate(
             )
         if not isinstance(arguments.get("pipeline_id"), str):
             raise typer.BadParameter("jarvis-mcp-validate requires a string pipeline_id argument")
-        return arguments, _require_cluster(cluster)
+        return arguments, _require_cluster(cluster), normalized_package_search_query
 
     try:
-        arguments, definition = preflight()
+        arguments, definition, normalized_package_search_query = preflight()
     except BaseException as exc:
         _write_failed_acceptance_report(
             path=report_path,
@@ -7617,6 +7628,15 @@ def jarvis_mcp_validate(
             result=remote_tools_list_result,
             artifacts=remote_discovery_artifacts,
             artifact_payload=remote_discovery_payload,
+        )
+        package_search = _run_jarvis_package_search_query(
+            cluster=cluster,
+            definition=definition,
+            queue=queue,
+            profile=profile,
+            query=normalized_package_search_query,
+            wait_timeout_seconds=wait_timeout_seconds,
+            poll_seconds=poll_seconds,
         )
         stdio_session = run_packaged_mcp_stdio_session(
             profile=profile,
@@ -7688,6 +7708,16 @@ def jarvis_mcp_validate(
             remote_discovery_artifacts=remote_discovery_artifacts,
             initialize_response=stdio_session.initialize_response,
             stdio_evidence=stdio_session.evidence(),
+            package_search_query=normalized_package_search_query,
+            package_search_tools_list_response=package_search.tools_list_response,
+            package_search_call_response=package_search.call_response,
+            package_search_call_job_id=package_search.call_job_id,
+            package_search_call_status=package_search.call_status,
+            package_search_artifacts=package_search.artifacts,
+            package_search_mcp_result=package_search.mcp_result,
+            package_search_provenance=package_search.provenance,
+            package_search_initialize_response=package_search.initialize_response,
+            package_search_stdio_evidence=package_search.stdio_evidence,
             query_tools_list_response=execution_query.tools_list_response,
             query_call_response=execution_query.call_response,
             query_call_job_id=execution_query.call_job_id,
@@ -10635,6 +10665,84 @@ def _decode_artifact_envelope(envelope: dict[str, object]) -> bytes:
         return base64.b64decode(encoded, validate=True)
     except (binascii.Error, ValueError) as exc:
         raise RelayError("remote MCP result artifact contains invalid base64") from exc
+
+
+@dataclass(frozen=True)
+class _JarvisPackageSearchAcceptance:
+    """Durable evidence from one bounded JARVIS package-discovery query."""
+
+    tools_list_response: dict[str, Any]
+    call_response: dict[str, Any]
+    call_job_id: str
+    call_status: dict[str, Any]
+    artifacts: list[dict[str, Any]]
+    mcp_result: dict[str, Any] | None
+    provenance: dict[str, Any] | None
+    initialize_response: dict[str, Any]
+    stdio_evidence: dict[str, Any]
+
+
+def _run_jarvis_package_search_query(
+    *,
+    cluster: str,
+    definition: ClusterDefinition,
+    queue: ClioCoreQueue,
+    profile: str,
+    query: str,
+    wait_timeout_seconds: float,
+    poll_seconds: float,
+) -> _JarvisPackageSearchAcceptance:
+    """Exercise bounded package discovery through the local virtual MCP surface."""
+    session = run_packaged_mcp_stdio_session(
+        profile=profile,
+        tool="jarvis_describe",
+        arguments={
+            "cluster": cluster,
+            "target": "package_search",
+            "query": query,
+            "page_size": 5,
+        },
+    )
+    call_job_id = _mcp_response_job_id(session.tools_call_response)
+    if should_execute_on_cluster(definition):
+        call_status = _wait_for_remote_job_terminal(
+            definition,
+            call_job_id,
+            timeout_seconds=wait_timeout_seconds,
+            poll_seconds=poll_seconds,
+        )
+        artifacts = _remote_artifact_records(definition, call_job_id)
+        mcp_result = _read_remote_json_artifact_kind(
+            definition,
+            artifacts,
+            kind="mcp_result",
+        )
+        provenance = _read_remote_json_artifact_kind(
+            definition,
+            artifacts,
+            kind="provenance",
+        )
+    else:
+        call_status = _wait_for_local_job_terminal(
+            queue,
+            call_job_id,
+            timeout_seconds=wait_timeout_seconds,
+            poll_seconds=poll_seconds,
+        )
+        artifacts = _complete_local_artifact_records(queue, call_job_id)
+        mcp_result = _read_local_json_artifact_kind(queue, artifacts, kind="mcp_result")
+        provenance = _read_local_json_artifact_kind(queue, artifacts, kind="provenance")
+    return _JarvisPackageSearchAcceptance(
+        tools_list_response=session.tools_list_response,
+        call_response=session.tools_call_response,
+        call_job_id=call_job_id,
+        call_status=cast(dict[str, Any], call_status),
+        artifacts=artifacts,
+        mcp_result=mcp_result,
+        provenance=provenance,
+        initialize_response=session.initialize_response,
+        stdio_evidence=session.evidence(),
+    )
 
 
 @dataclass(frozen=True)

--- a/src/clio_relay/installation.py
+++ b/src/clio_relay/installation.py
@@ -45,7 +45,7 @@ JARVIS_EXECUTION_ARTIFACTS_SCHEMA = "jarvis.execution.artifacts.v1"
 JARVIS_ARTIFACT_SCHEMA = "jarvis.artifact.v1"
 JARVIS_EXECUTION_SERVICE_RUNTIMES_SCHEMA = "jarvis.execution.service-runtimes.v1"
 CLIO_KIT_JARVIS_EXECUTION_SCHEMA = "clio-kit.jarvis-execution.v2"
-CLIO_KIT_JARVIS_CONTRACT_ID = "clio-kit-jarvis-user-v3.1"
+CLIO_KIT_JARVIS_CONTRACT_ID = "clio-kit-jarvis-user-v3.2"
 CLIO_KIT_MCP_CONTRACT_SCHEMA = "clio-kit.mcp-user-contract.v1"
 CLIO_KIT_NATIVE_OPERATIONS = (
     "jarvis_get_execution",

--- a/src/clio_relay/jarvis_mcp.py
+++ b/src/clio_relay/jarvis_mcp.py
@@ -22,16 +22,16 @@ from clio_relay.remote_mcp import (
 if TYPE_CHECKING:
     from clio_relay.installation import ComponentArtifactIdentity, InstallReceipt
 
-CLIO_KIT_JARVIS_MCP_VERSION = "2.4.9"
+CLIO_KIT_JARVIS_MCP_VERSION = "2.5.0"
 CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME = f"clio_kit-{CLIO_KIT_JARVIS_MCP_VERSION}-py3-none-any.whl"
 CLIO_KIT_JARVIS_MCP_WHEEL_URL = (
     "https://github.com/iowarp/clio-kit/releases/download/"
     f"v{CLIO_KIT_JARVIS_MCP_VERSION}/{CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME}"
 )
 CLIO_KIT_JARVIS_MCP_WHEEL_SHA256 = (
-    "a9d771bcd40ec98de2626ac2a8706fcc614a2eaac462defb10f8d7bec13693e3"
+    "acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f"
 )
-CLIO_KIT_JARVIS_USER_CONTRACT_ID = "clio-kit-jarvis-user-v3.1"
+CLIO_KIT_JARVIS_USER_CONTRACT_ID = "clio-kit-jarvis-user-v3.2"
 DEFAULT_JARVIS_MCP_COMMAND = [
     "clio-kit",
     "mcp-server",
@@ -45,12 +45,12 @@ JARVIS_MCP_CACHE_SERVER_NAME = "__builtin_jarvis__"
 JSON = dict[str, Any]
 
 CLIO_KIT_JARVIS_USER_CONTRACT_SHA256 = (
-    "adc7756025fbcc90b0695bd4eaac00bda5c6cff4eb2f248fd7be263bd90b9b8b"
+    "12f6d349c9d44d8ce3594943dcd4018ec9b6e01ebb0e59d468bb1bb783a1ad5d"
 )
 CLIO_KIT_JARVIS_USER_WIRE_SHA256 = (
-    "b2a6e531399c5a24678adf55e5133c1234718363661bde0636d81d0b1ae5db11"
+    "bda0abe2b57d5e52ef639bf530e967c3b65072ebc4761d25cd9cbbcf0cd934e9"
 )
-_JARVIS_USER_CONTRACT_PATH = Path(__file__).with_name("_contracts") / "jarvis-user-v3.1.json"
+_JARVIS_USER_CONTRACT_PATH = Path(__file__).with_name("_contracts") / "jarvis-user-v3.2.json"
 _EXPECTED_JARVIS_USER_TOOLS = {
     "jarvis_add_step",
     "jarvis_create_pipeline",
@@ -562,7 +562,9 @@ def render_virtual_jarvis_agent_context() -> str:
         "argument. clio-relay routes each call to the JARVIS MCP server running "
         "on that cluster and returns a durable relay job_id. jarvis_get_execution "
         "includes progress by default and can optionally return a bounded artifact "
-        "page without adding another agent tool. Available "
+        "page without adding another agent tool. Use jarvis_describe with "
+        "target='package_search' for bounded package discovery, then describe the "
+        "selected canonical package name. Available "
         f"virtual JARVIS tools: {tool_names}."
     )
 

--- a/src/clio_relay/jarvis_mcp_validation.py
+++ b/src/clio_relay/jarvis_mcp_validation.py
@@ -63,6 +63,16 @@ def build_jarvis_mcp_validation_report(
     remote_discovery_artifacts: list[JSON] | None = None,
     initialize_response: JSON | None = None,
     stdio_evidence: JSON | None = None,
+    package_search_query: str,
+    package_search_tools_list_response: JSON | None,
+    package_search_call_response: JSON | None,
+    package_search_call_job_id: str,
+    package_search_call_status: JSON,
+    package_search_artifacts: list[JSON],
+    package_search_mcp_result: JSON | None,
+    package_search_provenance: JSON | None,
+    package_search_initialize_response: JSON | None,
+    package_search_stdio_evidence: JSON | None,
     query_tools_list_response: JSON | None,
     query_call_response: JSON | None,
     query_call_job_id: str,
@@ -90,7 +100,12 @@ def build_jarvis_mcp_validation_report(
     tool_definition = _listed_tool(tools_list_response, tool)
     input_schema = _mapping(tool_definition.get("inputSchema")) if tool_definition else None
     properties = _mapping(input_schema.get("properties")) if input_schema else None
-    required = input_schema.get("required") if input_schema else None
+    required = cast(object, input_schema.get("required")) if input_schema else None
+    required_fields: set[str] = (
+        {item for item in cast(list[object], required) if isinstance(item, str)}
+        if isinstance(required, list)
+        else set[str]()
+    )
     local_contract_evidence, local_contract_passed = _local_jarvis_contract(
         tool_definition,
         tool,
@@ -103,8 +118,7 @@ def build_jarvis_mcp_validation_report(
         tool_definition is not None
         and properties is not None
         and isinstance(properties.get("cluster"), dict)
-        and isinstance(required, list)
-        and "cluster" in required
+        and "cluster" in required_fields
         and local_contract_passed
         and stdio_boundary_passed
     )
@@ -137,6 +151,35 @@ def build_jarvis_mcp_validation_report(
             report.started_at,
             observed_at,
             remote_contract_evidence,
+        )
+    )
+
+    package_search_evidence, package_search_passed = _jarvis_package_search_evidence(
+        cluster=cluster,
+        query=package_search_query,
+        expected_server_artifact=(
+            _mapping(remote_tools_list_result.get("server_artifact"))
+            if remote_tools_list_result
+            else None
+        ),
+        tools_list_response=package_search_tools_list_response,
+        call_response=package_search_call_response,
+        call_job_id=package_search_call_job_id,
+        call_status=package_search_call_status,
+        artifacts=package_search_artifacts,
+        mcp_result=package_search_mcp_result,
+        provenance=package_search_provenance,
+        initialize_response=package_search_initialize_response,
+        stdio_evidence=package_search_stdio_evidence,
+    )
+    report.checks.append(
+        _check(
+            "remote-mcp.jarvis-package-search",
+            "bounded JARVIS package discovery returned a durable summary page",
+            package_search_passed,
+            report.started_at,
+            observed_at,
+            package_search_evidence,
         )
     )
 
@@ -464,6 +507,22 @@ def build_jarvis_mcp_validation_report(
                 metadata={**query_job, "execution_id": execution_id},
             )
         )
+    package_search_job = _mapping(package_search_call_status.get("job")) or {}
+    if isinstance(package_search_job.get("job_id"), str):
+        report.resources.append(
+            ValidationResource(
+                kind="relay_job",
+                resource_id=cast(str, package_search_job["job_id"]),
+                role="jarvis_mcp_package_search",
+                cluster=cluster,
+                state=(
+                    str(package_search_job.get("state"))
+                    if package_search_job.get("state") is not None
+                    else None
+                ),
+                metadata=package_search_job,
+            )
+        )
     if remote_discovery_job_id is not None:
         report.resources.append(
             ValidationResource(
@@ -551,6 +610,21 @@ def build_jarvis_mcp_validation_report(
                 metadata=artifact,
             )
         )
+    for artifact in package_search_artifacts:
+        artifact_id = artifact.get("artifact_id")
+        if not isinstance(artifact_id, str):
+            continue
+        uri = artifact.get("uri")
+        report.resources.append(
+            ValidationResource(
+                kind="artifact",
+                resource_id=artifact_id,
+                role=f"jarvis_package_search_{artifact.get('kind', 'artifact')}",
+                cluster=cluster,
+                references=[str(uri)] if isinstance(uri, str) else [],
+                metadata=artifact,
+            )
+        )
     for artifact in generated_artifacts:
         artifact_id = artifact.get("artifact_id")
         if not isinstance(artifact_id, str):
@@ -617,6 +691,208 @@ def _artifact_location_references(artifact: dict[str, object]) -> list[str]:
     if isinstance(kind, str) and kind and isinstance(value, str) and value:
         return [f"{kind}:{value}"]
     return []
+
+
+def _jarvis_package_search_evidence(
+    *,
+    cluster: str,
+    query: str,
+    expected_server_artifact: JSON | None,
+    tools_list_response: JSON | None,
+    call_response: JSON | None,
+    call_job_id: str,
+    call_status: JSON,
+    artifacts: list[JSON],
+    mcp_result: JSON | None,
+    provenance: JSON | None,
+    initialize_response: JSON | None,
+    stdio_evidence: JSON | None,
+) -> tuple[JSON, bool]:
+    """Validate one durable, bounded package-search result from JARVIS."""
+    tool = _listed_tool(tools_list_response, "jarvis_describe")
+    input_schema = _mapping(tool.get("inputSchema")) if tool else None
+    properties = _mapping(input_schema.get("properties")) if input_schema else None
+    required = cast(object, input_schema.get("required")) if input_schema else None
+    required_fields: set[str] = (
+        {item for item in cast(list[object], required) if isinstance(item, str)}
+        if isinstance(required, list)
+        else set[str]()
+    )
+    local_contract, local_contract_passed = _local_jarvis_contract(
+        tool,
+        "jarvis_describe",
+    )
+    stdio_passed = _stdio_initialize_passed(
+        initialize_response=initialize_response,
+        evidence=stdio_evidence,
+    )
+    local_surface_passed = bool(
+        properties is not None
+        and isinstance(properties.get("cluster"), dict)
+        and {"cluster", "target"}.issubset(required_fields)
+        and local_contract_passed
+        and stdio_passed
+    )
+
+    job = _mapping(call_status.get("job")) or {}
+    spec = _mapping(job.get("spec")) or {}
+    arguments = _mapping(spec.get("arguments")) or {}
+    page_size = cast(object, arguments.get("page_size"))
+    page_size_value: int | None = page_size if _positive_int(page_size) else None
+    request_bounded = bool(
+        bool(query)
+        and len(query) <= 256
+        and set(arguments) == {"target", "query", "page_size"}
+        and arguments.get("target") == "package_search"
+        and arguments.get("query") == query
+        and page_size_value is not None
+        and page_size_value <= 25
+    )
+    response_job_id = _response_job_id(call_response)
+    durable_artifacts = {
+        str(artifact.get("kind")): artifact
+        for artifact in artifacts
+        if isinstance(artifact.get("kind"), str)
+    }
+    required_artifacts = {"stdout", "stderr", "mcp_result", "provenance"}
+    provenance_job = _mapping(provenance.get("job")) if provenance else None
+    job_passed = bool(
+        response_job_id == call_job_id
+        and job.get("job_id") == call_job_id
+        and job.get("cluster") == cluster
+        and job.get("kind") == "mcp_call"
+        and job.get("state") == "succeeded"
+        and call_status.get("terminal") is True
+        and spec.get("operation") == "tools/call"
+        and spec.get("tool") == "jarvis_describe"
+        and request_bounded
+        and required_artifacts.issubset(durable_artifacts)
+        and provenance_job is not None
+        and provenance_job.get("job_id") == call_job_id
+    )
+
+    expected_server_artifact_digest = (
+        remote_mcp_server_artifact_digest(expected_server_artifact)
+        if expected_server_artifact is not None
+        else None
+    )
+    result_server_artifact = _mapping(mcp_result.get("server_artifact")) if mcp_result else None
+    server_binding_passed = bool(
+        _is_sha256(expected_server_artifact_digest)
+        and spec.get("expected_server_artifact_digest") == expected_server_artifact_digest
+        and mcp_result is not None
+        and mcp_result.get("expected_server_artifact_digest") == expected_server_artifact_digest
+        and mcp_result.get("observed_server_artifact_digest") == expected_server_artifact_digest
+        and result_server_artifact == expected_server_artifact
+    )
+
+    structured = _mapping(mcp_result.get("structured_result")) if mcp_result else None
+    raw_packages = structured.get("packages") if structured else None
+    packages = cast(list[object], raw_packages) if isinstance(raw_packages, list) else []
+    summaries_valid = bool(packages) and all(
+        _valid_package_search_summary(package) for package in packages
+    )
+    total_matches = cast(object, structured.get("total_matches")) if structured else None
+    returned_count = cast(object, structured.get("returned_count")) if structured else None
+    total_matches_value: int | None = total_matches if _positive_int(total_matches) else None
+    returned_count_value: int | None = returned_count if _positive_int(returned_count) else None
+    next_cursor = cast(object, structured.get("next_cursor")) if structured else None
+    encoded_bytes = (
+        len(
+            json.dumps(
+                structured,
+                allow_nan=False,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("utf-8")
+        )
+        if structured is not None
+        else None
+    )
+    result_bounded = bool(
+        structured is not None
+        and set(structured)
+        == {
+            "schema_version",
+            "target",
+            "query",
+            "inventory_revision",
+            "packages",
+            "total_matches",
+            "returned_count",
+            "next_cursor",
+        }
+        and structured.get("schema_version") == "jarvis.package-search.v1"
+        and structured.get("target") == "package_search"
+        and structured.get("query") == query
+        and _is_sha256(structured.get("inventory_revision"))
+        and summaries_valid
+        and returned_count_value is not None
+        and total_matches_value is not None
+        and page_size_value is not None
+        and returned_count_value == len(packages)
+        and returned_count_value <= page_size_value
+        and total_matches_value >= returned_count_value
+        and (
+            next_cursor is None or (isinstance(next_cursor, str) and 1 <= len(next_cursor) <= 1024)
+        )
+        and encoded_bytes is not None
+        and encoded_bytes <= 64 * 1024
+    )
+    protocol_passed = bool(
+        mcp_result is not None
+        and mcp_result.get("returncode") == 0
+        and mcp_result.get("operation") == "tools/call"
+        and mcp_result.get("tool") == "jarvis_describe"
+        and mcp_result.get("protocol_error") is None
+    )
+    assertions = {
+        "local_surface": local_surface_passed,
+        "durable_call": job_passed,
+        "server_artifact_binding": server_binding_passed,
+        "protocol_result": protocol_passed,
+        "bounded_summary_page": result_bounded,
+    }
+    return (
+        {
+            "query": query,
+            "page_size": page_size_value,
+            "response_job_id": response_job_id,
+            "job_id": job.get("job_id"),
+            "artifact_kinds": sorted(durable_artifacts),
+            "required_artifact_kinds": sorted(required_artifacts),
+            "expected_server_artifact_digest": expected_server_artifact_digest,
+            "returned_count": returned_count_value,
+            "total_matches": total_matches_value,
+            "next_cursor_present": isinstance(next_cursor, str),
+            "serialized_result_bytes": encoded_bytes,
+            "result": structured or {},
+            "local_contract": local_contract,
+            "packaged_stdio": stdio_evidence or {},
+            "assertions": assertions,
+        },
+        all(assertions.values()),
+    )
+
+
+def _valid_package_search_summary(value: object) -> bool:
+    """Return whether one package-search item is summary-only and bounded."""
+    summary = _mapping(value)
+    if summary is None:
+        return False
+    if not {"name", "short_name", "repository"}.issubset(summary):
+        return False
+    if not set(summary).issubset({"name", "short_name", "repository", "description"}):
+        return False
+    for key in ("name", "short_name", "repository"):
+        item = summary.get(key)
+        if not isinstance(item, str) or not item:
+            return False
+    description = summary.get("description")
+    return description is None or (
+        isinstance(description, str) and len(description.encode("utf-8")) <= 4096
+    )
 
 
 def _jarvis_execution_query_evidence(
@@ -1145,6 +1421,9 @@ def _remote_jarvis_contract(document: JSON | None) -> tuple[JSON, bool]:
     query_evidence, query_passed = _execution_query_contract_evidence(
         by_name.get("jarvis_get_execution")
     )
+    package_search_evidence, package_search_passed = _package_search_contract_evidence(
+        by_name.get("jarvis_describe")
+    )
     observed_digest: str | None = None
     contract_error: str | None = None
     try:
@@ -1160,6 +1439,7 @@ def _remote_jarvis_contract(document: JSON | None) -> tuple[JSON, bool]:
         and operation.get("enum") == ["edit", "remove"]
         and spack_specs is not None
         and query_passed
+        and package_search_passed
         and observed_digest == CLIO_KIT_JARVIS_USER_CONTRACT_SHA256
     )
     return (
@@ -1168,11 +1448,67 @@ def _remote_jarvis_contract(document: JSON | None) -> tuple[JSON, bool]:
             "expected_tool_names": sorted(expected),
             "edit_operation_schema": operation or {},
             "spack_specs_schema": spack_specs or {},
+            "package_search": package_search_evidence,
             "execution_query": query_evidence,
             "expected_contract_sha256": CLIO_KIT_JARVIS_USER_CONTRACT_SHA256,
             "expected_clio_kit_version": CLIO_KIT_JARVIS_MCP_VERSION,
             "observed_contract_sha256": observed_digest,
             "contract_error": contract_error,
+        },
+        passed,
+    )
+
+
+def _package_search_contract_evidence(tool: JSON | None) -> tuple[JSON, bool]:
+    """Summarize the bounded package-discovery surface from live tools/list."""
+    input_schema = _mapping(tool.get("inputSchema")) if tool else None
+    properties = _mapping(input_schema.get("properties")) if input_schema else None
+    required = input_schema.get("required") if input_schema else None
+    target = _mapping(properties.get("target")) if properties else None
+    query_selector = _mapping(properties.get("query")) if properties else None
+    query = _schema_option(query_selector, expected_type="string")
+    page_size = _mapping(properties.get("page_size")) if properties else None
+    cursor_selector = _mapping(properties.get("cursor")) if properties else None
+    cursor = _schema_option(cursor_selector, expected_type="string")
+    expected_fields = {
+        "target",
+        "package_name",
+        "query",
+        "page_size",
+        "cursor",
+        "pipeline_id",
+        "step_id",
+        "include_yaml",
+    }
+    target_values = (
+        cast(list[object], target.get("enum"))
+        if target is not None and isinstance(target.get("enum"), list)
+        else []
+    )
+    passed = (
+        input_schema is not None
+        and input_schema.get("additionalProperties") is False
+        and properties is not None
+        and set(properties) == expected_fields
+        and required == ["target"]
+        and target_values == ["packages", "package_search", "package", "pipeline", "step"]
+        and query == {"maxLength": 256, "minLength": 1, "type": "string"}
+        and page_size is not None
+        and page_size.get("default") == 10
+        and page_size.get("minimum") == 1
+        and page_size.get("maximum") == 25
+        and page_size.get("type") == "integer"
+        and cursor == {"maxLength": 1024, "minLength": 1, "type": "string"}
+    )
+    return (
+        {
+            "input_fields": sorted(properties) if properties is not None else [],
+            "required": required if isinstance(required, list) else [],
+            "target_values": target_values,
+            "query_schema": query or {},
+            "page_size_schema": page_size or {},
+            "cursor_schema": cursor or {},
+            "bounded": passed,
         },
         passed,
     )

--- a/src/clio_relay/remote_mcp.py
+++ b/src/clio_relay/remote_mcp.py
@@ -73,7 +73,7 @@ MAX_REMOTE_MCP_CATALOG_ISSUES = 10_000
 MAX_VIRTUAL_REMOTE_MCP_ALIAS_LENGTH = 64
 REMOTE_MCP_REPLACE_ATTEMPTS = 25
 REMOTE_MCP_REPLACE_RETRY_SECONDS = 0.02
-CLIO_KIT_SPACK_USER_WHEEL_VERSION = "2.4.9"
+CLIO_KIT_SPACK_USER_WHEEL_VERSION = "2.5.0"
 CLIO_KIT_SPACK_USER_CONTRACT_ID = "clio-kit-spack-user-v2"
 # Digest the MCP wire ``tools/list`` result. FastMCP's in-process FunctionTool
 # schemas retain ``$defs`` that its protocol serializer dereferences, so their

--- a/tests/test_acceptance_report_defaults.py
+++ b/tests/test_acceptance_report_defaults.py
@@ -346,6 +346,8 @@ ACCEPTANCE_COMMANDS = (
             "jarvis-mcp-validate",
             "--cluster",
             "test-cluster",
+            "--package-search-query",
+            "lammps",
             "--arguments-json",
             '{"pipeline_id":"pipeline"}',
         ),
@@ -353,6 +355,8 @@ ACCEPTANCE_COMMANDS = (
             "jarvis-mcp-validate",
             "--cluster",
             "missing",
+            "--package-search-query",
+            "lammps",
             "--arguments-json",
             '{"pipeline_id":"pipeline"}',
         ),
@@ -786,6 +790,20 @@ def _post_run_jarvis_query(**_kwargs: object) -> SimpleNamespace:
     )
 
 
+def _jarvis_package_search(**_kwargs: object) -> SimpleNamespace:
+    return SimpleNamespace(
+        tools_list_response={},
+        call_response={},
+        call_job_id="package-search-job",
+        call_status={"terminal": True},
+        artifacts=[],
+        mcp_result={},
+        provenance={},
+        initialize_response={},
+        stdio_evidence={},
+    )
+
+
 def _successful_jarvis_validation(**_kwargs: object) -> LiveValidationReport:
     return _passed_report(scenario="remote-mcp", cluster="test-cluster")
 
@@ -916,6 +934,11 @@ def _install_success_fakes(
             cli,
             "_run_post_run_jarvis_execution_query",
             _post_run_jarvis_query,
+        )
+        monkeypatch.setattr(
+            cli,
+            "_run_jarvis_package_search_query",
+            _jarvis_package_search,
         )
         monkeypatch.setattr(
             cli,

--- a/tests/test_ci_clio_kit_wheel.py
+++ b/tests/test_ci_clio_kit_wheel.py
@@ -17,14 +17,14 @@ from clio_relay.jarvis_mcp import (
 ROOT = Path(__file__).resolve().parents[1]
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
-WHEEL_FILENAME = "clio_kit-2.4.9-py3-none-any.whl"
-WHEEL_SHA256 = "a9d771bcd40ec98de2626ac2a8706fcc614a2eaac462defb10f8d7bec13693e3"
-WHEEL_URL = f"https://github.com/iowarp/clio-kit/releases/download/v2.4.9/{WHEEL_FILENAME}"
+WHEEL_FILENAME = "clio_kit-2.5.0-py3-none-any.whl"
+WHEEL_SHA256 = "acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f"
+WHEEL_URL = f"https://github.com/iowarp/clio-kit/releases/download/v2.5.0/{WHEEL_FILENAME}"
 
 
 def test_runtime_and_ci_share_one_exact_clio_kit_release_pin() -> None:
     """Keep bootstrap, JARVIS MCP, and CI on the same exact release wheel bytes."""
-    assert CLIO_KIT_JARVIS_MCP_VERSION == "2.4.9"
+    assert CLIO_KIT_JARVIS_MCP_VERSION == "2.5.0"
     assert CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME == WHEEL_FILENAME
     assert CLIO_KIT_JARVIS_MCP_WHEEL_SHA256 == WHEEL_SHA256
     assert CLIO_KIT_JARVIS_MCP_WHEEL_URL == WHEEL_URL

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5235,6 +5235,97 @@ def test_cli_jarvis_mcp_call_uses_builtin_cluster_command(
     assert job.spec.arguments == {"target": "packages"}
 
 
+def test_jarvis_package_search_query_uses_bounded_virtual_call(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+    session = SimpleNamespace(
+        tools_list_response={"result": {"tools": []}},
+        tools_call_response={"result": {"job_id": "job-search"}},
+        initialize_response={"result": {"protocolVersion": "2024-11-05"}},
+        evidence=lambda: {"transport": "stdio"},
+    )
+
+    def run_session(**kwargs: object) -> SimpleNamespace:
+        calls.append(dict(kwargs))
+        return session
+
+    def response_job_id(_response: object) -> str:
+        return "job-search"
+
+    def execute_locally(_definition: ClusterDefinition) -> bool:
+        return False
+
+    def wait_for_local_terminal(
+        _queue: ClioCoreQueue,
+        _job_id: str,
+        *,
+        timeout_seconds: float,
+        poll_seconds: float,
+    ) -> dict[str, object]:
+        assert timeout_seconds == 30
+        assert poll_seconds == 0.1
+        return {"job": {"job_id": "job-search"}, "terminal": True}
+
+    def complete_artifacts(
+        _queue: ClioCoreQueue,
+        _job_id: str,
+    ) -> list[dict[str, object]]:
+        return artifacts
+
+    monkeypatch.setattr(cli, "run_packaged_mcp_stdio_session", run_session)
+    monkeypatch.setattr(cli, "_mcp_response_job_id", response_job_id)
+    monkeypatch.setattr(cli, "should_execute_on_cluster", execute_locally)
+    monkeypatch.setattr(
+        cli,
+        "_wait_for_local_job_terminal",
+        wait_for_local_terminal,
+    )
+    artifacts: list[dict[str, object]] = [
+        {"artifact_id": "artifact-result", "kind": "mcp_result"},
+        {"artifact_id": "artifact-provenance", "kind": "provenance"},
+    ]
+    monkeypatch.setattr(cli, "_complete_local_artifact_records", complete_artifacts)
+
+    def read_artifact(
+        _queue: ClioCoreQueue,
+        _artifacts: list[dict[str, object]],
+        *,
+        kind: str,
+    ) -> dict[str, object]:
+        return {"kind": kind}
+
+    monkeypatch.setattr(cli, "_read_local_json_artifact_kind", read_artifact)
+
+    result = cli._run_jarvis_package_search_query(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        cluster="ares",
+        definition=ClusterDefinition(name="ares", ssh_host="ares"),
+        queue=ClioCoreQueue(tmp_path / "core"),
+        profile="user",
+        query="parallel visualization",
+        wait_timeout_seconds=30,
+        poll_seconds=0.1,
+    )
+
+    assert calls == [
+        {
+            "profile": "user",
+            "tool": "jarvis_describe",
+            "arguments": {
+                "cluster": "ares",
+                "target": "package_search",
+                "query": "parallel visualization",
+                "page_size": 5,
+            },
+        }
+    ]
+    assert result.call_job_id == "job-search"
+    assert result.artifacts == artifacts
+    assert result.mcp_result == {"kind": "mcp_result"}
+    assert result.provenance == {"kind": "provenance"}
+
+
 def test_jarvis_discovery_persists_exact_durable_artifact_bytes(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -5271,7 +5362,7 @@ def test_jarvis_discovery_persists_exact_durable_artifact_bytes(
         },
         "structured_result": None,
         "protocol_version": "2024-11-05",
-        "server_info": {"name": "clio-kit", "version": "2.4.9"},
+        "server_info": {"name": "clio-kit", "version": "2.5.0"},
         "server_artifact": server_artifact,
         "returncode": 0,
         "stdout": "",

--- a/tests/test_clio_kit_mcp_contracts.py
+++ b/tests/test_clio_kit_mcp_contracts.py
@@ -50,10 +50,23 @@ CONTRACT_PROJECTION = "mcp-agent-tool-schema-v1"
 MAX_CONTRACT_BYTES = 4 * 1024 * 1024
 MAX_PROBE_OUTPUT_BYTES = 16 * 1024 * 1024
 EXPECTED_CONTRACTS = {
+    "clio-kit-jarvis-user-v3.2": {
+        "server_name": "jarvis",
+        "artifact": "jarvis-user-v3.2.json",
+        "contract_sha256": CLIO_KIT_JARVIS_USER_CONTRACT_SHA256,
+        "tool_names": {
+            "jarvis_add_step",
+            "jarvis_create_pipeline",
+            "jarvis_describe",
+            "jarvis_edit_step",
+            "jarvis_get_execution",
+            "jarvis_run",
+        },
+    },
     "clio-kit-jarvis-user-v3.1": {
         "server_name": "jarvis",
         "artifact": "jarvis-user-v3.1.json",
-        "contract_sha256": CLIO_KIT_JARVIS_USER_CONTRACT_SHA256,
+        "contract_sha256": "adc7756025fbcc90b0695bd4eaac00bda5c6cff4eb2f248fd7be263bd90b9b8b",
         "tool_names": {
             "jarvis_add_step",
             "jarvis_create_pipeline",
@@ -104,7 +117,10 @@ EXPECTED_CONTRACTS = {
         },
     },
 }
-ACTIVE_CONTRACT_IDS = frozenset(EXPECTED_CONTRACTS) - {"clio-kit-jarvis-user-v3"}
+ACTIVE_CONTRACT_IDS = frozenset(EXPECTED_CONTRACTS) - {
+    "clio-kit-jarvis-user-v3",
+    "clio-kit-jarvis-user-v3.1",
+}
 UV_TOOL_PROBE_VERSION = "0.0.0"
 
 
@@ -190,7 +206,7 @@ def test_relay_contract_pins_match_clio_kit_wheel_artifacts(
         assert artifact["contract_sha256"] == expected["contract_sha256"]
         assert set(cast(list[str], artifact["tool_names"])) == expected["tool_names"]
 
-    jarvis_tools = _tools_by_name(shipped_contracts["clio-kit-jarvis-user-v3.1"])
+    jarvis_tools = _tools_by_name(shipped_contracts["clio-kit-jarvis-user-v3.2"])
     artifact_projection = {
         name: {
             "description": tool.get("description"),
@@ -206,6 +222,49 @@ def test_relay_contract_pins_match_clio_kit_wheel_artifacts(
     edit_input = cast(JSON, jarvis_tools["jarvis_edit_step"]["inputSchema"])
     edit_properties = cast(JSON, edit_input["properties"])
     assert cast(JSON, edit_properties["operation"])["enum"] == ["edit", "remove"]
+
+    describe_input = cast(JSON, jarvis_tools["jarvis_describe"]["inputSchema"])
+    describe_properties = cast(JSON, describe_input["properties"])
+    assert set(describe_properties) == {
+        "target",
+        "package_name",
+        "query",
+        "page_size",
+        "cursor",
+        "pipeline_id",
+        "step_id",
+        "include_yaml",
+    }
+    assert cast(JSON, describe_properties["target"])["enum"] == [
+        "packages",
+        "package_search",
+        "package",
+        "pipeline",
+        "step",
+    ]
+    assert describe_properties["page_size"] == {
+        "default": 10,
+        "description": (
+            "Maximum summary matches returned by target='package_search'; bounded to 25."
+        ),
+        "maximum": 25,
+        "minimum": 1,
+        "type": "integer",
+    }
+    query = cast(JSON, describe_properties["query"])
+    query_string = next(
+        cast(JSON, option)
+        for option in cast(list[object], query["anyOf"])
+        if isinstance(option, dict) and cast(JSON, option).get("type") == "string"
+    )
+    assert query_string == {"maxLength": 256, "minLength": 1, "type": "string"}
+    cursor = cast(JSON, describe_properties["cursor"])
+    cursor_string = next(
+        cast(JSON, option)
+        for option in cast(list[object], cursor["anyOf"])
+        if isinstance(option, dict) and cast(JSON, option).get("type") == "string"
+    )
+    assert cursor_string == {"maxLength": 1024, "minLength": 1, "type": "string"}
 
     query = jarvis_tools["jarvis_get_execution"]
     query_input = cast(JSON, query["inputSchema"])
@@ -262,7 +321,7 @@ def test_relay_contract_pins_match_clio_kit_wheel_artifacts(
         "default": False,
         "type": "boolean",
     }
-    assert shipped_contracts["clio-kit-jarvis-user-v3.1"]["wire_sha256"] == (
+    assert shipped_contracts["clio-kit-jarvis-user-v3.2"]["wire_sha256"] == (
         CLIO_KIT_JARVIS_USER_WIRE_SHA256
     )
 

--- a/tests/test_jarvis_mcp_validation.py
+++ b/tests/test_jarvis_mcp_validation.py
@@ -42,6 +42,7 @@ def test_jarvis_mcp_validation_accepts_structured_durable_run() -> None:
     assert {check.check_id for check in report.checks} == {
         "remote-mcp.jarvis-discovery",
         "remote-mcp.jarvis-remote-contract",
+        "remote-mcp.jarvis-package-search",
         "remote-mcp.jarvis-call",
         "remote-mcp.server-artifact",
         "remote-mcp.durable-result",
@@ -67,6 +68,36 @@ def test_jarvis_mcp_validation_accepts_structured_durable_run() -> None:
     contract = next(
         check for check in report.checks if check.check_id == "remote-mcp.jarvis-remote-contract"
     )
+    package_search = contract.evidence[0].metadata["package_search"]
+    assert package_search["target_values"] == [
+        "packages",
+        "package_search",
+        "package",
+        "pipeline",
+        "step",
+    ]
+    assert package_search["query_schema"] == {
+        "maxLength": 256,
+        "minLength": 1,
+        "type": "string",
+    }
+    assert package_search["page_size_schema"]["maximum"] == 25
+    assert package_search["cursor_schema"]["maxLength"] == 1024
+    assert package_search["bounded"] is True
+    package_search_call = next(
+        check for check in report.checks if check.check_id == "remote-mcp.jarvis-package-search"
+    )
+    package_search_evidence = package_search_call.evidence[0].metadata
+    assert package_search_evidence["returned_count"] == 1
+    assert package_search_evidence["total_matches"] == 1
+    assert package_search_evidence["result"]["packages"][0]["name"] == "builtin.lammps"
+    assert package_search_evidence["assertions"] == {
+        "local_surface": True,
+        "durable_call": True,
+        "server_artifact_binding": True,
+        "protocol_result": True,
+        "bounded_summary_page": True,
+    }
     query = contract.evidence[0].metadata["execution_query"]
     assert query["input_fields"] == [
         "artifacts",
@@ -227,6 +258,46 @@ def test_jarvis_mcp_validation_rejects_split_or_unbounded_execution_query() -> N
     assert evidence["execution_query"]["artifact_filter_fields"] == []
 
 
+def test_jarvis_mcp_validation_rejects_unbounded_package_search() -> None:
+    inputs = _acceptance_inputs()
+    discovery = cast(dict[str, Any], inputs["remote_tools_list_result"])
+    protocol = cast(dict[str, Any], discovery["protocol_result"])
+    tools = cast(list[dict[str, Any]], protocol["tools"])
+    describe = next(tool for tool in tools if tool["name"] == "jarvis_describe")
+    describe_input = cast(dict[str, Any], describe["inputSchema"])
+    describe_properties = cast(dict[str, Any], describe_input["properties"])
+    page_size = cast(dict[str, Any], describe_properties["page_size"])
+    page_size["maximum"] = 10_000
+
+    report = build_jarvis_mcp_validation_report(**inputs)
+
+    contract = next(
+        check for check in report.checks if check.check_id == "remote-mcp.jarvis-remote-contract"
+    )
+    assert report.status == ValidationStatus.FAILED
+    assert contract.status == ValidationStatus.FAILED
+    evidence = contract.evidence[0].metadata
+    assert evidence["package_search"]["bounded"] is False
+    assert evidence["package_search"]["page_size_schema"]["maximum"] == 10_000
+
+
+def test_jarvis_mcp_validation_rejects_package_search_result_with_settings() -> None:
+    inputs = _acceptance_inputs()
+    result = cast(dict[str, Any], inputs["package_search_mcp_result"])
+    structured = cast(dict[str, Any], result["structured_result"])
+    packages = cast(list[dict[str, Any]], structured["packages"])
+    packages[0]["settings"] = {"deploy_mode": "default"}
+
+    report = build_jarvis_mcp_validation_report(**inputs)
+
+    package_search = next(
+        check for check in report.checks if check.check_id == "remote-mcp.jarvis-package-search"
+    )
+    assert report.status == ValidationStatus.FAILED
+    assert package_search.status == ValidationStatus.FAILED
+    assert package_search.evidence[0].metadata["assertions"]["bounded_summary_page"] is False
+
+
 def test_jarvis_mcp_validation_rejects_unattributed_scheduler_identity() -> None:
     inputs = _acceptance_inputs()
     runtime = cast(dict[str, Any], inputs["runtime_metadata"])
@@ -341,6 +412,11 @@ def _acceptance_inputs() -> dict[str, Any]:
         tool
         for tool in virtual_jarvis_tool_definitions(clusters=["ares"])
         if tool["name"] == "jarvis_get_execution"
+    )
+    local_describe = next(
+        tool
+        for tool in virtual_jarvis_tool_definitions(clusters=["ares"])
+        if tool["name"] == "jarvis_describe"
     )
     artifacts = [
         {
@@ -549,6 +625,82 @@ def _acceptance_inputs() -> dict[str, Any]:
         "query_provenance": {"job": {"job_id": "job-jarvis-query"}},
         "query_initialize_response": None,
         "query_stdio_evidence": None,
+        "package_search_query": "lammps",
+        "package_search_tools_list_response": {
+            "jsonrpc": "2.0",
+            "id": "package-search-list",
+            "result": {"tools": [local_describe]},
+        },
+        "package_search_call_response": {
+            "jsonrpc": "2.0",
+            "id": "package-search-call",
+            "result": {
+                "structuredContent": {
+                    "job_id": "job-jarvis-package-search",
+                    "state": "queued",
+                }
+            },
+        },
+        "package_search_call_job_id": "job-jarvis-package-search",
+        "package_search_call_status": {
+            "job": {
+                "job_id": "job-jarvis-package-search",
+                "cluster": "ares",
+                "kind": "mcp_call",
+                "state": "succeeded",
+                "spec": {
+                    "server": jarvis_mcp_server(),
+                    "server_args": jarvis_mcp_server_args(),
+                    "operation": "tools/call",
+                    "tool": "jarvis_describe",
+                    "arguments": {
+                        "target": "package_search",
+                        "query": "lammps",
+                        "page_size": 5,
+                    },
+                    "expected_server_artifact_digest": server_artifact_digest,
+                },
+            },
+            "terminal": True,
+        },
+        "package_search_artifacts": [
+            {
+                "artifact_id": f"artifact-package-search-{kind}",
+                "kind": kind,
+                "uri": f"file:///spool/package-search-{kind}.json",
+                "sha256": "c" * 64,
+            }
+            for kind in ("stdout", "stderr", "mcp_result", "provenance")
+        ],
+        "package_search_mcp_result": {
+            "returncode": 0,
+            "operation": "tools/call",
+            "tool": "jarvis_describe",
+            "protocol_error": None,
+            "expected_server_artifact_digest": server_artifact_digest,
+            "observed_server_artifact_digest": server_artifact_digest,
+            "server_artifact": server_artifact,
+            "structured_result": {
+                "schema_version": "jarvis.package-search.v1",
+                "target": "package_search",
+                "query": "lammps",
+                "inventory_revision": "d" * 64,
+                "packages": [
+                    {
+                        "name": "builtin.lammps",
+                        "short_name": "lammps",
+                        "repository": "builtin",
+                        "description": "Run LAMMPS workloads.",
+                    }
+                ],
+                "total_matches": 1,
+                "returned_count": 1,
+                "next_cursor": None,
+            },
+        },
+        "package_search_provenance": {"job": {"job_id": "job-jarvis-package-search"}},
+        "package_search_initialize_response": None,
+        "package_search_stdio_evidence": None,
     }
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -179,6 +179,21 @@ def test_mcp_lists_relay_tools(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     )
     assert create_pipeline_tool["inputSchema"]["required"] == ["cluster", "pipeline_id"]
     assert "pipeline_id" in create_pipeline_tool["inputSchema"]["properties"]
+    describe_tool = next(
+        tool for tool in response["result"]["tools"] if tool["name"] == "jarvis_describe"
+    )
+    describe_properties = describe_tool["inputSchema"]["properties"]
+    assert describe_tool["inputSchema"]["required"] == ["cluster", "target"]
+    assert describe_properties["target"]["enum"] == [
+        "packages",
+        "package_search",
+        "package",
+        "pipeline",
+        "step",
+    ]
+    assert describe_properties["page_size"]["maximum"] == 25
+    assert describe_properties["query"]["anyOf"][0]["maxLength"] == 256
+    assert describe_properties["cursor"]["anyOf"][0]["maxLength"] == 1024
     edit_step_tool = next(
         tool for tool in response["result"]["tools"] if tool["name"] == "jarvis_edit_step"
     )
@@ -1453,7 +1468,9 @@ def test_remote_virtual_jarvis_call_defers_artifact_selection_to_cluster(
                 "name": "jarvis_describe",
                 "arguments": {
                     "cluster": "ares",
-                    "target": "packages",
+                    "target": "package_search",
+                    "query": "parallel visualization",
+                    "page_size": 7,
                     "idempotency_key": "remote-receipt-bound-jarvis",
                 },
             },
@@ -1471,7 +1488,11 @@ def test_remote_virtual_jarvis_call_defers_artifact_selection_to_cluster(
     assert structured["catalog_revision"] == session.observed_remote_mcp_catalog_revision(
         profile="user"
     )
-    assert writes and json.loads(writes[0][1]) == {"target": "packages"}
+    assert writes and json.loads(writes[0][1]) == {
+        "target": "package_search",
+        "query": "parallel visualization",
+        "page_size": 7,
+    }
     assert removals == [writes[0][0]]
     assert commands[0][0] == "jarvis-mcp-call"
     assert "--server" not in commands[0]

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.2.18"
+    assert version == "1.3.0"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -283,6 +283,7 @@ def test_jarvis_release_requirement_enforces_unified_gray_scott_contract() -> No
     jarvis = requirements["ares-jarvis-virtual-mcp"]
 
     assert "remote-mcp.jarvis-remote-contract" in jarvis["required_checks"]
+    assert "remote-mcp.jarvis-package-search" in jarvis["required_checks"]
     assert "remote-mcp.jarvis-execution-query" in jarvis["required_checks"]
     assert "jarvis.spack-runtime-environment" not in jarvis["required_checks"]
     server = next(
@@ -303,11 +304,11 @@ def test_jarvis_release_requirement_enforces_unified_gray_scott_contract() -> No
         if resource["kind"] == "relay_worker"
     )
     clio_kit_component = worker["metadata_equals"]["component_artifacts"]["clio-kit"]
-    assert clio_kit_component["distribution_version"] == "2.4.9"
+    assert clio_kit_component["distribution_version"] == "2.5.0"
     assert clio_kit_component["persistent_tool"]["manager"] == "uv"
     assert clio_kit_component["persistent_tool"]["uv_version"] == "0.11.28"
     assert clio_kit_component["persistent_tool"]["source_artifact_sha256"] == (
-        "a9d771bcd40ec98de2626ac2a8706fcc614a2eaac462defb10f8d7bec13693e3"
+        "acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f"
     )
     jarvis_component = worker["metadata_equals"]["component_artifacts"]["jarvis-cd"]
     assert jarvis_component["distribution_version"] == "1.3.6"
@@ -470,7 +471,7 @@ def test_spack_release_requirements_split_existing_resolution_from_fresh_install
     )
     assert fresh_server["metadata_equals"]["server_name"] == "spack-fresh"
     assert fresh_server["metadata_equals"]["install_artifact_sha256"] == (
-        "a9d771bcd40ec98de2626ac2a8706fcc614a2eaac462defb10f8d7bec13693e3"
+        "acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f"
     )
     assert fresh_server["metadata_equals"]["contract_id"] == "clio-kit-spack-user-v2"
     assert fresh_server["metadata_equals"]["contract_sha256"] == (

--- a/tests/test_remote_mcp.py
+++ b/tests/test_remote_mcp.py
@@ -143,7 +143,7 @@ def test_scientific_catalog_contract_is_read_only_and_exact(
         command="uvx",
         args=[
             "--from",
-            "/opt/clio/clio_kit-2.4.9-py3-none-any.whl",
+            "/opt/clio/clio_kit-2.5.0-py3-none-any.whl",
             "clio-kit",
             "mcp-server",
             "scientific-catalog",
@@ -2311,7 +2311,7 @@ def test_acceptance_report_requires_verified_persistent_uv_tool_runtime(
             "sha256": "a" * 64,
             "size_bytes": 256,
         },
-        "install_spec": "/opt/wheels/clio_kit-2.4.9-py3-none-any.whl",
+        "install_spec": "/opt/wheels/clio_kit-2.5.0-py3-none-any.whl",
         "install_source": "uv-tool",
         "install_artifact_sha256": "b" * 64,
         "python_distribution_runtime": {

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1940,7 +1940,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.2.18"
+    assert policy.release_version == "1.3.0"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256
@@ -3096,7 +3096,7 @@ def _fresh_spack_transition_report(
             ),
             ValidationResource(
                 kind="mcp_server",
-                resource_id="spack-fresh:clio-kit-2.4.9",
+                resource_id="spack-fresh:clio-kit-2.5.0",
                 role="remote_mcp_server",
                 cluster="ares",
                 state="verified",

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.2.18"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Upgrades clio-relay to 1.3.0 and pins the released clio-kit 2.5.0 JARVIS v3.2 contract. Adds bounded package_search forwarding, exact contract and wheel verification, and a durable behavioral package-search probe in jarvis-mcp-validate with machine-readable result evidence. Preserves the historical v3.1 contract and leaves other MCP contract majors unchanged.\n\nFocused verification: 29 original contract/release tests, 22 package-search/CLI tests, 22 release-policy/runbook tests, Ruff, targeted Pyright, wheel build, and Twine artifact checks all pass.