### PR TITLE
fix: harden remote MCP execution receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.0` uses a release-first patch process. A maintainer builds the
+> Version `1.3.1` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.0"
+$Version = "1.3.1"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.0"
+release_version: "1.3.1"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 8dd3064562bf72b20283435b0d1e87bb5f3b38da6dea222dabc661a4b4f2436b
+acceptance_matrix_sha256: 4a935a4d01c977c7f115ae65cbf369953f7febdf0273e1009feb75f8aebc3b06
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.0"
+$Tag = "v1.3.1"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.0" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.1" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.0",
-  "matrix_sha256": "8dd3064562bf72b20283435b0d1e87bb5f3b38da6dea222dabc661a4b4f2436b",
+  "release_version": "1.3.1",
+  "matrix_sha256": "4a935a4d01c977c7f115ae65cbf369953f7febdf0273e1009feb75f8aebc3b06",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.0"
+version = "1.3.1"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/src/clio_relay/http_api.py
+++ b/src/clio_relay/http_api.py
@@ -32,6 +32,7 @@ from clio_relay.errors import ConfigurationError, NotFoundError, QueueConflictEr
 from clio_relay.identifiers import DurableRecordId
 from clio_relay.jarvis_mcp import (
     jarvis_mcp_artifact_binding,
+    jarvis_mcp_env_from,
     jarvis_mcp_server,
     jarvis_mcp_server_args,
 )
@@ -829,6 +830,7 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
                 spec=McpCallSpec(
                     server=jarvis_mcp_server(),
                     server_args=jarvis_mcp_server_args(),
+                    env_from=jarvis_mcp_env_from(),
                     expected_server_artifact_digest=expected_digest,
                     tool=request.tool,
                     arguments=request.arguments,

--- a/src/clio_relay/jarvis_mcp.py
+++ b/src/clio_relay/jarvis_mcp.py
@@ -564,8 +564,13 @@ def render_virtual_jarvis_agent_context() -> str:
         "includes progress by default and can optionally return a bounded artifact "
         "page without adding another agent tool. Use jarvis_describe with "
         "target='package_search' for bounded package discovery, then describe the "
-        "selected canonical package name. Available "
-        f"virtual JARVIS tools: {tool_names}."
+        "selected canonical package name. "
+        "When wait_for_terminal=true, the same JARVIS tool returns a bounded, "
+        "artifact-bound mcp_result instead of requiring a second status or log call. "
+        "For later job queries, preserve cluster, job_id, and the opaque 64-character "
+        "route_revision from one receipt as a single handle; never substitute a catalog "
+        "or dataset revision. "
+        f"Available virtual JARVIS tools: {tool_names}."
     )
 
 

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -94,6 +94,7 @@ from clio_relay.remote_cli import (
 from clio_relay.remote_mcp import (
     RemoteMcpSchemaCache,
     VirtualRemoteMcpCatalog,
+    cluster_route_revision_json_schema,
     default_remote_mcp_cache_path,
     load_virtual_remote_mcp_catalog,
     remote_mcp_registration_revision,
@@ -112,6 +113,10 @@ from clio_relay.storage_runtime import (
 JSON = dict[str, Any]
 MCP_PROFILE_ENV = "CLIO_RELAY_MCP_PROFILE"
 MAX_INTERNAL_COLLECTION_RECORDS = 10_000
+MAX_AGENT_LOG_READ_BYTES = 32_768
+MAX_INLINE_MCP_RESULT_BYTES = 65_536
+MAX_OBSERVE_MATCHES = 100
+MAX_OBSERVE_MATCH_TEXT_CHARS = 1_024
 USER_MCP_TOOL_NAMES = {
     "relay_remote_mcp_context",
     "relay_submit_agent",
@@ -385,9 +390,13 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                 "properties": {
                     "job_id": durable_record_id_json_schema(),
                     "cluster": {"type": "string"},
-                    "route_revision": {"type": "string"},
+                    "route_revision": cluster_route_revision_json_schema(),
                 },
                 "required": ["job_id"],
+                "dependentRequired": {
+                    "cluster": ["route_revision"],
+                    "route_revision": ["cluster"],
+                },
                 "additionalProperties": False,
             },
         },
@@ -399,10 +408,14 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                 "properties": {
                     "job_id": durable_record_id_json_schema(),
                     "cluster": {"type": "string"},
-                    "route_revision": {"type": "string"},
+                    "route_revision": cluster_route_revision_json_schema(),
                     "cancel_scheduler_job": {"type": "boolean", "default": False},
                 },
                 "required": ["job_id"],
+                "dependentRequired": {
+                    "cluster": ["route_revision"],
+                    "route_revision": ["cluster"],
+                },
                 "additionalProperties": False,
             },
         },
@@ -417,7 +430,7 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                 "properties": {
                     "job_id": durable_record_id_json_schema(),
                     "cluster": {"type": "string"},
-                    "route_revision": {"type": "string"},
+                    "route_revision": cluster_route_revision_json_schema(),
                     "cursor": {"type": "integer", "default": 1, "minimum": 1},
                     "limit": {
                         "type": "integer",
@@ -429,12 +442,16 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                     "include_logs": {"type": "boolean", "default": True},
                     "log_limit": {
                         "type": "integer",
-                        "default": 65536,
+                        "default": MAX_AGENT_LOG_READ_BYTES,
                         "minimum": 1,
-                        "maximum": MAX_LOG_READ_BYTES,
+                        "maximum": MAX_AGENT_LOG_READ_BYTES,
                     },
                 },
                 "required": ["job_id"],
+                "dependentRequired": {
+                    "cluster": ["route_revision"],
+                    "route_revision": ["cluster"],
+                },
                 "additionalProperties": False,
             },
         },
@@ -446,18 +463,22 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                 "properties": {
                     "job_id": durable_record_id_json_schema(),
                     "cluster": {"type": "string"},
-                    "route_revision": {"type": "string"},
+                    "route_revision": cluster_route_revision_json_schema(),
                     "timeout_seconds": {"type": "number", "default": 600},
                     "poll_seconds": {"type": "number", "default": 2},
                     "include_logs": {"type": "boolean", "default": True},
                     "log_limit": {
                         "type": "integer",
-                        "default": 65536,
+                        "default": MAX_AGENT_LOG_READ_BYTES,
                         "minimum": 1,
-                        "maximum": MAX_LOG_READ_BYTES,
+                        "maximum": MAX_AGENT_LOG_READ_BYTES,
                     },
                 },
                 "required": ["job_id"],
+                "dependentRequired": {
+                    "cluster": ["route_revision"],
+                    "route_revision": ["cluster"],
+                },
                 "additionalProperties": False,
             },
         },
@@ -799,7 +820,7 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                 "properties": {
                     "job_id": durable_record_id_json_schema(),
                     "cluster": {"type": "string"},
-                    "route_revision": {"type": "string"},
+                    "route_revision": cluster_route_revision_json_schema(),
                     "cancel_scheduler_job": {"type": "boolean", "default": False},
                 },
                 "required": ["job_id"],
@@ -813,7 +834,7 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                 "type": "object",
                 "properties": {
                     "cluster": {"type": "string"},
-                    "route_revision": {"type": "string"},
+                    "route_revision": cluster_route_revision_json_schema(),
                     "state": {
                         "type": "string",
                         "enum": ["queued", "leased", "running", "succeeded", "failed", "canceled"],
@@ -843,7 +864,7 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                 "properties": {
                     "job_id": durable_record_id_json_schema(),
                     "cluster": {"type": "string"},
-                    "route_revision": {"type": "string"},
+                    "route_revision": cluster_route_revision_json_schema(),
                     "older_than_seconds": {
                         "type": "integer",
                         "minimum": 1,
@@ -867,7 +888,7 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                 "type": "object",
                 "properties": {
                     "cluster": {"type": "string"},
-                    "route_revision": {"type": "string"},
+                    "route_revision": cluster_route_revision_json_schema(),
                     "job_id": durable_record_id_json_schema(),
                     "older_than_seconds": {"type": "integer", "minimum": 1},
                     "kind": {
@@ -895,7 +916,7 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                 "type": "object",
                 "properties": {
                     "cluster": {"type": "string"},
-                    "route_revision": {"type": "string"},
+                    "route_revision": cluster_route_revision_json_schema(),
                     "job_id": durable_record_id_json_schema(),
                     "older_than_seconds": {
                         "type": "integer",
@@ -974,7 +995,7 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                 "type": "object",
                 "properties": {
                     "cluster": {"type": "string"},
-                    "route_revision": {"type": "string"},
+                    "route_revision": cluster_route_revision_json_schema(),
                 },
                 "additionalProperties": False,
             },
@@ -1652,6 +1673,17 @@ def _route_revision(definition: ClusterDefinition) -> str:
     return cluster_route_revision(definition)
 
 
+def _validated_route_revision(value: object) -> str:
+    """Validate one opaque route token before comparing or routing with it."""
+
+    if not isinstance(value, str) or re.fullmatch(r"[0-9a-f]{64}", value) is None:
+        raise ValueError(
+            "route_revision must be the 64-character lowercase hexadecimal token "
+            "copied from the same relay job receipt"
+        )
+    return value
+
+
 def _job_target(arguments: JSON) -> ClusterDefinition | None:
     """Resolve and verify an optional self-routing cluster job handle."""
     raw_cluster = arguments.get("cluster")
@@ -1662,9 +1694,12 @@ def _job_target(arguments: JSON) -> ClusterDefinition | None:
         return None
     if not isinstance(raw_cluster, str) or not raw_cluster:
         raise ValueError("cluster must be a non-empty string")
+    if raw_revision is None:
+        raise ValueError("route_revision is required when cluster routes an existing job handle")
+    revision = _validated_route_revision(raw_revision)
     definition = _remote_cluster_definition(raw_cluster)
     expected_revision = _route_revision(definition)
-    if raw_revision is not None and raw_revision != expected_revision:
+    if not hmac.compare_digest(revision, expected_revision):
         raise ValueError(
             f"cluster route changed for {raw_cluster}; refuse to route an existing job handle"
         )
@@ -2098,8 +2133,8 @@ def _queue_tool_target(arguments: JSON) -> ClusterDefinition | None:
         return None
     if not isinstance(raw_cluster, str) or not raw_cluster:
         raise ValueError("cluster must be a non-empty string")
-    if raw_revision is not None and (not isinstance(raw_revision, str) or not raw_revision):
-        raise ValueError("route_revision must be a non-empty string")
+    if raw_revision is not None:
+        _validated_route_revision(raw_revision)
     registry_path = default_registry_path()
     if not registry_path.exists():
         if raw_revision is not None:
@@ -2111,7 +2146,7 @@ def _queue_tool_target(arguments: JSON) -> ClusterDefinition | None:
             raise ValueError(f"cluster route is not configured: {raw_cluster}")
         return None
     expected_revision = _route_revision(definition)
-    if raw_revision is not None and raw_revision != expected_revision:
+    if raw_revision is not None and not hmac.compare_digest(raw_revision, expected_revision):
         raise ValueError(
             f"cluster route changed for {raw_cluster}; refuse to use stale queue routing"
         )
@@ -2543,12 +2578,111 @@ def _decode_verified_mcp_result(envelope: JSON, *, artifact: JSON, job_id: str) 
     }
 
 
+def _mcp_result_artifact(artifacts: list[JSON], *, job_id: str) -> JSON | None:
+    """Return the unique durable MCP-result artifact for one job, if present."""
+
+    matches = [
+        artifact
+        for artifact in artifacts
+        if artifact.get("job_id") == job_id and artifact.get("kind") == "mcp_result"
+    ]
+    if len(matches) > 1:
+        raise ValueError(f"job {job_id} has multiple MCP result artifacts")
+    return matches[0] if matches else None
+
+
+def _bounded_mcp_result(result: JSON) -> JSON:
+    """Inline a complete MCP result when small, otherwise return a bounded summary."""
+
+    encoded = json.dumps(
+        result,
+        allow_nan=False,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    if len(encoded) <= MAX_INLINE_MCP_RESULT_BYTES:
+        return result
+
+    preferred = (
+        "operation",
+        "tool",
+        "returncode",
+        "timed_out",
+        "protocol_error",
+        "protocol_version",
+        "server_info",
+        "structured_result",
+        "result_validation",
+        "protocol_result",
+    )
+    summary: JSON = {}
+    omitted: list[str] = []
+    for key in preferred:
+        candidate = {**summary, key: result.get(key)}
+        candidate_size = len(
+            json.dumps(
+                candidate,
+                allow_nan=False,
+                ensure_ascii=True,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
+        if candidate_size <= MAX_INLINE_MCP_RESULT_BYTES - 2_048:
+            summary[key] = result.get(key)
+        else:
+            omitted.append(key)
+    summary["content_truncated"] = True
+    summary["omitted_fields"] = omitted
+    return summary
+
+
+def _public_mcp_result_artifact(artifact: JSON) -> JSON:
+    """Return the compact immutable binding for a durable MCP result artifact."""
+
+    return {
+        key: artifact.get(key)
+        for key in (
+            "artifact_id",
+            "job_id",
+            "kind",
+            "size_bytes",
+            "sha256",
+            "created_at",
+        )
+    }
+
+
+def _attach_terminal_mcp_evidence(
+    receipt: JSON,
+    *,
+    job_id: str,
+    last_error: str | None,
+    artifacts: list[JSON],
+    parsed_result: JSON | None,
+) -> None:
+    """Attach bounded terminal MCP evidence to a waited submission receipt."""
+
+    receipt["last_error"] = last_error
+    if parsed_result is None:
+        return
+    artifact = _mcp_result_artifact(artifacts, job_id=job_id)
+    if artifact is None:
+        raise ValueError(f"verified MCP result for {job_id} has no durable artifact")
+    receipt["mcp_result"] = _bounded_mcp_result(parsed_result)
+    receipt["mcp_result_artifact"] = _public_mcp_result_artifact(artifact)
+
+
 def _render_remote_mcp_context(catalog: VirtualRemoteMcpCatalog) -> str:
     generic = (
         " Registered remote MCP tools are exposed with remote_<server>_<tool> aliases; "
         "their cluster argument selects the execution target and is not forwarded to the "
         "remote tool. Operators explicitly refresh the durable schema cache before new or "
-        "changed tools appear."
+        "changed tools appear. Treat cluster, job_id, and the opaque 64-character "
+        "route_revision returned by one submission as an indivisible handle. A route "
+        "revision is never interchangeable with this tool catalog's revision or a "
+        "scientific dataset's catalog revision."
     )
     available = ""
     if catalog.tools:
@@ -2653,6 +2787,7 @@ def _observe_job(arguments: JSON, *, queue: ClioCoreQueue, settings: RelaySettin
         observed = monitor_job(queue, job_id, cursor=cursor, limit=limit)
     pattern = _optional_str(arguments, "pattern")
     matches: list[JSON] = []
+    matches_truncated = False
     logs: JSON | None = None
     if arguments.get("include_logs", True) is not False:
         log_limit = _log_limit(arguments)
@@ -2669,34 +2804,39 @@ def _observe_job(arguments: JSON, *, queue: ClioCoreQueue, settings: RelaySettin
         compiled = re.compile(pattern)
         for event in cast(list[JSON], observed.get("events", [])):
             for text in _event_match_candidates(event):
-                for match in compiled.finditer(text):
-                    matches.append(
-                        {
-                            "event_seq": event.get("seq"),
-                            "event_type": event.get("event_type"),
-                            "text": text,
-                            "match": match.group(0),
-                            "groups": list(match.groups()),
-                            "groupdict": match.groupdict(),
-                        }
-                    )
+                matches_truncated = _append_bounded_observe_matches(
+                    matches,
+                    compiled=compiled,
+                    text=text,
+                    identity={
+                        "event_seq": event.get("seq"),
+                        "event_type": event.get("event_type"),
+                    },
+                )
+                if matches_truncated:
+                    break
+            if matches_truncated:
+                break
         if logs is not None:
             for stream_name in ("stdout", "stderr"):
+                if matches_truncated:
+                    break
                 stream = _object(logs[stream_name])
                 text = stream.get("text")
                 if not isinstance(text, str):
                     continue
-                for match in compiled.finditer(text):
-                    matches.append(
-                        {
-                            "source": stream_name,
-                            "text": text,
-                            "match": match.group(0),
-                            "groups": list(match.groups()),
-                            "groupdict": match.groupdict(),
-                        }
-                    )
-    result: JSON = {**observed, "matched": bool(matches), "matches": matches}
+                matches_truncated = _append_bounded_observe_matches(
+                    matches,
+                    compiled=compiled,
+                    text=text,
+                    identity={"source": stream_name},
+                )
+    result: JSON = {
+        **observed,
+        "matched": bool(matches),
+        "matches": matches,
+        "matches_truncated": matches_truncated,
+    }
     if logs is not None:
         result["logs"] = logs
     if target is not None:
@@ -2834,6 +2974,51 @@ def _event_match_candidates(event: JSON) -> list[str]:
             if isinstance(value, str):
                 candidates.append(value)
     return candidates
+
+
+def _bounded_observe_value(value: str | None) -> str | None:
+    """Bound one regex-derived value before returning it to an agent."""
+
+    if value is None or len(value) <= MAX_OBSERVE_MATCH_TEXT_CHARS:
+        return value
+    return value[:MAX_OBSERVE_MATCH_TEXT_CHARS]
+
+
+def _append_bounded_observe_matches(
+    matches: list[JSON],
+    *,
+    compiled: re.Pattern[str],
+    text: str,
+    identity: JSON,
+) -> bool:
+    """Append bounded regex matches and report whether more matches were omitted."""
+
+    for match in compiled.finditer(text):
+        if len(matches) >= MAX_OBSERVE_MATCHES:
+            return True
+        start, end = match.span()
+        context_start = max(0, start - MAX_OBSERVE_MATCH_TEXT_CHARS // 4)
+        context_end = min(len(text), context_start + MAX_OBSERVE_MATCH_TEXT_CHARS)
+        if context_end - context_start < MAX_OBSERVE_MATCH_TEXT_CHARS:
+            context_start = max(0, context_end - MAX_OBSERVE_MATCH_TEXT_CHARS)
+        raw_match = match.group(0)
+        groups = [_bounded_observe_value(value) for value in match.groups()]
+        groupdict = {key: _bounded_observe_value(value) for key, value in match.groupdict().items()}
+        matches.append(
+            {
+                **identity,
+                "text": text[context_start:context_end],
+                "text_start": context_start,
+                "text_truncated": context_start != 0 or context_end != len(text),
+                "match": _bounded_observe_value(raw_match),
+                "match_start": start,
+                "match_end": end,
+                "match_truncated": len(raw_match) > MAX_OBSERVE_MATCH_TEXT_CHARS,
+                "groups": groups,
+                "groupdict": groupdict,
+            }
+        )
+    return False
 
 
 def _submit_jarvis_pipeline(
@@ -3145,6 +3330,7 @@ def _submit_mcp_call(
                 wait_for_terminal_result=bool(arguments.get("wait_for_terminal", False)),
                 wait_timeout_seconds=float(arguments.get("wait_timeout_seconds", 600)),
                 poll_seconds=float(arguments.get("poll_seconds", 2)),
+                include_terminal_mcp_result=True,
             )
         remote_args_path = (
             ".local/share/clio-relay/desktop-submissions/"
@@ -3184,7 +3370,11 @@ def _submit_mcp_call(
             output = run_remote_clio(definition, remote_args)
         finally:
             remove_remote_file(definition, remote_args_path, remove_empty_parent=True)
-        return _remote_submission_result(output, kind=JobKind.MCP_CALL, definition=definition)
+        return _remote_mcp_submission_result(
+            output,
+            definition=definition,
+            arguments=arguments,
+        )
     job = _submit_local_job(
         queue,
         RelayJob(
@@ -3203,7 +3393,13 @@ def _submit_mcp_call(
         ),
         settings=settings,
     )
-    return _submission_result(job, arguments, queue=queue, definition=definition)
+    return _submission_result(
+        job,
+        arguments,
+        queue=queue,
+        definition=definition,
+        include_terminal_mcp_result=True,
+    )
 
 
 def _remote_cluster_definition(cluster: str) -> ClusterDefinition:
@@ -3239,6 +3435,58 @@ def _remote_submission_result(
     }
 
 
+def _remote_mcp_submission_result(
+    output: str,
+    *,
+    definition: ClusterDefinition,
+    arguments: JSON,
+) -> JSON:
+    """Return a remote MCP receipt and bounded result when the caller waited."""
+
+    result = _remote_submission_result(output, kind=JobKind.MCP_CALL, definition=definition)
+    if not bool(arguments.get("wait_for_terminal", False)):
+        return result
+    job_id = _required_durable_record_id(result, "job_id")
+    run_remote_clio(
+        definition,
+        [
+            "job",
+            "wait",
+            job_id,
+            "--timeout-seconds",
+            str(float(arguments.get("wait_timeout_seconds", 600))),
+            "--poll-seconds",
+            str(float(arguments.get("poll_seconds", 2))),
+        ],
+    )
+    status = _remote_json(definition, ["job", "status", job_id], "remote job status")
+    job = _object(status.get("job"))
+    if job.get("job_id") != job_id or job.get("cluster") != definition.name:
+        raise ValueError("remote MCP wait returned a different job")
+    state = job.get("state")
+    if state not in {"succeeded", "failed", "canceled"} or status.get("terminal") is not True:
+        raise ValueError("remote MCP wait did not return one terminal job")
+    artifacts = _complete_remote_collection(
+        definition,
+        ["job", "list-artifacts", job_id],
+        record_key="artifacts",
+        label=f"remote artifacts for {job_id}",
+    )
+    parsed_result = _verified_mcp_result(definition, job_id, artifacts)
+    result.update({"state": state, "terminal": True})
+    last_error = job.get("last_error")
+    if last_error is not None and not isinstance(last_error, str):
+        raise ValueError("remote MCP job returned an invalid last_error")
+    _attach_terminal_mcp_evidence(
+        result,
+        job_id=job_id,
+        last_error=last_error,
+        artifacts=artifacts,
+        parsed_result=parsed_result,
+    )
+    return result
+
+
 def _owned_session_submission_result(
     job: RelayJob,
     *,
@@ -3247,8 +3495,11 @@ def _owned_session_submission_result(
     wait_for_terminal_result: bool,
     wait_timeout_seconds: float,
     poll_seconds: float,
+    include_terminal_mcp_result: bool = False,
 ) -> JSON:
     """Return an owned receipt, optionally waiting through the same protected API."""
+    artifacts: list[JSON] = []
+    parsed_result: JSON | None = None
     if wait_for_terminal_result:
         with OwnedSessionApiClient(definition=definition, settings=settings) as client:
             document = _owned_json(
@@ -3261,7 +3512,15 @@ def _owned_session_submission_result(
                 },
                 label="owned remote submitted job wait",
             )
-        waited = RelayJob.model_validate(document)
+            waited = RelayJob.model_validate(document)
+            if include_terminal_mcp_result:
+                artifacts = _complete_owned_collection(
+                    client,
+                    path=f"/jobs/{job.job_id}/artifacts",
+                    record_key="artifacts",
+                    label=f"owned remote artifacts for {job.job_id}",
+                )
+                parsed_result = _verified_owned_mcp_result(client, job.job_id, artifacts)
         if (
             waited.job_id != job.job_id
             or waited.cluster != definition.name
@@ -3271,7 +3530,7 @@ def _owned_session_submission_result(
         ):
             raise ValueError("owned remote wait returned a different submission receipt")
         job = waited
-    return {
+    result: JSON = {
         "cluster": definition.name,
         "job_id": job.job_id,
         "state": job.state.value,
@@ -3280,6 +3539,15 @@ def _owned_session_submission_result(
         "remote": True,
         "route_revision": _route_revision(definition),
     }
+    if wait_for_terminal_result and include_terminal_mcp_result:
+        _attach_terminal_mcp_evidence(
+            result,
+            job_id=job.job_id,
+            last_error=job.last_error,
+            artifacts=artifacts,
+            parsed_result=parsed_result,
+        )
+    return result
 
 
 def _submit_local_job(
@@ -3403,6 +3671,7 @@ def _submit_jarvis_mcp_call(
                 wait_for_terminal_result=bool(arguments.get("wait_for_terminal", False)),
                 wait_timeout_seconds=float(arguments.get("wait_timeout_seconds", 600)),
                 poll_seconds=float(arguments.get("poll_seconds", 2)),
+                include_terminal_mcp_result=True,
             )
         routing_digest = _stable_digest(
             {"cluster": cluster, "tool": tool, "arguments": tool_arguments}
@@ -3438,7 +3707,11 @@ def _submit_jarvis_mcp_call(
             output = run_remote_clio(definition, remote_args)
         finally:
             remove_remote_file(definition, remote_args_path, remove_empty_parent=True)
-        return _remote_submission_result(output, kind=JobKind.MCP_CALL, definition=definition)
+        return _remote_mcp_submission_result(
+            output,
+            definition=definition,
+            arguments=arguments,
+        )
     server = jarvis_mcp_server()
     server_args = jarvis_mcp_server_args()
     forwarded["server"] = server
@@ -3452,8 +3725,10 @@ def _submission_result(
     *,
     queue: ClioCoreQueue,
     definition: ClusterDefinition | None = None,
+    include_terminal_mcp_result: bool = False,
 ) -> JSON:
-    if bool(arguments.get("wait_for_terminal", False)):
+    waited = bool(arguments.get("wait_for_terminal", False))
+    if waited:
         job = wait_for_terminal(
             queue,
             job.job_id,
@@ -3469,6 +3744,15 @@ def _submission_result(
     }
     if definition is not None:
         result["route_revision"] = _route_revision(definition)
+    if waited and include_terminal_mcp_result:
+        artifacts = _complete_local_artifacts(queue, job.job_id)
+        _attach_terminal_mcp_evidence(
+            result,
+            job_id=job.job_id,
+            last_error=job.last_error,
+            artifacts=artifacts,
+            parsed_result=_verified_local_mcp_result(queue, job.job_id),
+        )
     return result
 
 
@@ -3800,8 +4084,8 @@ def _log_limit(arguments: JSON) -> int:
     return _bounded_integer_limit(
         arguments,
         field_name="log_limit",
-        default=65_536,
-        maximum=MAX_LOG_READ_BYTES,
+        default=MAX_AGENT_LOG_READ_BYTES,
+        maximum=MAX_AGENT_LOG_READ_BYTES,
     )
 
 

--- a/src/clio_relay/remote_mcp.py
+++ b/src/clio_relay/remote_mcp.py
@@ -148,6 +148,21 @@ class _JsonSchemaInstanceValidator(Protocol):
 
 
 _SAFE_NAME_PATTERN = re.compile(r"[^a-z0-9_]+")
+
+
+def cluster_route_revision_json_schema() -> JSON:
+    """Return the agent-facing schema for an opaque cluster route revision."""
+
+    return {
+        "type": "string",
+        "pattern": "^[0-9a-f]{64}$",
+        "description": (
+            "Opaque cluster-route revision copied exactly from a relay job receipt. "
+            "This is not a scientific-dataset catalog revision."
+        ),
+    }
+
+
 VIRTUAL_REMOTE_MCP_JOB_OUTPUT_SCHEMA: JSON = {
     "type": "object",
     "properties": {
@@ -160,8 +175,18 @@ VIRTUAL_REMOTE_MCP_JOB_OUTPUT_SCHEMA: JSON = {
         "kind": {"type": "string", "const": "mcp_call"},
         "terminal": {"type": "boolean"},
         "remote": {"type": "boolean"},
-        "route_revision": {"type": "string"},
-        "catalog_revision": {"type": "string"},
+        "route_revision": cluster_route_revision_json_schema(),
+        "catalog_revision": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$",
+            "description": (
+                "Opaque revision of the locally advertised remote-MCP tool catalog; "
+                "this is not a scientific-dataset catalog revision."
+            ),
+        },
+        "last_error": {"type": ["string", "null"]},
+        "mcp_result": {"type": "object"},
+        "mcp_result_artifact": {"type": "object"},
     },
     "required": [
         "cluster",

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -345,6 +345,39 @@ def test_http_typed_submit_endpoints_create_real_jobs(tmp_path: Path) -> None:
     assert jarvis_mcp.spec.arguments == {"target": "packages"}
 
 
+def test_owned_jarvis_mcp_submission_inherits_operator_spack_reference(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cluster API, not the desktop process, binds the site Spack executable."""
+
+    monkeypatch.setenv(
+        "JARVIS_MCP_SPACK_COMMAND",
+        "/opt/site-profiles/ares/bin/spack",
+    )
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    client = cast(Any, TestClient(create_app(settings)))
+
+    response = client.post(
+        "/jobs/jarvis-mcp-call",
+        json={
+            "cluster": "test-cluster",
+            "tool": "jarvis_run",
+            "arguments": {
+                "pipeline_id": "simulation",
+                "spack_specs": ["lammps"],
+            },
+            "idempotency_key": "http-site-spack-reference",
+        },
+    )
+
+    assert response.status_code == 200
+    job = queue.get_job(response.json()["job_id"])
+    assert isinstance(job.spec, McpCallSpec)
+    assert job.spec.env_from == {"JARVIS_MCP_SPACK_COMMAND": "JARVIS_MCP_SPACK_COMMAND"}
+
+
 def test_http_progress_endpoints_record_and_list_progress(tmp_path: Path) -> None:
     settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
     queue = ClioCoreQueue(settings.core_dir)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -261,10 +261,13 @@ def test_mcp_lists_relay_tools(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
         "relay_queue_stale",
     ):
         tool = next(tool for tool in response["result"]["tools"] if tool["name"] == name)
-        assert tool["inputSchema"]["properties"]["route_revision"] == {"type": "string"}
+        route_revision = tool["inputSchema"]["properties"]["route_revision"]
+        assert route_revision["type"] == "string"
+        assert route_revision["pattern"] == "^[0-9a-f]{64}$"
+        assert "not a scientific-dataset catalog revision" in route_revision["description"]
     for name in ("relay_observe", "relay_wait"):
         log_tool = next(tool for tool in response["result"]["tools"] if tool["name"] == name)
-        assert log_tool["inputSchema"]["properties"]["log_limit"]["maximum"] == 1_048_576
+        assert log_tool["inputSchema"]["properties"]["log_limit"]["maximum"] == 32_768
 
 
 def test_mcp_admin_profile_lists_operational_tools(tmp_path: Path) -> None:
@@ -669,7 +672,108 @@ def test_mcp_compact_log_limit_is_enforced_before_log_access(tmp_path: Path) -> 
     )
 
     assert response is not None
-    assert response["error"]["message"] == "log_limit must be between 1 and 1048576"
+    assert response["error"]["message"] == "log_limit must be between 1 and 32768"
+
+
+def test_mcp_observe_bounds_broad_regex_matches_and_log_context(tmp_path: Path) -> None:
+    """A broad agent-authored regex cannot duplicate an entire large log response."""
+
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    job = queue.submit_job(
+        RelayJob(
+            cluster="test-cluster",
+            kind=JobKind.JARVIS,
+            spec=JarvisRunSpec(command=["echo", "hello"]),
+            idempotency_key="bounded-broad-observe",
+        )
+    )
+    spool = JobSpool(settings.spool_dir, job)
+    spool.initialize()
+    spool.append_stdout("x" * 50_000)
+
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 34,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_observe",
+                "arguments": {
+                    "job_id": job.job_id,
+                    "pattern": ".+",
+                    "log_limit": 32_768,
+                },
+            },
+        },
+        queue=queue,
+        settings=settings,
+    )
+
+    assert response is not None and "error" not in response
+    observed = response["result"]["structuredContent"]
+    assert observed["matched"] is True
+    assert len(observed["logs"]["stdout"]["text"]) == 32_768
+    stdout_match = next(item for item in observed["matches"] if item.get("source") == "stdout")
+    assert len(stdout_match["text"]) <= 1_024
+    assert len(stdout_match["match"]) <= 1_024
+    assert stdout_match["match_truncated"] is True
+    assert len(json.dumps(observed)) < 40_000
+
+
+def test_mcp_job_route_rejects_missing_or_catalog_revisions_before_remote_io(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Remote job handles require the exact opaque route token from their receipt."""
+
+    definition = ClusterDefinition(name="ares", ssh_host="ares-login")
+    registry_path = tmp_path / "clusters.json"
+    ClusterRegistry(clusters={"ares": definition}).save(registry_path)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+
+    def remote_io_forbidden(_definition: ClusterDefinition, _args: list[str]) -> str:
+        raise AssertionError("invalid route identity reached remote I/O")
+
+    monkeypatch.setattr(mcp_server_module, "run_remote_clio", remote_io_forbidden)
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+
+    missing = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 35,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_status",
+                "arguments": {"cluster": "ares", "job_id": "job_remote_1"},
+            },
+        },
+        queue=queue,
+        settings=settings,
+    )
+    catalog_revision = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 36,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_status",
+                "arguments": {
+                    "cluster": "ares",
+                    "job_id": "job_remote_1",
+                    "route_revision": "2026-07-15-live-demo-v1",
+                },
+            },
+        },
+        queue=queue,
+        settings=settings,
+    )
+
+    assert missing is not None
+    assert "route_revision is required" in missing["error"]["message"]
+    assert catalog_revision is not None
+    assert "64-character lowercase hexadecimal token" in catalog_revision["error"]["message"]
 
 
 def test_mcp_compact_job_handle_routes_remote_lifecycle_and_verifies_result(
@@ -677,9 +781,8 @@ def test_mcp_compact_job_handle_routes_remote_lifecycle_and_verifies_result(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     registry_path = tmp_path / "clusters.json"
-    ClusterRegistry(clusters={"ares": ClusterDefinition(name="ares", ssh_host="ares-login")}).save(
-        registry_path
-    )
+    definition = ClusterDefinition(name="ares", ssh_host="ares-login")
+    ClusterRegistry(clusters={"ares": definition}).save(registry_path)
     monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
     queue = ClioCoreQueue(tmp_path / "desktop-core")
     settings = RelaySettings(core_dir=tmp_path / "desktop-core", spool_dir=tmp_path / "spool")
@@ -758,7 +861,11 @@ def test_mcp_compact_job_handle_routes_remote_lifecycle_and_verifies_result(
             "method": "tools/call",
             "params": {
                 "name": "relay_status",
-                "arguments": {"cluster": "ares", "job_id": job_id},
+                "arguments": {
+                    "cluster": "ares",
+                    "route_revision": cluster_route_revision(definition),
+                    "job_id": job_id,
+                },
             },
         },
         queue=queue,
@@ -1604,6 +1711,293 @@ def test_owned_remote_virtual_jarvis_call_uses_authenticated_session_api(
     assert queue.list_jobs() == []
 
 
+def test_waited_owned_jarvis_call_returns_bounded_artifact_bound_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A waited virtual call returns its structured error without a second relay query."""
+
+    definition = ClusterDefinition(name="ares", ssh_host="ares-login")
+    registry_path = tmp_path / "clusters.json"
+    ClusterRegistry(clusters={"ares": definition}).save(registry_path)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+    _bind_virtual_jarvis_catalog(monkeypatch, cluster="ares")
+
+    def artifact_binding(_cluster: str) -> str:
+        return "a" * 64
+
+    monkeypatch.setattr(
+        "clio_relay.mcp_server.jarvis_mcp_artifact_binding",
+        artifact_binding,
+    )
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        api_token="session-api-token",
+        owner_session_id="desktop-session-1",
+        owner_session_generation_id="generation-1",
+        remote_cluster="ares",
+    )
+    queued = RelayJob(
+        cluster="ares",
+        kind=JobKind.MCP_CALL,
+        spec=McpCallSpec(
+            server="clio-kit",
+            server_args=["mcp-server", "jarvis"],
+            expected_server_artifact_digest="a" * 64,
+            tool="jarvis_run",
+            arguments={"pipeline_id": "simulation"},
+        ),
+        idempotency_key="waited-owned-jarvis-failure",
+        metadata={
+            "owner": "clio-relay",
+            "owner_session_id": "desktop-session-1",
+            "owner_session_generation_id": "generation-1",
+        },
+    )
+    terminal = queued.model_copy(update={"state": JobState.FAILED, "last_error": "exit code 1"})
+    payload = json.dumps(
+        {
+            "operation": "tools/call",
+            "tool": "jarvis_run",
+            "returncode": 1,
+            "timed_out": False,
+            "protocol_error": None,
+            "structured_result": {
+                "schema_version": "jarvis.error.v1",
+                "error": {
+                    "code": "jarvis_run_failed",
+                    "message": "site software resolution failed",
+                },
+            },
+            "protocol_result": {"isError": True},
+            "protocol_version": "2024-11-05",
+            "server_info": {"name": "jarvis"},
+            "result_validation": None,
+        },
+        sort_keys=True,
+    ).encode()
+    artifact = {
+        "artifact_id": "artifact_waited_result",
+        "job_id": queued.job_id,
+        "kind": "mcp_result",
+        "size_bytes": len(payload),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "created_at": "2026-07-16T12:38:30Z",
+    }
+    requests: list[tuple[str, str]] = []
+
+    class FakeOwnedSessionApiClient:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        def __enter__(self) -> FakeOwnedSessionApiClient:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def request_json(
+            self,
+            *,
+            method: str,
+            path: str,
+            query: dict[str, object] | None = None,
+            body: dict[str, object] | None = None,
+        ) -> object:
+            del query, body
+            requests.append((method, path))
+            if path == f"/jobs/{queued.job_id}/wait":
+                return terminal.model_dump(mode="json")
+            if path == f"/jobs/{queued.job_id}/artifacts":
+                return {
+                    "artifacts": [artifact],
+                    "cursor": 1,
+                    "limit": 500,
+                    "next_cursor": None,
+                    "total": 1,
+                }
+            if path == f"/artifacts/{artifact['artifact_id']}/content":
+                return {
+                    "artifact": artifact,
+                    "encoding": "base64",
+                    "data": base64.b64encode(payload).decode("ascii"),
+                }
+            raise AssertionError(f"unexpected owned request: {method} {path}")
+
+    def submit_owned(**_kwargs: object) -> RelayJob:
+        return queued
+
+    monkeypatch.setattr(mcp_server_module, "submit_owned_session_job", submit_owned)
+    monkeypatch.setattr(
+        mcp_server_module,
+        "OwnedSessionApiClient",
+        FakeOwnedSessionApiClient,
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+    session = McpSessionState()
+    listed = handle_request(
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        queue=queue,
+        settings=settings,
+        profile="user",
+        session=session,
+    )
+    assert listed is not None
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "jarvis_run",
+                "arguments": {
+                    "cluster": "ares",
+                    "pipeline_id": "simulation",
+                    "wait_for_terminal": True,
+                },
+            },
+        },
+        queue=queue,
+        settings=settings,
+        profile="user",
+        session=session,
+    )
+
+    assert response is not None and "error" not in response
+    result = response["result"]["structuredContent"]
+    advertised = next(tool for tool in listed["result"]["tools"] if tool["name"] == "jarvis_run")
+    cast(_SchemaValidator, Draft202012Validator(advertised["outputSchema"])).validate(result)
+    assert result["state"] == "failed"
+    assert result["last_error"] == "exit code 1"
+    assert result["mcp_result"]["structured_result"]["error"]["code"] == ("jarvis_run_failed")
+    assert result["mcp_result_artifact"]["artifact_id"] == artifact["artifact_id"]
+    assert requests == [
+        ("POST", f"/jobs/{queued.job_id}/wait"),
+        ("GET", f"/jobs/{queued.job_id}/artifacts"),
+        ("GET", f"/artifacts/{artifact['artifact_id']}/content"),
+    ]
+
+
+def test_direct_remote_waited_mcp_submission_returns_artifact_bound_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The SSH fallback returns terminal MCP evidence in the original receipt."""
+
+    definition = ClusterDefinition(name="ares", ssh_host="ares-login")
+    job_id = "job_direct_waited_1"
+    payload = json.dumps(
+        {
+            "operation": "tools/call",
+            "tool": "jarvis_describe",
+            "returncode": 0,
+            "timed_out": False,
+            "protocol_error": None,
+            "structured_result": {"package": "builtin.paraview"},
+            "protocol_result": {"structuredContent": {"package": "builtin.paraview"}},
+            "protocol_version": "2024-11-05",
+            "server_info": {"name": "jarvis"},
+            "result_validation": None,
+        },
+        sort_keys=True,
+    ).encode()
+    artifact = {
+        "artifact_id": "artifact_direct_waited_result",
+        "job_id": job_id,
+        "kind": "mcp_result",
+        "size_bytes": len(payload),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "created_at": "2026-07-16T12:45:00Z",
+    }
+    commands: list[list[str]] = []
+
+    def run_remote(_definition: ClusterDefinition, args: list[str]) -> str:
+        commands.append(args)
+        if args[:2] == ["job", "wait"]:
+            return ""
+        if args[:2] == ["job", "status"]:
+            return json.dumps(
+                {
+                    "job": {
+                        "job_id": job_id,
+                        "cluster": "ares",
+                        "kind": "mcp_call",
+                        "state": "succeeded",
+                        "last_error": None,
+                    },
+                    "terminal": True,
+                }
+            )
+        if args[:2] == ["job", "list-artifacts"]:
+            return json.dumps(
+                {
+                    "artifacts": [artifact],
+                    "cursor": 1,
+                    "limit": 500,
+                    "next_cursor": None,
+                    "total": 1,
+                }
+            )
+        if args[:2] == ["job", "read-artifact"]:
+            return json.dumps(
+                {
+                    "artifact": artifact,
+                    "encoding": "base64",
+                    "data": base64.b64encode(payload).decode("ascii"),
+                }
+            )
+        raise AssertionError(f"unexpected remote command: {args}")
+
+    monkeypatch.setattr(mcp_server_module, "run_remote_clio", run_remote)
+
+    result = mcp_server_module._remote_mcp_submission_result(  # pyright: ignore[reportPrivateUsage]
+        f"{job_id}\n",
+        definition=definition,
+        arguments={
+            "wait_for_terminal": True,
+            "wait_timeout_seconds": 30,
+            "poll_seconds": 0.25,
+        },
+    )
+
+    assert result["state"] == "succeeded"
+    assert result["terminal"] is True
+    assert result["last_error"] is None
+    assert result["mcp_result"]["structured_result"] == {"package": "builtin.paraview"}
+    assert result["mcp_result_artifact"]["artifact_id"] == artifact["artifact_id"]
+    assert [command[:2] for command in commands] == [
+        ["job", "wait"],
+        ["job", "status"],
+        ["job", "list-artifacts"],
+        ["job", "read-artifact"],
+    ]
+
+
+def test_large_terminal_mcp_result_omits_payload_but_keeps_summary() -> None:
+    """Oversized MCP payloads remain durable without overflowing an agent context."""
+
+    bounded = mcp_server_module._bounded_mcp_result(  # pyright: ignore[reportPrivateUsage]
+        {
+            "operation": "tools/call",
+            "tool": "jarvis_describe",
+            "returncode": 0,
+            "timed_out": False,
+            "protocol_error": None,
+            "structured_result": {"yaml": "x" * 100_000},
+            "protocol_result": {"structuredContent": {"yaml": "x" * 100_000}},
+            "protocol_version": "2024-11-05",
+            "server_info": {"name": "jarvis"},
+            "result_validation": None,
+        }
+    )
+
+    assert bounded["content_truncated"] is True
+    assert "structured_result" in bounded["omitted_fields"]
+    assert "protocol_result" in bounded["omitted_fields"]
+    assert bounded["tool"] == "jarvis_describe"
+    assert len(json.dumps(bounded)) < 65_536
+
+
 def test_owned_registered_remote_mcp_call_uses_authenticated_session_api(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1918,7 +2312,11 @@ def test_owned_remote_followups_use_session_api_and_never_direct_ssh(
         remote_cluster="ares",
     )
     queue = ClioCoreQueue(settings.core_dir)
-    route = {"cluster": "ares", "job_id": running.job_id}
+    route = {
+        "cluster": "ares",
+        "job_id": running.job_id,
+        "route_revision": cluster_route_revision(definition),
+    }
     calls = [
         ("relay_status", route),
         ("relay_cancel", route),

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.0"
+    assert version == "1.3.1"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.0"
+version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Fixes three production defects exposed by the live Phase-1 run: owner-session JARVIS submissions now inherit the cluster operator's configured Spack command; waited MCP submissions return bounded, SHA-verified terminal result evidence in the original receipt; and remote job handles strictly distinguish the opaque route revision from dataset/catalog revisions. Agent-facing observe/log output is bounded to prevent context amplification. Focused tests cover owner API, direct SSH, local result binding, route rejection, and broad-regex bounds. Ruff and pyright pass. Release version: 1.3.1.