### PR TITLE
fix: separate direct JARVIS scheduler semantics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,13 @@ jobs:
       - name: stage exact clio-kit release wheel
         shell: bash
         env:
-          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.5.0-py3-none-any.whl
-          CLIO_KIT_WHEEL_SHA256: acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f
-          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.5.0/clio_kit-2.5.0-py3-none-any.whl
+          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.5.1-py3-none-any.whl
+          CLIO_KIT_WHEEL_SHA256: e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1
+          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.5.1/clio_kit-2.5.1-py3-none-any.whl
         run: |
           set -euo pipefail
           umask 077
-          wheel_dir="$RUNNER_TEMP/clio-kit-v2.5.0"
+          wheel_dir="$RUNNER_TEMP/clio-kit-v2.5.1"
           mkdir "$wheel_dir"
           wheel="$wheel_dir/$CLIO_KIT_WHEEL_FILENAME"
           curl --fail --show-error --silent --location \
@@ -160,13 +160,13 @@ jobs:
       - name: stage exact clio-kit release wheel
         shell: bash
         env:
-          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.5.0-py3-none-any.whl
-          CLIO_KIT_WHEEL_SHA256: acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f
-          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.5.0/clio_kit-2.5.0-py3-none-any.whl
+          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.5.1-py3-none-any.whl
+          CLIO_KIT_WHEEL_SHA256: e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1
+          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.5.1/clio_kit-2.5.1-py3-none-any.whl
         run: |
           set -euo pipefail
           umask 077
-          wheel_dir="$RUNNER_TEMP/clio-kit-v2.5.0"
+          wheel_dir="$RUNNER_TEMP/clio-kit-v2.5.1"
           mkdir "$wheel_dir"
           wheel="$wheel_dir/$CLIO_KIT_WHEEL_FILENAME"
           curl --fail --show-error --silent --location \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.1` uses a release-first patch process. A maintainer builds the
+> Version `1.3.2` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -214,7 +214,7 @@ For the legacy clio-kit 2.2.6 compatibility path, a successful synchronous
 `jarvis_run` MCP return is normalized to a terminal `completed` record even
 though that release labels the result `status=running`; the original status and
 completion basis remain in `details.completion_normalization` for auditability.
-The pinned clio-kit 2.5.0 production path removes that ambiguity upstream and
+The pinned clio-kit 2.5.1 production path removes that ambiguity upstream and
 returns a structured completed result directly. The legacy normalization is
 diagnostic compatibility evidence and cannot satisfy the 1.0 gate. Scheduler
 submissions remain non-terminal unless JARVIS was asked to wait.
@@ -449,7 +449,7 @@ Install the cluster-side server once, then launch its persistent executable:
 
 ```bash
 uv tool install --python 3.12 --no-config \
-  https://github.com/iowarp/clio-kit/releases/download/v2.5.0/clio_kit-2.5.0-py3-none-any.whl
+  https://github.com/iowarp/clio-kit/releases/download/v2.5.1/clio_kit-2.5.1-py3-none-any.whl
 clio-kit mcp-server jarvis
 ```
 

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.1"
+$Version = "1.3.2"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.1"
+release_version: "1.3.2"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 4a935a4d01c977c7f115ae65cbf369953f7febdf0273e1009feb75f8aebc3b06
+acceptance_matrix_sha256: c1996dd023e1014d8bf6d9af3c40885d99493c92cd19b37b5fa69394f6608790
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true
@@ -108,16 +108,16 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.5.0"
+            clio-kit: "2.5.1"
             jarvis-cd: "1.3.6"
             jarvis-util: c91bfdc9bba802e4b03bfb1babe614ffa3e09644
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.5.0"
-              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.0/clio_kit-2.5.0-py3-none-any.whl
+              distribution_version: "2.5.1"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.1/clio_kit-2.5.1-py3-none-any.whl
               requested_source: github_release
-              artifact_sha256: acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f
+              artifact_sha256: e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1
               native_execution:
                 schema_version: clio-relay.jarvis-native-execution-capability.v1
                 handle_schema: jarvis.execution.handle.v1
@@ -218,14 +218,14 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.5.0"
+            clio-kit: "2.5.1"
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.5.0"
-              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.0/clio_kit-2.5.0-py3-none-any.whl
+              distribution_version: "2.5.1"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.1/clio_kit-2.5.1-py3-none-any.whl
               requested_source: github_release
-              artifact_sha256: acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f
+              artifact_sha256: e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1
       - kind: scheduler_job
         roles: [queue-preservation-fixture]
         states: [completed]
@@ -286,24 +286,24 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.5.0"
+            clio-kit: "2.5.1"
             jarvis-cd: "1.3.6"
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.5.0"
-              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.0/clio_kit-2.5.0-py3-none-any.whl
+              distribution_version: "2.5.1"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.1/clio_kit-2.5.1-py3-none-any.whl
               requested_source: github_release
-              artifact_filename: clio_kit-2.5.0-py3-none-any.whl
-              artifact_sha256: acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f
+              artifact_filename: clio_kit-2.5.1-py3-none-any.whl
+              artifact_sha256: e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1
               persistent_tool:
                 manager: uv
                 uv_version: "0.11.28"
                 pyvenv_uv_version: "0.11.28"
                 distribution: clio-kit
-                distribution_version: "2.5.0"
+                distribution_version: "2.5.1"
                 entry_point: clio-kit
-                source_artifact_sha256: acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f
+                source_artifact_sha256: e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1
               native_execution:
                 schema_version: clio-relay.jarvis-native-execution-capability.v1
                 handle_schema: jarvis.execution.handle.v1
@@ -361,10 +361,10 @@ requirements:
         states: [verified]
         metadata_equals:
           install_source: uv-tool
-          install_artifact_sha256: acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f
+          install_artifact_sha256: e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1
           python_distribution_runtime:
             distribution: clio-kit
-            distribution_version: "2.5.0"
+            distribution_version: "2.5.1"
             entry_point: clio-kit
             runtime_closure_verified: true
           nested_runtime:
@@ -622,7 +622,7 @@ requirements:
         states: [verified]
         metadata_equals:
           install_source: wheel
-          install_artifact_sha256: acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f
+          install_artifact_sha256: e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1
           server_process_artifact_verified: true
           verified: true
 
@@ -721,7 +721,7 @@ requirements:
           remote_tool_names: [spack_find, spack_install, spack_locate]
           allowlisted_tool_names: [spack_find, spack_install, spack_locate]
           install_source: wheel
-          install_artifact_sha256: acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f
+          install_artifact_sha256: e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1
           contract_id: clio-kit-spack-user-v2
           contract_sha256: 3c5412148c770f4844e98eb893c4db0d0afdbf13afe967df67bd5f7d25e1f7db
           server_process_artifact_verified: true
@@ -826,7 +826,7 @@ requirements:
           remote_tool_names: [spack_find, spack_install, spack_locate]
           allowlisted_tool_names: [spack_find, spack_install, spack_locate]
           install_source: wheel
-          install_artifact_sha256: acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f
+          install_artifact_sha256: e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1
           contract_id: clio-kit-spack-user-v2
           contract_sha256: 3c5412148c770f4844e98eb893c4db0d0afdbf13afe967df67bd5f7d25e1f7db
           server_process_artifact_verified: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.1"
+$Tag = "v1.3.2"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.1" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.2" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/docs/remote-mcp-federation.md
+++ b/docs/remote-mcp-federation.md
@@ -264,7 +264,7 @@ Virtual JARVIS mutations and runs receive a fresh relay job by default. Supply
 an explicit `idempotency_key` only when retry de-duplication is intentional; an
 identical second `jarvis_run` is otherwise a new execution.
 
-The released clio-kit 2.5.0 artifact is the pinned six-tool JARVIS v3.2 contract.
+The released clio-kit 2.5.1 artifact is the pinned six-tool JARVIS v3.2 contract.
 Bootstrap
 downloads and hashes the exact coordinated wheel, installs it once with
 `uv tool install`, and persists the wheel plus the direct JARVIS command in the
@@ -275,13 +275,13 @@ that persistent executable directly. clio-kit's child launcher still uses its
 wheel-owned server source and lock with `uv run --frozen --no-editable`, so the
 live MCP response binds both the installed outer tool and the locked child
 server rather than trusting an unobserved nested resolution. The release gate
-requires that exact 2.5.0 artifact to be rerun on every target selected by the
+requires that exact 2.5.1 artifact to be rerun on every target selected by the
 release policy. Other servers use the operator registry and generated
 `remote_...` aliases.
 
 The exact release wheel is
-`clio_kit-2.5.0-py3-none-any.whl` with SHA-256
-`acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f`.
+`clio_kit-2.5.1-py3-none-any.whl` with SHA-256
+`e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1`.
 Its canonical contract is `clio-kit-jarvis-user-v3.2`, with contract SHA-256
 `12f6d349c9d44d8ce3594943dcd4018ec9b6e01ebb0e59d468bb1bb783a1ad5d`
 and canonical tools-wire SHA-256
@@ -300,7 +300,7 @@ operator-defined and do not select behavior.
 
 ## Register the scientific catalog MCP
 
-clio-kit 2.5.0 also ships the two-tool
+clio-kit 2.5.1 also ships the two-tool
 `clio-kit-scientific-catalog-user-v1` contract. It separates dataset discovery
 from visualization control: `scientific_dataset_search` finds operator catalog
 records and `scientific_dataset_describe` returns one exact

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.1",
-  "matrix_sha256": "4a935a4d01c977c7f115ae65cbf369953f7febdf0273e1009feb75f8aebc3b06",
+  "release_version": "1.3.2",
+  "matrix_sha256": "c1996dd023e1014d8bf6d9af3c40885d99493c92cd19b37b5fa69394f6608790",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.1"
+version = "1.3.2"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"

--- a/src/clio_relay/jarvis_mcp.py
+++ b/src/clio_relay/jarvis_mcp.py
@@ -22,14 +22,14 @@ from clio_relay.remote_mcp import (
 if TYPE_CHECKING:
     from clio_relay.installation import ComponentArtifactIdentity, InstallReceipt
 
-CLIO_KIT_JARVIS_MCP_VERSION = "2.5.0"
+CLIO_KIT_JARVIS_MCP_VERSION = "2.5.1"
 CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME = f"clio_kit-{CLIO_KIT_JARVIS_MCP_VERSION}-py3-none-any.whl"
 CLIO_KIT_JARVIS_MCP_WHEEL_URL = (
     "https://github.com/iowarp/clio-kit/releases/download/"
     f"v{CLIO_KIT_JARVIS_MCP_VERSION}/{CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME}"
 )
 CLIO_KIT_JARVIS_MCP_WHEEL_SHA256 = (
-    "acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f"
+    "e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1"
 )
 CLIO_KIT_JARVIS_USER_CONTRACT_ID = "clio-kit-jarvis-user-v3.2"
 DEFAULT_JARVIS_MCP_COMMAND = [

--- a/src/clio_relay/remote_mcp.py
+++ b/src/clio_relay/remote_mcp.py
@@ -73,7 +73,7 @@ MAX_REMOTE_MCP_CATALOG_ISSUES = 10_000
 MAX_VIRTUAL_REMOTE_MCP_ALIAS_LENGTH = 64
 REMOTE_MCP_REPLACE_ATTEMPTS = 25
 REMOTE_MCP_REPLACE_RETRY_SECONDS = 0.02
-CLIO_KIT_SPACK_USER_WHEEL_VERSION = "2.5.0"
+CLIO_KIT_SPACK_USER_WHEEL_VERSION = "2.5.1"
 CLIO_KIT_SPACK_USER_CONTRACT_ID = "clio-kit-spack-user-v2"
 # Digest the MCP wire ``tools/list`` result. FastMCP's in-process FunctionTool
 # schemas retain ``$defs`` that its protocol serializer dereferences, so their

--- a/src/clio_relay/runtime_metadata.py
+++ b/src/clio_relay/runtime_metadata.py
@@ -405,7 +405,7 @@ class _JarvisRuntimeProjectionDocument(BaseModel):
     cluster: str | None
     scheduler_type: str | None
     scheduler_job_id: str | None
-    scheduler_phase: str
+    scheduler_phase: str | None
     script_path: str | None
     hostfile_path: str | None
     output_path: str | None
@@ -520,7 +520,7 @@ def runtime_metadata_from_native_documents(
         scheduler_provider=record.scheduler_provider,
         scheduler_type=record.scheduler_provider,
         scheduler_job_id=record.scheduler_native_id,
-        scheduler_phase=record.state,
+        scheduler_phase=_native_scheduler_phase(record),
         script_path=_first_str(record.metadata, "script_path")
         or (_first_str(submission, "script_path") if submission is not None else None),
         hostfile_path=(_first_str(submission, "hostfile_path") if submission is not None else None),
@@ -558,6 +558,19 @@ def runtime_metadata_from_native_documents(
     return metadata.model_copy(update={"field_sources": _field_sources(metadata, source)})
 
 
+def _native_scheduler_phase(record: JarvisExecutionRecordDocument) -> str | None:
+    """Return lifecycle state only when a scheduler owns a submitted native job."""
+
+    if (
+        record.mode != "scheduler"
+        or record.submitted is not True
+        or record.scheduler_provider is None
+        or record.scheduler_native_id is None
+    ):
+        return None
+    return record.state
+
+
 def _merge_native_runtime_projection(
     metadata: JarvisRuntimeMetadata,
     documents: JarvisNativeExecutionDocuments,
@@ -578,7 +591,7 @@ def _merge_native_runtime_projection(
         "cluster": record.cluster,
         "scheduler_type": record.scheduler_provider,
         "scheduler_job_id": record.scheduler_native_id,
-        "scheduler_phase": record.state,
+        "scheduler_phase": _native_scheduler_phase(record),
     }
     for field_name, expected in authoritative.items():
         if getattr(projection, field_name) != expected:

--- a/tests/test_ci_clio_kit_wheel.py
+++ b/tests/test_ci_clio_kit_wheel.py
@@ -17,14 +17,14 @@ from clio_relay.jarvis_mcp import (
 ROOT = Path(__file__).resolve().parents[1]
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
-WHEEL_FILENAME = "clio_kit-2.5.0-py3-none-any.whl"
-WHEEL_SHA256 = "acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f"
-WHEEL_URL = f"https://github.com/iowarp/clio-kit/releases/download/v2.5.0/{WHEEL_FILENAME}"
+WHEEL_FILENAME = "clio_kit-2.5.1-py3-none-any.whl"
+WHEEL_SHA256 = "e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1"
+WHEEL_URL = f"https://github.com/iowarp/clio-kit/releases/download/v2.5.1/{WHEEL_FILENAME}"
 
 
 def test_runtime_and_ci_share_one_exact_clio_kit_release_pin() -> None:
     """Keep bootstrap, JARVIS MCP, and CI on the same exact release wheel bytes."""
-    assert CLIO_KIT_JARVIS_MCP_VERSION == "2.5.0"
+    assert CLIO_KIT_JARVIS_MCP_VERSION == "2.5.1"
     assert CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME == WHEEL_FILENAME
     assert CLIO_KIT_JARVIS_MCP_WHEEL_SHA256 == WHEEL_SHA256
     assert CLIO_KIT_JARVIS_MCP_WHEEL_URL == WHEEL_URL

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -3299,7 +3299,7 @@ def _native_mcp_result_document(
             "cluster": None,
             "scheduler_type": None,
             "scheduler_job_id": None,
-            "scheduler_phase": "completed",
+            "scheduler_phase": None,
             "script_path": None,
             "hostfile_path": None,
             "output_path": f"/runs/{pipeline_id}/stdout.log",
@@ -5772,6 +5772,7 @@ def test_worker_native_direct_execution_discards_stdout_scheduler_fallback(
     assert runtime["execution_id"] == "native-direct-execution"
     assert runtime["scheduler_provider"] is None
     assert runtime["scheduler_job_id"] is None
+    assert runtime["scheduler_phase"] is None
     assert runtime["output_path"] == "/runs/native-direct/stdout.log"
     assert runtime["error_path"] == "/runs/native-direct/stderr.log"
     assert runtime["packages"] == [
@@ -5793,6 +5794,16 @@ def test_worker_native_direct_execution_discards_stdout_scheduler_fallback(
     assert task.metadata["scheduler"] is None
     assert task.metadata["scheduler_job_ids"] == []
     assert task.metadata["scheduler_job_ownership"] == []
+    events, _ = queue.drain_events(Cursor(job_id=job.job_id), limit=100)
+    event_types = {event.event_type for event in events}
+    assert event_types.isdisjoint(
+        {
+            "scheduler.pending",
+            "scheduler.allocated",
+            "scheduler.running",
+            "scheduler.completed",
+        }
+    )
     assert task.metadata["jarvis_execution_handle"]["schema_version"] == (
         "jarvis.execution.handle.v1"
     )

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.1"
+    assert version == "1.3.2"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -304,11 +304,11 @@ def test_jarvis_release_requirement_enforces_unified_gray_scott_contract() -> No
         if resource["kind"] == "relay_worker"
     )
     clio_kit_component = worker["metadata_equals"]["component_artifacts"]["clio-kit"]
-    assert clio_kit_component["distribution_version"] == "2.5.0"
+    assert clio_kit_component["distribution_version"] == "2.5.1"
     assert clio_kit_component["persistent_tool"]["manager"] == "uv"
     assert clio_kit_component["persistent_tool"]["uv_version"] == "0.11.28"
     assert clio_kit_component["persistent_tool"]["source_artifact_sha256"] == (
-        "acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f"
+        "e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1"
     )
     jarvis_component = worker["metadata_equals"]["component_artifacts"]["jarvis-cd"]
     assert jarvis_component["distribution_version"] == "1.3.6"
@@ -471,7 +471,7 @@ def test_spack_release_requirements_split_existing_resolution_from_fresh_install
     )
     assert fresh_server["metadata_equals"]["server_name"] == "spack-fresh"
     assert fresh_server["metadata_equals"]["install_artifact_sha256"] == (
-        "acc13d7924045f2b636a8ceededf4816cfb3b936512b7e5d3dd0d50055540f5f"
+        "e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1"
     )
     assert fresh_server["metadata_equals"]["contract_id"] == "clio-kit-spack-user-v2"
     assert fresh_server["metadata_equals"]["contract_sha256"] == (

--- a/tests/test_runtime_metadata.py
+++ b/tests/test_runtime_metadata.py
@@ -169,6 +169,7 @@ def test_mcp_runtime_metadata_prefers_exact_native_execution_documents() -> None
     assert metadata.pipeline_id == "pipeline-a"
     assert metadata.scheduler_provider is None
     assert metadata.scheduler_job_id is None
+    assert metadata.scheduler_phase is None
     assert metadata.terminal.state == "completed"
     assert metadata.terminal.terminal is True
     assert metadata.terminal.returncode == 0
@@ -720,7 +721,7 @@ def _native_execution_envelope(*, mode: str, state: str) -> dict[str, object]:
         "cluster": cluster,
         "scheduler_type": provider,
         "scheduler_job_id": native_id,
-        "scheduler_phase": state,
+        "scheduler_phase": state if scheduler else None,
         "script_path": "/tmp/submit.sh" if scheduler else None,
         "hostfile_path": "/tmp/hosts" if scheduler else None,
         "output_path": None,

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.1"
+version = "1.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Live released-wheel acceptance exposed scheduler.running/completed events for a direct JARVIS execution with no scheduler provider, native ID, or submission. Relay now projects scheduler_phase only for scheduler-owned submitted native executions; direct lifecycle remains in terminal.state. The patch pins released clio-kit 2.5.1 and its exact wheel hash while retaining the unchanged JARVIS v3.2 contract. Fourteen focused contract, runtime, release-pin, Ruff, and Pyright checks pass.