### PR TITLE
fix: validate bootstrap wheel before SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.4` uses a release-first patch process. A maintainer builds the
+> Version `1.3.5` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.4"
+$Version = "1.3.5"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.4"
+release_version: "1.3.5"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: d8a172c1aecebfd0a572652d533f297e83e71ac9fbff7b9e5fa9dac0b2e18985
+acceptance_matrix_sha256: ef2d2bcb190035e98297784d20b4c7668e5fa796bb17ebdd01d2d1c6cecae9f0
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.4"
+$Tag = "v1.3.5"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.4" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.5" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.4",
-  "matrix_sha256": "d8a172c1aecebfd0a572652d533f297e83e71ac9fbff7b9e5fa9dac0b2e18985",
+  "release_version": "1.3.5",
+  "matrix_sha256": "ef2d2bcb190035e98297784d20b4c7668e5fa796bb17ebdd01d2d1c6cecae9f0",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.4"
+version = "1.3.5"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"
@@ -10,6 +10,7 @@ dependencies = [
     "filelock>=3.15",
     "httpx>=0.27",
     "jsonschema>=4.23",
+    "packaging>=24.2",
     "pydantic>=2.8",
     "pyyaml>=6.0",
     "typer>=0.12",

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.4"
+__version__ = "1.3.5"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -8,16 +8,23 @@ import os
 import platform
 import shlex
 import shutil
+import stat
 import subprocess
 import tarfile
 import tempfile
 import zipfile
 from dataclasses import dataclass
+from email.message import Message
+from email.parser import BytesParser
+from email.policy import default
 from importlib import resources
 from pathlib import Path, PurePosixPath
 from typing import cast
 from urllib.request import urlretrieve
 from uuid import uuid4
+
+from packaging.utils import InvalidWheelFilename, canonicalize_name, parse_wheel_filename
+from packaging.version import InvalidVersion, Version
 
 from clio_relay import __version__
 from clio_relay.deployment import endpoint_user_service_name
@@ -53,6 +60,7 @@ JARVIS_CD_WHEEL_URL = (
 JARVIS_CD_WHEEL_SHA256 = "2b15fc74bb586724a8c714cabc02102fe2695afe08edc4521b7ec049c85a0c04"
 DEFAULT_REMOTE_CORE_DIR = "$HOME/.local/share/clio-relay/core"
 DEFAULT_REMOTE_SPOOL_DIR = "$HOME/.local/share/clio-relay/spool"
+MAX_RELAY_WHEEL_METADATA_BYTES = 1024 * 1024
 
 _WORKER_WRITER_PROOF_PYTHON = r'''from __future__ import annotations
 
@@ -677,6 +685,11 @@ def bootstrap_cluster_over_ssh(
     render_remote_shell_path(core_dir, field="core_dir")
     render_remote_shell_path(spool_dir, field="spool_dir")
     _validate_ssh_destination(ssh_host)
+    observed_relay_sha256: str | None = None
+    if relay_wheel is not None:
+        observed_relay_sha256 = _validate_relay_bootstrap_wheel(relay_wheel)
+        if relay_artifact_sha256 is not None and relay_artifact_sha256 != observed_relay_sha256:
+            raise ConfigurationError("relay bootstrap wheel SHA-256 does not match its pin")
     if shutil.which("ssh") is None or shutil.which("scp") is None:
         raise ConfigurationError("ssh and scp are required for remote bootstrap")
     invocation_id = f"bootstrap_{uuid4().hex}"
@@ -708,12 +721,7 @@ def bootstrap_cluster_over_ssh(
             )
             expected_relay_sha256 = relay_artifact_sha256
             if relay_wheel is not None:
-                observed_relay_sha256 = hashlib.sha256(relay_wheel.read_bytes()).hexdigest()
-                if (
-                    expected_relay_sha256 is not None
-                    and expected_relay_sha256 != observed_relay_sha256
-                ):
-                    raise ConfigurationError("relay bootstrap wheel SHA-256 does not match its pin")
+                assert observed_relay_sha256 is not None
                 expected_relay_sha256 = observed_relay_sha256
             source_archive_sha256 = hashlib.sha256(deployment.archive.read_bytes()).hexdigest()
             _run(["scp", str(deployment.archive), f"{ssh_host}:{remote_archive}"])
@@ -1660,6 +1668,83 @@ def _render_relay_install_spec(relay_install_spec: str) -> str:
     if relay_install_spec.startswith("$DEST/"):
         return '"$DEST"/' + shlex.quote(relay_install_spec.removeprefix("$DEST/"))
     return shlex.quote(relay_install_spec)
+
+
+def _validate_relay_bootstrap_wheel(path: Path) -> str:
+    """Validate one local relay wheel before any remote bootstrap mutation."""
+    try:
+        details = path.lstat()
+    except OSError as exc:
+        raise ConfigurationError(f"could not inspect relay bootstrap wheel {path}: {exc}") from exc
+    if path.is_symlink() or not stat.S_ISREG(details.st_mode):
+        raise ConfigurationError(f"relay bootstrap wheel must be one regular file: {path}")
+
+    try:
+        project, version, _build, _tags = parse_wheel_filename(path.name)
+    except InvalidWheelFilename as exc:
+        raise ConfigurationError(
+            f"relay bootstrap wheel filename is not canonical: {path.name}: {exc}"
+        ) from exc
+    if project != canonicalize_name("clio-relay"):
+        raise ConfigurationError(
+            f"relay bootstrap wheel distribution must be clio-relay, got {project}"
+        )
+
+    metadata = _read_relay_wheel_metadata(path)
+    names = metadata.get_all("Name", [])
+    versions = metadata.get_all("Version", [])
+    if len(names) != 1 or not str(names[0]).strip():
+        raise ConfigurationError("relay bootstrap wheel METADATA must contain exactly one Name")
+    if len(versions) != 1 or not str(versions[0]).strip():
+        raise ConfigurationError("relay bootstrap wheel METADATA must contain exactly one Version")
+    metadata_name = str(names[0]).strip()
+    metadata_version = str(versions[0]).strip()
+    if canonicalize_name(metadata_name) != project:
+        raise ConfigurationError("relay bootstrap wheel METADATA Name does not match its filename")
+    try:
+        parsed_metadata_version = Version(metadata_version)
+    except InvalidVersion as exc:
+        raise ConfigurationError(
+            f"relay bootstrap wheel METADATA Version is invalid: {metadata_version}"
+        ) from exc
+    if parsed_metadata_version != version:
+        raise ConfigurationError(
+            "relay bootstrap wheel METADATA Version does not match its filename"
+        )
+    try:
+        with path.open("rb") as stream:
+            return hashlib.file_digest(stream, "sha256").hexdigest()
+    except OSError as exc:
+        raise ConfigurationError(f"could not hash relay bootstrap wheel {path}: {exc}") from exc
+
+
+def _read_relay_wheel_metadata(path: Path) -> Message:
+    """Read bounded core metadata from one wheel without executing package code."""
+    try:
+        with zipfile.ZipFile(path) as archive:
+            candidates = [
+                member
+                for member in archive.infolist()
+                if not member.is_dir()
+                and member.filename.count("/") == 1
+                and member.filename.endswith(".dist-info/METADATA")
+            ]
+            if len(candidates) != 1:
+                raise ConfigurationError(
+                    "relay bootstrap wheel must contain exactly one top-level METADATA file"
+                )
+            member = candidates[0]
+            if not 1 <= member.file_size <= MAX_RELAY_WHEEL_METADATA_BYTES:
+                raise ConfigurationError("relay bootstrap wheel METADATA size is invalid")
+            with archive.open(member) as stream:
+                content = stream.read(MAX_RELAY_WHEEL_METADATA_BYTES + 1)
+    except ConfigurationError:
+        raise
+    except (OSError, RuntimeError, zipfile.BadZipFile, NotImplementedError) as exc:
+        raise ConfigurationError(f"could not inspect relay bootstrap wheel {path}: {exc}") from exc
+    if len(content) > MAX_RELAY_WHEEL_METADATA_BYTES:
+        raise ConfigurationError("relay bootstrap wheel METADATA exceeds the size limit")
+    return BytesParser(policy=default).parsebytes(content, headersonly=True)
 
 
 def create_bootstrap_archive(

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 import subprocess
 import tarfile
 import tomllib
+import zipfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -39,6 +41,60 @@ from clio_relay.bootstrap import (
 )
 from clio_relay.errors import ConfigurationError, RelayError
 from tests.plugin_fakes import FakeEntryPoint, FakeEntryPoints
+
+
+def _write_test_relay_wheel(
+    path: Path,
+    *,
+    metadata_name: str = "clio-relay",
+    metadata_version: str = __version__,
+) -> None:
+    """Write a minimal wheel with explicit core metadata for bootstrap tests."""
+    dist_info = f"clio_relay-{__version__}.dist-info"
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(
+            f"{dist_info}/METADATA",
+            (f"Metadata-Version: 2.4\nName: {metadata_name}\nVersion: {metadata_version}\n\n"),
+        )
+        archive.writestr(
+            f"{dist_info}/WHEEL",
+            "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+        )
+        archive.writestr(f"{dist_info}/RECORD", "")
+
+
+def _assert_bootstrap_rejected_before_remote_call(
+    *,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    wheel: Path,
+    expected_error: str,
+    relay_artifact_sha256: str | None = None,
+) -> None:
+    """Require local wheel validation to fail before any remote command."""
+    from clio_relay import bootstrap
+
+    remote_calls: list[list[str]] = []
+
+    def record_remote_call(
+        command: list[str],
+        *,
+        cwd: Path | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        del cwd
+        remote_calls.append(command)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(bootstrap, "_run", record_remote_call)
+    with pytest.raises(ConfigurationError, match=expected_error):
+        bootstrap.bootstrap_cluster_over_ssh(
+            bootstrap_profile="linux-user",
+            ssh_host="ares",
+            source_root=tmp_path,
+            relay_wheel=wheel,
+            relay_artifact_sha256=relay_artifact_sha256,
+        )
+    assert remote_calls == []
 
 
 @dataclass(frozen=True)
@@ -487,6 +543,106 @@ def test_bootstrap_over_ssh_rejects_option_like_destination(tmp_path: Path) -> N
         )
 
 
+def test_bootstrap_over_ssh_rejects_invalid_relay_wheel_filename_before_ssh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wheel = tmp_path / f"clio_relay-{__version__}-release-check.whl"
+    _write_test_relay_wheel(wheel)
+    _assert_bootstrap_rejected_before_remote_call(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        wheel=wheel,
+        expected_error="wheel filename is not canonical",
+    )
+
+
+def test_bootstrap_over_ssh_rejects_relay_wheel_digest_mismatch_before_ssh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wheel = tmp_path / f"clio_relay-{__version__}-py3-none-any.whl"
+    _write_test_relay_wheel(wheel)
+    _assert_bootstrap_rejected_before_remote_call(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        wheel=wheel,
+        expected_error="SHA-256 does not match its pin",
+        relay_artifact_sha256="0" * 64,
+    )
+
+
+def test_bootstrap_over_ssh_rejects_foreign_wheel_distribution_before_ssh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wheel = tmp_path / f"other_project-{__version__}-py3-none-any.whl"
+    _write_test_relay_wheel(wheel, metadata_name="other-project")
+    _assert_bootstrap_rejected_before_remote_call(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        wheel=wheel,
+        expected_error="distribution must be clio-relay",
+    )
+
+
+@pytest.mark.parametrize(
+    ("metadata_name", "metadata_version", "expected_error"),
+    [
+        ("other-project", __version__, "METADATA Name does not match"),
+        ("clio-relay", "9.9.9", "METADATA Version does not match"),
+    ],
+)
+def test_bootstrap_over_ssh_rejects_relay_wheel_metadata_mismatch_before_ssh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    metadata_name: str,
+    metadata_version: str,
+    expected_error: str,
+) -> None:
+    wheel = tmp_path / f"clio_relay-{__version__}-py3-none-any.whl"
+    _write_test_relay_wheel(
+        wheel,
+        metadata_name=metadata_name,
+        metadata_version=metadata_version,
+    )
+    _assert_bootstrap_rejected_before_remote_call(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        wheel=wheel,
+        expected_error=expected_error,
+    )
+
+
+def test_relay_wheel_preflight_accepts_canonical_filename_and_matching_metadata(
+    tmp_path: Path,
+) -> None:
+    from clio_relay import bootstrap
+
+    wheel = tmp_path / f"clio_relay-{__version__}-py3-none-any.whl"
+    _write_test_relay_wheel(wheel)
+
+    observed = bootstrap._validate_relay_bootstrap_wheel(  # pyright: ignore[reportPrivateUsage]
+        wheel
+    )
+
+    assert observed == hashlib.sha256(wheel.read_bytes()).hexdigest()
+
+
+def test_bootstrap_over_ssh_rejects_non_regular_relay_wheel_before_ssh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wheel = tmp_path / f"clio_relay-{__version__}-py3-none-any.whl"
+    wheel.mkdir()
+    _assert_bootstrap_rejected_before_remote_call(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        wheel=wheel,
+        expected_error="must be one regular file",
+    )
+
+
 def test_local_frp_install_publishes_only_a_verified_staged_pair(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -652,8 +808,8 @@ def test_bootstrap_archive_uses_packaged_assets_without_git_checkout(tmp_path: P
 
 
 def test_bootstrap_archive_can_include_local_relay_wheel(tmp_path: Path) -> None:
-    wheel = tmp_path / "clio_relay-0.0.0-py3-none-any.whl"
-    wheel.write_bytes(b"wheel")
+    wheel = tmp_path / f"clio_relay-{__version__}-py3-none-any.whl"
+    _write_test_relay_wheel(wheel)
 
     deployment = create_bootstrap_archive(
         source_root=tmp_path / "not-a-repo",

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1696,7 +1696,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "d8a172c1aecebfd0a572652d533f297e83e71ac9fbff7b9e5fa9dac0b2e18985"
+        "ef2d2bcb190035e98297784d20b4c7668e5fa796bb17ebdd01d2d1c6cecae9f0"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.4"
+    assert version == "1.3.5"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1940,7 +1940,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.3.4"
+    assert policy.release_version == "1.3.5"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,13 +186,14 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.4"
+version = "1.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "filelock" },
     { name = "httpx" },
     { name = "jsonschema" },
+    { name = "packaging" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "typer" },
@@ -217,6 +218,7 @@ requires-dist = [
     { name = "filelock", specifier = ">=3.15" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "jsonschema", specifier = ">=4.23" },
+    { name = "packaging", specifier = ">=24.2" },
     { name = "pydantic", specifier = ">=2.8" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "typer", specifier = ">=0.12" },


### PR DESCRIPTION
## Summary
- reject missing, non-regular, malformed, foreign, or metadata-mismatched relay wheels before the first remote bootstrap command
- verify a caller-supplied wheel digest locally before worker fencing or upload
- add packaging as the explicit wheel-identity parser dependency
- prepare clio-relay 1.3.5 release metadata

## Focused verification
- 11 targeted bootstrap and release-identity tests passed
- ruff check and format passed
- pyright passed for bootstrap implementation and focused tests