### PR TITLE
fix: preserve relay service availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.5` uses a release-first patch process. A maintainer builds the
+> Version `1.3.6` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.5"
+$Version = "1.3.6"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.5"
+release_version: "1.3.6"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: ef2d2bcb190035e98297784d20b4c7668e5fa796bb17ebdd01d2d1c6cecae9f0
+acceptance_matrix_sha256: 12d14c14566e0ea50883115fc457f1b4933f96cf93edb43fa0b738f937803637
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.5"
+$Tag = "v1.3.6"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.5" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.6" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.5",
-  "matrix_sha256": "ef2d2bcb190035e98297784d20b4c7668e5fa796bb17ebdd01d2d1c6cecae9f0",
+  "release_version": "1.3.6",
+  "matrix_sha256": "12d14c14566e0ea50883115fc457f1b4933f96cf93edb43fa0b738f937803637",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.5"
+version = "1.3.6"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.5"
+__version__ = "1.3.6"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -884,6 +884,26 @@ def _worker_upgrade_fence_script(
     fence = "\n".join(
         [
             declarations,
+            "bootstrap_bounded_worker_restart() {",
+            "  WORKER_RESTART_ATTEMPTED=1",
+            (
+                "  if ! timeout --signal=TERM --kill-after=5s 30s systemctl --user start "
+                '"$WORKER_SERVICE_NAME"; then'
+            ),
+            "    return 1",
+            "  fi",
+            (
+                '  if ! WORKER_POST_START_STATE="$(timeout --signal=TERM --kill-after=2s 5s '
+                'systemctl --user show "$WORKER_SERVICE_NAME" '
+                '--property=ActiveState --value)"; then'
+            ),
+            "    return 1",
+            "  fi",
+            '  if [ "$WORKER_POST_START_STATE" != "active" ]; then',
+            "    return 1",
+            "  fi",
+            "  WORKER_RESTARTED=1",
+            "}",
             "bootstrap_worker_fence_exit() {",
             "  status=$?",
             "  trap - EXIT",
@@ -894,37 +914,46 @@ def _worker_upgrade_fence_script(
                 '  if [ "$status" -ne 0 ] && [ "$WORKER_WAS_ACTIVE" = "1" ]'
                 ' && [ "$WORKER_RESTARTED" != "1" ]; then'
             ),
-            '    if [ "$WORKER_RESTART_ATTEMPTED" = "1" ]; then',
+            '    if [ "$WORKER_STOP_CONFIRMED" = "1" ]; then',
             (
-                '      if WORKER_EXIT_STATE="$(systemctl --user show '
-                '"$WORKER_SERVICE_NAME" --property=ActiveState --value 2>/dev/null)"; then'
+                '      echo "bootstrap failed; attempting bounded recovery of '
+                '$WORKER_SERVICE_NAME" >&2'
             ),
-            '        case "$WORKER_EXIT_STATE" in',
-            "          inactive|failed)",
+            "      if bootstrap_bounded_worker_restart; then",
             (
-                '            echo "bootstrap failed; $WORKER_SERVICE_NAME is confirmed '
-                '$WORKER_EXIT_STATE after restart attempt; operator action is required" >&2'
+                '        echo "bootstrap worker_recovery=restored '
+                'service=$WORKER_SERVICE_NAME state=active" >&2'
             ),
-            "            ;;",
-            "          *)",
-            (
-                '            echo "bootstrap failed after restart attempt; '
-                "$WORKER_SERVICE_NAME state is $WORKER_EXIT_STATE and requires "
-                'operator verification" >&2'
-            ),
-            "            ;;",
-            "        esac",
             "      else",
             (
-                '        echo "bootstrap failed after restart attempt; '
-                '$WORKER_SERVICE_NAME state is unknown and requires operator verification" >&2'
+                '        if WORKER_EXIT_STATE="$(timeout --signal=TERM --kill-after=2s 5s '
+                'systemctl --user show "$WORKER_SERVICE_NAME" '
+                '--property=ActiveState --value 2>/dev/null)"; then'
             ),
-            "      fi",
-            '    elif [ "$WORKER_STOP_CONFIRMED" = "1" ]; then',
+            '          case "$WORKER_EXIT_STATE" in',
+            "            inactive|failed)",
             (
-                '      echo "bootstrap failed; $WORKER_SERVICE_NAME remains stopped; '
+                '              echo "bootstrap worker_recovery=failed '
+                "service=$WORKER_SERVICE_NAME state=$WORKER_EXIT_STATE; "
                 'operator action is required" >&2'
             ),
+            "              ;;",
+            "            *)",
+            (
+                '              echo "bootstrap worker_recovery=unverified '
+                "service=$WORKER_SERVICE_NAME state=$WORKER_EXIT_STATE; "
+                'operator verification is required" >&2'
+            ),
+            "              ;;",
+            "          esac",
+            "        else",
+            (
+                '          echo "bootstrap worker_recovery=unverified '
+                "service=$WORKER_SERVICE_NAME state=unknown; "
+                'operator verification is required" >&2'
+            ),
+            "        fi",
+            "      fi",
             "    else",
             (
                 '      echo "bootstrap failed while fencing $WORKER_SERVICE_NAME; '
@@ -937,6 +966,10 @@ def _worker_upgrade_fence_script(
             "trap bootstrap_worker_fence_exit EXIT",
             "command -v systemctl >/dev/null 2>&1 || {",
             '  echo "systemctl is required to fence the configured relay worker" >&2',
+            "  exit 1",
+            "}",
+            "command -v timeout >/dev/null 2>&1 || {",
+            '  echo "timeout is required to bound relay worker recovery" >&2',
             "  exit 1",
             "}",
             (
@@ -1003,23 +1036,13 @@ def _worker_upgrade_fence_script(
         [
             'if [ "$WORKER_WAS_ACTIVE" = "1" ]; then',
             "  bootstrap_require_worker_lifetime_guard",
-            "  WORKER_RESTART_ATTEMPTED=1",
-            '  systemctl --user start "$WORKER_SERVICE_NAME"',
-            (
-                '  if ! WORKER_POST_START_STATE="$(systemctl --user show '
-                '"$WORKER_SERVICE_NAME" --property=ActiveState --value)"; then'
-            ),
-            '    echo "cannot verify restarted relay worker: $WORKER_SERVICE_NAME" >&2',
-            "    exit 1",
-            "  fi",
-            '  if [ "$WORKER_POST_START_STATE" != "active" ]; then',
+            "  if ! bootstrap_bounded_worker_restart; then",
             (
                 '    echo "relay worker did not become active '
-                '($WORKER_POST_START_STATE): $WORKER_SERVICE_NAME" >&2'
+                '(${WORKER_POST_START_STATE:-unknown}): $WORKER_SERVICE_NAME" >&2'
             ),
             "    exit 1",
             "  fi",
-            "  WORKER_RESTARTED=1",
             "fi",
         ]
     )

--- a/src/clio_relay/session_lifecycle.py
+++ b/src/clio_relay/session_lifecycle.py
@@ -34,6 +34,7 @@ SESSION_SCHEDULER_RETAINED_CHECK_ID = "cleanup.jobs-preserved-default"
 SESSION_RELAY_CANCELED_CHECK_ID = "cleanup.relay-jobs-canceled"
 SESSION_SCHEDULER_CANCELED_CHECK_ID = "cleanup.explicit-job-cancel"
 _REMOTE_SESSION_COMMAND_TIMEOUT_SECONDS = 120.0
+_REMOTE_API_READINESS_TIMEOUT_SECONDS = 60.0
 
 
 @dataclass(frozen=True)
@@ -1121,11 +1122,19 @@ api_pid = int(sys.argv[1])
 port = int(sys.argv[2])
 url = f"http://127.0.0.1:{{port}}/healthz"
 last_error = "API did not become ready"
-for _ in range(100):
+readiness_timeout_seconds = {_REMOTE_API_READINESS_TIMEOUT_SECONDS!r}
+readiness_started = time.monotonic()
+readiness_deadline = readiness_started + readiness_timeout_seconds
+attempts = 0
+while time.monotonic() < readiness_deadline:
+    attempts += 1
     try:
         os.kill(api_pid, 0)
     except OSError as exc:
-        raise RuntimeError("owned API process exited before readiness") from exc
+        elapsed = time.monotonic() - readiness_started
+        raise RuntimeError(
+            f"owned API process exited before readiness after {{elapsed:.3f}} seconds"
+        ) from exc
     try:
         with urllib.request.urlopen(url, timeout=0.25) as response:
             payload = json.load(response)
@@ -1136,7 +1145,12 @@ for _ in range(100):
         last_error = str(exc)
     time.sleep(0.1)
 else:
-    raise RuntimeError(f"owned API did not become ready: {{last_error}}")
+    elapsed = time.monotonic() - readiness_started
+    raise RuntimeError(
+        "owned API did not become ready within "
+        f"{{readiness_timeout_seconds:.1f}} seconds after {{attempts}} attempts: {{last_error}}"
+    )
+print(f"remote_api_ready_seconds={{time.monotonic() - readiness_started:.3f}}")
 __CLIO_RELAY_API_READY__
 clio-relay session resume-intake \
   --session-id "$session_id" \

--- a/tests/test_bootstrap_cluster_paths.py
+++ b/tests/test_bootstrap_cluster_paths.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import socket
 import subprocess
 import sys
@@ -64,15 +65,105 @@ def test_managed_bootstrap_fences_worker_around_migration() -> None:
     assert f"WORKER_SERVICE_NAME={service_name}" in script
     assert script.index(stop) < first_proof < script.index(install)
     assert script.index(install) < relay_replacement < second_proof
-    assert second_proof < script.index(migrate) < script.index(restart)
+    assert (
+        second_proof
+        < script.index(migrate)
+        < script.rindex("if ! bootstrap_bounded_worker_restart; then")
+    )
+    assert restart in script
     assert "WORKER_WRITER_PROOF=1" in script
     assert 'exec 9>"$HOME/.local/share/clio-relay/bootstrap.lock"' in script
     assert "if ! flock -n 9; then" in script
     assert 'exec 8<>"$WORKER_LIFETIME_LOCK_PATH"' in script
     assert "WORKER_LIFETIME_GUARD_FD=8" in script
     assert 'exec 9<>"$WORKER_LIFETIME_LOCK_PATH"' not in script
-    assert "remains stopped" in script
+    assert "bootstrap_bounded_worker_restart" in script
+    assert "worker_recovery=restored" in script
     assert "worker state is unknown and requires operator verification" in script
+
+
+@pytest.mark.parametrize("restart_succeeds", [True, False])
+def test_failed_managed_bootstrap_restores_previously_active_worker(
+    restart_succeeds: bool,
+) -> None:
+    """A sabotaged post-stop step preserves its error and boundedly restores the worker."""
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.fail("bash is required to validate the Linux bootstrap recovery trap")
+    worker_fence, _recheck, _init, _restart = bootstrap._worker_upgrade_fence_script(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        "ares",
+        rendered_core_dir='"$test_root/core"',
+    )
+    restart_result = (
+        'echo active > "$BOOTSTRAP_TEST_STATE"\nexit 0' if restart_succeeds else "exit 1"
+    )
+    harness = f"""set -euo pipefail
+test_root="$(mktemp -d)"
+mkdir -p "$test_root/bin"
+export BOOTSTRAP_TEST_STATE="$test_root/worker-state"
+export BOOTSTRAP_TEST_STARTED="$test_root/start-attempted"
+echo active > "$BOOTSTRAP_TEST_STATE"
+cat > "$test_root/bin/python3" <<'__FAKE_PYTHON__'
+#!/usr/bin/env bash
+cat >/dev/null
+__FAKE_PYTHON__
+cat > "$test_root/bin/systemctl" <<'__FAKE_SYSTEMCTL__'
+#!/usr/bin/env bash
+set -u
+case "${{2:-}}" in
+  show)
+    case " $* " in
+      *" --property=LoadState "*) echo loaded ;;
+      *" --property=ActiveState "*)
+        state="$(cat "$BOOTSTRAP_TEST_STATE")"
+        echo "$state"
+        if [ -f "$BOOTSTRAP_TEST_STARTED" ]; then
+          rm -rf -- "$(dirname "$BOOTSTRAP_TEST_STATE")"
+        fi
+        ;;
+      *) exit 2 ;;
+    esac
+    ;;
+  stop)
+    echo "fake-systemctl=stop" >&2
+    echo inactive > "$BOOTSTRAP_TEST_STATE"
+    ;;
+  start)
+    echo "fake-systemctl=start" >&2
+    : > "$BOOTSTRAP_TEST_STARTED"
+    {restart_result}
+    ;;
+  *) exit 2 ;;
+esac
+__FAKE_SYSTEMCTL__
+chmod +x "$test_root/bin/python3" "$test_root/bin/systemctl"
+export PATH="$test_root/bin:$PATH"
+{worker_fence}
+echo "remote-bootstrap-step=sabotaged" >&2
+exit 37
+"""
+
+    result = subprocess.run(
+        [bash, "-s"],
+        input=harness.encode("utf-8"),
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 37
+    assert "remote-bootstrap-step=sabotaged" in stderr
+    assert stderr.count("fake-systemctl=stop") == 1
+    assert "fake-systemctl=start" in stderr
+    if restart_succeeds:
+        assert stderr.count("fake-systemctl=start") == 1
+        assert "worker_recovery=restored" in stderr
+        assert "worker_recovery=failed" not in stderr
+    else:
+        assert stderr.count("fake-systemctl=start") == 1
+        assert "worker_recovery=failed" in stderr
+        assert "state=inactive" in stderr
 
 
 def test_standalone_bootstrap_cannot_mutate_legacy_output() -> None:

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1696,7 +1696,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "ef2d2bcb190035e98297784d20b4c7668e5fa796bb17ebdd01d2d1c6cecae9f0"
+        "12d14c14566e0ea50883115fc457f1b4933f96cf93edb43fa0b738f937803637"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.5"
+    assert version == "1.3.6"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -269,6 +269,10 @@ def test_start_remote_session_writes_owned_pid_and_metadata(monkeypatch: MonkeyP
     assert 'kill -0 -- "-$api_pid"' in script
     assert "os.replace(temporary, path)" in script
     assert 'url = f"http://127.0.0.1:{port}/healthz"' in script
+    assert "readiness_timeout_seconds = 60.0" in script
+    assert "while time.monotonic() < readiness_deadline" in script
+    assert "remote_api_ready_seconds=" in script
+    assert "for _ in range(100)" not in script
     assert "owned API did not become ready" in script
     assert "\x00" not in script
     assert "pkill" not in script

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1940,7 +1940,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.3.5"
+    assert policy.release_version == "1.3.6"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.5"
+version = "1.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- restore a previously-active endpoint worker when a managed bootstrap fails after fencing it
- bound and verify worker restart attempts while preserving the original bootstrap exit code
- wait up to 60 seconds for owned remote API readiness and report measured startup time
- bump the release identity to 1.3.6

## Live defects reproduced

A failed 1.3.5 bootstrap intentionally stopped the Ares worker and left it inactive because systemd correctly does not restart an explicitly stopped unit. Separately, an otherwise healthy Ares API needed 12.2 seconds to start, exceeding the former hard-coded 10-second loop.

## Focused validation

- 4 causal tests passed (worker fence/recovery success and failure; remote session rendering)
- 3 release identity and acceptance-matrix checks passed
- Ruff formatting/checks clean
- Pyright clean