### PR TITLE
fix: keep persistent endpoints available

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -29,7 +29,9 @@ and fails before writing the unit otherwise. If site policy intentionally
 forbids lingering, `--allow-login-scoped` installs a diagnostic, login-scoped
 worker. It may stop after the last login and is not eligible for live release
 claims. Desktop detach and default teardown never stop either service; only an
-explicit `session teardown --stop-worker` does.
+explicit `session teardown --stop-worker` does. The persistent unit restarts
+after both clean and failed worker-process exits; an explicit systemd stop is
+still respected and remains stopped until an operator starts it again.
 
 ### Upgrade durable queue indexes
 

--- a/src/clio_relay/deployment.py
+++ b/src/clio_relay/deployment.py
@@ -146,7 +146,9 @@ Environment="{INSTALL_RECEIPT_PATH_ENV}=%h/.local/share/clio-relay/install-recei
 {jarvis_mcp_spack_unset_line}
 ExecStartPre={exec_start_pre}
 ExecStart={exec_start}
-Restart=on-failure
+# Keep an enabled persistent endpoint available after clean or failed process
+# exits. Explicit systemd stop operations are not restarted by this policy.
+Restart=always
 RestartSec=5
 
 [Install]

--- a/src/clio_relay/doctor.py
+++ b/src/clio_relay/doctor.py
@@ -8,6 +8,7 @@ import subprocess
 
 from clio_relay.cluster_config import ClusterDefinition
 from clio_relay.config import RelaySettings
+from clio_relay.deployment import endpoint_user_service_name
 from clio_relay.errors import ConfigurationError, RelayError
 from clio_relay.remote_values import render_remote_shell_value
 
@@ -43,6 +44,23 @@ def run_doctor(
 
 def run_cluster_doctor(definition: ClusterDefinition) -> list[str]:
     """Run live cluster-side checks over SSH and return status lines."""
+    script = _cluster_doctor_script(definition)
+    result = subprocess.run(
+        ["ssh", definition.ssh_host, "bash", "-s"],
+        input=script.encode("utf-8"),
+        capture_output=True,
+        check=False,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+    if result.returncode != 0:
+        detail = stderr.strip() or stdout.strip()
+        raise RelayError(f"cluster doctor failed for {definition.name}: {detail}")
+    return stdout.splitlines()
+
+
+def _cluster_doctor_script(definition: ClusterDefinition) -> str:
+    """Render the bounded remote checks used by the cluster doctor."""
     jarvis_bin = render_remote_shell_value(
         definition.jarvis_bin or "$HOME/.local/bin/jarvis",
         field="jarvis_bin",
@@ -53,10 +71,22 @@ def run_cluster_doctor(definition: ClusterDefinition) -> list[str]:
     )
     agent_bin = render_remote_shell_value(definition.agent_bin or "", field="agent_bin")
     agent_npm_bin = shlex.quote(definition.agent_npm_bin or "")
-    script = f"""set -euo pipefail
+    endpoint_service = shlex.quote(endpoint_user_service_name(definition.name))
+    return f"""set -euo pipefail
 export PATH="$HOME/.local/bin:$PATH"
 echo "cluster: {definition.name}"
 echo "ssh_host: {definition.ssh_host}"
+ENDPOINT_SERVICE={endpoint_service}
+ENDPOINT_SERVICE_ENABLED="$(systemctl --user is-enabled "$ENDPOINT_SERVICE" 2>/dev/null || true)"
+ENDPOINT_SERVICE_ACTIVE="$(systemctl --user is-active "$ENDPOINT_SERVICE" 2>/dev/null || true)"
+echo "endpoint_service.name=$ENDPOINT_SERVICE"
+echo "endpoint_service.enabled=${{ENDPOINT_SERVICE_ENABLED:-unknown}}"
+echo "endpoint_service.active=${{ENDPOINT_SERVICE_ACTIVE:-unknown}}"
+if [ "$ENDPOINT_SERVICE_ENABLED" = enabled ] && [ "$ENDPOINT_SERVICE_ACTIVE" != active ]; then
+  echo "endpoint service is enabled but not active: $ENDPOINT_SERVICE" \
+    "(${{ENDPOINT_SERVICE_ACTIVE:-unknown}})" >&2
+  exit 1
+fi
 FRPC_BIN={frpc_bin}
 JARVIS_BIN={jarvis_bin}
 AGENT_BIN="${{CLIO_RELAY_AGENT_BIN:-}}"
@@ -80,15 +110,3 @@ if [ -n "$AGENT_BIN" ]; then
 fi
 echo "clio_relay=$(clio-relay --help | head -n 1)"
 """
-    result = subprocess.run(
-        ["ssh", definition.ssh_host, "bash", "-s"],
-        input=script.encode("utf-8"),
-        capture_output=True,
-        check=False,
-    )
-    stdout = result.stdout.decode("utf-8", errors="replace")
-    stderr = result.stderr.decode("utf-8", errors="replace")
-    if result.returncode != 0:
-        detail = stderr.strip() or stdout.strip()
-        raise RelayError(f"cluster doctor failed for {definition.name}: {detail}")
-    return stdout.splitlines()

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1696,7 +1696,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "1b5e5b4ab864ad37920bde06d4435d9eb007f88301f6b34f875dea4c7d89aec4"
+        "df51eda2a95ef562950dedf946f6596373a4f9badb6c7c81292d7c22ca2a5b60"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1178,7 +1178,10 @@ def test_cli_tests_http_transport_and_writes_canonical_report(
     def fake_worker_identity(
         report: LiveValidationReport,
         definition: ClusterDefinition,
+        *,
+        observed_worker_info: dict[str, object] | None = None,
     ) -> None:
+        assert observed_worker_info is None
         assert definition.name == "ares"
         recorder = ValidationRecorder(report)
         with recorder.check("worker.artifact-version", "verified remote worker") as evidence:
@@ -1338,7 +1341,10 @@ def test_cli_transport_worker_identity_failure_fails_canonical_report(
     def fail_worker_identity(
         _report: LiveValidationReport,
         _definition: ClusterDefinition,
+        *,
+        observed_worker_info: dict[str, object] | None = None,
     ) -> None:
+        assert observed_worker_info is None
         raise ConfigurationError("remote wheel hash does not match")
 
     monkeypatch.setattr(cli, "run_frp_http_probe", fake_probe)
@@ -2234,10 +2240,18 @@ def test_cli_remote_teardown_writes_closure_only_in_remote_authoritative_core(
     def skip_worker_verification(
         _report: LiveValidationReport,
         _definition: ClusterDefinition,
+        *,
+        observed_worker_info: dict[str, object] | None = None,
     ) -> None:
+        del observed_worker_info
         return
 
     monkeypatch.setattr(cli, "_attach_verified_remote_worker", skip_worker_verification)
+    monkeypatch.setattr(
+        cli,
+        "_observe_worker_before_cleanup",
+        lambda _definition: (None, None),
+    )
 
     result = CliRunner().invoke(
         app,

--- a/tests/test_doctor_and_relay_host.py
+++ b/tests/test_doctor_and_relay_host.py
@@ -8,13 +8,14 @@ from typing import cast
 import pytest
 
 import clio_relay.deployment as deployment
+import clio_relay.doctor as doctor
 from clio_relay.cluster_config import ClusterDefinition
 from clio_relay.config import RelaySettings
 from clio_relay.deployment import (
     install_endpoint_user_service_over_ssh,
     render_endpoint_user_service,
 )
-from clio_relay.doctor import run_doctor
+from clio_relay.doctor import run_cluster_doctor, run_doctor
 from clio_relay.errors import ConfigurationError, RelayError
 from clio_relay.relay_host import (
     FrpcConfig,
@@ -195,7 +196,67 @@ def test_endpoint_user_service_is_sudo_less_and_configured() -> None:
     assert (
         'Environment="CLIO_RELAY_INSTALL_RECEIPT=%h/.local/share/clio-relay/install-receipt.json"'
     ) in rendered
+    assert "Restart=always" in rendered
+    assert "Restart=on-failure" not in rendered
+    assert "RestartSec=5" in rendered
     assert "sudo" not in rendered
+
+
+def test_cluster_doctor_rejects_enabled_but_inactive_endpoint_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Doctor reports the persistent-worker stall before unrelated tool checks."""
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.fail("bash is required to validate the cluster doctor service check")
+    rendered = doctor._cluster_doctor_script(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        ClusterDefinition(
+            name="test-cluster",
+            ssh_host="test-host",
+            jarvis_bin="jarvis-test",
+            frpc_bin="frpc-test",
+        )
+    )
+    harness = f"""set -u
+systemctl() {{
+  case "${{2:-}}" in
+    is-enabled) echo enabled ;;
+    is-active) echo inactive ;;
+  esac
+}}
+{rendered}
+"""
+    original_run = subprocess.run
+
+    def run(
+        command: list[str],
+        *,
+        input: bytes,
+        capture_output: bool,
+        check: bool,
+    ) -> subprocess.CompletedProcess[bytes]:
+        assert command == ["ssh", "test-host", "bash", "-s"]
+        assert capture_output is True
+        assert check is False
+        return original_run(
+            [bash, "-s"],
+            input=harness.encode("utf-8"),
+            capture_output=True,
+            check=False,
+            timeout=10,
+        )
+
+    monkeypatch.setattr(doctor.subprocess, "run", run)
+
+    with pytest.raises(RelayError, match="endpoint service is enabled but not active"):
+        run_cluster_doctor(
+            ClusterDefinition(
+                name="test-cluster",
+                ssh_host="test-host",
+                jarvis_bin="jarvis-test",
+                frpc_bin="frpc-test",
+            )
+        )
 
 
 def test_endpoint_user_service_uses_cluster_executable_overrides() -> None:

--- a/tests/test_service_runtime.py
+++ b/tests/test_service_runtime.py
@@ -2051,7 +2051,10 @@ def test_gateway_start_runtime_cli_uses_service_runtime_spec(
     def fake_worker_identity(
         report: LiveValidationReport,
         definition: ClusterDefinition,
+        *,
+        observed_worker_info: dict[str, object] | None = None,
     ) -> None:
+        assert observed_worker_info is None
         assert definition.name == "test-cluster"
         recorder = ValidationRecorder(report)
         with recorder.check("worker.artifact-version", "verified remote worker") as evidence:
@@ -2289,7 +2292,10 @@ def test_owned_gateway_start_holds_transition_lock_through_runtime_start(
     def skip_worker_identity(
         _report: LiveValidationReport,
         _definition: ClusterDefinition,
+        *,
+        observed_worker_info: dict[str, object] | None = None,
     ) -> None:
+        assert observed_worker_info is None
         return
 
     monkeypatch.setattr(relay_cli, "_attach_verified_remote_worker", skip_worker_identity)
@@ -2577,7 +2583,10 @@ def test_gateway_detach_runtime_default_report_requires_verified_retention(
     def record_worker_verification(
         _report: LiveValidationReport,
         definition: ClusterDefinition,
+        *,
+        observed_worker_info: dict[str, object] | None = None,
     ) -> None:
+        assert observed_worker_info is None
         worker_verifications.append(definition.name)
 
     def return_detach_result(
@@ -2631,7 +2640,10 @@ def test_gateway_report_fails_when_remote_worker_identity_does_not_match(
     def fail_identity(
         _report: LiveValidationReport,
         _definition: ClusterDefinition,
+        *,
+        observed_worker_info: dict[str, object] | None = None,
     ) -> None:
+        assert observed_worker_info is None
         raise RelayError("remote installation receipt mismatch")
 
     monkeypatch.setattr(relay_cli, "_attach_verified_remote_worker", fail_identity)


### PR DESCRIPTION
## Summary

- render persistent endpoint services with Restart=always so clean or failed unexpected worker exits recover automatically
- preserve explicit systemd stop semantics and document the operator contract
- make cluster doctor fail clearly when an endpoint service is enabled but inactive
- repair stale v1.3.8 tag-CI assertions and test doubles exposed by the asynchronous full suite

## Incident

The Ares 10:30 endpoint stop happened during an older 1.3.5 bootstrap failure, not because the desktop detached. Bootstrap recovery was added in 1.3.6. This patch closes the remaining clean-exit resilience gap in the generated unit.

## Verification

- 10 directly affected tests passed
- Ruff check and format check passed
- Pyright passed for touched production modules
- git diff --check passed