### PR TITLE
fix: bind built-in JARVIS runtime to released artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,13 @@ jobs:
       - name: stage exact clio-kit release wheel
         shell: bash
         env:
-          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.5.1-py3-none-any.whl
-          CLIO_KIT_WHEEL_SHA256: e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1
-          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.5.1/clio_kit-2.5.1-py3-none-any.whl
+          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.5.3-py3-none-any.whl
+          CLIO_KIT_WHEEL_SHA256: 1c528be468f156b14ae40b72214360c6fe923765d75b244c4505d3689dad0c6b
+          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.5.3/clio_kit-2.5.3-py3-none-any.whl
         run: |
           set -euo pipefail
           umask 077
-          wheel_dir="$RUNNER_TEMP/clio-kit-v2.5.1"
+          wheel_dir="$RUNNER_TEMP/clio-kit-v2.5.3"
           mkdir "$wheel_dir"
           wheel="$wheel_dir/$CLIO_KIT_WHEEL_FILENAME"
           curl --fail --show-error --silent --location \
@@ -160,13 +160,13 @@ jobs:
       - name: stage exact clio-kit release wheel
         shell: bash
         env:
-          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.5.1-py3-none-any.whl
-          CLIO_KIT_WHEEL_SHA256: e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1
-          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.5.1/clio_kit-2.5.1-py3-none-any.whl
+          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.5.3-py3-none-any.whl
+          CLIO_KIT_WHEEL_SHA256: 1c528be468f156b14ae40b72214360c6fe923765d75b244c4505d3689dad0c6b
+          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.5.3/clio_kit-2.5.3-py3-none-any.whl
         run: |
           set -euo pipefail
           umask 077
-          wheel_dir="$RUNNER_TEMP/clio-kit-v2.5.1"
+          wheel_dir="$RUNNER_TEMP/clio-kit-v2.5.3"
           mkdir "$wheel_dir"
           wheel="$wheel_dir/$CLIO_KIT_WHEEL_FILENAME"
           curl --fail --show-error --silent --location \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.9` uses a release-first patch process. A maintainer builds the
+> Version `1.3.10` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -258,7 +258,7 @@ For the legacy clio-kit 2.2.6 compatibility path, a successful synchronous
 `jarvis_run` MCP return is normalized to a terminal `completed` record even
 though that release labels the result `status=running`; the original status and
 completion basis remain in `details.completion_normalization` for auditability.
-The pinned clio-kit 2.5.1 production path removes that ambiguity upstream and
+The pinned clio-kit 2.5.3 production path removes that ambiguity upstream and
 returns a structured completed result directly. The legacy normalization is
 diagnostic compatibility evidence and cannot satisfy the 1.0 gate. Scheduler
 submissions remain non-terminal unless JARVIS was asked to wait.
@@ -493,7 +493,7 @@ Install the cluster-side server once, then launch its persistent executable:
 
 ```bash
 uv tool install --python 3.12 --no-config \
-  https://github.com/iowarp/clio-kit/releases/download/v2.5.1/clio_kit-2.5.1-py3-none-any.whl
+  https://github.com/iowarp/clio-kit/releases/download/v2.5.3/clio_kit-2.5.3-py3-none-any.whl
 clio-kit mcp-server jarvis
 ```
 

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.9"
+$Version = "1.3.10"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.9"
+release_version: "1.3.10"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: a0cd720daeafdbd3841805054d36ff649b55194c301c0db72013fd5584580299
+acceptance_matrix_sha256: a64b851d9e72b44e0b2dbb103ba6d72a2ca72c71703a803e618bfec493a87d9c
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true
@@ -110,16 +110,16 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.5.1"
+            clio-kit: "2.5.3"
             jarvis-cd: "1.3.11"
             jarvis-util: c91bfdc9bba802e4b03bfb1babe614ffa3e09644
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.5.1"
-              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.1/clio_kit-2.5.1-py3-none-any.whl
+              distribution_version: "2.5.3"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.3/clio_kit-2.5.3-py3-none-any.whl
               requested_source: github_release
-              artifact_sha256: e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1
+              artifact_sha256: 1c528be468f156b14ae40b72214360c6fe923765d75b244c4505d3689dad0c6b
               native_execution:
                 schema_version: clio-relay.jarvis-native-execution-capability.v1
                 handle_schema: jarvis.execution.handle.v1
@@ -220,14 +220,14 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.5.1"
+            clio-kit: "2.5.3"
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.5.1"
-              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.1/clio_kit-2.5.1-py3-none-any.whl
+              distribution_version: "2.5.3"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.3/clio_kit-2.5.3-py3-none-any.whl
               requested_source: github_release
-              artifact_sha256: e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1
+              artifact_sha256: 1c528be468f156b14ae40b72214360c6fe923765d75b244c4505d3689dad0c6b
       - kind: scheduler_job
         roles: [queue-preservation-fixture]
         states: [completed]
@@ -288,24 +288,24 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.5.1"
+            clio-kit: "2.5.3"
             jarvis-cd: "1.3.11"
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.5.1"
-              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.1/clio_kit-2.5.1-py3-none-any.whl
+              distribution_version: "2.5.3"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.3/clio_kit-2.5.3-py3-none-any.whl
               requested_source: github_release
-              artifact_filename: clio_kit-2.5.1-py3-none-any.whl
-              artifact_sha256: e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1
+              artifact_filename: clio_kit-2.5.3-py3-none-any.whl
+              artifact_sha256: 1c528be468f156b14ae40b72214360c6fe923765d75b244c4505d3689dad0c6b
               persistent_tool:
                 manager: uv
                 uv_version: "0.11.28"
                 pyvenv_uv_version: "0.11.28"
                 distribution: clio-kit
-                distribution_version: "2.5.1"
+                distribution_version: "2.5.3"
                 entry_point: clio-kit
-                source_artifact_sha256: e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1
+                source_artifact_sha256: 1c528be468f156b14ae40b72214360c6fe923765d75b244c4505d3689dad0c6b
               native_execution:
                 schema_version: clio-relay.jarvis-native-execution-capability.v1
                 handle_schema: jarvis.execution.handle.v1
@@ -345,6 +345,7 @@ requirements:
               source_identity_verified: true
               uv_tool_environment_verified: true
               record_closure_verified: true
+              locked_server_runtime_verified: true
               native_execution_capability_verified: true
             jarvis-cd:
               verified: true
@@ -363,16 +364,40 @@ requirements:
         states: [verified]
         metadata_equals:
           install_source: uv-tool
-          install_artifact_sha256: e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1
+          install_artifact_sha256: 1c528be468f156b14ae40b72214360c6fe923765d75b244c4505d3689dad0c6b
           python_distribution_runtime:
             distribution: clio-kit
-            distribution_version: "2.5.1"
+            distribution_version: "2.5.3"
             entry_point: clio-kit
             runtime_closure_verified: true
           nested_runtime:
             server_name: jarvis
             persistent_tool: true
             locked_runtime_verified: true
+            jarvis_cd_lock_binding:
+              schema_version: clio-relay.jarvis-cd-lock-binding.v1
+              dependency: jarvis-cd
+              error: null
+              expected_version: "1.3.11"
+              expected_url: https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.11/jarvis_cd-1.3.11-py3-none-any.whl
+              expected_sha256: ebd6ca162bd15f25d80c2ea4e0f5928b0b1575cd811b146f7cd6ef5a61045474
+              jarvis_mcp_package_entry_count: 1
+              resolved_dependency_entry_count: 1
+              observed_resolved_dependency_entries:
+                - name: jarvis-cd
+              metadata_requirement_entry_count: 1
+              observed_metadata_requirement_entries:
+                - name: jarvis-cd
+                  url: https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.11/jarvis_cd-1.3.11-py3-none-any.whl
+              observed_metadata_requirement_urls:
+                - https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.11/jarvis_cd-1.3.11-py3-none-any.whl
+              package_entry_count: 1
+              wheel_entry_count: 1
+              observed_version: "1.3.11"
+              observed_source_url: https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.11/jarvis_cd-1.3.11-py3-none-any.whl
+              observed_wheel_url: https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.11/jarvis_cd-1.3.11-py3-none-any.whl
+              observed_wheel_sha256: ebd6ca162bd15f25d80c2ea4e0f5928b0b1575cd811b146f7cd6ef5a61045474
+              verified: true
           server_process_artifact_verified: true
           verified: true
       - kind: jarvis_execution_progress
@@ -624,7 +649,7 @@ requirements:
         states: [verified]
         metadata_equals:
           install_source: wheel
-          install_artifact_sha256: e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1
+          install_artifact_sha256: 1c528be468f156b14ae40b72214360c6fe923765d75b244c4505d3689dad0c6b
           server_process_artifact_verified: true
           verified: true
 
@@ -723,7 +748,7 @@ requirements:
           remote_tool_names: [spack_find, spack_install, spack_locate]
           allowlisted_tool_names: [spack_find, spack_install, spack_locate]
           install_source: wheel
-          install_artifact_sha256: e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1
+          install_artifact_sha256: 1c528be468f156b14ae40b72214360c6fe923765d75b244c4505d3689dad0c6b
           contract_id: clio-kit-spack-user-v2
           contract_sha256: 3c5412148c770f4844e98eb893c4db0d0afdbf13afe967df67bd5f7d25e1f7db
           server_process_artifact_verified: true
@@ -828,7 +853,7 @@ requirements:
           remote_tool_names: [spack_find, spack_install, spack_locate]
           allowlisted_tool_names: [spack_find, spack_install, spack_locate]
           install_source: wheel
-          install_artifact_sha256: e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1
+          install_artifact_sha256: 1c528be468f156b14ae40b72214360c6fe923765d75b244c4505d3689dad0c6b
           contract_id: clio-kit-spack-user-v2
           contract_sha256: 3c5412148c770f4844e98eb893c4db0d0afdbf13afe967df67bd5f7d25e1f7db
           server_process_artifact_verified: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.9"
+$Tag = "v1.3.10"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.9" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.10" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/docs/remote-mcp-federation.md
+++ b/docs/remote-mcp-federation.md
@@ -264,7 +264,7 @@ Virtual JARVIS mutations and runs receive a fresh relay job by default. Supply
 an explicit `idempotency_key` only when retry de-duplication is intentional; an
 identical second `jarvis_run` is otherwise a new execution.
 
-The released clio-kit 2.5.1 artifact is the pinned six-tool JARVIS v3.2 contract.
+The released clio-kit 2.5.3 artifact is the pinned six-tool JARVIS v3.2 contract.
 Bootstrap
 downloads and hashes the exact coordinated wheel, installs it once with
 `uv tool install`, and persists the wheel plus the direct JARVIS command in the
@@ -274,14 +274,22 @@ ownership, and complete installed RECORD closure. At call time the worker uses
 that persistent executable directly. clio-kit's child launcher still uses its
 wheel-owned server source and lock with `uv run --frozen --no-editable`, so the
 live MCP response binds both the installed outer tool and the locked child
-server rather than trusting an unobserved nested resolution. The release gate
-requires that exact 2.5.1 artifact to be rerun on every target selected by the
-release policy. Other servers use the operator registry and generated
-`remote_...` aliases.
+server rather than trusting an unobserved nested resolution. For the built-in
+JARVIS route, bootstrap and every process launch additionally require the
+embedded lock's unique unconditional `jarvis-mcp` to `jarvis-cd` resolved
+dependency edge, exact unconditional direct-URL metadata requirement, unique
+`jarvis-cd` package record, source wheel URL, and wheel SHA-256 to match the
+relay's exact JARVIS-CD release pin. That dependency edge is recorded in the
+install receipt and call result. Operator-registered MCP servers remain bound
+by their own discovery artifact and are not constrained to the relay's
+JARVIS-CD version.
+The release gate requires that exact 2.5.3 artifact to be rerun on every target
+selected by the release policy. Other servers use the operator registry and
+generated `remote_...` aliases.
 
 The exact release wheel is
-`clio_kit-2.5.1-py3-none-any.whl` with SHA-256
-`e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1`.
+`clio_kit-2.5.3-py3-none-any.whl` with SHA-256
+`1c528be468f156b14ae40b72214360c6fe923765d75b244c4505d3689dad0c6b`.
 Its canonical contract is `clio-kit-jarvis-user-v3.2`, with contract SHA-256
 `12f6d349c9d44d8ce3594943dcd4018ec9b6e01ebb0e59d468bb1bb783a1ad5d`
 and canonical tools-wire SHA-256
@@ -300,7 +308,7 @@ operator-defined and do not select behavior.
 
 ## Register the scientific catalog MCP
 
-clio-kit 2.5.1 also ships the two-tool
+clio-kit 2.5.3 also ships the two-tool
 `clio-kit-scientific-catalog-user-v1` contract. It separates dataset discovery
 from visualization control: `scientific_dataset_search` finds operator catalog
 records and `scientific_dataset_describe` returns one exact

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.9",
-  "matrix_sha256": "a0cd720daeafdbd3841805054d36ff649b55194c301c0db72013fd5584580299",
+  "release_version": "1.3.10",
+  "matrix_sha256": "a64b851d9e72b44e0b2dbb103ba6d72a2ca72c71703a803e618bfec493a87d9c",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/jarvis-packages/clio_relay/clio_relay/mcp_call/runner.py
+++ b/jarvis-packages/clio_relay/clio_relay/mcp_call/runner.py
@@ -18,6 +18,7 @@ import sys
 import tempfile
 import threading
 import time
+import tomllib
 import zipfile
 from collections.abc import Callable, Generator, Iterator
 from contextlib import contextmanager
@@ -142,6 +143,7 @@ _JARVIS_REACHABLE_STATES: dict[str, frozenset[str]] = {
 FILE_HASH_CHUNK_BYTES = 1024 * 1024
 CLIO_KIT_WHEEL_MAX_FILES = 10_000
 CLIO_KIT_WHEEL_MAX_LAUNCHER_BYTES = 1024 * 1024
+CLIO_KIT_LOCK_MAX_BYTES = 16 * 1024 * 1024
 CLIO_KIT_WHEEL_MAX_PROJECT_FILES = 20_000
 CLIO_KIT_WHEEL_MAX_PROJECT_BYTES = 512 * 1024 * 1024
 PYTHON_DISTRIBUTION_MAX_DISTRIBUTIONS = 10_000
@@ -154,6 +156,17 @@ _STREAM_READ_CHARS = 64 * 1024
 _TOOLS_LIST_PAGINATION_KEY = "_clioRelayPagination"
 _CLIO_KIT_LOCKED_SERVER_SCHEMA = "clio-kit.locked-server.v4"
 _CLIO_KIT_LOCKED_SERVER_RUNTIME_POLICY = "uv-run:materialized:frozen:no-editable:no-dev:v3"
+_JARVIS_CD_LOCK_BINDING_SCHEMA = "clio-relay.jarvis-cd-lock-binding.v1"
+# These values intentionally mirror clio_relay.bootstrap. A focused release test
+# prevents either copy from moving independently. The JARVIS package also runs as
+# a standalone repository package, where importing the installed relay bootstrap
+# module is not a valid dependency boundary.
+JARVIS_CD_VERSION = "1.3.11"
+JARVIS_CD_WHEEL_URL = (
+    "https://github.com/grc-iit/jarvis-cd/releases/download/"
+    f"v{JARVIS_CD_VERSION}/jarvis_cd-{JARVIS_CD_VERSION}-py3-none-any.whl"
+)
+JARVIS_CD_WHEEL_SHA256 = "ebd6ca162bd15f25d80c2ea4e0f5928b0b1575cd811b146f7cd6ef5a61045474"
 _CLIO_KIT_RUNTIME_PROJECT_EXCLUDED_NAMES = frozenset(
     {
         ".git",
@@ -851,6 +864,7 @@ def _is_locked_jarvis_execution_query(
     operation: str,
     tool: str | None,
     expected_server_artifact_digest: str | None,
+    expected_jarvis_cd_lock_binding: dict[str, str] | None,
     observed_server_artifact_digest: str | None,
     server_artifact: dict[str, Any] | None,
 ) -> bool:
@@ -858,6 +872,7 @@ def _is_locked_jarvis_execution_query(
     if (
         operation != "tools/call"
         or tool != "jarvis_get_execution"
+        or expected_jarvis_cd_lock_binding is None
         or expected_server_artifact_digest is None
         or observed_server_artifact_digest != expected_server_artifact_digest
         or server_artifact is None
@@ -1754,6 +1769,9 @@ def run_mcp_call_from_params(params: dict[str, Any]) -> int:
         params.get("expected_server_artifact_digest"),
         key="expected_server_artifact_digest",
     )
+    expected_jarvis_cd_lock_binding = _jarvis_cd_lock_expectation(
+        params.get("expected_jarvis_cd_lock_binding")
+    )
     operation = _operation(params.get("operation", "tools/call"))
     tool = _optional_str(params.get("tool"))
     arguments = _object(params.get("arguments", {}))
@@ -1773,8 +1791,21 @@ def run_mcp_call_from_params(params: dict[str, Any]) -> int:
     result_validation: dict[str, Any] | None = None
     try:
         command = [_resolve_executable(server), *server_args]
-        server_artifact = _server_artifact_identity(server, server_args)
+        server_artifact = (
+            _server_artifact_identity(
+                server,
+                server_args,
+                verify_relay_jarvis_cd_lock=True,
+            )
+            if expected_jarvis_cd_lock_binding is not None
+            else _server_artifact_identity(server, server_args)
+        )
         observed_server_artifact_digest = _server_artifact_digest(server_artifact)
+        if expected_jarvis_cd_lock_binding is not None:
+            _require_locked_jarvis_cd_binding(
+                server_artifact,
+                expected=expected_jarvis_cd_lock_binding,
+            )
         if expected_server_artifact_digest is not None:
             if server_artifact.get("verified") is not True:
                 raise ValueError("MCP server artifact is not verified before launch")
@@ -1787,6 +1818,7 @@ def run_mcp_call_from_params(params: dict[str, Any]) -> int:
             tool=tool,
             arguments=arguments,
             expected_server_artifact_digest=expected_server_artifact_digest,
+            expected_jarvis_cd_lock_binding=expected_jarvis_cd_lock_binding,
             observed_server_artifact_digest=observed_server_artifact_digest,
             server_artifact=server_artifact,
         )
@@ -1838,6 +1870,7 @@ def run_mcp_call_from_params(params: dict[str, Any]) -> int:
                     operation=operation,
                     tool=tool,
                     expected_server_artifact_digest=expected_server_artifact_digest,
+                    expected_jarvis_cd_lock_binding=expected_jarvis_cd_lock_binding,
                     observed_server_artifact_digest=observed_server_artifact_digest,
                     server_artifact=server_artifact,
                 ):
@@ -1876,6 +1909,7 @@ def run_mcp_call_from_params(params: dict[str, Any]) -> int:
         server_args=server_args,
         env_from=env_from,
         expected_server_artifact_digest=expected_server_artifact_digest,
+        expected_jarvis_cd_lock_binding=expected_jarvis_cd_lock_binding,
         server_artifact=server_artifact,
         observed_server_artifact_digest=observed_server_artifact_digest,
         execution_artifact=execution_artifact,
@@ -1902,6 +1936,7 @@ def _package_progress_bridge_from_invocation(
     tool: str | None,
     arguments: dict[str, Any],
     expected_server_artifact_digest: str | None,
+    expected_jarvis_cd_lock_binding: dict[str, str] | None,
     observed_server_artifact_digest: str,
     server_artifact: dict[str, Any],
 ) -> _McpProgressBridge | None:
@@ -1920,6 +1955,7 @@ def _package_progress_bridge_from_invocation(
     )
     if (
         expected_server_artifact_digest is None
+        or expected_jarvis_cd_lock_binding is None
         or observed_server_artifact_digest != expected_server_artifact_digest
         or server_artifact.get("verified") is not True
         or nested_runtime is None
@@ -2101,6 +2137,7 @@ def _write_mcp_result(
     server_args: list[str],
     env_from: dict[str, str],
     expected_server_artifact_digest: str | None,
+    expected_jarvis_cd_lock_binding: dict[str, str] | None,
     server_artifact: dict[str, Any] | None,
     observed_server_artifact_digest: str | None,
     execution_artifact: dict[str, Any] | None,
@@ -2132,38 +2169,49 @@ def _write_mcp_result(
         initialize_result.get("serverInfo", {}) if initialize_result is not None else {}
     )
     if server_artifact is None:
-        server_artifact = _server_artifact_identity(server, server_args)
+        server_artifact = (
+            _server_artifact_identity(
+                server,
+                server_args,
+                verify_relay_jarvis_cd_lock=True,
+            )
+            if expected_jarvis_cd_lock_binding is not None
+            else _server_artifact_identity(server, server_args)
+        )
     if observed_server_artifact_digest is None:
         observed_server_artifact_digest = _server_artifact_digest(server_artifact)
+    result_document: dict[str, Any] = {
+        "server": server,
+        "server_args": server_args,
+        "env_from": env_from,
+        "operation": operation,
+        "tool": tool,
+        "arguments": arguments,
+        "protocol_result": protocol_result,
+        "structured_result": _structured_result(protocol_result, operation=operation),
+        "protocol_version": protocol_version,
+        "server_info": server_info,
+        "server_artifact": server_artifact,
+        "server_execution_artifact": execution_artifact,
+        "expected_server_artifact_digest": expected_server_artifact_digest,
+        "observed_server_artifact_digest": observed_server_artifact_digest,
+        "pagination": pagination,
+        "returncode": returncode,
+        "stdout": stdout,
+        "stderr": stderr,
+        "timed_out": timed_out,
+        "protocol_error": protocol_error,
+        "package_progress_bridge": progress_bridge,
+        "result_validation": result_validation,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "duration_seconds": finished_at - started_at,
+    }
+    if expected_jarvis_cd_lock_binding is not None:
+        result_document["expected_jarvis_cd_lock_binding"] = expected_jarvis_cd_lock_binding
     result_path.write_text(
         json.dumps(
-            {
-                "server": server,
-                "server_args": server_args,
-                "env_from": env_from,
-                "operation": operation,
-                "tool": tool,
-                "arguments": arguments,
-                "protocol_result": protocol_result,
-                "structured_result": _structured_result(protocol_result, operation=operation),
-                "protocol_version": protocol_version,
-                "server_info": server_info,
-                "server_artifact": server_artifact,
-                "server_execution_artifact": execution_artifact,
-                "expected_server_artifact_digest": expected_server_artifact_digest,
-                "observed_server_artifact_digest": observed_server_artifact_digest,
-                "pagination": pagination,
-                "returncode": returncode,
-                "stdout": stdout,
-                "stderr": stderr,
-                "timed_out": timed_out,
-                "protocol_error": protocol_error,
-                "package_progress_bridge": progress_bridge,
-                "result_validation": result_validation,
-                "started_at": started_at,
-                "finished_at": finished_at,
-                "duration_seconds": finished_at - started_at,
-            },
+            result_document,
             indent=2,
             sort_keys=True,
         ),
@@ -2876,7 +2924,26 @@ def _remove_windows_private_snapshot(
             _close_windows_snapshot_cleanup_handle(active_directory_handle)
 
 
-def _server_artifact_identity(server: str, server_args: list[str]) -> dict[str, Any]:
+def mcp_server_artifact_identity(
+    server: str,
+    server_args: list[str],
+    *,
+    verify_relay_jarvis_cd_lock: bool = False,
+) -> dict[str, Any]:
+    """Return machine-readable launch identity for one stdio MCP server."""
+    return _server_artifact_identity(
+        server,
+        server_args,
+        verify_relay_jarvis_cd_lock=verify_relay_jarvis_cd_lock,
+    )
+
+
+def _server_artifact_identity(
+    server: str,
+    server_args: list[str],
+    *,
+    verify_relay_jarvis_cd_lock: bool = False,
+) -> dict[str, Any]:
     """Describe the executable and immutable package inputs used for one MCP server."""
     resolved_executable = Path(_resolve_executable(server)).expanduser()
     executable = _file_identity(resolved_executable)
@@ -2936,12 +3003,14 @@ def _server_artifact_identity(server: str, server_args: list[str]) -> dict[str, 
                 install_artifact,
                 server_name=nested_server_name,
                 resolved_executable=resolved_executable,
+                verify_relay_jarvis_cd_lock=verify_relay_jarvis_cd_lock,
             )
             if install_artifact is not None
             else _installed_clio_kit_runtime_identity(
                 python_distribution_runtime,
                 server_name=nested_server_name,
                 resolved_executable=resolved_executable,
+                verify_relay_jarvis_cd_lock=verify_relay_jarvis_cd_lock,
             )
         )
         if nested_server_name is not None
@@ -3579,6 +3648,7 @@ def _installed_clio_kit_runtime_identity(
     *,
     server_name: str,
     resolved_executable: Path,
+    verify_relay_jarvis_cd_lock: bool,
 ) -> dict[str, Any]:
     """Verify clio-kit's locked child launcher from a persistent tool environment."""
     uv_name = "uv.exe" if resolved_executable.suffix.lower() == ".exe" else "uv"
@@ -3619,8 +3689,12 @@ def _installed_clio_kit_runtime_identity(
         source_path,
         max_bytes=CLIO_KIT_WHEEL_MAX_LAUNCHER_BYTES,
     )
+    lock = _bounded_regular_file_bytes(
+        lock_path,
+        max_bytes=CLIO_KIT_LOCK_MAX_BYTES,
+    )
     lock_identity = _file_identity(lock_path)
-    if source is None or lock_identity is None:
+    if source is None or lock is None or lock_identity is None:
         evidence["error"] = "persistent clio-kit launcher or lock file is unavailable"
         return evidence
     try:
@@ -3644,6 +3718,11 @@ def _installed_clio_kit_runtime_identity(
     project_sha256 = distribution_runtime.get("runtime_closure_sha256")
     runtime_file_count = distribution_runtime.get("runtime_file_count")
     runtime_bytes = distribution_runtime.get("runtime_bytes")
+    jarvis_cd_lock_binding = (
+        _jarvis_cd_lock_binding(lock)
+        if server_name == "jarvis" and verify_relay_jarvis_cd_lock
+        else None
+    )
     locked = (
         contract_source_verified
         and uv_identity is not None
@@ -3671,6 +3750,8 @@ def _installed_clio_kit_runtime_identity(
             ),
         }
     )
+    if jarvis_cd_lock_binding is not None:
+        evidence["jarvis_cd_lock_binding"] = jarvis_cd_lock_binding
     return evidence
 
 
@@ -3727,6 +3808,7 @@ def _locked_clio_kit_runtime_identity(
     *,
     server_name: str,
     resolved_executable: Path,
+    verify_relay_jarvis_cd_lock: bool,
 ) -> dict[str, Any]:
     """Verify the locked embedded project selected by a clio-kit wheel."""
     wheel_path = (
@@ -3798,6 +3880,7 @@ def _locked_clio_kit_runtime_identity(
             digest.update(len(inputs).to_bytes(8, "big"))
             project_bytes = 0
             lock_sha256: str | None = None
+            lock_content: bytes | None = None
             for relative, member in inputs:
                 encoded = relative.encode("utf-8")
                 digest.update(len(encoded).to_bytes(8, "big"))
@@ -3818,8 +3901,15 @@ def _locked_clio_kit_runtime_identity(
                 digest.update(content_digest.digest())
                 if relative == "uv.lock":
                     lock_sha256 = content_digest.hexdigest()
+                    lock_content = _read_bounded_zip_member(
+                        wheel,
+                        member.filename,
+                        max_bytes=CLIO_KIT_LOCK_MAX_BYTES,
+                    )
             if lock_sha256 is None:
                 raise ValueError("clio-kit embedded server project has no lock digest")
+            if lock_content is None:
+                raise ValueError("clio-kit embedded server project has no readable lock")
     except (
         NotImplementedError,
         OSError,
@@ -3830,6 +3920,12 @@ def _locked_clio_kit_runtime_identity(
     ) as exc:
         evidence["error"] = f"could not verify locked clio-kit runtime: {exc}"
         return evidence
+    jarvis_cd_lock_binding = (
+        _jarvis_cd_lock_binding(lock_content)
+        if server_name == "jarvis" and verify_relay_jarvis_cd_lock
+        else None
+    )
+    locked = contract_source_verified and uv_identity is not None
     evidence.update(
         {
             "project_sha256": digest.hexdigest(),
@@ -3837,15 +3933,295 @@ def _locked_clio_kit_runtime_identity(
             "runtime_file_count": len(inputs),
             "runtime_bytes": project_bytes,
             "contract_source_verified": contract_source_verified,
-            "locked_runtime_verified": contract_source_verified and uv_identity is not None,
+            "locked_runtime_verified": locked,
             "error": (
                 None
-                if contract_source_verified and uv_identity is not None
+                if locked
                 else "clio-kit locked launcher contract or uv executable is unverified"
             ),
         }
     )
+    if jarvis_cd_lock_binding is not None:
+        evidence["jarvis_cd_lock_binding"] = jarvis_cd_lock_binding
     return evidence
+
+
+def _jarvis_cd_lock_binding(lock_content: bytes) -> dict[str, Any]:
+    """Verify the unique JARVIS-CD wheel selected by one embedded uv lock."""
+    evidence: dict[str, Any] = {
+        "schema_version": _JARVIS_CD_LOCK_BINDING_SCHEMA,
+        "dependency": "jarvis-cd",
+        "expected_version": JARVIS_CD_VERSION,
+        "expected_url": JARVIS_CD_WHEEL_URL,
+        "expected_sha256": JARVIS_CD_WHEEL_SHA256,
+        "jarvis_mcp_package_entry_count": 0,
+        "resolved_dependency_entry_count": 0,
+        "observed_resolved_dependency_entries": [],
+        "metadata_requirement_entry_count": 0,
+        "observed_metadata_requirement_entries": [],
+        "observed_metadata_requirement_urls": [],
+        "package_entry_count": 0,
+        "wheel_entry_count": 0,
+        "observed_version": None,
+        "observed_source_url": None,
+        "observed_wheel_url": None,
+        "observed_wheel_sha256": None,
+        "verified": False,
+        "error": None,
+    }
+    try:
+        document = tomllib.loads(lock_content.decode("utf-8", errors="strict"))
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
+        evidence["error"] = f"clio-kit JARVIS uv.lock is invalid: {exc}"
+        return evidence
+    raw_packages = document.get("package")
+    if not isinstance(raw_packages, list):
+        evidence["error"] = "clio-kit JARVIS uv.lock omitted package records"
+        return evidence
+    package_records = [
+        cast(dict[str, Any], value)
+        for value in cast(list[object], raw_packages)
+        if isinstance(value, dict)
+    ]
+    jarvis_mcp_packages = [
+        value
+        for value in package_records
+        if _normalized_distribution_name(value.get("name")) == "jarvis-mcp"
+    ]
+    evidence["jarvis_mcp_package_entry_count"] = len(jarvis_mcp_packages)
+    if len(jarvis_mcp_packages) != 1:
+        evidence["error"] = (
+            "clio-kit JARVIS uv.lock must contain exactly one jarvis-mcp package record"
+        )
+        return evidence
+    raw_dependencies = jarvis_mcp_packages[0].get("dependencies")
+    dependencies = (
+        cast(list[object], raw_dependencies) if isinstance(raw_dependencies, list) else []
+    )
+    jarvis_cd_dependencies = [
+        cast(dict[str, Any], value)
+        for value in dependencies
+        if isinstance(value, dict)
+        and _normalized_distribution_name(cast(dict[str, Any], value).get("name")) == "jarvis-cd"
+    ]
+    evidence["resolved_dependency_entry_count"] = len(jarvis_cd_dependencies)
+    evidence["observed_resolved_dependency_entries"] = [
+        _lock_entry_evidence(value, expected_fields=("name",)) for value in jarvis_cd_dependencies
+    ]
+    if len(jarvis_cd_dependencies) != 1:
+        evidence["error"] = (
+            "clio-kit JARVIS uv.lock jarvis-mcp must resolve exactly one direct "
+            "jarvis-cd dependency"
+        )
+        return evidence
+    if jarvis_cd_dependencies[0] != {"name": "jarvis-cd"}:
+        evidence["error"] = (
+            "clio-kit JARVIS uv.lock jarvis-mcp resolved jarvis-cd dependency must be unconditional"
+        )
+        return evidence
+    raw_metadata = jarvis_mcp_packages[0].get("metadata")
+    metadata_value = cast(dict[str, Any], raw_metadata) if isinstance(raw_metadata, dict) else None
+    raw_requirements = metadata_value.get("requires-dist") if metadata_value is not None else None
+    requirements = (
+        cast(list[object], raw_requirements) if isinstance(raw_requirements, list) else []
+    )
+    jarvis_cd_requirements = [
+        cast(dict[str, Any], value)
+        for value in requirements
+        if isinstance(value, dict)
+        and _normalized_distribution_name(cast(dict[str, Any], value).get("name")) == "jarvis-cd"
+    ]
+    evidence["metadata_requirement_entry_count"] = len(jarvis_cd_requirements)
+    evidence["observed_metadata_requirement_entries"] = [
+        _lock_entry_evidence(value, expected_fields=("name", "url"))
+        for value in jarvis_cd_requirements
+    ]
+    evidence["observed_metadata_requirement_urls"] = [
+        _safe_observed_lock_text(value.get("url")) for value in jarvis_cd_requirements
+    ]
+    if len(jarvis_cd_requirements) != 1:
+        evidence["error"] = (
+            "clio-kit JARVIS uv.lock jarvis-mcp metadata must contain exactly one "
+            "jarvis-cd requirement"
+        )
+        return evidence
+    if jarvis_cd_requirements[0].get("url") != JARVIS_CD_WHEEL_URL:
+        evidence["error"] = (
+            "clio-kit JARVIS uv.lock jarvis-mcp metadata jarvis-cd URL does not match relay pin"
+        )
+        return evidence
+    if jarvis_cd_requirements[0] != {
+        "name": "jarvis-cd",
+        "url": JARVIS_CD_WHEEL_URL,
+    }:
+        evidence["error"] = (
+            "clio-kit JARVIS uv.lock jarvis-mcp metadata jarvis-cd requirement "
+            "must be an unconditional direct URL"
+        )
+        return evidence
+    packages = [
+        value
+        for value in package_records
+        if _normalized_distribution_name(value.get("name")) == "jarvis-cd"
+    ]
+    evidence["package_entry_count"] = len(packages)
+    if len(packages) != 1:
+        evidence["error"] = (
+            "clio-kit JARVIS uv.lock must contain exactly one jarvis-cd package record"
+        )
+        return evidence
+    package = packages[0]
+    version = package.get("version")
+    evidence["observed_version"] = _safe_observed_lock_text(version)
+    raw_source = package.get("source")
+    source = cast(dict[str, Any], raw_source) if isinstance(raw_source, dict) else None
+    source_url = source.get("url") if source is not None else None
+    evidence["observed_source_url"] = _safe_observed_lock_text(source_url)
+    raw_wheels = package.get("wheels")
+    wheels = cast(list[object], raw_wheels) if isinstance(raw_wheels, list) else []
+    evidence["wheel_entry_count"] = len(wheels)
+    if len(wheels) == 1 and isinstance(wheels[0], dict):
+        wheel = cast(dict[str, Any], wheels[0])
+        wheel_url = wheel.get("url")
+        wheel_hash = wheel.get("hash")
+        evidence["observed_wheel_url"] = _safe_observed_lock_text(wheel_url)
+        if isinstance(wheel_hash, str) and wheel_hash.startswith("sha256:"):
+            evidence["observed_wheel_sha256"] = wheel_hash.removeprefix("sha256:")
+    if version != JARVIS_CD_VERSION:
+        evidence["error"] = "clio-kit JARVIS uv.lock jarvis-cd version does not match relay pin"
+        return evidence
+    if not isinstance(source_url, str) or source_url != JARVIS_CD_WHEEL_URL:
+        evidence["error"] = "clio-kit JARVIS uv.lock jarvis-cd source URL does not match relay pin"
+        return evidence
+    if len(wheels) != 1 or not isinstance(wheels[0], dict):
+        evidence["error"] = (
+            "clio-kit JARVIS uv.lock jarvis-cd must contain exactly one wheel record"
+        )
+        return evidence
+    wheel_url = evidence["observed_wheel_url"]
+    if wheel_url != source_url:
+        evidence["error"] = "clio-kit JARVIS uv.lock jarvis-cd source and wheel URLs do not match"
+        return evidence
+    if wheel_url != JARVIS_CD_WHEEL_URL:
+        evidence["error"] = "clio-kit JARVIS uv.lock jarvis-cd wheel URL does not match relay pin"
+        return evidence
+    wheel_sha256 = evidence["observed_wheel_sha256"]
+    if wheel_sha256 != JARVIS_CD_WHEEL_SHA256:
+        evidence["error"] = (
+            "clio-kit JARVIS uv.lock jarvis-cd wheel SHA-256 does not match relay pin"
+        )
+        return evidence
+    evidence["verified"] = True
+    return evidence
+
+
+def _lock_entry_evidence(
+    value: dict[str, Any],
+    *,
+    expected_fields: tuple[str, ...],
+) -> dict[str, Any]:
+    """Project one TOML table into bounded, always-JSON-safe lock evidence."""
+    evidence: dict[str, Any] = {}
+    for field_name in expected_fields:
+        if field_name in value:
+            evidence[field_name] = _safe_observed_lock_text(value[field_name])
+    unexpected_fields = sorted(set(value).difference(expected_fields))
+    if unexpected_fields:
+        evidence["unexpected_field_count"] = len(unexpected_fields)
+        evidence["unexpected_fields"] = unexpected_fields[:32]
+    return evidence
+
+
+def _safe_observed_lock_text(value: object) -> str | None:
+    """Keep expected lock text verbatim and safely identify every other TOML type."""
+    if value is None or isinstance(value, str):
+        return value
+    return f"<invalid TOML {type(value).__name__}>"
+
+
+def _normalized_distribution_name(value: object) -> str | None:
+    """Return the normalized distribution name used by Python package metadata."""
+    if not isinstance(value, str) or not value:
+        return None
+    return re.sub(r"[-_.]+", "-", value).lower()
+
+
+def _require_locked_jarvis_cd_binding(
+    server_artifact: dict[str, Any],
+    *,
+    expected: dict[str, str],
+) -> None:
+    """Refuse the built-in locked clio-kit JARVIS server when its JARVIS pin drifts."""
+    raw_runtime = server_artifact.get("nested_runtime")
+    if not isinstance(raw_runtime, dict):
+        raise ValueError("built-in JARVIS MCP server omitted locked clio-kit runtime evidence")
+    runtime = cast(dict[str, Any], raw_runtime)
+    if runtime.get("server_name") != "jarvis":
+        raise ValueError("built-in JARVIS MCP server did not select the locked jarvis runtime")
+    raw_binding = runtime.get("jarvis_cd_lock_binding")
+    binding = cast(dict[str, Any], raw_binding) if isinstance(raw_binding, dict) else None
+    if (
+        server_artifact.get("verified") is True
+        and runtime.get("schema_version") == "clio-kit.locked-server.v4"
+        and runtime.get("locked_runtime_verified") is True
+        and binding is not None
+        and binding.get("schema_version") == _JARVIS_CD_LOCK_BINDING_SCHEMA
+        and binding.get("dependency") == "jarvis-cd"
+        and binding.get("verified") is True
+        and binding.get("error") is None
+        and binding.get("expected_version") == expected["version"]
+        and binding.get("expected_url") == expected["url"]
+        and binding.get("expected_sha256") == expected["sha256"]
+        and binding.get("observed_version") == expected["version"]
+        and binding.get("observed_source_url") == expected["url"]
+        and binding.get("observed_wheel_url") == expected["url"]
+        and binding.get("observed_wheel_sha256") == expected["sha256"]
+        and binding.get("resolved_dependency_entry_count") == 1
+        and binding.get("observed_resolved_dependency_entries") == [{"name": "jarvis-cd"}]
+        and binding.get("jarvis_mcp_package_entry_count") == 1
+        and binding.get("metadata_requirement_entry_count") == 1
+        and binding.get("observed_metadata_requirement_entries")
+        == [{"name": "jarvis-cd", "url": expected["url"]}]
+        and binding.get("observed_metadata_requirement_urls") == [expected["url"]]
+        and binding.get("package_entry_count") == 1
+        and binding.get("wheel_entry_count") == 1
+    ):
+        return
+    if server_artifact.get("verified") is not True:
+        reason = (
+            server_artifact.get("identity_error")
+            or server_artifact.get("error")
+            or "outer MCP server artifact did not verify"
+        )
+    elif runtime.get("schema_version") != "clio-kit.locked-server.v4":
+        reason = "locked clio-kit runtime schema did not verify"
+    elif runtime.get("locked_runtime_verified") is not True:
+        reason = runtime.get("error") or "locked clio-kit launcher/runtime did not verify"
+    elif binding is None:
+        reason = "JARVIS-CD lock binding evidence is missing"
+    else:
+        reason = binding.get("error") or "JARVIS-CD lock binding evidence did not match"
+    raise ValueError(
+        f"built-in locked clio-kit JARVIS MCP has an unverified jarvis-cd dependency: {reason}"
+    )
+
+
+def _jarvis_cd_lock_expectation(value: object) -> dict[str, str] | None:
+    """Validate the explicit built-in JARVIS dependency expectation from the relay spec."""
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError("expected_jarvis_cd_lock_binding must be an object")
+    typed = cast(dict[object, object], value)
+    expected = {
+        "schema_version": "clio-relay.jarvis-cd-lock-expectation.v1",
+        "version": JARVIS_CD_VERSION,
+        "url": JARVIS_CD_WHEEL_URL,
+        "sha256": JARVIS_CD_WHEEL_SHA256,
+    }
+    if typed != expected:
+        raise ValueError("expected_jarvis_cd_lock_binding does not match the relay release pin")
+    return expected
 
 
 @contextmanager

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.9"
+version = "1.3.10"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.9"
+__version__ = "1.3.10"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -1124,6 +1124,17 @@ def render_linux_user_bootstrap_script(
         character not in "0123456789abcdef" for character in resolved_jarvis_mcp_artifact_sha256
     ):
         raise ConfigurationError("clio-kit bootstrap wheel SHA-256 must be lowercase hex")
+    if resolved_jarvis_mcp_artifact_sha256 != CLIO_KIT_JARVIS_MCP_WHEEL_SHA256:
+        raise ConfigurationError(
+            "the built-in JARVIS MCP bootstrap requires the released clio-kit wheel; "
+            "register a different JARVIS server through the generic remote MCP registry"
+        )
+    if resolved_jarvis_mcp_install_spec.startswith("clio-kit==") and (
+        resolved_jarvis_mcp_install_spec != f"clio-kit=={CLIO_KIT_JARVIS_MCP_VERSION}"
+    ):
+        raise ConfigurationError(
+            "the built-in JARVIS MCP bootstrap requires the released clio-kit version"
+        )
     rendered_jarvis_mcp_install_spec = shlex.quote(resolved_jarvis_mcp_install_spec)
     rendered_jarvis_mcp_artifact_sha256 = shlex.quote(resolved_jarvis_mcp_artifact_sha256)
     script = f"""set -euo pipefail
@@ -1470,6 +1481,7 @@ from clio_relay.installation import (
     probe_jarvis_native_execution_capability,
     write_install_receipt,
 )
+from clio_relay.mcp_call.runner import mcp_server_artifact_identity
 from clio_relay.validation_report import sha256_file
 
 artifact_value = os.environ["CLIO_RELAY_BOOTSTRAP_ARTIFACT"]
@@ -1517,6 +1529,52 @@ persistent_clio_kit_tool = probe_persistent_uv_tool_identity(
     distribution_version=component_version,
     entry_point="clio-kit",
 )
+clio_kit_server_artifact = mcp_server_artifact_identity(
+    runtime_command[0],
+    runtime_command[1:],
+    verify_relay_jarvis_cd_lock=True,
+)
+locked_server_runtime = clio_kit_server_artifact.get("nested_runtime")
+if not isinstance(locked_server_runtime, dict):
+    raise SystemExit("clio-kit JARVIS runtime omitted locked-server evidence")
+jarvis_cd_lock_binding = locked_server_runtime.get("jarvis_cd_lock_binding")
+if not isinstance(jarvis_cd_lock_binding, dict):
+    raise SystemExit("clio-kit JARVIS runtime omitted jarvis-cd lock binding")
+expected_jarvis_cd_url = os.environ["CLIO_RELAY_BOOTSTRAP_JARVIS_CD_WHEEL_URL"]
+expected_jarvis_cd_version = os.environ["CLIO_RELAY_BOOTSTRAP_JARVIS_CD_VERSION"]
+expected_jarvis_cd_sha256 = os.environ["CLIO_RELAY_BOOTSTRAP_JARVIS_CD_WHEEL_SHA256"]
+if not (
+    clio_kit_server_artifact.get("verified") is True
+    and locked_server_runtime.get("schema_version") == "clio-kit.locked-server.v4"
+    and locked_server_runtime.get("server_name") == "jarvis"
+    and locked_server_runtime.get("locked_runtime_verified") is True
+    and jarvis_cd_lock_binding.get("schema_version")
+    == "clio-relay.jarvis-cd-lock-binding.v1"
+    and jarvis_cd_lock_binding.get("dependency") == "jarvis-cd"
+    and jarvis_cd_lock_binding.get("verified") is True
+    and jarvis_cd_lock_binding.get("error") is None
+    and jarvis_cd_lock_binding.get("expected_version") == expected_jarvis_cd_version
+    and jarvis_cd_lock_binding.get("expected_url") == expected_jarvis_cd_url
+    and jarvis_cd_lock_binding.get("expected_sha256") == expected_jarvis_cd_sha256
+    and jarvis_cd_lock_binding.get("observed_version") == expected_jarvis_cd_version
+    and jarvis_cd_lock_binding.get("observed_source_url") == expected_jarvis_cd_url
+    and jarvis_cd_lock_binding.get("observed_wheel_url") == expected_jarvis_cd_url
+    and jarvis_cd_lock_binding.get("observed_wheel_sha256") == expected_jarvis_cd_sha256
+    and jarvis_cd_lock_binding.get("jarvis_mcp_package_entry_count") == 1
+    and jarvis_cd_lock_binding.get("resolved_dependency_entry_count") == 1
+    and jarvis_cd_lock_binding.get("observed_resolved_dependency_entries")
+    == [{{"name": "jarvis-cd"}}]
+    and jarvis_cd_lock_binding.get("metadata_requirement_entry_count") == 1
+    and jarvis_cd_lock_binding.get("observed_metadata_requirement_entries")
+    == [{{"name": "jarvis-cd", "url": expected_jarvis_cd_url}}]
+    and jarvis_cd_lock_binding.get("observed_metadata_requirement_urls")
+    == [expected_jarvis_cd_url]
+    and jarvis_cd_lock_binding.get("package_entry_count") == 1
+    and jarvis_cd_lock_binding.get("wheel_entry_count") == 1
+):
+    raise SystemExit(
+        "clio-kit locked JARVIS dependency does not match the relay jarvis-cd release pin"
+    )
 jarvis_execution_native_execution = probe_jarvis_native_execution_capability(
     os.environ["CLIO_RELAY_BOOTSTRAP_JARVIS_CD_EXECUTION_PYTHON"]
 )
@@ -1573,6 +1631,7 @@ receipt = write_install_receipt(
             }},
             native_execution=clio_kit_native_execution,
             persistent_tool=persistent_clio_kit_tool,
+            locked_server_runtime=locked_server_runtime,
         ),
         "jarvis-cd": ComponentArtifactIdentity(
             distribution=jarvis_cd_distribution.name,

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -67,6 +67,7 @@ from clio_relay.jarvis_mcp import (
     CLIO_KIT_JARVIS_MCP_VERSION,
     CLIO_KIT_JARVIS_USER_CONTRACT_SHA256,
     JARVIS_MCP_CACHE_SERVER_NAME,
+    jarvis_cd_lock_binding_expectation,
     jarvis_mcp_artifact_binding_from_entry,
     jarvis_mcp_env_from,
     jarvis_mcp_server,
@@ -7634,6 +7635,7 @@ def jarvis_mcp_call(
             server_args=server_args,
             env_from=jarvis_mcp_env_from(),
             expected_server_artifact_digest=expected_server_artifact_digest,
+            expected_jarvis_cd_lock_binding=jarvis_cd_lock_binding_expectation(),
             operation=operation,
             tool=tool,
             arguments=arguments,
@@ -10613,6 +10615,7 @@ def _run_jarvis_remote_contract_discovery(
                     server=server,
                     server_args=server_args,
                     env_from=jarvis_mcp_env_from(),
+                    expected_jarvis_cd_lock_binding=jarvis_cd_lock_binding_expectation(),
                     operation=McpOperation.TOOLS_LIST,
                     timeout_seconds=max(1, int(wait_timeout_seconds)),
                 ),
@@ -10648,6 +10651,15 @@ def _persist_jarvis_remote_contract_discovery(
     artifact_payload: bytes,
 ) -> tuple[RemoteMcpSchemaCacheEntry, str]:
     """Persist and verify the exact discovery identity used by built-in JARVIS calls."""
+    durable_result = _decode_json_artifact(artifact_payload, kind="mcp_result")
+    if durable_result != result:
+        raise RelayError(
+            "JARVIS MCP discovery result did not match its durable mcp_result artifact"
+        )
+    result = durable_result
+    expected_jarvis_cd_lock_binding = jarvis_cd_lock_binding_expectation()
+    if result.get("expected_jarvis_cd_lock_binding") != expected_jarvis_cd_lock_binding:
+        raise RelayError("JARVIS MCP discovery did not enforce the relay JARVIS-CD lock pin")
     server = result.get("server")
     raw_server_args = result.get("server_args")
     raw_env_from = result.get("env_from", {})
@@ -10742,7 +10754,12 @@ def _artifact_record(
     *,
     kind: str,
 ) -> dict[str, Any] | None:
-    return next((artifact for artifact in artifacts if artifact.get("kind") == kind), None)
+    matches = [artifact for artifact in artifacts if artifact.get("kind") == kind]
+    if len(matches) > 1:
+        raise RelayError(
+            f"durable artifact authority is ambiguous: found {len(matches)} {kind} artifacts"
+        )
+    return matches[0] if matches else None
 
 
 def _read_remote_json_artifact_kind(
@@ -10836,14 +10853,8 @@ def _read_local_mcp_result_artifact(
     queue: ClioCoreQueue,
     job_id: str,
 ) -> tuple[dict[str, object], bytes]:
-    artifact = next(
-        (
-            item
-            for item in _complete_local_artifact_records(queue, job_id)
-            if item.get("kind") == "mcp_result"
-        ),
-        None,
-    )
+    artifacts = _complete_local_artifact_records(queue, job_id)
+    artifact = _artifact_record(artifacts, kind="mcp_result")
     if artifact is None:
         raise RelayError(f"remote MCP discovery job has no mcp_result artifact: {job_id}")
     artifact_id = artifact.get("artifact_id")

--- a/src/clio_relay/core_queue.py
+++ b/src/clio_relay/core_queue.py
@@ -13629,6 +13629,13 @@ def _job_idempotency_digest(job: RelayJob) -> str:
     # upgrade. Non-empty dependency pins remain part of the canonical identity.
     if not payload.get("used_artifact_refs"):
         payload.pop("used_artifact_refs", None)
+    # Preserve the pre-JARVIS-lock digest for generic MCP calls. The marker is
+    # release authority only when explicitly present on the built-in route.
+    raw_spec = payload.get("spec")
+    if isinstance(raw_spec, dict):
+        spec_payload = cast(dict[str, object], raw_spec)
+        if spec_payload.get("expected_jarvis_cd_lock_binding") is None:
+            spec_payload.pop("expected_jarvis_cd_lock_binding", None)
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
 

--- a/src/clio_relay/endpoint.py
+++ b/src/clio_relay/endpoint.py
@@ -43,7 +43,11 @@ from clio_relay.filesystem_paths import (
 from clio_relay.identifiers import filesystem_key
 from clio_relay.installation import installation_info
 from clio_relay.jarvis_execution import RUNTIME_SCHEDULER_PROVIDER_ENV
-from clio_relay.jarvis_mcp import jarvis_mcp_command
+from clio_relay.jarvis_mcp import (
+    jarvis_cd_lock_binding_expectation,
+    jarvis_mcp_command,
+    jarvis_mcp_server_artifact_binding_verified,
+)
 from clio_relay.jarvis_provider import JarvisCdProvider
 from clio_relay.models import (
     EndpointRegistration,
@@ -2046,6 +2050,9 @@ class EndpointWorker:
         scheduler_job_ids: list[str],
     ) -> None:
         """Ingest structured runtime metadata returned by a remote MCP call."""
+        route_valid, _route_reason = _trusted_jarvis_mcp_route(job)
+        if not route_valid:
+            return
         result_path = spool.path / "mcp-result.json"
         storage_result_path = internal_filesystem_path(result_path)
         if not storage_result_path.exists():
@@ -2057,6 +2064,19 @@ class EndpointWorker:
                 job.job_id,
                 "runtime.metadata_read_failed",
                 f"MCP runtime result could not be read: {exc}",
+            )
+            return
+        trusted, reason = _trusted_jarvis_mcp_result(job, result_document)
+        if not trusted:
+            self.queue.append_event(
+                job.job_id,
+                "runtime.metadata_refused",
+                f"Refused JARVIS MCP runtime metadata: {reason}",
+                payload={
+                    "source": RuntimeMetadataSource.JARVIS_MCP.value,
+                    "ownership_verified": False,
+                    "reason": reason,
+                },
             )
             return
         try:
@@ -2094,19 +2114,6 @@ class EndpointWorker:
                     },
                 )
                 raise ConfigurationError(reason)
-        trusted, reason = _trusted_jarvis_mcp_result(job, result_document)
-        if not trusted:
-            self.queue.append_event(
-                job.job_id,
-                "runtime.metadata_refused",
-                f"Refused JARVIS MCP runtime metadata: {reason}",
-                payload={
-                    "source": RuntimeMetadataSource.JARVIS_MCP.value,
-                    "ownership_verified": False,
-                    "reason": reason,
-                },
-            )
-            return
         current_runtime = state[0]
         superseded_transport_runtime = (
             current_runtime
@@ -4162,6 +4169,8 @@ def _trusted_jarvis_mcp_route(job: RelayJob) -> tuple[bool, str]:
         return False, "MCP command does not match the configured JARVIS server"
     if job.spec.tool != "jarvis_run":
         return False, "MCP tool is not the owned jarvis_run operation"
+    if job.spec.expected_jarvis_cd_lock_binding != jarvis_cd_lock_binding_expectation():
+        return False, "MCP call did not enforce the relay JARVIS-CD lock pin"
     if job.spec.expected_server_artifact_digest is None:
         return False, "MCP call is not bound to its discovered server artifact"
     return True, "configured JARVIS MCP route and artifact binding matched"
@@ -4187,11 +4196,18 @@ def _trusted_jarvis_mcp_result(
         return False, "MCP result arguments do not match the durable job spec"
     if typed.get("env_from") != job.spec.env_from:
         return False, "MCP result environment references do not match the durable job spec"
+    if typed.get("expected_jarvis_cd_lock_binding") != job.spec.expected_jarvis_cd_lock_binding:
+        return False, "MCP result JARVIS-CD lock pin does not match the durable job spec"
     if (
         typed.get("expected_server_artifact_digest") != job.spec.expected_server_artifact_digest
         or typed.get("observed_server_artifact_digest") != job.spec.expected_server_artifact_digest
     ):
         return False, "MCP result server artifact does not match the durable job spec"
+    if not jarvis_mcp_server_artifact_binding_verified(
+        typed.get("server_artifact"),
+        expected_digest=job.spec.expected_server_artifact_digest,
+    ):
+        return False, "MCP result server artifact identity is not the exact relay release pin"
     if (
         typed.get("returncode") != 0
         or typed.get("timed_out") is True

--- a/src/clio_relay/http_api.py
+++ b/src/clio_relay/http_api.py
@@ -31,6 +31,7 @@ from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.errors import ConfigurationError, NotFoundError, QueueConflictError
 from clio_relay.identifiers import DurableRecordId
 from clio_relay.jarvis_mcp import (
+    jarvis_cd_lock_binding_expectation,
     jarvis_mcp_artifact_binding,
     jarvis_mcp_env_from,
     jarvis_mcp_server,
@@ -864,6 +865,7 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
                     server_args=jarvis_mcp_server_args(),
                     env_from=jarvis_mcp_env_from(),
                     expected_server_artifact_digest=expected_digest,
+                    expected_jarvis_cd_lock_binding=jarvis_cd_lock_binding_expectation(),
                     tool=request.tool,
                     arguments=request.arguments,
                     timeout_seconds=request.timeout_seconds,

--- a/src/clio_relay/installation.py
+++ b/src/clio_relay/installation.py
@@ -194,6 +194,7 @@ class ComponentArtifactIdentity(BaseModel):
     entry_points: list[str] = Field(default_factory=list)
     native_execution: NativeJarvisExecutionCapability | None = None
     persistent_tool: PersistentUvToolIdentity | None = None
+    locked_server_runtime: dict[str, object] | None = None
 
 
 class InstallReceipt(BaseModel):
@@ -1134,6 +1135,7 @@ def attach_verified_worker_identity(
         and _is_released_component(component)
         and runtime_identity.get("artifact_identity_verified") is True
         and runtime_identity.get("command_matches_receipt") is True
+        and runtime_identity.get("locked_server_runtime_verified") is True
     )
     report.checks.append(
         ValidationCheck(
@@ -1764,13 +1766,20 @@ def _component_runtime_identity(receipt: InstallReceipt) -> dict[str, object]:
         component = receipt.component_artifacts["clio-kit"]
         runtime_identity = jarvis_mcp_runtime_identity(receipt)
         expected_capability = component.native_execution
-        try:
-            observed_capability = probe_clio_kit_native_execution_contract(
-                component.runtime_command
-            )
-        except ConfigurationError as exc:
+        if runtime_identity.get("artifact_identity_verified") is not True:
             observed_capability = None
-            runtime_identity["native_execution_error"] = str(exc)
+            runtime_identity["native_execution_error"] = str(
+                runtime_identity.get("error")
+                or "receipt-bound clio-kit runtime identity did not verify"
+            )
+        else:
+            try:
+                observed_capability = probe_clio_kit_native_execution_contract(
+                    component.runtime_command
+                )
+            except ConfigurationError as exc:
+                observed_capability = None
+                runtime_identity["native_execution_error"] = str(exc)
         runtime_identity.update(
             {
                 "native_execution_capability": (
@@ -2146,6 +2155,7 @@ def verify_remote_clio_kit_native_execution_component(
     for field in (
         "artifact_identity_verified",
         "command_matches_receipt",
+        "locked_server_runtime_verified",
         "native_execution_capability_verified",
     ):
         if runtime.get(field) is not True:

--- a/src/clio_relay/jarvis_mcp.py
+++ b/src/clio_relay/jarvis_mcp.py
@@ -22,14 +22,14 @@ from clio_relay.remote_mcp import (
 if TYPE_CHECKING:
     from clio_relay.installation import ComponentArtifactIdentity, InstallReceipt
 
-CLIO_KIT_JARVIS_MCP_VERSION = "2.5.1"
+CLIO_KIT_JARVIS_MCP_VERSION = "2.5.3"
 CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME = f"clio_kit-{CLIO_KIT_JARVIS_MCP_VERSION}-py3-none-any.whl"
 CLIO_KIT_JARVIS_MCP_WHEEL_URL = (
     "https://github.com/iowarp/clio-kit/releases/download/"
     f"v{CLIO_KIT_JARVIS_MCP_VERSION}/{CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME}"
 )
 CLIO_KIT_JARVIS_MCP_WHEEL_SHA256 = (
-    "e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1"
+    "1c528be468f156b14ae40b72214360c6fe923765d75b244c4505d3689dad0c6b"
 )
 CLIO_KIT_JARVIS_USER_CONTRACT_ID = "clio-kit-jarvis-user-v3.2"
 DEFAULT_JARVIS_MCP_COMMAND = [
@@ -207,6 +207,22 @@ def jarvis_mcp_env_from() -> dict[str, str]:
     return {JARVIS_MCP_SPACK_COMMAND_ENV: JARVIS_MCP_SPACK_COMMAND_ENV}
 
 
+def jarvis_cd_lock_binding_expectation() -> dict[str, str]:
+    """Return the exact relay release pin required by its built-in JARVIS MCP."""
+    from clio_relay.bootstrap import (
+        JARVIS_CD_VERSION,
+        JARVIS_CD_WHEEL_SHA256,
+        JARVIS_CD_WHEEL_URL,
+    )
+
+    return {
+        "schema_version": "clio-relay.jarvis-cd-lock-expectation.v1",
+        "version": JARVIS_CD_VERSION,
+        "url": JARVIS_CD_WHEEL_URL,
+        "sha256": JARVIS_CD_WHEEL_SHA256,
+    }
+
+
 def jarvis_mcp_runtime_identity(receipt: InstallReceipt) -> dict[str, object]:
     """Verify the persistent clio-kit tool against its receipt-bound source wheel."""
     component = receipt.component_artifacts.get("clio-kit")
@@ -249,12 +265,14 @@ def jarvis_mcp_runtime_identity(receipt: InstallReceipt) -> dict[str, object]:
         command=command,
         source_artifact=runtime_path_resolved,
     )
+    locked_server_runtime_verified = _receipt_locked_server_runtime_verified(component)
     artifact_identity_verified = (
         command_matches_receipt
         and artifact_exists
         and expected_digest is not None
         and observed_digest == expected_digest
         and tool_identity.get("persistent_tool_verified") is True
+        and locked_server_runtime_verified
     )
     error: str | None = None
     if not command_matches_receipt:
@@ -265,6 +283,8 @@ def jarvis_mcp_runtime_identity(receipt: InstallReceipt) -> dict[str, object]:
         error = "receipt-bound clio-kit runtime wheel SHA-256 does not match"
     elif tool_identity.get("persistent_tool_verified") is not True:
         error = str(tool_identity.get("error") or "persistent clio-kit tool did not verify")
+    elif not locked_server_runtime_verified:
+        error = "receipt-bound clio-kit locked JARVIS dependency did not verify"
     return {
         "source": "environment" if configured is not None and configured.strip() else "receipt",
         "launcher": "uv tool",
@@ -276,10 +296,91 @@ def jarvis_mcp_runtime_identity(receipt: InstallReceipt) -> dict[str, object]:
         "artifact_exists": artifact_exists,
         "artifact_path_matches": tool_identity.get("source_identity_verified") is True,
         "command_matches_receipt": command_matches_receipt,
+        "locked_server_runtime": component.locked_server_runtime,
+        "locked_server_runtime_verified": locked_server_runtime_verified,
         "artifact_identity_verified": artifact_identity_verified,
         **tool_identity,
         "error": error,
     }
+
+
+def _receipt_locked_server_runtime_verified(component: ComponentArtifactIdentity) -> bool:
+    """Verify the bootstrap-recorded clio-kit to JARVIS-CD dependency edge."""
+    return jarvis_cd_lock_binding_verified(component.locked_server_runtime)
+
+
+def jarvis_cd_lock_binding_verified(value: object) -> bool:
+    """Return whether one nested runtime proves the relay's built-in JARVIS-CD pin."""
+    runtime = cast(dict[str, object], value) if isinstance(value, dict) else None
+    if not isinstance(runtime, dict):
+        return False
+    raw_binding = runtime.get("jarvis_cd_lock_binding")
+    if not isinstance(raw_binding, dict):
+        return False
+    binding = cast(dict[str, object], raw_binding)
+    expected = jarvis_cd_lock_binding_expectation()
+    return (
+        runtime.get("schema_version") == "clio-kit.locked-server.v4"
+        and runtime.get("server_name") == "jarvis"
+        and runtime.get("locked_runtime_verified") is True
+        and binding.get("schema_version") == "clio-relay.jarvis-cd-lock-binding.v1"
+        and binding.get("dependency") == "jarvis-cd"
+        and binding.get("verified") is True
+        and binding.get("error") is None
+        and binding.get("expected_version") == expected["version"]
+        and binding.get("expected_url") == expected["url"]
+        and binding.get("expected_sha256") == expected["sha256"]
+        and binding.get("observed_version") == expected["version"]
+        and binding.get("observed_source_url") == expected["url"]
+        and binding.get("observed_wheel_url") == expected["url"]
+        and binding.get("observed_wheel_sha256") == expected["sha256"]
+        and binding.get("jarvis_mcp_package_entry_count") == 1
+        and binding.get("resolved_dependency_entry_count") == 1
+        and binding.get("observed_resolved_dependency_entries") == [{"name": "jarvis-cd"}]
+        and binding.get("metadata_requirement_entry_count") == 1
+        and binding.get("observed_metadata_requirement_entries")
+        == [{"name": "jarvis-cd", "url": expected["url"]}]
+        and binding.get("observed_metadata_requirement_urls") == [expected["url"]]
+        and binding.get("package_entry_count") == 1
+        and binding.get("wheel_entry_count") == 1
+    )
+
+
+def jarvis_mcp_server_artifact_verified(value: object) -> bool:
+    """Verify the exact released outer clio-kit artifact and its nested JARVIS-CD pin."""
+    if not isinstance(value, dict):
+        return False
+    server_artifact = cast(dict[str, object], value)
+    python_runtime_value = server_artifact.get("python_distribution_runtime")
+    nested_runtime = server_artifact.get("nested_runtime")
+    if not isinstance(python_runtime_value, dict) or not isinstance(nested_runtime, dict):
+        return False
+    python_runtime = cast(dict[str, object], python_runtime_value)
+    return (
+        server_artifact.get("verified") is True
+        and server_artifact.get("server_process_artifact_verified") is True
+        and isinstance(server_artifact.get("executable"), dict)
+        and server_artifact.get("install_source") == "uv-tool"
+        and server_artifact.get("install_artifact_sha256") == CLIO_KIT_JARVIS_MCP_WHEEL_SHA256
+        and str(python_runtime.get("distribution", "")).lower().replace("_", "-") == "clio-kit"
+        and python_runtime.get("distribution_version") == CLIO_KIT_JARVIS_MCP_VERSION
+        and python_runtime.get("entry_point") == "clio-kit"
+        and python_runtime.get("runtime_closure_verified") is True
+        and cast(dict[str, object], nested_runtime).get("persistent_tool") is True
+        and jarvis_cd_lock_binding_verified(cast(dict[str, object], nested_runtime))
+    )
+
+
+def jarvis_mcp_server_artifact_binding_verified(
+    value: object,
+    *,
+    expected_digest: str | None,
+) -> bool:
+    """Verify an exact built-in server artifact and its content-derived digest."""
+    if expected_digest is None or not jarvis_mcp_server_artifact_verified(value):
+        return False
+    server_artifact = cast(JSON, value)
+    return remote_mcp_server_artifact_digest(server_artifact) == expected_digest
 
 
 def _persistent_clio_kit_tool_identity(
@@ -494,12 +595,11 @@ def jarvis_mcp_artifact_binding_from_entry(
     if {tool.name for tool in entry.tools} != set(_VIRTUAL_JARVIS_TOOLS):
         raise ValueError("JARVIS MCP discovery does not contain the exact user tool set")
     server_artifact = entry.provenance.server_artifact
-    if (
-        server_artifact.get("verified") is not True
-        or server_artifact.get("server_process_artifact_verified") is not True
-        or not isinstance(server_artifact.get("executable"), dict)
-    ):
-        raise ValueError("JARVIS MCP discovered server artifact identity is unverified")
+    if not jarvis_mcp_server_artifact_verified(server_artifact):
+        raise ValueError(
+            "JARVIS MCP discovered persistent server or JARVIS-CD lock identity is "
+            "unverified; run jarvis-mcp-refresh"
+        )
     return remote_mcp_server_artifact_digest(server_artifact)
 
 

--- a/src/clio_relay/jarvis_mcp_validation.py
+++ b/src/clio_relay/jarvis_mcp_validation.py
@@ -16,6 +16,8 @@ from clio_relay.installation import (
 from clio_relay.jarvis_mcp import (
     CLIO_KIT_JARVIS_MCP_VERSION,
     CLIO_KIT_JARVIS_USER_CONTRACT_SHA256,
+    jarvis_cd_lock_binding_expectation,
+    jarvis_mcp_server_artifact_verified,
     jarvis_user_contract,
 )
 from clio_relay.remote_mcp import (
@@ -96,6 +98,7 @@ def build_jarvis_mcp_validation_report(
     )
     observed_at = datetime.now(UTC)
     report.completed_at = observed_at
+    expected_jarvis_cd_lock_binding = jarvis_cd_lock_binding_expectation()
 
     tool_definition = _listed_tool(tools_list_response, tool)
     input_schema = _mapping(tool_definition.get("inputSchema")) if tool_definition else None
@@ -236,6 +239,7 @@ def build_jarvis_mcp_validation_report(
     )
     server_artifact_passed = (
         server_artifact is not None
+        and jarvis_mcp_server_artifact_verified(server_artifact)
         and server_artifact.get("verified") is True
         and server_artifact.get("server_process_artifact_verified") is True
         and bool(server_artifact.get("executable"))
@@ -256,7 +260,9 @@ def build_jarvis_mcp_validation_report(
         and server_artifact == discovery_server_artifact
         and _is_sha256(expected_server_artifact_digest)
         and expected_server_artifact_digest == computed_server_artifact_digest
+        and spec.get("expected_jarvis_cd_lock_binding") == expected_jarvis_cd_lock_binding
         and mcp_result is not None
+        and mcp_result.get("expected_jarvis_cd_lock_binding") == expected_jarvis_cd_lock_binding
         and mcp_result.get("expected_server_artifact_digest") == expected_server_artifact_digest
         and mcp_result.get("observed_server_artifact_digest") == expected_server_artifact_digest
     )
@@ -272,6 +278,11 @@ def build_jarvis_mcp_validation_report(
                 "discovery_server_artifact": discovery_server_artifact or {},
                 "expected_server_artifact_digest": expected_server_artifact_digest,
                 "computed_server_artifact_digest": computed_server_artifact_digest,
+                "expected_jarvis_cd_lock_binding": expected_jarvis_cd_lock_binding,
+                "spec_jarvis_cd_lock_binding": spec.get("expected_jarvis_cd_lock_binding"),
+                "result_jarvis_cd_lock_binding": (
+                    mcp_result.get("expected_jarvis_cd_lock_binding") if mcp_result else None
+                ),
                 "launcher": "uv tool",
                 "python_distribution_runtime": python_runtime or {},
                 "nested_runtime": nested_runtime or {},
@@ -777,10 +788,14 @@ def _jarvis_package_search_evidence(
         else None
     )
     result_server_artifact = _mapping(mcp_result.get("server_artifact")) if mcp_result else None
+    expected_jarvis_cd_lock_binding = jarvis_cd_lock_binding_expectation()
     server_binding_passed = bool(
         _is_sha256(expected_server_artifact_digest)
+        and jarvis_mcp_server_artifact_verified(expected_server_artifact)
         and spec.get("expected_server_artifact_digest") == expected_server_artifact_digest
+        and spec.get("expected_jarvis_cd_lock_binding") == expected_jarvis_cd_lock_binding
         and mcp_result is not None
+        and mcp_result.get("expected_jarvis_cd_lock_binding") == expected_jarvis_cd_lock_binding
         and mcp_result.get("expected_server_artifact_digest") == expected_server_artifact_digest
         and mcp_result.get("observed_server_artifact_digest") == expected_server_artifact_digest
         and result_server_artifact == expected_server_artifact
@@ -863,6 +878,11 @@ def _jarvis_package_search_evidence(
             "artifact_kinds": sorted(durable_artifacts),
             "required_artifact_kinds": sorted(required_artifacts),
             "expected_server_artifact_digest": expected_server_artifact_digest,
+            "expected_jarvis_cd_lock_binding": expected_jarvis_cd_lock_binding,
+            "spec_jarvis_cd_lock_binding": spec.get("expected_jarvis_cd_lock_binding"),
+            "result_jarvis_cd_lock_binding": (
+                mcp_result.get("expected_jarvis_cd_lock_binding") if mcp_result else None
+            ),
             "returned_count": returned_count_value,
             "total_matches": total_matches_value,
             "next_cursor_present": isinstance(next_cursor, str),
@@ -977,10 +997,14 @@ def _jarvis_execution_query_evidence(
     )
 
     result_server_artifact = _mapping(mcp_result.get("server_artifact")) if mcp_result else None
+    expected_jarvis_cd_lock_binding = jarvis_cd_lock_binding_expectation()
     server_binding_passed = (
         _is_sha256(expected_server_artifact_digest)
+        and jarvis_mcp_server_artifact_verified(expected_server_artifact)
         and spec.get("expected_server_artifact_digest") == expected_server_artifact_digest
+        and spec.get("expected_jarvis_cd_lock_binding") == expected_jarvis_cd_lock_binding
         and mcp_result is not None
+        and mcp_result.get("expected_jarvis_cd_lock_binding") == expected_jarvis_cd_lock_binding
         and mcp_result.get("expected_server_artifact_digest") == expected_server_artifact_digest
         and mcp_result.get("observed_server_artifact_digest") == expected_server_artifact_digest
         and result_server_artifact == expected_server_artifact
@@ -1142,6 +1166,12 @@ def _jarvis_execution_query_evidence(
         "terminal": call_status.get("terminal"),
         "required_artifact_kinds": sorted(required_artifacts),
         "artifact_kinds": sorted(durable_artifacts),
+        "expected_server_artifact_digest": expected_server_artifact_digest,
+        "expected_jarvis_cd_lock_binding": expected_jarvis_cd_lock_binding,
+        "spec_jarvis_cd_lock_binding": spec.get("expected_jarvis_cd_lock_binding"),
+        "result_jarvis_cd_lock_binding": (
+            mcp_result.get("expected_jarvis_cd_lock_binding") if mcp_result else None
+        ),
         "local_contract": local_contract,
         "packaged_stdio": stdio_evidence or {},
         "runner_validation": runner_validation or {},

--- a/src/clio_relay/jarvis_provider.py
+++ b/src/clio_relay/jarvis_provider.py
@@ -161,6 +161,7 @@ class JarvisCdProvider:
                     "server_args": spec.server_args or None,
                     "env_from": spec.env_from or None,
                     "expected_server_artifact_digest": spec.expected_server_artifact_digest,
+                    "expected_jarvis_cd_lock_binding": spec.expected_jarvis_cd_lock_binding,
                     "operation": spec.operation.value,
                     "tool": spec.tool,
                     "arguments": spec.arguments or None,

--- a/src/clio_relay/jarvis_service_runtime.py
+++ b/src/clio_relay/jarvis_service_runtime.py
@@ -15,6 +15,10 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from clio_relay.cluster_config import ClusterDefinition
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
+from clio_relay.jarvis_mcp import (
+    jarvis_cd_lock_binding_expectation,
+    jarvis_mcp_server_artifact_binding_verified,
+)
 from clio_relay.models import (
     ArtifactRef,
     JobKind,
@@ -518,6 +522,8 @@ def _validate_source_job(job: RelayJob, *, definition: ClusterDefinition) -> Mcp
         raise ValueError(
             "jarvis_get_execution service source must set include_service_runtimes=true"
         )
+    if job.spec.expected_jarvis_cd_lock_binding != jarvis_cd_lock_binding_expectation():
+        raise ValueError("JARVIS service source did not enforce the relay JARVIS-CD lock pin")
     if job.spec.expected_server_artifact_digest is None:
         raise ValueError("JARVIS service source is not bound to a discovered server artifact")
     return job.spec
@@ -538,11 +544,18 @@ def _validate_mcp_result(
         or document.get("env_from") != spec.env_from
     ):
         raise ValueError("JARVIS MCP result route did not match its durable relay job")
+    if document.get("expected_jarvis_cd_lock_binding") != spec.expected_jarvis_cd_lock_binding:
+        raise ValueError("JARVIS MCP result JARVIS-CD lock pin did not match")
     if (
         document.get("expected_server_artifact_digest") != spec.expected_server_artifact_digest
         or document.get("observed_server_artifact_digest") != spec.expected_server_artifact_digest
     ):
         raise ValueError("JARVIS MCP result server artifact binding did not match")
+    if not jarvis_mcp_server_artifact_binding_verified(
+        document.get("server_artifact"),
+        expected_digest=spec.expected_server_artifact_digest,
+    ):
+        raise ValueError("JARVIS MCP result server artifact identity is not the exact release pin")
     if (
         document.get("returncode") != 0
         or document.get("timed_out") is True

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -35,6 +35,7 @@ from clio_relay.identifiers import (
 from clio_relay.jarvis_mcp import (
     JARVIS_MCP_CACHE_SERVER_NAME,
     is_virtual_jarvis_tool,
+    jarvis_cd_lock_binding_expectation,
     jarvis_mcp_artifact_binding,
     jarvis_mcp_artifact_binding_from_entry,
     jarvis_mcp_server,
@@ -3449,6 +3450,15 @@ def _submit_mcp_call(
         arguments,
         "expected_server_artifact_digest",
     )
+    raw_expected_jarvis_cd_lock_binding = arguments.get("expected_jarvis_cd_lock_binding")
+    expected_jarvis_cd_lock_binding = (
+        _string_mapping(
+            raw_expected_jarvis_cd_lock_binding,
+            "expected_jarvis_cd_lock_binding",
+        )
+        if raw_expected_jarvis_cd_lock_binding is not None
+        else None
+    )
     tool = _required_str(arguments, "tool")
     tool_arguments = _object(arguments.get("arguments", {}))
     timeout_seconds = _optional_int(arguments, "timeout_seconds")
@@ -3465,6 +3475,8 @@ def _submit_mcp_call(
         "arguments_digest": digest,
         "timeout_seconds": timeout_seconds,
     }
+    if expected_jarvis_cd_lock_binding is not None:
+        identity["expected_jarvis_cd_lock_binding"] = expected_jarvis_cd_lock_binding
     if used_artifact_refs:
         identity["used_artifact_refs"] = [
             item.model_dump(mode="json") for item in used_artifact_refs
@@ -3607,6 +3619,7 @@ def _submit_mcp_call(
                 server_args=server_args,
                 env_from=env_from,
                 expected_server_artifact_digest=expected_server_artifact_digest,
+                expected_jarvis_cd_lock_binding=expected_jarvis_cd_lock_binding,
                 tool=tool,
                 arguments=tool_arguments,
                 timeout_seconds=timeout_seconds,
@@ -3856,6 +3869,7 @@ def _submit_jarvis_mcp_call(
         or f"mcp:{cluster}:jarvis:{tool}:{digest}{dependency_suffix}"
     )
     forwarded["idempotency_key"] = idempotency_key
+    forwarded["expected_jarvis_cd_lock_binding"] = jarvis_cd_lock_binding_expectation()
     registered_route = arguments.get("registered_route") is True
     definition = (
         _remote_cluster_definition(cluster)

--- a/src/clio_relay/models.py
+++ b/src/clio_relay/models.py
@@ -427,6 +427,7 @@ class McpCallSpec(BaseModel):
     server_args: list[str] = Field(default_factory=list)
     env_from: dict[str, str] = Field(default_factory=dict)
     expected_server_artifact_digest: str | None = None
+    expected_jarvis_cd_lock_binding: dict[str, str] | None = None
     operation: McpOperation = McpOperation.TOOLS_CALL
     tool: str | None = None
     arguments: dict[str, Any] = Field(default_factory=dict)
@@ -450,6 +451,25 @@ class McpCallSpec(BaseModel):
         ):
             raise ValueError("expected_server_artifact_digest must be a SHA-256")
         return normalized
+
+    @field_validator("expected_jarvis_cd_lock_binding")
+    @classmethod
+    def validate_expected_jarvis_cd_lock_binding(
+        cls,
+        value: dict[str, str] | None,
+    ) -> dict[str, str] | None:
+        """Require a complete expected dependency artifact identity when present."""
+        if value is None:
+            return None
+        expected_keys = {"schema_version", "version", "url", "sha256"}
+        if set(value) != expected_keys or any(not item for item in value.values()):
+            raise ValueError("expected_jarvis_cd_lock_binding must be a complete identity")
+        if value["schema_version"] != "clio-relay.jarvis-cd-lock-expectation.v1":
+            raise ValueError("expected_jarvis_cd_lock_binding schema is unsupported")
+        sha256 = value["sha256"].lower()
+        if len(sha256) != 64 or any(character not in "0123456789abcdef" for character in sha256):
+            raise ValueError("expected_jarvis_cd_lock_binding SHA-256 is invalid")
+        return {**value, "sha256": sha256}
 
     @model_validator(mode="after")
     def validate_operation_contract(self) -> McpCallSpec:

--- a/src/clio_relay/remote_mcp.py
+++ b/src/clio_relay/remote_mcp.py
@@ -74,7 +74,7 @@ MAX_VIRTUAL_REMOTE_MCP_ALIAS_LENGTH = 64
 MAX_VIRTUAL_REMOTE_MCP_LOG_BYTES = 32_768
 REMOTE_MCP_REPLACE_ATTEMPTS = 25
 REMOTE_MCP_REPLACE_RETRY_SECONDS = 0.02
-CLIO_KIT_SPACK_USER_WHEEL_VERSION = "2.5.1"
+CLIO_KIT_SPACK_USER_WHEEL_VERSION = "2.5.3"
 CLIO_KIT_SPACK_USER_CONTRACT_ID = "clio-kit-spack-user-v2"
 # Digest the MCP wire ``tools/list`` result. FastMCP's in-process FunctionTool
 # schemas retain ``$defs`` that its protocol serializer dereferences, so their

--- a/tests/jarvis_mcp_fakes.py
+++ b/tests/jarvis_mcp_fakes.py
@@ -1,0 +1,61 @@
+"""Exact built-in JARVIS MCP artifact evidence for trust-boundary tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from clio_relay.jarvis_mcp import (
+    CLIO_KIT_JARVIS_MCP_VERSION,
+    CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
+    jarvis_cd_lock_binding_expectation,
+)
+
+
+def verified_jarvis_server_artifact() -> dict[str, Any]:
+    """Return minimal evidence satisfying the exact outer and nested release pins."""
+    expected = jarvis_cd_lock_binding_expectation()
+    return {
+        "verified": True,
+        "server_process_artifact_verified": True,
+        "install_source": "uv-tool",
+        "install_artifact_sha256": CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
+        "executable": {
+            "path": "/home/operator/.local/bin/clio-kit",
+            "sha256": "a" * 64,
+        },
+        "python_distribution_runtime": {
+            "distribution": "clio-kit",
+            "distribution_version": CLIO_KIT_JARVIS_MCP_VERSION,
+            "entry_point": "clio-kit",
+            "runtime_closure_verified": True,
+        },
+        "nested_runtime": {
+            "schema_version": "clio-kit.locked-server.v4",
+            "server_name": "jarvis",
+            "persistent_tool": True,
+            "locked_runtime_verified": True,
+            "jarvis_cd_lock_binding": {
+                "schema_version": "clio-relay.jarvis-cd-lock-binding.v1",
+                "dependency": "jarvis-cd",
+                "verified": True,
+                "error": None,
+                "expected_version": expected["version"],
+                "expected_url": expected["url"],
+                "expected_sha256": expected["sha256"],
+                "observed_version": expected["version"],
+                "observed_source_url": expected["url"],
+                "observed_wheel_url": expected["url"],
+                "observed_wheel_sha256": expected["sha256"],
+                "jarvis_mcp_package_entry_count": 1,
+                "resolved_dependency_entry_count": 1,
+                "observed_resolved_dependency_entries": [{"name": "jarvis-cd"}],
+                "metadata_requirement_entry_count": 1,
+                "observed_metadata_requirement_entries": [
+                    {"name": "jarvis-cd", "url": expected["url"]}
+                ],
+                "observed_metadata_requirement_urls": [expected["url"]],
+                "package_entry_count": 1,
+                "wheel_entry_count": 1,
+            },
+        },
+    }

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -185,6 +185,19 @@ def test_linux_user_bootstrap_script_installs_required_components() -> None:
     assert 'JARVIS_MCP_UV_EXECUTABLE="$(command -v uv)"' in script
     assert '"$JARVIS_MCP_EXECUTABLE" --help' in script
     assert 'JARVIS_MCP_INSTALL_TARGET="$JARVIS_MCP_ARTIFACT_PATH"' in script
+    assert "from clio_relay.mcp_call.runner import mcp_server_artifact_identity" in script
+    assert "clio_kit_server_artifact = mcp_server_artifact_identity(" in script
+    assert "verify_relay_jarvis_cd_lock=True" in script
+    assert 'locked_server_runtime.get("server_name") == "jarvis"' in script
+    assert 'jarvis_cd_lock_binding.get("resolved_dependency_entry_count") == 1' in script
+    assert 'jarvis_cd_lock_binding.get("observed_resolved_dependency_entries")' in script
+    assert 'jarvis_cd_lock_binding.get("observed_version") == expected_jarvis_cd_version' in script
+    assert 'jarvis_cd_lock_binding.get("observed_source_url") == expected_jarvis_cd_url' in script
+    assert (
+        'jarvis_cd_lock_binding.get("observed_wheel_sha256") == expected_jarvis_cd_sha256' in script
+    )
+    assert 'jarvis_cd_lock_binding.get("observed_metadata_requirement_entries")' in script
+    assert "locked_server_runtime=locked_server_runtime" in script
     assert (
         "runtime_artifact_path=(str(component_artifact) if component_artifact else None)" in script
     )
@@ -298,17 +311,23 @@ def test_linux_user_bootstrap_embedded_python_programs_compile() -> None:
         compile(program.group("body"), f"bootstrap:{marker}", "exec")
 
 
-def test_custom_clio_kit_bootstrap_wheel_requires_preinstall_digest() -> None:
+def test_local_clio_kit_bootstrap_wheel_must_match_release_pin() -> None:
     with pytest.raises(ConfigurationError, match="requires its expected wheel SHA-256"):
         render_linux_user_bootstrap_script(
             jarvis_mcp_install_spec="/tmp/clio_kit-2.3.1-py3-none-any.whl"
         )
 
+    with pytest.raises(ConfigurationError, match="requires the released clio-kit wheel"):
+        render_linux_user_bootstrap_script(
+            jarvis_mcp_install_spec="/tmp/clio_kit-2.3.1-py3-none-any.whl",
+            jarvis_mcp_artifact_sha256="d" * 64,
+        )
+
     script = render_linux_user_bootstrap_script(
-        jarvis_mcp_install_spec="/tmp/clio_kit-2.3.1-py3-none-any.whl",
-        jarvis_mcp_artifact_sha256="d" * 64,
+        jarvis_mcp_install_spec=f"/tmp/{CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME}",
+        jarvis_mcp_artifact_sha256=CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
     )
-    assert "JARVIS_MCP_ARTIFACT_SHA256=" + "d" * 64 in script
+    assert "JARVIS_MCP_ARTIFACT_SHA256=" + CLIO_KIT_JARVIS_MCP_WHEEL_SHA256 in script
     assert script.index("JARVIS_MCP_ARTIFACT_SHA256 *$JARVIS_MCP_ARTIFACT_PATH") < (
         script.index("uv tool install --force")
     )
@@ -318,6 +337,12 @@ def test_clio_kit_exact_version_override_requires_its_own_digest() -> None:
     with pytest.raises(ConfigurationError, match="requires its expected wheel SHA-256"):
         render_linux_user_bootstrap_script(
             jarvis_mcp_install_spec=f"clio-kit=={CLIO_KIT_JARVIS_MCP_VERSION}"
+        )
+
+    with pytest.raises(ConfigurationError, match="requires the released clio-kit version"):
+        render_linux_user_bootstrap_script(
+            jarvis_mcp_install_spec="clio-kit==0.0.0",
+            jarvis_mcp_artifact_sha256=CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
         )
 
 

--- a/tests/test_ci_clio_kit_wheel.py
+++ b/tests/test_ci_clio_kit_wheel.py
@@ -17,14 +17,14 @@ from clio_relay.jarvis_mcp import (
 ROOT = Path(__file__).resolve().parents[1]
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
-WHEEL_FILENAME = "clio_kit-2.5.1-py3-none-any.whl"
-WHEEL_SHA256 = "e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1"
-WHEEL_URL = f"https://github.com/iowarp/clio-kit/releases/download/v2.5.1/{WHEEL_FILENAME}"
+WHEEL_FILENAME = "clio_kit-2.5.3-py3-none-any.whl"
+WHEEL_SHA256 = "1c528be468f156b14ae40b72214360c6fe923765d75b244c4505d3689dad0c6b"
+WHEEL_URL = f"https://github.com/iowarp/clio-kit/releases/download/v2.5.3/{WHEEL_FILENAME}"
 
 
 def test_runtime_and_ci_share_one_exact_clio_kit_release_pin() -> None:
     """Keep bootstrap, JARVIS MCP, and CI on the same exact release wheel bytes."""
-    assert CLIO_KIT_JARVIS_MCP_VERSION == "2.5.1"
+    assert CLIO_KIT_JARVIS_MCP_VERSION == "2.5.3"
     assert CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME == WHEEL_FILENAME
     assert CLIO_KIT_JARVIS_MCP_WHEEL_SHA256 == WHEEL_SHA256
     assert CLIO_KIT_JARVIS_MCP_WHEEL_URL == WHEEL_URL

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,7 +27,10 @@ from clio_relay.cluster_config import (
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.errors import ConfigurationError, QueueConflictError, RelayError
 from clio_relay.jarvis_mcp import (
+    CLIO_KIT_JARVIS_MCP_VERSION,
+    CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
     CLIO_KIT_JARVIS_USER_CONTRACT_SHA256,
+    jarvis_cd_lock_binding_expectation,
     jarvis_user_contract,
 )
 from clio_relay.models import (
@@ -88,6 +91,40 @@ def _write_test_cluster(
             )
         }
     ).save(root / ".clio-relay" / "clusters.json")
+
+
+def _verified_jarvis_nested_runtime() -> dict[str, object]:
+    """Return complete discovery evidence for the relay's built-in JARVIS child."""
+    expected = jarvis_cd_lock_binding_expectation()
+    return {
+        "schema_version": "clio-kit.locked-server.v4",
+        "server_name": "jarvis",
+        "persistent_tool": True,
+        "locked_runtime_verified": True,
+        "jarvis_cd_lock_binding": {
+            "schema_version": "clio-relay.jarvis-cd-lock-binding.v1",
+            "dependency": "jarvis-cd",
+            "verified": True,
+            "error": None,
+            "expected_version": expected["version"],
+            "expected_url": expected["url"],
+            "expected_sha256": expected["sha256"],
+            "observed_version": expected["version"],
+            "observed_source_url": expected["url"],
+            "observed_wheel_url": expected["url"],
+            "observed_wheel_sha256": expected["sha256"],
+            "jarvis_mcp_package_entry_count": 1,
+            "resolved_dependency_entry_count": 1,
+            "observed_resolved_dependency_entries": [{"name": "jarvis-cd"}],
+            "metadata_requirement_entry_count": 1,
+            "observed_metadata_requirement_entries": [
+                {"name": "jarvis-cd", "url": expected["url"]}
+            ],
+            "observed_metadata_requirement_urls": [expected["url"]],
+            "package_entry_count": 1,
+            "wheel_entry_count": 1,
+        },
+    }
 
 
 def _write_passing_validation_report(
@@ -2247,11 +2284,13 @@ def test_cli_remote_teardown_writes_closure_only_in_remote_authoritative_core(
         return
 
     monkeypatch.setattr(cli, "_attach_verified_remote_worker", skip_worker_verification)
-    monkeypatch.setattr(
-        cli,
-        "_observe_worker_before_cleanup",
-        lambda _definition: (None, None),
-    )
+
+    def observe_no_worker(
+        _definition: ClusterDefinition,
+    ) -> tuple[None, None]:
+        return None, None
+
+    monkeypatch.setattr(cli, "_observe_worker_before_cleanup", observe_no_worker)
 
     result = CliRunner().invoke(
         app,
@@ -5467,6 +5506,7 @@ def test_cli_jarvis_mcp_call_uses_builtin_cluster_command(
     assert job.spec.server_args == ["mcp-server", "jarvis"]
     assert job.spec.env_from == {"JARVIS_MCP_SPACK_COMMAND": "JARVIS_MCP_SPACK_COMMAND"}
     assert job.spec.tool == "jarvis_describe"
+    assert job.spec.expected_jarvis_cd_lock_binding == jarvis_cd_lock_binding_expectation()
     assert job.spec.arguments == {"target": "packages"}
 
 
@@ -5571,10 +5611,19 @@ def test_jarvis_discovery_persists_exact_durable_artifact_bytes(
     server_artifact: dict[str, object] = {
         "verified": True,
         "server_process_artifact_verified": True,
+        "install_source": "uv-tool",
+        "install_artifact_sha256": CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
         "executable": {
             "path": "/opt/clio-kit/bin/clio-kit",
             "sha256": "a" * 64,
         },
+        "python_distribution_runtime": {
+            "distribution": "clio-kit",
+            "distribution_version": CLIO_KIT_JARVIS_MCP_VERSION,
+            "entry_point": "clio-kit",
+            "runtime_closure_verified": True,
+        },
+        "nested_runtime": _verified_jarvis_nested_runtime(),
     }
     result: dict[str, object] = {
         "server": "clio-kit",
@@ -5599,6 +5648,7 @@ def test_jarvis_discovery_persists_exact_durable_artifact_bytes(
         "protocol_version": "2024-11-05",
         "server_info": {"name": "clio-kit", "version": "2.5.0"},
         "server_artifact": server_artifact,
+        "expected_jarvis_cd_lock_binding": jarvis_cd_lock_binding_expectation(),
         "returncode": 0,
         "stdout": "",
         "stderr": "",
@@ -5628,6 +5678,112 @@ def test_jarvis_discovery_persists_exact_durable_artifact_bytes(
     assert entry.schema_digest == CLIO_KIT_JARVIS_USER_CONTRACT_SHA256
     assert entry.provenance.artifact_sha256 == artifact_sha256
     assert binding
+
+    unmarked = dict(result)
+    unmarked.pop("expected_jarvis_cd_lock_binding")
+    unmarked_payload = (json.dumps(unmarked, indent=2) + "\n").encode()
+    with pytest.raises(RelayError, match="did not enforce the relay JARVIS-CD lock pin"):
+        cli._persist_jarvis_remote_contract_discovery(  # pyright: ignore[reportPrivateUsage]
+            cluster="ares",
+            discovery_job_id="job_unmarked",
+            result=unmarked,
+            artifacts=[
+                {
+                    "artifact_id": "artifact_unmarked",
+                    "kind": "mcp_result",
+                    "sha256": hashlib.sha256(unmarked_payload).hexdigest(),
+                }
+            ],
+            artifact_payload=unmarked_payload,
+        )
+
+    mismatched_payload = unmarked_payload
+    with pytest.raises(RelayError, match="did not match its durable mcp_result artifact"):
+        cli._persist_jarvis_remote_contract_discovery(  # pyright: ignore[reportPrivateUsage]
+            cluster="ares",
+            discovery_job_id="job_mismatched_payload",
+            result=result,
+            artifacts=[
+                {
+                    "artifact_id": "artifact_mismatched_payload",
+                    "kind": "mcp_result",
+                    "sha256": hashlib.sha256(mismatched_payload).hexdigest(),
+                }
+            ],
+            artifact_payload=mismatched_payload,
+        )
+
+    stale = entry.model_copy(deep=True)
+    nested = cast(
+        dict[str, object],
+        stale.provenance.server_artifact["nested_runtime"],
+    )
+    nested.pop("jarvis_cd_lock_binding")
+    with pytest.raises(ValueError, match="run jarvis-mcp-refresh"):
+        cli.jarvis_mcp_artifact_binding_from_entry(stale)
+
+    wrong_outer_version = entry.model_copy(deep=True)
+    python_runtime = cast(
+        dict[str, object],
+        wrong_outer_version.provenance.server_artifact["python_distribution_runtime"],
+    )
+    python_runtime["distribution_version"] = "0.0.0"
+    with pytest.raises(ValueError, match="run jarvis-mcp-refresh"):
+        cli.jarvis_mcp_artifact_binding_from_entry(wrong_outer_version)
+
+    wrong_outer_hash = entry.model_copy(deep=True)
+    wrong_outer_hash.provenance.server_artifact["install_artifact_sha256"] = "0" * 64
+    with pytest.raises(ValueError, match="run jarvis-mcp-refresh"):
+        cli.jarvis_mcp_artifact_binding_from_entry(wrong_outer_hash)
+
+
+def test_jarvis_discovery_rejects_ambiguous_mcp_result_artifacts(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A retry cannot make an earlier MCP result the implicit discovery authority."""
+    definition = ClusterDefinition(name="configured-target", ssh_host="cluster.example")
+
+    def duplicate_results(
+        _definition: ClusterDefinition,
+        _job_id: str,
+    ) -> list[dict[str, object]]:
+        return [
+            {"artifact_id": "artifact-first", "kind": "mcp_result"},
+            {"artifact_id": "artifact-retry", "kind": "mcp_result"},
+        ]
+
+    monkeypatch.setattr(cli, "_remote_artifact_records", duplicate_results)
+
+    with pytest.raises(RelayError, match="durable artifact authority is ambiguous"):
+        cli._read_remote_mcp_result_artifact(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            definition,
+            "job-retried-discovery",
+        )
+
+
+def test_local_jarvis_discovery_rejects_ambiguous_mcp_result_artifacts(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Local mode applies the same unique durable authority as remote mode."""
+    queue = ClioCoreQueue(tmp_path / "core")
+
+    def duplicate_results(
+        _queue: ClioCoreQueue,
+        _job_id: str,
+    ) -> list[dict[str, object]]:
+        return [
+            {"artifact_id": "artifact-first", "kind": "mcp_result"},
+            {"artifact_id": "artifact-retry", "kind": "mcp_result"},
+        ]
+
+    monkeypatch.setattr(cli, "_complete_local_artifact_records", duplicate_results)
+
+    with pytest.raises(RelayError, match="durable artifact authority is ambiguous"):
+        cli._read_local_mcp_result_artifact(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            queue,
+            "job-retried-local-discovery",
+        )
 
 
 def test_cli_remote_jarvis_call_defers_artifact_selection_to_target(
@@ -5719,6 +5875,7 @@ def test_target_side_jarvis_discovery_uses_receipt_without_cluster_registry(
     assert isinstance(job.spec, McpCallSpec)
     assert job.spec.operation.value == "tools/list"
     assert job.spec.tool is None
+    assert job.spec.expected_jarvis_cd_lock_binding == jarvis_cd_lock_binding_expectation()
 
 
 def test_cli_mcp_call_reads_arguments_json_file(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:

--- a/tests/test_clio_kit_mcp_contracts.py
+++ b/tests/test_clio_kit_mcp_contracts.py
@@ -30,6 +30,7 @@ from clio_relay.installation import (
 from clio_relay.jarvis_mcp import (
     CLIO_KIT_JARVIS_USER_CONTRACT_SHA256,
     CLIO_KIT_JARVIS_USER_WIRE_SHA256,
+    jarvis_cd_lock_binding_expectation,
     jarvis_mcp_runtime_identity,
     jarvis_user_contract,
 )
@@ -117,6 +118,41 @@ EXPECTED_CONTRACTS = {
         },
     },
 }
+
+
+def _verified_locked_jarvis_runtime() -> dict[str, object]:
+    """Return complete receipt evidence for the relay's built-in JARVIS child."""
+    expectation = jarvis_cd_lock_binding_expectation()
+    return {
+        "schema_version": "clio-kit.locked-server.v4",
+        "server_name": "jarvis",
+        "locked_runtime_verified": True,
+        "jarvis_cd_lock_binding": {
+            "schema_version": "clio-relay.jarvis-cd-lock-binding.v1",
+            "dependency": "jarvis-cd",
+            "verified": True,
+            "error": None,
+            "expected_version": expectation["version"],
+            "expected_url": expectation["url"],
+            "expected_sha256": expectation["sha256"],
+            "observed_version": expectation["version"],
+            "observed_source_url": expectation["url"],
+            "observed_wheel_url": expectation["url"],
+            "observed_wheel_sha256": expectation["sha256"],
+            "jarvis_mcp_package_entry_count": 1,
+            "resolved_dependency_entry_count": 1,
+            "observed_resolved_dependency_entries": [{"name": "jarvis-cd"}],
+            "metadata_requirement_entry_count": 1,
+            "observed_metadata_requirement_entries": [
+                {"name": "jarvis-cd", "url": expectation["url"]}
+            ],
+            "observed_metadata_requirement_urls": [expectation["url"]],
+            "package_entry_count": 1,
+            "wheel_entry_count": 1,
+        },
+    }
+
+
 ACTIVE_CONTRACT_IDS = frozenset(EXPECTED_CONTRACTS) - {
     "clio-kit-jarvis-user-v3",
     "clio-kit-jarvis-user-v3.1",
@@ -343,6 +379,50 @@ def test_relay_contract_pins_match_clio_kit_wheel_artifacts(
     )
 
 
+def test_install_receipt_exposes_verified_locked_jarvis_dependency_edge(
+    tmp_path: Path,
+) -> None:
+    locked_server_runtime = _verified_locked_jarvis_runtime()
+    receipt_path = tmp_path / "install-receipt.json"
+    receipt = write_install_receipt(
+        install_spec="checkout",
+        path=receipt_path,
+        component_artifacts={
+            "clio-kit": ComponentArtifactIdentity(
+                distribution="clio-kit",
+                install_spec="clio-kit.whl",
+                requested_source="wheel",
+                runtime_command=["clio-kit", "mcp-server", "jarvis"],
+                locked_server_runtime=locked_server_runtime,
+            )
+        },
+    )
+
+    runtime_identity = jarvis_mcp_runtime_identity(receipt)
+    persisted = json.loads(receipt_path.read_text(encoding="utf-8"))
+
+    assert runtime_identity["locked_server_runtime_verified"] is True
+    assert runtime_identity["locked_server_runtime"] == locked_server_runtime
+    assert (
+        persisted["component_artifacts"]["clio-kit"]["locked_server_runtime"]
+        == locked_server_runtime
+    )
+
+    receipt_runtime = cast(
+        dict[str, object],
+        receipt.component_artifacts["clio-kit"].locked_server_runtime,
+    )
+    binding = cast(dict[str, object], receipt_runtime["jarvis_cd_lock_binding"])
+    binding["resolved_dependency_entry_count"] = 0
+    invalid_runtime_identity = jarvis_mcp_runtime_identity(receipt)
+    assert invalid_runtime_identity["locked_server_runtime_verified"] is False
+    assert invalid_runtime_identity["artifact_identity_verified"] is False
+
+    binding["resolved_dependency_entry_count"] = 1
+    receipt_runtime["schema_version"] = "clio-kit.locked-server.v5"
+    assert jarvis_mcp_runtime_identity(receipt)["locked_server_runtime_verified"] is False
+
+
 def test_real_uv_tool_install_binds_external_launcher_to_receipt_and_record(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -418,6 +498,7 @@ def test_real_uv_tool_install_binds_external_launcher_to_receipt_and_record(
                 runtime_interpreters={"provider": str(provider)},
                 runtime_executables={"clio-kit": str(executable), "uv": uv},
                 persistent_tool=identity,
+                locked_server_runtime=_verified_locked_jarvis_runtime(),
             )
         },
     )

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -49,7 +49,9 @@ from clio_relay.models import (
 from clio_relay.progress_adapters import package_progress_adapter_from_pipeline
 from clio_relay.queue_management import cleanup_stale_jobs, diagnose_job
 from clio_relay.relay_ops import cancel_job
+from clio_relay.remote_mcp import remote_mcp_server_artifact_digest
 from clio_relay.runtime_metadata import runtime_sidecar_record
+from tests.jarvis_mcp_fakes import verified_jarvis_server_artifact
 from tests.plugin_fakes import SiteSimulationProgressAdapter, install_site_progress_plugin
 
 
@@ -2972,6 +2974,9 @@ def test_virtual_jarvis_progress_is_visible_while_outer_job_is_running(
                 server=command[0],
                 server_args=command[1:],
                 expected_server_artifact_digest=digest,
+                expected_jarvis_cd_lock_binding=(
+                    endpoint_module.jarvis_cd_lock_binding_expectation()
+                ),
                 tool="jarvis_run",
                 arguments={"pipeline_id": "pipeline-live"},
             ),
@@ -3069,6 +3074,9 @@ def test_virtual_jarvis_progress_rejects_provider_identity_mismatch(
                 server=command[0],
                 server_args=command[1:],
                 expected_server_artifact_digest=digest,
+                expected_jarvis_cd_lock_binding=(
+                    endpoint_module.jarvis_cd_lock_binding_expectation()
+                ),
                 tool="jarvis_run",
                 arguments={"pipeline_id": "pipeline-live"},
             ),
@@ -3158,6 +3166,9 @@ def test_virtual_jarvis_native_progress_accepts_indeterminate_event_without_adap
                 server=command[0],
                 server_args=command[1:],
                 expected_server_artifact_digest=digest,
+                expected_jarvis_cd_lock_binding=(
+                    endpoint_module.jarvis_cd_lock_binding_expectation()
+                ),
                 tool="jarvis_run",
                 arguments={"pipeline_id": "pipeline-live"},
             ),
@@ -3306,6 +3317,7 @@ def _native_mcp_result_document(
     command: list[str],
     digest: str,
     pipeline_id: str,
+    server_artifact: dict[str, Any],
 ) -> dict[str, object]:
     execution_id = f"{pipeline_id}-execution"
     handle: dict[str, object] = {
@@ -3397,7 +3409,9 @@ def _native_mcp_result_document(
         "server": command[0],
         "server_args": command[1:],
         "expected_server_artifact_digest": digest,
+        "expected_jarvis_cd_lock_binding": (endpoint_module.jarvis_cd_lock_binding_expectation()),
         "observed_server_artifact_digest": digest,
+        "server_artifact": server_artifact,
         "operation": "tools/call",
         "tool": "jarvis_run",
         "arguments": {"pipeline_id": pipeline_id},
@@ -5601,27 +5615,26 @@ def test_worker_prefers_structured_jarvis_mcp_runtime_metadata(
 ) -> None:
     settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
     queue = ClioCoreQueue(settings.core_dir)
-    server_args = [
-        "--from",
-        "clio-kit==2.3.1",
-        "clio-kit",
-        "mcp-server",
-        "jarvis",
-    ]
-    digest = "c" * 64
+    command = ["clio-kit", "mcp-server", "jarvis"]
+    server_args = command[1:]
+    server_artifact = verified_jarvis_server_artifact()
+    digest = remote_mcp_server_artifact_digest(server_artifact)
     monkeypatch.setattr(
         endpoint_module,
         "jarvis_mcp_command",
-        lambda: ["uvx", *server_args],
+        lambda: command,
     )
     job = queue.submit_job(
         RelayJob(
             cluster="research-cluster",
             kind=JobKind.MCP_CALL,
             spec=McpCallSpec(
-                server="uvx",
+                server=command[0],
                 server_args=server_args,
                 expected_server_artifact_digest=digest,
+                expected_jarvis_cd_lock_binding=(
+                    endpoint_module.jarvis_cd_lock_binding_expectation()
+                ),
                 tool="jarvis_run",
                 arguments={"pipeline_id": "runtime-test"},
             ),
@@ -5655,10 +5668,14 @@ def test_worker_prefers_structured_jarvis_mcp_runtime_metadata(
             (cwd / "mcp-result.json").write_text(
                 json.dumps(
                     {
-                        "server": "uvx",
+                        "server": command[0],
                         "server_args": server_args,
                         "expected_server_artifact_digest": digest,
+                        "expected_jarvis_cd_lock_binding": (
+                            endpoint_module.jarvis_cd_lock_binding_expectation()
+                        ),
                         "observed_server_artifact_digest": digest,
+                        "server_artifact": server_artifact,
                         "operation": "tools/call",
                         "tool": "jarvis_run",
                         "arguments": {"pipeline_id": "runtime-test"},
@@ -5774,7 +5791,8 @@ def test_worker_native_direct_execution_discards_stdout_scheduler_fallback(
     settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
     queue = ClioCoreQueue(settings.core_dir)
     command = ["locked-clio-kit", "mcp-server", "jarvis"]
-    digest = "d" * 64
+    server_artifact = verified_jarvis_server_artifact()
+    digest = remote_mcp_server_artifact_digest(server_artifact)
     monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
     job = queue.submit_job(
         RelayJob(
@@ -5784,6 +5802,9 @@ def test_worker_native_direct_execution_discards_stdout_scheduler_fallback(
                 server=command[0],
                 server_args=command[1:],
                 expected_server_artifact_digest=digest,
+                expected_jarvis_cd_lock_binding=(
+                    endpoint_module.jarvis_cd_lock_binding_expectation()
+                ),
                 tool="jarvis_run",
                 arguments={"pipeline_id": "native-direct"},
             ),
@@ -5819,6 +5840,7 @@ def test_worker_native_direct_execution_discards_stdout_scheduler_fallback(
                         command=command,
                         digest=digest,
                         pipeline_id="native-direct",
+                        server_artifact=server_artifact,
                     )
                 ),
                 encoding="utf-8",
@@ -5922,6 +5944,190 @@ def test_worker_refuses_runtime_identity_from_unconfigured_jarvis_named_tool() -
     assert reason == "MCP command does not match the configured JARVIS server"
 
 
+def test_generic_jarvis_named_mcp_result_is_ignored_before_native_validation(
+    tmp_path: Path,
+) -> None:
+    """Operator MCP tools do not acquire built-in JARVIS parsing semantics by name."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    job = queue.submit_job(
+        RelayJob(
+            cluster="research-cluster",
+            kind=JobKind.MCP_CALL,
+            spec=McpCallSpec(
+                server="operator-mcp",
+                tool="jarvis_run",
+                arguments={"pipeline_id": "operator-pipeline"},
+            ),
+            idempotency_key="generic-jarvis-shaped-result",
+        )
+    )
+
+    class GenericProvider(RecordingProvider):
+        def run_pipeline_streaming(
+            self,
+            pipeline_path: Path,
+            *,
+            cwd: Path | None = None,
+            env: dict[str, str] | None = None,
+            on_stdout: Callable[[str], None] | None = None,
+            on_stderr: Callable[[str], None] | None = None,
+            on_start: Callable[[int], None] | None = None,
+            should_cancel: Callable[[], bool] | None = None,
+            on_poll: Callable[[], None] | None = None,
+            timeout_seconds: int | None = None,
+            on_timeout: Callable[[], None] | None = None,
+        ) -> subprocess.CompletedProcess[str]:
+            del pipeline_path, env, on_stdout, on_stderr, should_cancel, on_poll
+            del timeout_seconds, on_timeout
+            assert cwd is not None
+            if on_start is not None:
+                on_start(702)
+            (cwd / "mcp-result.json").write_text(
+                json.dumps(
+                    {
+                        "server": "operator-mcp",
+                        "server_args": [],
+                        "operation": "tools/call",
+                        "tool": "jarvis_run",
+                        "arguments": {"pipeline_id": "operator-pipeline"},
+                        "structured_result": {
+                            "runtime_metadata": {"schema_version": "not-a-jarvis-runtime"}
+                        },
+                        "returncode": 0,
+                        "timed_out": False,
+                        "protocol_error": None,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            return subprocess.CompletedProcess(["operator-mcp"], 0, "", "")
+
+    worker = EndpointWorker(
+        role=EndpointRole.WORKER,
+        settings=settings,
+        cluster="research-cluster",
+        queue=queue,
+        provider=GenericProvider(),
+    )
+
+    result = worker.run_once()
+    task = queue.list_tasks(job.job_id)[0]
+    events, _ = queue.drain_events(Cursor(job_id=job.job_id), limit=100)
+
+    assert result is not None
+    assert result.state is JobState.SUCCEEDED
+    assert "runtime_metadata" not in task.metadata
+    assert "runtime.metadata_refused" not in {event.event_type for event in events}
+
+
+def test_trusted_jarvis_mcp_result_requires_content_derived_server_digest(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Self-reported digests cannot substitute for the persisted artifact document."""
+    command = ["clio-kit", "mcp-server", "jarvis"]
+    claimed_digest = "f" * 64
+    expected_lock = endpoint_module.jarvis_cd_lock_binding_expectation()
+    monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
+    job = RelayJob(
+        cluster="research-cluster",
+        kind=JobKind.MCP_CALL,
+        spec=McpCallSpec(
+            server=command[0],
+            server_args=command[1:],
+            expected_server_artifact_digest=claimed_digest,
+            expected_jarvis_cd_lock_binding=expected_lock,
+            tool="jarvis_run",
+            arguments={"pipeline_id": "owned"},
+        ),
+        idempotency_key="self-reported-server-digest",
+    )
+    document: dict[str, object] = {
+        "server": command[0],
+        "server_args": command[1:],
+        "env_from": {},
+        "expected_jarvis_cd_lock_binding": expected_lock,
+        "expected_server_artifact_digest": claimed_digest,
+        "observed_server_artifact_digest": claimed_digest,
+        "server_artifact": verified_jarvis_server_artifact(),
+        "operation": "tools/call",
+        "tool": "jarvis_run",
+        "arguments": {"pipeline_id": "owned"},
+        "returncode": 0,
+        "timed_out": False,
+        "protocol_error": None,
+        "protocol_result": {"structuredContent": {"runtime_metadata": {}}},
+    }
+
+    trusted, reason = cast(Any, endpoint_module)._trusted_jarvis_mcp_result(job, document)
+
+    assert trusted is False
+    assert reason == "MCP result server artifact identity is not the exact relay release pin"
+
+
+def test_worker_refuses_builtin_semantics_without_jarvis_lock_marker(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A generic JARVIS call cannot unlock built-in progress/runtime handling."""
+    command = ["clio-kit", "mcp-server", "jarvis"]
+    monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
+    job = RelayJob(
+        cluster="research-cluster",
+        kind=JobKind.MCP_CALL,
+        spec=McpCallSpec(
+            server=command[0],
+            server_args=command[1:],
+            expected_server_artifact_digest="a" * 64,
+            tool="jarvis_run",
+            arguments={"pipeline_id": "operator-pipeline"},
+        ),
+        idempotency_key="generic-jarvis-route",
+    )
+
+    trusted, reason = cast(Any, endpoint_module)._trusted_jarvis_mcp_route(job)
+
+    assert trusted is False
+    assert reason == "MCP call did not enforce the relay JARVIS-CD lock pin"
+
+
+def test_worker_refuses_result_with_mismatched_jarvis_lock_marker(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Built-in result evidence must carry the same lock marker as its job."""
+    command = ["clio-kit", "mcp-server", "jarvis"]
+    expected = endpoint_module.jarvis_cd_lock_binding_expectation()
+    monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
+    job = RelayJob(
+        cluster="research-cluster",
+        kind=JobKind.MCP_CALL,
+        spec=McpCallSpec(
+            server=command[0],
+            server_args=command[1:],
+            expected_server_artifact_digest="a" * 64,
+            expected_jarvis_cd_lock_binding=expected,
+            tool="jarvis_run",
+            arguments={"pipeline_id": "owned"},
+        ),
+        idempotency_key="mismatched-jarvis-lock-result",
+    )
+
+    trusted, reason = cast(Any, endpoint_module)._trusted_jarvis_mcp_result(
+        job,
+        {
+            "server": command[0],
+            "server_args": command[1:],
+            "env_from": {},
+            "expected_jarvis_cd_lock_binding": None,
+            "operation": "tools/call",
+            "tool": "jarvis_run",
+            "arguments": {"pipeline_id": "owned"},
+        },
+    )
+
+    assert trusted is False
+    assert reason == "MCP result JARVIS-CD lock pin does not match the durable job spec"
+
+
 def test_worker_refuses_runtime_identity_when_result_arguments_do_not_match(
     monkeypatch: MonkeyPatch,
 ) -> None:
@@ -5945,6 +6151,7 @@ def test_worker_refuses_runtime_identity_when_result_arguments_do_not_match(
             server="uvx",
             server_args=server_args,
             expected_server_artifact_digest=digest,
+            expected_jarvis_cd_lock_binding=(endpoint_module.jarvis_cd_lock_binding_expectation()),
             tool="jarvis_run",
             arguments={"pipeline_id": "owned"},
         ),
@@ -5960,6 +6167,9 @@ def test_worker_refuses_runtime_identity_when_result_arguments_do_not_match(
                 "server_args": server_args,
                 "env_from": {},
                 "expected_server_artifact_digest": digest,
+                "expected_jarvis_cd_lock_binding": (
+                    endpoint_module.jarvis_cd_lock_binding_expectation()
+                ),
                 "observed_server_artifact_digest": digest,
                 "operation": "tools/call",
                 "tool": "jarvis_run",
@@ -6000,6 +6210,7 @@ def test_worker_refuses_stdout_only_jarvis_mcp_runtime_identity(
             server="uvx",
             server_args=server_args,
             expected_server_artifact_digest=digest,
+            expected_jarvis_cd_lock_binding=(endpoint_module.jarvis_cd_lock_binding_expectation()),
             tool="jarvis_run",
             arguments=arguments,
         ),
@@ -6013,6 +6224,9 @@ def test_worker_refuses_stdout_only_jarvis_mcp_runtime_identity(
             "server_args": server_args,
             "env_from": {},
             "expected_server_artifact_digest": digest,
+            "expected_jarvis_cd_lock_binding": (
+                endpoint_module.jarvis_cd_lock_binding_expectation()
+            ),
             "observed_server_artifact_digest": digest,
             "operation": "tools/call",
             "tool": "jarvis_run",

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -12,6 +12,7 @@ from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.errors import ConfigurationError
 from clio_relay.http_api import create_app
+from clio_relay.jarvis_mcp import jarvis_cd_lock_binding_expectation
 from clio_relay.models import (
     ArtifactRef,
     Cursor,
@@ -977,6 +978,7 @@ def test_owned_jarvis_mcp_submission_forwards_desktop_binding_without_remote_cac
     job = queue.get_job(accepted.json()["job_id"])
     assert isinstance(job.spec, McpCallSpec)
     assert job.spec.expected_server_artifact_digest == expected_digest
+    assert job.spec.expected_jarvis_cd_lock_binding == jarvis_cd_lock_binding_expectation()
     assert job.metadata == {
         "owner": "clio-relay",
         "owner_session_id": "desktop-session-1",
@@ -1047,6 +1049,7 @@ def test_unowned_jarvis_mcp_submission_still_validates_operator_cache(
     job = queue.get_job(accepted.json()["job_id"])
     assert isinstance(job.spec, McpCallSpec)
     assert job.spec.expected_server_artifact_digest == expected_digest
+    assert job.spec.expected_jarvis_cd_lock_binding == jarvis_cd_lock_binding_expectation()
 
 
 def test_owned_session_submission_race_with_quiesce_returns_conflict(

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -34,10 +34,44 @@ from clio_relay.installation import (
 from clio_relay.jarvis_mcp import (
     CLIO_KIT_JARVIS_USER_CONTRACT_SHA256,
     JARVIS_MCP_COMMAND_ENV,
+    jarvis_cd_lock_binding_expectation,
     jarvis_mcp_command,
     jarvis_user_contract,
 )
 from clio_relay.validation_report import InstallSource, InstallSourceKind, SoftwareIdentity
+
+
+def _verified_locked_jarvis_runtime() -> dict[str, object]:
+    """Return complete receipt evidence for the relay's built-in JARVIS child."""
+    expected = jarvis_cd_lock_binding_expectation()
+    return {
+        "schema_version": "clio-kit.locked-server.v4",
+        "server_name": "jarvis",
+        "locked_runtime_verified": True,
+        "jarvis_cd_lock_binding": {
+            "schema_version": "clio-relay.jarvis-cd-lock-binding.v1",
+            "dependency": "jarvis-cd",
+            "verified": True,
+            "error": None,
+            "expected_version": expected["version"],
+            "expected_url": expected["url"],
+            "expected_sha256": expected["sha256"],
+            "observed_version": expected["version"],
+            "observed_source_url": expected["url"],
+            "observed_wheel_url": expected["url"],
+            "observed_wheel_sha256": expected["sha256"],
+            "jarvis_mcp_package_entry_count": 1,
+            "resolved_dependency_entry_count": 1,
+            "observed_resolved_dependency_entries": [{"name": "jarvis-cd"}],
+            "metadata_requirement_entry_count": 1,
+            "observed_metadata_requirement_entries": [
+                {"name": "jarvis-cd", "url": expected["url"]}
+            ],
+            "observed_metadata_requirement_urls": [expected["url"]],
+            "package_entry_count": 1,
+            "wheel_entry_count": 1,
+        },
+    }
 
 
 def test_distribution_file_source_accepts_a_canonical_filesystem_alias(
@@ -630,12 +664,17 @@ def test_remote_clio_kit_component_requires_receipt_bound_native_contract(
     runtime = {
         "artifact_identity_verified": True,
         "command_matches_receipt": True,
+        "locked_server_runtime_verified": True,
         "native_execution_capability_verified": True,
         "native_execution_capability": capability.model_dump(mode="json"),
     }
     info: dict[str, object] = {"installation": {"component_runtime": {"clio-kit": runtime}}}
 
     assert verify_remote_clio_kit_native_execution_component(info, receipt) == runtime
+    runtime["locked_server_runtime_verified"] = False
+    with pytest.raises(ConfigurationError, match="locked_server_runtime_verified"):
+        verify_remote_clio_kit_native_execution_component(info, receipt)
+    runtime["locked_server_runtime_verified"] = True
     runtime["native_execution_capability"] = {
         **capability.model_dump(mode="json"),
         "contract_sha256": "d" * 64,
@@ -810,6 +849,7 @@ def test_jarvis_mcp_defaults_to_persistent_receipt_bound_clio_kit_tool(
                 runtime_interpreters={"provider": sys.executable},
                 runtime_executables={"clio-kit": str(tool), "uv": str(uv)},
                 persistent_tool=persistent_tool,
+                locked_server_runtime=_verified_locked_jarvis_runtime(),
             )
         },
     )
@@ -830,6 +870,52 @@ def test_jarvis_mcp_defaults_to_persistent_receipt_bound_clio_kit_tool(
     assert runtime["clio-kit"]["command_matches_receipt"] is True
     assert runtime["clio-kit"]["launcher"] == "uv tool"
     assert runtime["clio-kit"]["persistent_tool_verified"] is True
+
+
+def test_component_runtime_identity_does_not_probe_unverified_clio_kit_launcher(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Doctor must not execute a launcher whose receipt identity failed."""
+    receipt = write_install_receipt(
+        install_spec="checkout",
+        path=tmp_path / "install-receipt.json",
+        component_artifacts={
+            "clio-kit": ComponentArtifactIdentity(
+                distribution="clio-kit",
+                install_spec="tampered-clio-kit.whl",
+                requested_source="wheel",
+                runtime_command=["tampered-clio-kit", "mcp-server", "jarvis"],
+            )
+        },
+    )
+    monkeypatch.setattr(
+        "clio_relay.jarvis_mcp.jarvis_mcp_runtime_identity",
+        lambda _receipt: {
+            "artifact_identity_verified": False,
+            "error": "locked JARVIS dependency did not verify",
+        },
+    )
+    probed = False
+
+    def fail_if_probed(_command: list[str]) -> NativeJarvisExecutionCapability:
+        nonlocal probed
+        probed = True
+        raise AssertionError("unverified clio-kit launcher must not execute")
+
+    monkeypatch.setattr(
+        installation_module,
+        "probe_clio_kit_native_execution_contract",
+        fail_if_probed,
+    )
+
+    identities = installation_module._component_runtime_identity(receipt)
+    runtime = cast(dict[str, object], identities["clio-kit"])
+
+    assert probed is False
+    assert runtime["native_execution_capability"] is None
+    assert runtime["native_execution_capability_verified"] is False
+    assert runtime["native_execution_error"] == "locked JARVIS dependency did not verify"
 
 
 def test_receipt_bound_jarvis_mcp_refuses_changed_clio_kit_wheel(

--- a/tests/test_jarvis_mcp_validation.py
+++ b/tests/test_jarvis_mcp_validation.py
@@ -6,7 +6,10 @@ from typing import Any, cast
 import pytest
 
 from clio_relay.jarvis_mcp import (
+    CLIO_KIT_JARVIS_MCP_VERSION,
+    CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
     CLIO_KIT_JARVIS_USER_CONTRACT_SHA256,
+    jarvis_cd_lock_binding_expectation,
     jarvis_mcp_server,
     jarvis_mcp_server_args,
     jarvis_user_contract,
@@ -216,6 +219,57 @@ def test_jarvis_mcp_validation_rejects_unattested_nested_server_process() -> Non
     assert server_check.status == ValidationStatus.FAILED
 
 
+def test_jarvis_mcp_validation_rejects_missing_builtin_lock_marker() -> None:
+    """The release gate must prove pre-launch JARVIS-CD enforcement was active."""
+    inputs = _acceptance_inputs()
+    mcp_result = cast(dict[str, Any], inputs["mcp_result"])
+    mcp_result.pop("expected_jarvis_cd_lock_binding")
+
+    report = build_jarvis_mcp_validation_report(**inputs)
+
+    server_check = next(
+        check for check in report.checks if check.check_id == "remote-mcp.server-artifact"
+    )
+    assert report.status == ValidationStatus.FAILED
+    assert server_check.status == ValidationStatus.FAILED
+
+
+@pytest.mark.parametrize("binding_state", ["missing", "unverified"])
+def test_jarvis_mcp_validation_rejects_invalid_nested_lock_binding(
+    binding_state: str,
+) -> None:
+    """A coherent outer artifact digest cannot replace independent nested pin proof."""
+    inputs = _acceptance_inputs()
+    mcp_result = cast(dict[str, Any], inputs["mcp_result"])
+    server_artifact = cast(dict[str, Any], mcp_result["server_artifact"])
+    nested_runtime = cast(dict[str, Any], server_artifact["nested_runtime"])
+    if binding_state == "missing":
+        nested_runtime.pop("jarvis_cd_lock_binding")
+    else:
+        binding = cast(dict[str, Any], nested_runtime["jarvis_cd_lock_binding"])
+        binding["verified"] = False
+        binding["error"] = "synthetic nested binding failure"
+    _rebind_acceptance_server_artifact(inputs, server_artifact)
+
+    report = build_jarvis_mcp_validation_report(**inputs)
+
+    server_check = next(
+        check for check in report.checks if check.check_id == "remote-mcp.server-artifact"
+    )
+    package_search = next(
+        check for check in report.checks if check.check_id == "remote-mcp.jarvis-package-search"
+    )
+    execution_query = next(
+        check for check in report.checks if check.check_id == "remote-mcp.jarvis-execution-query"
+    )
+    assert server_check.status == ValidationStatus.FAILED
+    assert package_search.evidence[0].metadata["assertions"]["server_artifact_binding"] is False
+    assert (
+        execution_query.evidence[0].metadata["assertions"]["server_artifact_binding_verified"]
+        is False
+    )
+
+
 def test_jarvis_mcp_validation_rejects_released_contract_drift() -> None:
     inputs = _acceptance_inputs()
     discovery = cast(dict[str, Any], inputs["remote_tools_list_result"])
@@ -403,6 +457,7 @@ def _acceptance_inputs() -> dict[str, Any]:
     execution_id = "jarvis-execution-acceptance"
     server_artifact = _jarvis_server_artifact()
     server_artifact_digest = remote_mcp_server_artifact_digest(server_artifact)
+    expected_jarvis_cd_lock_binding = jarvis_cd_lock_binding_expectation()
     local_run = next(
         tool
         for tool in virtual_jarvis_tool_definitions(clusters=["ares"])
@@ -464,6 +519,7 @@ def _acceptance_inputs() -> dict[str, Any]:
                         "spack_specs": ["lammps"],
                     },
                     "expected_server_artifact_digest": server_artifact_digest,
+                    "expected_jarvis_cd_lock_binding": expected_jarvis_cd_lock_binding,
                 },
             },
             "terminal": True,
@@ -474,6 +530,7 @@ def _acceptance_inputs() -> dict[str, Any]:
             "operation": "tools/call",
             "tool": "jarvis_run",
             "expected_server_artifact_digest": server_artifact_digest,
+            "expected_jarvis_cd_lock_binding": expected_jarvis_cd_lock_binding,
             "observed_server_artifact_digest": server_artifact_digest,
             "server_artifact": server_artifact,
             "package_progress_bridge": {
@@ -604,6 +661,7 @@ def _acceptance_inputs() -> dict[str, Any]:
                         "artifacts": {"page_size": 25},
                     },
                     "expected_server_artifact_digest": server_artifact_digest,
+                    "expected_jarvis_cd_lock_binding": expected_jarvis_cd_lock_binding,
                 },
             },
             "terminal": True,
@@ -659,6 +717,7 @@ def _acceptance_inputs() -> dict[str, Any]:
                         "page_size": 5,
                     },
                     "expected_server_artifact_digest": server_artifact_digest,
+                    "expected_jarvis_cd_lock_binding": expected_jarvis_cd_lock_binding,
                 },
             },
             "terminal": True,
@@ -678,6 +737,7 @@ def _acceptance_inputs() -> dict[str, Any]:
             "tool": "jarvis_describe",
             "protocol_error": None,
             "expected_server_artifact_digest": server_artifact_digest,
+            "expected_jarvis_cd_lock_binding": expected_jarvis_cd_lock_binding,
             "observed_server_artifact_digest": server_artifact_digest,
             "server_artifact": server_artifact,
             "structured_result": {
@@ -702,6 +762,30 @@ def _acceptance_inputs() -> dict[str, Any]:
         "package_search_initialize_response": None,
         "package_search_stdio_evidence": None,
     }
+
+
+def _rebind_acceptance_server_artifact(
+    inputs: dict[str, Any],
+    server_artifact: dict[str, Any],
+) -> None:
+    """Keep every synthetic digest coherent after mutating shared server evidence."""
+    digest = remote_mcp_server_artifact_digest(server_artifact)
+    for status_name in ("call_status", "package_search_call_status", "query_call_status"):
+        status = cast(dict[str, Any], inputs[status_name])
+        job = cast(dict[str, Any], status["job"])
+        spec = cast(dict[str, Any], job["spec"])
+        spec["expected_server_artifact_digest"] = digest
+    for result_name in ("mcp_result", "package_search_mcp_result", "query_mcp_result"):
+        result = cast(dict[str, Any], inputs[result_name])
+        result["expected_server_artifact_digest"] = digest
+        result["observed_server_artifact_digest"] = digest
+    main_result = cast(dict[str, Any], inputs["mcp_result"])
+    bridge = cast(dict[str, Any], main_result["package_progress_bridge"])
+    bridge["expected_server_artifact_digest"] = digest
+    bridge["observed_server_artifact_digest"] = digest
+    for raw_record in cast(list[dict[str, Any]], inputs["progress"]):
+        metadata = cast(dict[str, Any], raw_record["metadata"])
+        metadata["server_artifact_digest"] = digest
 
 
 def _mcp_progress_records(
@@ -826,6 +910,7 @@ def _execution_query_mcp_result(
         "protocol_error": None,
         "structured_result": structured,
         "expected_server_artifact_digest": server_artifact_digest,
+        "expected_jarvis_cd_lock_binding": jarvis_cd_lock_binding_expectation(),
         "observed_server_artifact_digest": server_artifact_digest,
         "server_artifact": server_artifact,
         "result_validation": {
@@ -915,7 +1000,8 @@ def _native_execution_documents(execution_id: str) -> dict[str, object]:
 
 
 def _jarvis_server_artifact() -> dict[str, object]:
-    install_spec = "/opt/wheels/clio_kit-2.3.1-py3-none-any.whl"
+    install_spec = f"/opt/wheels/clio_kit-{CLIO_KIT_JARVIS_MCP_VERSION}-py3-none-any.whl"
+    expected = jarvis_cd_lock_binding_expectation()
     return {
         "requested_command": jarvis_mcp_server(),
         "resolved_executable": "/home/user/.local/bin/clio-kit",
@@ -927,12 +1013,12 @@ def _jarvis_server_artifact() -> dict[str, object]:
         },
         "install_spec": install_spec,
         "install_source": "uv-tool",
-        "install_artifact_sha256": "d" * 64,
+        "install_artifact_sha256": CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
         "input_files": [
             {
                 "path": install_spec,
-                "filename": "clio_kit-2.3.1-py3-none-any.whl",
-                "sha256": "d" * 64,
+                "filename": f"clio_kit-{CLIO_KIT_JARVIS_MCP_VERSION}-py3-none-any.whl",
+                "sha256": CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
                 "size_bytes": 3,
             }
         ],
@@ -940,10 +1026,10 @@ def _jarvis_server_artifact() -> dict[str, object]:
         "python_distribution_runtime": {
             "schema_version": "clio-relay.python-distribution-runtime.v1",
             "distribution": "clio-kit",
-            "distribution_version": "2.3.1",
+            "distribution_version": CLIO_KIT_JARVIS_MCP_VERSION,
             "entry_point": "clio-kit",
             "runtime_closure_verified": True,
-            "direct_url": {"url": "file:///opt/wheels/clio_kit-2.3.1-py3-none-any.whl"},
+            "direct_url": {"url": f"file://{install_spec}"},
         },
         "nested_launcher": True,
         "nested_runtime": {
@@ -951,6 +1037,29 @@ def _jarvis_server_artifact() -> dict[str, object]:
             "server_name": "jarvis",
             "persistent_tool": True,
             "locked_runtime_verified": True,
+            "jarvis_cd_lock_binding": {
+                "schema_version": "clio-relay.jarvis-cd-lock-binding.v1",
+                "dependency": "jarvis-cd",
+                "verified": True,
+                "error": None,
+                "expected_version": expected["version"],
+                "expected_url": expected["url"],
+                "expected_sha256": expected["sha256"],
+                "observed_version": expected["version"],
+                "observed_source_url": expected["url"],
+                "observed_wheel_url": expected["url"],
+                "observed_wheel_sha256": expected["sha256"],
+                "jarvis_mcp_package_entry_count": 1,
+                "resolved_dependency_entry_count": 1,
+                "observed_resolved_dependency_entries": [{"name": "jarvis-cd"}],
+                "metadata_requirement_entry_count": 1,
+                "observed_metadata_requirement_entries": [
+                    {"name": "jarvis-cd", "url": expected["url"]}
+                ],
+                "observed_metadata_requirement_urls": [expected["url"]],
+                "package_entry_count": 1,
+                "wheel_entry_count": 1,
+            },
         },
         "server_process_artifact_verified": True,
         "identity_error": None,

--- a/tests/test_jarvis_provider.py
+++ b/tests/test_jarvis_provider.py
@@ -21,6 +21,7 @@ from clio_relay import jarvis_provider
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.errors import ConfigurationError, RelayError
 from clio_relay.jarvis_execution import sanitized_jarvis_environment
+from clio_relay.jarvis_mcp import jarvis_cd_lock_binding_expectation
 from clio_relay.jarvis_provider import JarvisCdProvider
 from clio_relay.models import JarvisRunSpec, JobKind, McpCallSpec, RelayJob, RemoteAgentTaskSpec
 
@@ -466,6 +467,7 @@ def test_mcp_call_yaml_generation() -> None:
                 "jarvis",
             ],
             env_from={"SCIENCE_TOKEN": "SITE_SCIENCE_TOKEN"},
+            expected_jarvis_cd_lock_binding=jarvis_cd_lock_binding_expectation(),
             tool="inspect",
             arguments={"path": "x"},
         )
@@ -483,6 +485,7 @@ def test_mcp_call_yaml_generation() -> None:
         "jarvis",
     ]
     assert package["env_from"] == {"SCIENCE_TOKEN": "SITE_SCIENCE_TOKEN"}
+    assert package["expected_jarvis_cd_lock_binding"] == jarvis_cd_lock_binding_expectation()
     assert package["tool"] == "inspect"
     assert package["arguments"] == {"path": "x"}
 

--- a/tests/test_jarvis_service_runtime.py
+++ b/tests/test_jarvis_service_runtime.py
@@ -23,6 +23,7 @@ from clio_relay.cluster_config import (
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.errors import ConfigurationError
+from clio_relay.jarvis_mcp import jarvis_cd_lock_binding_expectation
 from clio_relay.jarvis_service_runtime import (
     RELAY_JARVIS_RUNTIME_BINDING_SCHEMA,
     JarvisServiceRuntime,
@@ -40,8 +41,10 @@ from clio_relay.models import (
     SchedulerConnectorStepIdentity,
     ServiceRuntimeSpec,
 )
+from clio_relay.remote_mcp import remote_mcp_server_artifact_digest
 from clio_relay.service_runtime import ServiceRuntimeSupervisor
 from clio_relay.session_lifecycle import CleanupResource
+from tests.jarvis_mcp_fakes import verified_jarvis_server_artifact
 
 
 def test_resolve_jarvis_service_runtime_binds_only_exact_durable_result(
@@ -390,6 +393,78 @@ def test_service_runtime_source_rejects_jarvis_run_and_unconfigured_mcp_route(
             definition=definition,
             source_job_id=route_job.job_id,
             source_artifact_id=route_artifact.artifact_id,
+            package_id="paraview-1",
+            package_name="builtin.paraview",
+        )
+
+
+def test_service_runtime_source_rejects_generic_unmarked_jarvis_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Operator JARVIS calls cannot authorize the built-in gateway binding path."""
+    queue, definition, job, artifact, envelope = _source_result(
+        tmp_path,
+        bind_relay_jarvis=False,
+    )
+    monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
+
+    with pytest.raises(ValueError, match="JARVIS-CD lock pin"):
+        resolve_jarvis_service_runtime(
+            queue=queue,
+            definition=definition,
+            source_job_id=job.job_id,
+            source_artifact_id=artifact.artifact_id,
+            package_id="paraview-1",
+            package_name="builtin.paraview",
+        )
+
+
+def test_service_runtime_source_rejects_result_lock_marker_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Persisted result evidence must carry the same built-in lock marker as its job."""
+    queue, definition, job, artifact, envelope = _source_result(tmp_path)
+    document = json.loads(base64.b64decode(envelope["data"], validate=True).decode("utf-8"))
+    document["expected_jarvis_cd_lock_binding"] = None
+    _replace_envelope_document(envelope, document)
+    monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
+
+    with pytest.raises(ValueError, match="result JARVIS-CD lock pin"):
+        resolve_jarvis_service_runtime(
+            queue=queue,
+            definition=definition,
+            source_job_id=job.job_id,
+            source_artifact_id=artifact.artifact_id,
+            package_id="paraview-1",
+            package_name="builtin.paraview",
+        )
+
+
+def test_service_runtime_rejects_unverified_outer_clio_kit_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A self-consistent digest cannot authorize a different clio-kit release."""
+    server_artifact = verified_jarvis_server_artifact()
+    python_runtime = cast(
+        dict[str, object],
+        server_artifact["python_distribution_runtime"],
+    )
+    python_runtime["distribution_version"] = "0.0.0"
+    queue, definition, job, artifact, envelope = _source_result(
+        tmp_path,
+        server_artifact=server_artifact,
+    )
+    monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
+
+    with pytest.raises(ValueError, match="not the exact release pin"):
+        resolve_jarvis_service_runtime(
+            queue=queue,
+            definition=definition,
+            source_job_id=job.job_id,
+            source_artifact_id=artifact.artifact_id,
             package_id="paraview-1",
             package_name="builtin.paraview",
         )
@@ -1432,9 +1507,14 @@ def _source_result(
     tool: str = "jarvis_get_execution",
     include_service_runtimes: bool | None = True,
     server: str = "/home/cluster/.local/bin/clio-kit",
+    bind_relay_jarvis: bool = True,
+    server_artifact: dict[str, Any] | None = None,
 ) -> tuple[ClioCoreQueue, ClusterDefinition, RelayJob, ArtifactRef, dict[str, Any]]:
     queue = ClioCoreQueue(tmp_path / "core")
-    digest = "a" * 64
+    resolved_server_artifact = (
+        verified_jarvis_server_artifact() if server_artifact is None else server_artifact
+    )
+    digest = remote_mcp_server_artifact_digest(resolved_server_artifact)
     job = queue.submit_job(
         RelayJob(
             cluster="test-cluster",
@@ -1443,6 +1523,9 @@ def _source_result(
                 server=server,
                 server_args=["mcp-server", "jarvis"],
                 expected_server_artifact_digest=digest,
+                expected_jarvis_cd_lock_binding=(
+                    jarvis_cd_lock_binding_expectation() if bind_relay_jarvis else None
+                ),
                 tool=tool,
                 arguments={
                     "pipeline_id": "pipeline-1",
@@ -1458,7 +1541,11 @@ def _source_result(
         )
     )
     job = queue.update_job_state(job.job_id, JobState.SUCCEEDED)
-    document = _mcp_result_document(digest=digest, spec=cast(McpCallSpec, job.spec))
+    document = _mcp_result_document(
+        digest=digest,
+        spec=cast(McpCallSpec, job.spec),
+        server_artifact=resolved_server_artifact,
+    )
     payload = json.dumps(document, sort_keys=True, separators=(",", ":")).encode("utf-8")
     artifact = ArtifactRef(
         artifact_id="artifact-result",
@@ -1486,7 +1573,12 @@ def _source_result(
     return queue, definition, job, artifact, envelope
 
 
-def _mcp_result_document(*, digest: str, spec: McpCallSpec) -> dict[str, Any]:
+def _mcp_result_document(
+    *,
+    digest: str,
+    spec: McpCallSpec,
+    server_artifact: dict[str, Any],
+) -> dict[str, Any]:
     submission = {
         "schema_version": "jarvis.scheduler.submission.v1",
         "execution_id": "execution-1",
@@ -1583,7 +1675,9 @@ def _mcp_result_document(*, digest: str, spec: McpCallSpec) -> dict[str, Any]:
         "server_args": spec.server_args,
         "env_from": spec.env_from,
         "expected_server_artifact_digest": digest,
+        "expected_jarvis_cd_lock_binding": spec.expected_jarvis_cd_lock_binding,
         "observed_server_artifact_digest": digest,
+        "server_artifact": server_artifact,
         "operation": "tools/call",
         "tool": spec.tool,
         "arguments": spec.arguments,

--- a/tests/test_mcp_call_runner.py
+++ b/tests/test_mcp_call_runner.py
@@ -20,11 +20,144 @@ from typing import Any, Protocol, cast
 
 from pytest import MonkeyPatch, mark, raises
 
+from clio_relay.bootstrap import (
+    JARVIS_CD_VERSION,
+    JARVIS_CD_WHEEL_SHA256,
+    JARVIS_CD_WHEEL_URL,
+)
+
 
 class McpCallRunnerModule(Protocol):
     def run_mcp_call_from_params(self, params: dict[str, object]) -> int:
         """Run a remote MCP call from serialized parameters."""
         ...
+
+
+def _jarvis_cd_uv_lock(
+    *,
+    version: str = JARVIS_CD_VERSION,
+    source_url: str = JARVIS_CD_WHEEL_URL,
+    wheel_url: str = JARVIS_CD_WHEEL_URL,
+    sha256: str = JARVIS_CD_WHEEL_SHA256,
+    package_entries: int = 1,
+    metadata_entries: int = 1,
+    metadata_url: str = JARVIS_CD_WHEEL_URL,
+    metadata_marker: str | None = None,
+    jarvis_mcp_entries: int = 1,
+    resolved_dependency_entries: int = 1,
+    resolved_dependency_marker: str | None = None,
+) -> bytes:
+    """Return a minimal uv lock with independently mutable JARVIS binding surfaces."""
+    lines = ["version = 1", ""]
+    for _index in range(jarvis_mcp_entries):
+        lines.extend(
+            [
+                "[[package]]",
+                'name = "jarvis-mcp"',
+                'version = "3.2.1"',
+                'source = { editable = "." }',
+                "dependencies = [",
+                *(
+                    (
+                        '    { name = "jarvis-cd"'
+                        + (
+                            f", marker = {json.dumps(resolved_dependency_marker)}"
+                            if resolved_dependency_marker is not None
+                            else ""
+                        )
+                        + " },"
+                    )
+                    for _dependency_index in range(resolved_dependency_entries)
+                ),
+                "]",
+                "",
+                "[package.metadata]",
+                "requires-dist = [",
+                *(
+                    (
+                        f'    {{ name = "jarvis-cd", url = {json.dumps(metadata_url)}'
+                        + (
+                            f", marker = {json.dumps(metadata_marker)}"
+                            if metadata_marker is not None
+                            else ""
+                        )
+                        + " },"
+                    )
+                    for _requirement_index in range(metadata_entries)
+                ),
+                "]",
+                "",
+            ]
+        )
+    if package_entries == 0:
+        lines.extend(
+            [
+                "[[package]]",
+                'name = "unrelated"',
+                'version = "1.0.0"',
+                'source = { registry = "https://pypi.org/simple" }',
+                "",
+            ]
+        )
+    for _index in range(package_entries):
+        lines.extend(
+            [
+                "[[package]]",
+                'name = "jarvis-cd"',
+                f"version = {json.dumps(version)}",
+                f"source = {{ url = {json.dumps(source_url)} }}",
+                "wheels = [",
+                (f'    {{ url = {json.dumps(wheel_url)}, hash = "sha256:{sha256}" }},'),
+                "]",
+                "",
+            ]
+        )
+    return "\n".join(lines).encode("utf-8")
+
+
+def _jarvis_cd_lock_expectation() -> dict[str, str]:
+    return {
+        "schema_version": "clio-relay.jarvis-cd-lock-expectation.v1",
+        "version": JARVIS_CD_VERSION,
+        "url": JARVIS_CD_WHEEL_URL,
+        "sha256": JARVIS_CD_WHEEL_SHA256,
+    }
+
+
+def _verified_jarvis_server_artifact() -> dict[str, Any]:
+    """Return the minimal verified built-in JARVIS artifact boundary."""
+    expected = _jarvis_cd_lock_expectation()
+    return {
+        "verified": True,
+        "nested_runtime": {
+            "schema_version": "clio-kit.locked-server.v4",
+            "server_name": "jarvis",
+            "locked_runtime_verified": True,
+            "jarvis_cd_lock_binding": {
+                "schema_version": "clio-relay.jarvis-cd-lock-binding.v1",
+                "dependency": "jarvis-cd",
+                "verified": True,
+                "error": None,
+                "expected_version": expected["version"],
+                "expected_url": expected["url"],
+                "expected_sha256": expected["sha256"],
+                "observed_version": expected["version"],
+                "observed_source_url": expected["url"],
+                "observed_wheel_url": expected["url"],
+                "observed_wheel_sha256": expected["sha256"],
+                "jarvis_mcp_package_entry_count": 1,
+                "resolved_dependency_entry_count": 1,
+                "observed_resolved_dependency_entries": [{"name": "jarvis-cd"}],
+                "metadata_requirement_entry_count": 1,
+                "observed_metadata_requirement_entries": [
+                    {"name": "jarvis-cd", "url": expected["url"]}
+                ],
+                "observed_metadata_requirement_urls": [expected["url"]],
+                "package_entry_count": 1,
+                "wheel_entry_count": 1,
+            },
+        },
+    }
 
 
 def test_mcp_call_runner_invokes_tool_with_defaults(
@@ -353,7 +486,7 @@ def test_persistent_uv_tool_clio_kit_runtime_is_receipt_bindable(
     uv.write_bytes(b"pinned-uv")
     wheel.write_bytes(b"released-clio-kit-wheel")
     source.write_text(_locked_clio_kit_v4_launcher_source(), encoding="utf-8")
-    lock.write_text("version = 1\n", encoding="utf-8")
+    lock.write_bytes(_jarvis_cd_uv_lock())
 
     def console_distribution_identity(_path: Path) -> dict[str, object]:
         return {
@@ -383,6 +516,7 @@ def test_persistent_uv_tool_clio_kit_runtime_is_receipt_bindable(
     identity = cast(Any, runner)._server_artifact_identity(
         str(tool),
         ["mcp-server", "jarvis"],
+        verify_relay_jarvis_cd_lock=True,
     )
 
     assert identity["install_source"] == "uv-tool"
@@ -393,6 +527,7 @@ def test_persistent_uv_tool_clio_kit_runtime_is_receipt_bindable(
     )
     assert identity["nested_launcher"] is True
     assert identity["nested_runtime"]["persistent_tool"] is True
+    assert identity["nested_runtime"]["jarvis_cd_lock_binding"]["verified"] is True
     assert identity["nested_runtime"]["locked_runtime_verified"] is True
     assert identity["server_process_artifact_verified"] is True
     assert identity["verified"] is True
@@ -554,6 +689,346 @@ def test_mcp_call_runner_verifies_locked_clio_kit_child_runtime(
     assert identity["server_process_artifact_verified"] is True
     assert identity["verified"] is True
     assert identity["identity_error"] is None
+
+
+def test_mcp_call_runner_verifies_relay_jarvis_cd_pin_in_locked_child_runtime(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    runner = _load_runner()
+    assert cast(Any, runner).JARVIS_CD_VERSION == JARVIS_CD_VERSION
+    assert cast(Any, runner).JARVIS_CD_WHEEL_URL == JARVIS_CD_WHEEL_URL
+    assert cast(Any, runner).JARVIS_CD_WHEEL_SHA256 == JARVIS_CD_WHEEL_SHA256
+    monkeypatch.chdir(tmp_path)
+    uvx = tmp_path / ("uvx.exe" if os.name == "nt" else "uvx")
+    uv = tmp_path / ("uv.exe" if os.name == "nt" else "uv")
+    uvx.write_bytes(b"pinned-uv-launcher")
+    uv.write_bytes(b"pinned-uv-runtime")
+    wheel = tmp_path / "clio_kit-2.5.3-py3-none-any.whl"
+    _write_synthetic_clio_kit_wheel(
+        wheel,
+        server_name="jarvis",
+        project={
+            "pyproject.toml": b"[project]\nname='jarvis-mcp'\n",
+            "uv.lock": _jarvis_cd_uv_lock(),
+        },
+    )
+    launched = False
+
+    def fake_run(
+        command: list[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal launched
+        launched = True
+        stdout = "\n".join(
+            [
+                json.dumps({"jsonrpc": "2.0", "id": "clio-relay-mcp-init", "result": {}}),
+                json.dumps({"jsonrpc": "2.0", "id": "clio-relay-mcp-call", "result": {}}),
+            ]
+        )
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(cast(Any, runner), "_run_mcp_session", fake_run)
+
+    return_code = cast(McpCallRunnerModule, runner).run_mcp_call_from_params(
+        {
+            "server": str(uvx),
+            "server_args": [
+                "--from",
+                str(wheel),
+                "clio-kit",
+                "mcp-server",
+                "jarvis",
+            ],
+            "expected_jarvis_cd_lock_binding": _jarvis_cd_lock_expectation(),
+            "tool": "jarvis_describe",
+        }
+    )
+    result = json.loads((tmp_path / "mcp-result.json").read_text(encoding="utf-8"))
+
+    assert return_code == 0
+    assert launched is True
+    binding = result["server_artifact"]["nested_runtime"]["jarvis_cd_lock_binding"]
+    assert binding == {
+        "dependency": "jarvis-cd",
+        "error": None,
+        "expected_sha256": JARVIS_CD_WHEEL_SHA256,
+        "expected_url": JARVIS_CD_WHEEL_URL,
+        "expected_version": JARVIS_CD_VERSION,
+        "jarvis_mcp_package_entry_count": 1,
+        "observed_resolved_dependency_entries": [{"name": "jarvis-cd"}],
+        "metadata_requirement_entry_count": 1,
+        "observed_metadata_requirement_entries": [
+            {"name": "jarvis-cd", "url": JARVIS_CD_WHEEL_URL}
+        ],
+        "observed_metadata_requirement_urls": [JARVIS_CD_WHEEL_URL],
+        "observed_source_url": JARVIS_CD_WHEEL_URL,
+        "observed_version": JARVIS_CD_VERSION,
+        "observed_wheel_sha256": JARVIS_CD_WHEEL_SHA256,
+        "observed_wheel_url": JARVIS_CD_WHEEL_URL,
+        "package_entry_count": 1,
+        "resolved_dependency_entry_count": 1,
+        "schema_version": "clio-relay.jarvis-cd-lock-binding.v1",
+        "verified": True,
+        "wheel_entry_count": 1,
+    }
+
+
+@mark.parametrize(
+    ("lock_content", "expected_error"),
+    [
+        (_jarvis_cd_uv_lock(version="0.0.0"), "version does not match relay pin"),
+        (
+            _jarvis_cd_uv_lock(
+                source_url=("https://example.invalid/jarvis_cd-1.3.11-py3-none-any.whl"),
+                wheel_url=("https://example.invalid/jarvis_cd-1.3.11-py3-none-any.whl"),
+            ),
+            "source URL does not match relay pin",
+        ),
+        (_jarvis_cd_uv_lock(sha256="0" * 64), "wheel SHA-256 does not match relay pin"),
+        (_jarvis_cd_uv_lock(package_entries=0), "exactly one jarvis-cd package record"),
+        (_jarvis_cd_uv_lock(package_entries=2), "exactly one jarvis-cd package record"),
+        (
+            _jarvis_cd_uv_lock(
+                wheel_url="https://example.invalid/jarvis_cd-1.3.11-py3-none-any.whl"
+            ),
+            "source and wheel URLs do not match",
+        ),
+        (
+            _jarvis_cd_uv_lock(
+                metadata_url="https://example.invalid/jarvis_cd-1.3.11-py3-none-any.whl"
+            ),
+            "metadata jarvis-cd URL does not match relay pin",
+        ),
+        (
+            _jarvis_cd_uv_lock(metadata_entries=0),
+            "metadata must contain exactly one jarvis-cd requirement",
+        ),
+        (
+            _jarvis_cd_uv_lock(metadata_entries=2),
+            "metadata must contain exactly one jarvis-cd requirement",
+        ),
+        (
+            _jarvis_cd_uv_lock(metadata_marker="sys_platform == 'never'"),
+            "metadata jarvis-cd requirement must be an unconditional direct URL",
+        ),
+        (
+            _jarvis_cd_uv_lock(jarvis_mcp_entries=2),
+            "exactly one jarvis-mcp package record",
+        ),
+        (
+            _jarvis_cd_uv_lock(resolved_dependency_entries=0),
+            "must resolve exactly one direct jarvis-cd dependency",
+        ),
+        (
+            _jarvis_cd_uv_lock(resolved_dependency_entries=2),
+            "must resolve exactly one direct jarvis-cd dependency",
+        ),
+        (
+            _jarvis_cd_uv_lock(resolved_dependency_marker="sys_platform == 'never'"),
+            "resolved jarvis-cd dependency must be unconditional",
+        ),
+        (
+            _jarvis_cd_uv_lock(resolved_dependency_marker="typed-marker").replace(
+                b'marker = "typed-marker"',
+                b"marker = 1979-05-27T07:32:00Z",
+            ),
+            "resolved jarvis-cd dependency must be unconditional",
+        ),
+        (
+            _jarvis_cd_uv_lock(metadata_marker="typed-marker").replace(
+                b'marker = "typed-marker"',
+                b"marker = nan",
+            ),
+            "metadata jarvis-cd requirement must be an unconditional direct URL",
+        ),
+    ],
+    ids=[
+        "wrong-version",
+        "wrong-url",
+        "wrong-hash",
+        "missing",
+        "duplicate",
+        "source-wheel-mismatch",
+        "wrong-metadata-url",
+        "missing-metadata-requirement",
+        "duplicate-metadata-requirement",
+        "conditional-metadata-requirement",
+        "duplicate-jarvis-mcp-package",
+        "missing-resolved-dependency",
+        "duplicate-resolved-dependency",
+        "conditional-resolved-dependency",
+        "datetime-resolved-dependency-marker",
+        "nonfinite-metadata-requirement-marker",
+    ],
+)
+def test_mcp_call_runner_refuses_unbound_jarvis_cd_lock_before_process_launch(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    lock_content: bytes,
+    expected_error: str,
+) -> None:
+    runner = _load_runner()
+    monkeypatch.chdir(tmp_path)
+    uvx = tmp_path / ("uvx.exe" if os.name == "nt" else "uvx")
+    uv = tmp_path / ("uv.exe" if os.name == "nt" else "uv")
+    uvx.write_bytes(b"pinned-uv-launcher")
+    uv.write_bytes(b"pinned-uv-runtime")
+    wheel = tmp_path / "clio_kit-2.5.3-py3-none-any.whl"
+    _write_synthetic_clio_kit_wheel(
+        wheel,
+        server_name="jarvis",
+        project={
+            "pyproject.toml": b"[project]\nname='jarvis-mcp'\n",
+            "uv.lock": lock_content,
+        },
+    )
+    opened = False
+
+    def fail_if_opened(
+        _command: list[str],
+        *,
+        env_from: dict[str, str] | None = None,
+    ) -> subprocess.Popen[str]:
+        del env_from
+        nonlocal opened
+        opened = True
+        raise AssertionError("_open_process must not run for an unbound JARVIS lock")
+
+    monkeypatch.setattr(cast(Any, runner), "_open_process", fail_if_opened)
+
+    return_code = cast(McpCallRunnerModule, runner).run_mcp_call_from_params(
+        {
+            "server": str(uvx),
+            "server_args": [
+                "--from",
+                str(wheel),
+                "clio-kit",
+                "mcp-server",
+                "jarvis",
+            ],
+            "expected_jarvis_cd_lock_binding": _jarvis_cd_lock_expectation(),
+            "tool": "jarvis_describe",
+        }
+    )
+    result_text = (tmp_path / "mcp-result.json").read_text(encoding="utf-8")
+
+    def reject_nonfinite_json(value: str) -> None:
+        raise ValueError(f"non-finite JSON constant: {value}")
+
+    result = json.loads(result_text, parse_constant=reject_nonfinite_json)
+
+    assert return_code == 1
+    assert opened is False
+    assert expected_error in result["protocol_error"]
+    binding = result["server_artifact"]["nested_runtime"]["jarvis_cd_lock_binding"]
+    assert binding["verified"] is False
+    assert expected_error in binding["error"]
+
+
+def test_mcp_call_runner_refuses_unverified_builtin_jarvis_launcher_before_launch(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A correct nested pin cannot authorize an unverified outer launcher."""
+    runner = _load_runner()
+    monkeypatch.chdir(tmp_path)
+    uvx = tmp_path / ("uvx.exe" if os.name == "nt" else "uvx")
+    uvx.write_bytes(b"unverified-launcher")
+    artifact = _verified_jarvis_server_artifact()
+    artifact["verified"] = False
+    artifact["identity_error"] = "launcher digest did not verify"
+    monkeypatch.setattr(
+        runner,
+        "_server_artifact_identity",
+        lambda *_args, **_kwargs: artifact,
+    )
+    opened = False
+
+    def fail_if_opened(
+        _command: list[str],
+        *,
+        env_from: dict[str, str] | None = None,
+    ) -> subprocess.Popen[str]:
+        del env_from
+        nonlocal opened
+        opened = True
+        raise AssertionError("_open_process must not run for an unverified launcher")
+
+    monkeypatch.setattr(runner, "_open_process", fail_if_opened)
+
+    return_code = cast(McpCallRunnerModule, runner).run_mcp_call_from_params(
+        {
+            "server": str(uvx),
+            "expected_jarvis_cd_lock_binding": _jarvis_cd_lock_expectation(),
+            "tool": "jarvis_describe",
+        }
+    )
+    result = json.loads((tmp_path / "mcp-result.json").read_text(encoding="utf-8"))
+
+    assert return_code == 1
+    assert opened is False
+    assert "launcher digest did not verify" in result["protocol_error"]
+
+
+def test_registered_jarvis_server_uses_artifact_binding_without_relay_dependency_pin(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    runner = _load_runner()
+    monkeypatch.chdir(tmp_path)
+    uvx = tmp_path / ("uvx.exe" if os.name == "nt" else "uvx")
+    uv = tmp_path / ("uv.exe" if os.name == "nt" else "uv")
+    uvx.write_bytes(b"pinned-uv-launcher")
+    uv.write_bytes(b"pinned-uv-runtime")
+    wheel = tmp_path / "operator_clio_kit-py3-none-any.whl"
+    _write_synthetic_clio_kit_wheel(
+        wheel,
+        server_name="jarvis",
+        project={
+            "pyproject.toml": b"[project]\nname='jarvis-mcp'\n",
+            "uv.lock": _jarvis_cd_uv_lock(version="9.9.9"),
+        },
+    )
+    launched = False
+
+    def fake_run(
+        command: list[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal launched
+        launched = True
+        stdout = "\n".join(
+            [
+                json.dumps({"jsonrpc": "2.0", "id": "clio-relay-mcp-init", "result": {}}),
+                json.dumps({"jsonrpc": "2.0", "id": "clio-relay-mcp-call", "result": {}}),
+            ]
+        )
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(cast(Any, runner), "_run_mcp_session", fake_run)
+
+    return_code = cast(McpCallRunnerModule, runner).run_mcp_call_from_params(
+        {
+            "server": str(uvx),
+            "server_args": [
+                "--from",
+                str(wheel),
+                "clio-kit",
+                "mcp-server",
+                "jarvis",
+            ],
+            "tool": "jarvis_describe",
+        }
+    )
+    result = json.loads((tmp_path / "mcp-result.json").read_text(encoding="utf-8"))
+
+    assert return_code == 0
+    assert launched is True
+    assert "expected_jarvis_cd_lock_binding" not in result
+    assert result["server_artifact"]["nested_runtime"]["locked_runtime_verified"] is True
+    assert "jarvis_cd_lock_binding" not in result["server_artifact"]["nested_runtime"]
 
 
 def test_mcp_call_runner_v4_identity_resists_structural_collision(tmp_path: Path) -> None:
@@ -1750,6 +2225,7 @@ def test_mcp_call_runner_does_not_unlock_progress_for_unverified_server(
         tool="jarvis_run",
         arguments={"pipeline_id": "pipeline-a"},
         expected_server_artifact_digest="a" * 64,
+        expected_jarvis_cd_lock_binding=_jarvis_cd_lock_expectation(),
         observed_server_artifact_digest="a" * 64,
         server_artifact={
             "verified": False,
@@ -1758,6 +2234,28 @@ def test_mcp_call_runner_does_not_unlock_progress_for_unverified_server(
                 "locked_runtime_verified": False,
             },
         },
+    )
+
+    assert bridge is None
+
+
+def test_registered_jarvis_run_does_not_enable_builtin_progress_bridge(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Keep built-in package progress semantics out of operator JARVIS servers."""
+    runner = _load_runner()
+    monkeypatch.setenv("CLIO_RELAY_PROGRESS_FILE", str(tmp_path / "progress.jsonl"))
+    monkeypatch.setenv("CLIO_RELAY_PROGRESS_TOKEN", "outer")
+
+    bridge = cast(Any, runner)._package_progress_bridge_from_invocation(
+        operation="tools/call",
+        tool="jarvis_run",
+        arguments={"pipeline_id": "operator-pipeline"},
+        expected_server_artifact_digest="a" * 64,
+        expected_jarvis_cd_lock_binding=None,
+        observed_server_artifact_digest="a" * 64,
+        server_artifact=_verified_jarvis_server_artifact(),
     )
 
     assert bridge is None
@@ -2126,15 +2624,13 @@ def test_mcp_call_runner_persists_query_validation_in_durable_result(
         tmp_path,
         _jarvis_execution_query_result(include_progress=True, include_artifacts=True),
     )
-    artifact = {
-        "verified": True,
-        "nested_runtime": {
-            "server_name": "jarvis",
-            "locked_runtime_verified": True,
-        },
-    }
+    artifact = _verified_jarvis_server_artifact()
 
-    def server_identity(_server: str, _args: list[str]) -> dict[str, Any]:
+    def server_identity(
+        _server: str,
+        _args: list[str],
+        **_kwargs: object,
+    ) -> dict[str, Any]:
         return artifact
 
     def server_digest(_artifact: dict[str, Any]) -> str:
@@ -2155,6 +2651,7 @@ def test_mcp_call_runner_persists_query_validation_in_durable_result(
                 "artifacts": {"role": "output"},
             },
             "expected_server_artifact_digest": "a" * 64,
+            "expected_jarvis_cd_lock_binding": _jarvis_cd_lock_expectation(),
         }
     )
 
@@ -2166,6 +2663,41 @@ def test_mcp_call_runner_persists_query_validation_in_durable_result(
         "clio-relay.jarvis-execution-query-validation.v1"
     )
     assert result["result_validation"]["returned_artifact_count"] == 1
+
+
+def test_registered_jarvis_execution_query_keeps_operator_result_schema(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Do not impose the relay's built-in result schema on registered JARVIS MCPs."""
+    runner = _load_runner()
+    monkeypatch.chdir(tmp_path)
+    server = _write_structured_tools_call_server(
+        tmp_path,
+        {"operator_contract": "custom", "status": "ready"},
+    )
+    artifact = _verified_jarvis_server_artifact()
+    monkeypatch.setattr(runner, "_server_artifact_identity", lambda *_args: artifact)
+    monkeypatch.setattr(runner, "_server_artifact_digest", lambda _artifact: "a" * 64)
+
+    returncode = cast(Any, runner).run_mcp_call_from_params(
+        {
+            "server": sys.executable,
+            "server_args": [str(server)],
+            "operation": "tools/call",
+            "tool": "jarvis_get_execution",
+            "arguments": {"operator_argument": True},
+            "expected_server_artifact_digest": "a" * 64,
+        }
+    )
+
+    result = json.loads((tmp_path / "mcp-result.json").read_text(encoding="utf-8"))
+    assert returncode == 0
+    assert result["structured_result"] == {
+        "operator_contract": "custom",
+        "status": "ready",
+    }
+    assert result["result_validation"] is None
 
 
 def test_mcp_call_runner_accepts_explicit_execution_query_opt_outs() -> None:
@@ -2561,10 +3093,11 @@ def _write_synthetic_clio_kit_wheel(
     wheel: Path,
     *,
     project: dict[str, bytes],
+    server_name: str = "spack",
     excluded: dict[str, bytes] | None = None,
     outer_members: dict[str, bytes] | None = None,
 ) -> None:
-    prefix = "clio_kit-2.3.1.data/data/clio-kit-mcp-servers/spack/"
+    prefix = f"clio_kit-2.3.1.data/data/clio-kit-mcp-servers/{server_name}/"
     with zipfile.ZipFile(wheel, "w") as archive:
         archive.writestr("clio_kit/__init__.py", _locked_clio_kit_v4_launcher_source())
         for relative, content in project.items():

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1405,6 +1405,51 @@ def test_mcp_submit_mcp_call_creates_real_job_with_arguments(tmp_path: Path) -> 
     assert job.spec.timeout_seconds == 60
 
 
+def test_generic_mcp_default_idempotency_key_excludes_builtin_jarvis_marker(
+    tmp_path: Path,
+) -> None:
+    """Keep generic MCP call identity stable when the built-in marker is absent."""
+    queue = ClioCoreQueue(tmp_path / "core")
+    tool_arguments = {"case": "site-simulation", "steps": 100}
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 221,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_submit_mcp_call",
+                "arguments": {
+                    "cluster": "test-cluster",
+                    "server": "remote-tool-server",
+                    "server_args": ["--stdio"],
+                    "tool": "run",
+                    "arguments": tool_arguments,
+                },
+            },
+        },
+        queue=queue,
+    )
+
+    assert response is not None
+    job = queue.get_job(response["result"]["structuredContent"]["job_id"])
+    argument_digest = hashlib.sha256(
+        json.dumps(tool_arguments, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    expected_identity: dict[str, object] = {
+        "cluster": "test-cluster",
+        "server": "remote-tool-server",
+        "server_args": ["--stdio"],
+        "env_from": {},
+        "expected_server_artifact_digest": None,
+        "tool": "run",
+        "arguments_digest": argument_digest,
+        "timeout_seconds": None,
+    }
+    assert job.idempotency_key == (
+        "mcp:mcp-call:" + mcp_server_module._stable_digest(expected_identity)
+    )
+
+
 def test_mcp_call_jarvis_mcp_uses_builtin_cluster_command(tmp_path: Path) -> None:
     queue = ClioCoreQueue(tmp_path / "core")
 
@@ -1434,6 +1479,9 @@ def test_mcp_call_jarvis_mcp_uses_builtin_cluster_command(tmp_path: Path) -> Non
     assert job.spec.server_args == ["mcp-server", "jarvis"]
     assert job.spec.tool == "jarvis_describe"
     assert job.spec.arguments == {"target": "packages"}
+    assert job.spec.expected_jarvis_cd_lock_binding == (
+        mcp_server_module.jarvis_cd_lock_binding_expectation()
+    )
 
 
 def test_mcp_virtual_jarvis_tool_routes_to_cluster_mcp(

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import shutil
 import threading
@@ -24,6 +25,7 @@ from clio_relay.models import (
     JarvisRunSpec,
     JobKind,
     JobState,
+    McpCallSpec,
     MonitorRule,
     MonitorRuleAction,
     ProgressRecord,
@@ -1134,6 +1136,44 @@ def test_submit_rejects_reserved_idempotency_digest_mismatch(tmp_path: Path) -> 
                 idempotency_key="reserved",
             )
         )
+
+
+def test_null_jarvis_binding_preserves_pre_upgrade_mcp_submission_digest() -> None:
+    """An additive null trust marker cannot invalidate existing generic retries."""
+    job = RelayJob(
+        cluster="configured-target",
+        kind=JobKind.MCP_CALL,
+        spec=McpCallSpec(
+            server="operator-mcp",
+            tool="operator_query",
+            arguments={"query": "status"},
+        ),
+        idempotency_key="legacy-generic-mcp",
+    )
+    legacy_payload = job.model_dump(mode="json")
+    for generated_field in {
+        "job_id",
+        "state",
+        "created_at",
+        "updated_at",
+        "leased_by",
+        "attempts",
+        "last_error",
+        "submission_digest",
+        "used_artifact_refs",
+    }:
+        legacy_payload.pop(generated_field, None)
+    legacy_spec = cast(dict[str, object], legacy_payload["spec"])
+    legacy_spec.pop("expected_jarvis_cd_lock_binding")
+    expected = hashlib.sha256(
+        json.dumps(legacy_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+    observed = core_queue_module._job_idempotency_digest(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        job
+    )
+
+    assert observed == expected
 
 
 def test_submit_repairs_existing_job_missing_initial_event(tmp_path: Path) -> None:

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.9"
+    assert version == "1.3.10"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -292,11 +292,29 @@ def test_jarvis_release_requirement_enforces_unified_gray_scott_contract() -> No
         if resource["kind"] == "mcp_server"
     )
     assert server["metadata_equals"]["install_source"] == "uv-tool"
-    assert server["metadata_equals"]["nested_runtime"] == {
-        "server_name": "jarvis",
-        "persistent_tool": True,
-        "locked_runtime_verified": True,
-    }
+    nested_runtime = server["metadata_equals"]["nested_runtime"]
+    assert nested_runtime["server_name"] == "jarvis"
+    assert nested_runtime["persistent_tool"] is True
+    assert nested_runtime["locked_runtime_verified"] is True
+    lock_binding = nested_runtime["jarvis_cd_lock_binding"]
+    assert lock_binding["schema_version"] == "clio-relay.jarvis-cd-lock-binding.v1"
+    assert lock_binding["dependency"] == "jarvis-cd"
+    assert lock_binding["error"] is None
+    assert lock_binding["expected_version"] == "1.3.11"
+    assert lock_binding["expected_url"] == lock_binding["observed_source_url"]
+    assert lock_binding["expected_url"] == lock_binding["observed_wheel_url"]
+    assert lock_binding["expected_sha256"] == lock_binding["observed_wheel_sha256"]
+    assert lock_binding["observed_metadata_requirement_urls"] == [lock_binding["expected_url"]]
+    assert lock_binding["jarvis_mcp_package_entry_count"] == 1
+    assert lock_binding["resolved_dependency_entry_count"] == 1
+    assert lock_binding["observed_resolved_dependency_entries"] == [{"name": "jarvis-cd"}]
+    assert lock_binding["metadata_requirement_entry_count"] == 1
+    assert lock_binding["observed_metadata_requirement_entries"] == [
+        {"name": "jarvis-cd", "url": lock_binding["expected_url"]}
+    ]
+    assert lock_binding["package_entry_count"] == 1
+    assert lock_binding["wheel_entry_count"] == 1
+    assert lock_binding["verified"] is True
     assert server["metadata_equals"]["server_process_artifact_verified"] is True
     worker = next(
         resource
@@ -304,11 +322,11 @@ def test_jarvis_release_requirement_enforces_unified_gray_scott_contract() -> No
         if resource["kind"] == "relay_worker"
     )
     clio_kit_component = worker["metadata_equals"]["component_artifacts"]["clio-kit"]
-    assert clio_kit_component["distribution_version"] == "2.5.1"
+    assert clio_kit_component["distribution_version"] == "2.5.3"
     assert clio_kit_component["persistent_tool"]["manager"] == "uv"
     assert clio_kit_component["persistent_tool"]["uv_version"] == "0.11.28"
     assert clio_kit_component["persistent_tool"]["source_artifact_sha256"] == (
-        "e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1"
+        "1c528be468f156b14ae40b72214360c6fe923765d75b244c4505d3689dad0c6b"
     )
     jarvis_component = worker["metadata_equals"]["component_artifacts"]["jarvis-cd"]
     assert jarvis_component["distribution_version"] == "1.3.11"
@@ -324,6 +342,7 @@ def test_jarvis_release_requirement_enforces_unified_gray_scott_contract() -> No
     clio_kit_runtime = worker["metadata_equals"]["component_runtime"]["clio-kit"]
     assert clio_kit_runtime["uv_tool_environment_verified"] is True
     assert clio_kit_runtime["record_closure_verified"] is True
+    assert clio_kit_runtime["locked_server_runtime_verified"] is True
     progress = next(
         resource
         for resource in cast(list[dict[str, Any]], jarvis["required_resources"])
@@ -471,7 +490,7 @@ def test_spack_release_requirements_split_existing_resolution_from_fresh_install
     )
     assert fresh_server["metadata_equals"]["server_name"] == "spack-fresh"
     assert fresh_server["metadata_equals"]["install_artifact_sha256"] == (
-        "e2710b915e1b77d758f25118ed5cdf522687d2a813bdbf1abd3891164b9676d1"
+        "1c528be468f156b14ae40b72214360c6fe923765d75b244c4505d3689dad0c6b"
     )
     assert fresh_server["metadata_equals"]["contract_id"] == "clio-kit-spack-user-v2"
     assert fresh_server["metadata_equals"]["contract_sha256"] == (

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1944,7 +1944,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.3.9"
+    assert policy.release_version == "1.3.10"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.9"
+version = "1.3.10"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- bind the built-in JARVIS virtual MCP path to the exact released clio-kit 2.5.3 wheel and its unique JARVIS-CD 1.3.11 lock edge
- verify the outer server artifact and nested dependency before launch, discovery trust, runtime metadata ingestion, validation reporting, and service binding
- preserve arbitrary operator MCP isolation, legacy generic-MCP idempotency digests, and fail closed on ambiguous retry artifacts
- update the 1.3.10 release policy, acceptance matrix, documentation, CI pins, and machine-readable evidence expectations

## Focused verification

- 77 MCP runner tests
- 20 JARVIS validation tests
- 27 bootstrap/CLI/endpoint/service/provider/HTTP trust-path tests
- 10 new security and upgrade-compatibility tests
- exact released clio-kit 2.5.3 wheel hash and contract verification
- changed-file Ruff and Pyright checks
- local 1.3.10 wheel build and isolated persistent `uv tool` smoke test
