### PR TITLE
fix: verify Windows uv tool launchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.10` uses a release-first patch process. A maintainer builds the
+> Version `1.3.11` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.10"
+$Version = "1.3.11"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.10"
+release_version: "1.3.11"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: a64b851d9e72b44e0b2dbb103ba6d72a2ca72c71703a803e618bfec493a87d9c
+acceptance_matrix_sha256: 7b03e2db8b71acb0736ab476b39141715aea1b4841163f13e57eb7464af4483f
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.10"
+$Tag = "v1.3.11"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.10" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.11" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.10",
-  "matrix_sha256": "a64b851d9e72b44e0b2dbb103ba6d72a2ca72c71703a803e618bfec493a87d9c",
+  "release_version": "1.3.11",
+  "matrix_sha256": "7b03e2db8b71acb0736ab476b39141715aea1b4841163f13e57eb7464af4483f",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/jarvis-packages/clio_relay/clio_relay/mcp_call/runner.py
+++ b/jarvis-packages/clio_relay/clio_relay/mcp_call/runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
+import io
 import json
 import math
 import os
@@ -3169,6 +3170,36 @@ def _direct_distribution_source_identity(
     return _file_identity(source)
 
 
+def _persistent_tool_launcher_shebang(payload: bytes, *, executable_name: str) -> str:
+    """Return the provider shebang from a script or Windows uv trampoline."""
+    script = payload
+    if not payload.startswith(b"#!"):
+        if Path(executable_name).suffix.casefold() != ".exe":
+            raise ValueError("persistent tool launcher has no Python shebang")
+        with zipfile.ZipFile(io.BytesIO(payload), "r") as archive:
+            candidates = [
+                member for member in archive.infolist() if member.filename == "__main__.py"
+            ]
+            if len(candidates) != 1 or not _zip_member_is_regular(candidates[0]):
+                raise ValueError("Windows persistent tool launcher has no unique __main__.py")
+            if candidates[0].flag_bits & 0x1:
+                raise ValueError("Windows persistent tool launcher script is encrypted")
+            script = _read_bounded_zip_member(
+                archive,
+                candidates[0].filename,
+                max_bytes=CLIO_KIT_WHEEL_MAX_LAUNCHER_BYTES,
+            )
+    first_line = script.split(b"\n", 1)[0]
+    if len(first_line) > 4096:
+        raise ValueError("persistent tool launcher shebang exceeded its byte limit")
+    shebang = first_line.decode("utf-8", errors="strict").rstrip("\r")
+    if not shebang.startswith("#!") or not shebang[2:]:
+        raise ValueError("persistent tool launcher has no direct Python interpreter shebang")
+    if "\x00" in shebang:
+        raise ValueError("persistent tool launcher shebang contains a null byte")
+    return shebang
+
+
 def _external_python_console_distribution_identity(
     executable: Path,
     *,
@@ -3189,15 +3220,34 @@ def _external_python_console_distribution_identity(
         "direct_url": None,
         "provider_interpreter": None,
         "provider_interpreter_identity": None,
+        "external_launcher_identity": None,
+        "distribution_console_script": None,
+        "launcher_copy_verified": False,
         "contract_source_path": None,
         "server_lock_paths": {},
         "error": None,
     }
+    launcher_snapshot = _bounded_regular_file_snapshot(
+        executable,
+        max_bytes=PYTHON_TOOL_IDENTITY_MAX_BYTES,
+    )
+    if launcher_snapshot is None:
+        evidence["error"] = "persistent tool launcher is not one stable bounded file"
+        return evidence
+    launcher_bytes, launcher_descriptor = launcher_snapshot
+    launcher_sha256 = hashlib.sha256(launcher_bytes).hexdigest()
+    evidence["external_launcher_identity"] = {
+        "path": str(executable),
+        "filename": executable.name,
+        "sha256": launcher_sha256,
+        "size_bytes": len(launcher_bytes),
+    }
     try:
-        with executable.open("rb") as stream:
-            first_line = stream.readline(4096)
-        shebang = first_line.decode("utf-8", errors="strict").strip()
-    except (OSError, UnicodeDecodeError) as exc:
+        shebang = _persistent_tool_launcher_shebang(
+            launcher_bytes,
+            executable_name=executable.name,
+        )
+    except (UnicodeDecodeError, ValueError, zipfile.BadZipFile) as exc:
         evidence["error"] = f"could not read persistent tool launcher: {exc}"
         return evidence
     if not shebang.startswith("#!") or not shebang[2:]:
@@ -3218,25 +3268,62 @@ def _external_python_console_distribution_identity(
         evidence["error"] = "persistent tool provider interpreter has no file identity"
         return evidence
     probe = r"""
+import hashlib
 import json
 import sys
 from importlib import metadata
 from pathlib import Path
 
 command_name = sys.argv[1]
-launcher = Path(sys.argv[2]).resolve()
+external_launcher_sha256 = sys.argv[2]
 matches = []
+distribution_count = 0
+entry_point_count = 0
+candidate_names = {command_name.casefold(), f"{command_name}.exe".casefold()}
 for distribution in metadata.distributions():
+    distribution_count += 1
+    if distribution_count > 10_000:
+        raise SystemExit("installed Python distribution count exceeded its limit")
     files = distribution.files or []
-    owns_launcher = any(
-        Path(str(distribution.locate_file(member))).resolve() == launcher
-        for member in files
-    )
-    if not owns_launcher:
-        continue
+    if len(files) > 100_000:
+        raise SystemExit("installed Python distribution file count exceeded its limit")
+    entry_points = []
     for entry_point in distribution.entry_points:
-        if entry_point.group != "console_scripts" or entry_point.name != command_name:
+        entry_point_count += 1
+        if entry_point_count > 100_000:
+            raise SystemExit("installed Python entry-point count exceeded its limit")
+        if entry_point.group == "console_scripts" and entry_point.name == command_name:
+            entry_points.append(entry_point)
+    if len(entry_points) != 1:
+        continue
+    for launcher_member in files:
+        located_launcher = Path(str(distribution.locate_file(launcher_member))).resolve()
+        if located_launcher.name.casefold() not in candidate_names:
             continue
+        launcher_stat = located_launcher.stat()
+        if not located_launcher.is_file() or not 1 <= launcher_stat.st_size <= 8 * 1024 * 1024:
+            continue
+        launcher_hash = hashlib.sha256()
+        with located_launcher.open("rb") as launcher_stream:
+            while launcher_chunk := launcher_stream.read(1024 * 1024):
+                launcher_hash.update(launcher_chunk)
+        launcher_after = located_launcher.stat()
+        launcher_key = (
+            launcher_stat.st_dev,
+            launcher_stat.st_ino,
+            launcher_stat.st_size,
+            launcher_stat.st_mtime_ns,
+        )
+        if (
+            launcher_after.st_dev,
+            launcher_after.st_ino,
+            launcher_after.st_size,
+            launcher_after.st_mtime_ns,
+        ) != launcher_key:
+            raise SystemExit("persistent tool RECORD-owned launcher changed during inspection")
+        if launcher_hash.hexdigest() != external_launcher_sha256:
+            continue
+        entry_point = entry_points[0]
         direct_url_text = distribution.read_text("direct_url.json")
         direct_url = json.loads(direct_url_text) if direct_url_text else None
         serialized_files = []
@@ -3261,6 +3348,8 @@ for distribution in metadata.distributions():
                 server_lock_paths[server_name] = located
         matches.append({
             "executable": sys.executable,
+            "distribution_console_script": str(located_launcher),
+            "distribution_console_script_sha256": launcher_hash.hexdigest(),
             "distribution": distribution.metadata.get("Name"),
             "distribution_version": distribution.version,
             "entry_point": entry_point.name,
@@ -3274,7 +3363,7 @@ print(json.dumps({"matches": matches}, sort_keys=True))
 """
     try:
         completed = subprocess.run(
-            [str(provider_launcher), "-I", "-c", probe, command_name, str(executable)],
+            [str(provider_launcher), "-I", "-c", probe, command_name, launcher_sha256],
             check=False,
             capture_output=True,
             text=True,
@@ -3334,7 +3423,54 @@ print(json.dumps({"matches": matches}, sort_keys=True))
     if observed_provider != provider:
         evidence["error"] = "persistent tool probe executed under the wrong interpreter"
         return evidence
+    console_script_value = identity.get("distribution_console_script")
+    if not isinstance(console_script_value, str):
+        evidence["error"] = "persistent tool distribution omitted its RECORD-owned launcher"
+        return evidence
+    try:
+        console_script = Path(console_script_value).resolve(strict=True)
+        provider_environment_bin = provider_launcher.parent.resolve(strict=True)
+    except OSError as exc:
+        evidence["error"] = f"persistent tool RECORD-owned launcher is unavailable: {exc}"
+        return evidence
+    console_script_snapshot = _bounded_regular_file_snapshot(
+        console_script,
+        max_bytes=PYTHON_TOOL_IDENTITY_MAX_BYTES,
+    )
+    if console_script_snapshot is None:
+        evidence["error"] = "persistent tool RECORD-owned launcher is not one bounded file"
+        return evidence
+    console_script_bytes, console_script_descriptor = console_script_snapshot
+    console_script_sha256 = hashlib.sha256(console_script_bytes).hexdigest()
+    if (
+        console_script.parent != provider_environment_bin
+        or identity.get("distribution_console_script_sha256") != launcher_sha256
+        or not hmac.compare_digest(console_script_sha256, launcher_sha256)
+        or not hmac.compare_digest(console_script_bytes, launcher_bytes)
+    ):
+        evidence["error"] = (
+            "persistent tool launcher does not match its RECORD-owned console script"
+        )
+        return evidence
     closure = _verify_external_distribution_record_closure(cast(list[object], raw_files))
+    launcher_after = _bounded_regular_file_snapshot(
+        executable,
+        max_bytes=PYTHON_TOOL_IDENTITY_MAX_BYTES,
+    )
+    console_script_after = _bounded_regular_file_snapshot(
+        console_script,
+        max_bytes=PYTHON_TOOL_IDENTITY_MAX_BYTES,
+    )
+    if (
+        launcher_after is None
+        or console_script_after is None
+        or launcher_after[1] != launcher_descriptor
+        or console_script_after[1] != console_script_descriptor
+        or not hmac.compare_digest(launcher_after[0], launcher_bytes)
+        or not hmac.compare_digest(console_script_after[0], console_script_bytes)
+    ):
+        evidence["error"] = "persistent tool launcher changed during inspection"
+        return evidence
     evidence.update(
         {
             "distribution": identity.get("distribution"),
@@ -3344,6 +3480,13 @@ print(json.dumps({"matches": matches}, sort_keys=True))
             "direct_url": identity.get("direct_url"),
             "provider_interpreter": str(provider),
             "provider_interpreter_identity": provider_identity,
+            "distribution_console_script": {
+                "path": str(console_script),
+                "filename": console_script.name,
+                "sha256": console_script_sha256,
+                "size_bytes": len(console_script_bytes),
+            },
+            "launcher_copy_verified": True,
             "contract_source_path": identity.get("contract_source_path"),
             "server_lock_paths": identity.get("server_lock_paths", {}),
             **closure,
@@ -3651,8 +3794,7 @@ def _installed_clio_kit_runtime_identity(
     verify_relay_jarvis_cd_lock: bool,
 ) -> dict[str, Any]:
     """Verify clio-kit's locked child launcher from a persistent tool environment."""
-    uv_name = "uv.exe" if resolved_executable.suffix.lower() == ".exe" else "uv"
-    uv_identity = _file_identity(resolved_executable.with_name(uv_name))
+    uv_identity = _file_identity(Path(_resolve_executable("uv")).expanduser())
     evidence: dict[str, Any] = {
         "schema_version": _CLIO_KIT_LOCKED_SERVER_SCHEMA,
         "server_name": server_name,
@@ -3767,6 +3909,16 @@ def _is_sha256_text(value: object) -> bool:
 
 def _bounded_regular_file_bytes(path: Path, *, max_bytes: int) -> bytes | None:
     """Read one stable non-link regular file under an explicit byte limit."""
+    snapshot = _bounded_regular_file_snapshot(path, max_bytes=max_bytes)
+    return snapshot[0] if snapshot is not None else None
+
+
+def _bounded_regular_file_snapshot(
+    path: Path,
+    *,
+    max_bytes: int,
+) -> tuple[bytes, tuple[int, int, int, int]] | None:
+    """Read one stable regular file and return the descriptor identity read."""
     try:
         before = path.lstat()
     except OSError:
@@ -3800,7 +3952,7 @@ def _bounded_regular_file_bytes(path: Path, *, max_bytes: int) -> bytes | None:
         return None
     if (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns) != identity:
         return None
-    return payload
+    return payload, identity
 
 
 def _locked_clio_kit_runtime_identity(
@@ -3816,8 +3968,7 @@ def _locked_clio_kit_runtime_identity(
         if install_artifact is not None and isinstance(install_artifact.get("path"), str)
         else None
     )
-    uv_name = "uv.exe" if resolved_executable.suffix.lower() == ".exe" else "uv"
-    uv_identity = _file_identity(resolved_executable.with_name(uv_name))
+    uv_identity = _file_identity(Path(_resolve_executable("uv")).expanduser())
     evidence: dict[str, Any] = {
         "schema_version": _CLIO_KIT_LOCKED_SERVER_SCHEMA,
         "server_name": server_name,
@@ -4774,10 +4925,10 @@ def _resolve_executable(executable: str) -> str:
     resolved = shutil.which(executable)
     if resolved is not None:
         return resolved
-    if executable == "uvx":
-        user_local_uvx = Path.home() / ".local" / "bin" / "uvx"
-        if user_local_uvx.exists():
-            return str(user_local_uvx)
+    if executable in {"uv", "uvx"}:
+        user_local_executable = Path.home() / ".local" / "bin" / executable
+        if user_local_executable.exists():
+            return str(user_local_executable)
     return executable
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.10"
+version = "1.3.11"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.10"
+__version__ = "1.3.11"

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1696,7 +1696,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "a0cd720daeafdbd3841805054d36ff649b55194c301c0db72013fd5584580299"
+        "7b03e2db8b71acb0736ab476b39141715aea1b4841163f13e57eb7464af4483f"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -889,12 +889,16 @@ def test_component_runtime_identity_does_not_probe_unverified_clio_kit_launcher(
             )
         },
     )
-    monkeypatch.setattr(
-        "clio_relay.jarvis_mcp.jarvis_mcp_runtime_identity",
-        lambda _receipt: {
+
+    def unverified_runtime_identity(_receipt: object) -> dict[str, object]:
+        return {
             "artifact_identity_verified": False,
             "error": "locked JARVIS dependency did not verify",
-        },
+        }
+
+    monkeypatch.setattr(
+        "clio_relay.jarvis_mcp.jarvis_mcp_runtime_identity",
+        unverified_runtime_identity,
     )
     probed = False
 
@@ -909,7 +913,9 @@ def test_component_runtime_identity_does_not_probe_unverified_clio_kit_launcher(
         fail_if_probed,
     )
 
-    identities = installation_module._component_runtime_identity(receipt)
+    identities = installation_module._component_runtime_identity(  # pyright: ignore[reportPrivateUsage]
+        receipt
+    )
     runtime = cast(dict[str, object], identities["clio-kit"])
 
     assert probed is False

--- a/tests/test_mcp_call_runner.py
+++ b/tests/test_mcp_call_runner.py
@@ -11,6 +11,7 @@ import stat
 import subprocess
 import sys
 import time
+import warnings
 import zipfile
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
@@ -476,7 +477,9 @@ def test_persistent_uv_tool_clio_kit_runtime_is_receipt_bindable(
 ) -> None:
     runner = _load_runner()
     tool = tmp_path / ("clio-kit.exe" if os.name == "nt" else "clio-kit")
-    uv = tmp_path / ("uv.exe" if os.name == "nt" else "uv")
+    uv_bin = tmp_path / "uv-bin"
+    uv_bin.mkdir()
+    uv = uv_bin / ("uv.exe" if os.name == "nt" else "uv")
     wheel = tmp_path / "clio_kit-2.3.1-py3-none-any.whl"
     source = tmp_path / "clio_kit" / "__init__.py"
     lock = tmp_path / "share" / "clio-kit-mcp-servers" / "jarvis" / "uv.lock"
@@ -484,6 +487,8 @@ def test_persistent_uv_tool_clio_kit_runtime_is_receipt_bindable(
     lock.parent.mkdir(parents=True)
     tool.write_bytes(b"persistent-clio-kit-tool")
     uv.write_bytes(b"pinned-uv")
+    uv.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{uv_bin}{os.pathsep}{os.environ.get('PATH', '')}")
     wheel.write_bytes(b"released-clio-kit-wheel")
     source.write_text(_locked_clio_kit_v4_launcher_source(), encoding="utf-8")
     lock.write_bytes(_jarvis_cd_uv_lock())
@@ -527,6 +532,7 @@ def test_persistent_uv_tool_clio_kit_runtime_is_receipt_bindable(
     )
     assert identity["nested_launcher"] is True
     assert identity["nested_runtime"]["persistent_tool"] is True
+    assert identity["nested_runtime"]["uv_executable"]["path"] == str(uv.resolve())
     assert identity["nested_runtime"]["jarvis_cd_lock_binding"]["verified"] is True
     assert identity["nested_runtime"]["locked_runtime_verified"] is True
     assert identity["server_process_artifact_verified"] is True
@@ -572,6 +578,157 @@ def test_external_console_probe_preserves_logical_provider_path(
         evidence["error"]
         == "persistent tool launcher has no unique installed console-script distribution"
     )
+
+
+def test_windows_uv_trampoline_binds_digest_equal_record_launcher(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    runner = _load_runner()
+    provider = tmp_path / "tool" / "Scripts" / "python.exe"
+    provider.parent.mkdir(parents=True)
+    provider.write_bytes(b"provider")
+    public_launcher = tmp_path / "bin" / "science-mcp.exe"
+    public_launcher.parent.mkdir()
+    launcher_bytes = _write_uv_windows_trampoline(public_launcher, provider=provider)
+    record_launcher = provider.parent / public_launcher.name
+    record_launcher.write_bytes(launcher_bytes)
+    module = tmp_path / "tool" / "science_mcp" / "__init__.py"
+    module.parent.mkdir()
+    module.write_bytes(b"VALUE = 1\n")
+    record = tmp_path / "tool" / "science_mcp-1.0.0.dist-info" / "RECORD"
+    record.parent.mkdir()
+    record.write_bytes(b"record\n")
+
+    def record_member(name: str, path: Path) -> dict[str, object]:
+        content = path.read_bytes()
+        digest = base64.urlsafe_b64encode(hashlib.sha256(content).digest()).decode().rstrip("=")
+        return {
+            "name": name,
+            "path": str(path.resolve()),
+            "hash_mode": "sha256",
+            "hash_value": digest,
+            "size": len(content),
+        }
+
+    raw_files: list[dict[str, object]] = [
+        record_member("../../../Scripts/science-mcp.exe", record_launcher),
+        record_member("science_mcp/__init__.py", module),
+        {
+            "name": "science_mcp-1.0.0.dist-info/RECORD",
+            "path": str(record.resolve()),
+            "hash_mode": None,
+            "hash_value": None,
+            "size": None,
+        },
+    ]
+
+    def run_probe(
+        command: list[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        assert command[-1] == hashlib.sha256(launcher_bytes).hexdigest()
+        identity: dict[str, object] = {
+            "executable": str(provider.resolve()),
+            "distribution_console_script": str(record_launcher.resolve()),
+            "distribution_console_script_sha256": hashlib.sha256(launcher_bytes).hexdigest(),
+            "distribution": "science-mcp",
+            "distribution_version": "1.0.0",
+            "entry_point": "science-mcp",
+            "entry_point_value": "science_mcp:main",
+            "direct_url": None,
+            "files": raw_files,
+            "contract_source_path": None,
+            "server_lock_paths": {},
+        }
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps({"matches": [identity]}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(cast(Any, runner).subprocess, "run", run_probe)
+
+    evidence = cast(Any, runner)._external_python_console_distribution_identity(
+        public_launcher,
+        command_name="science-mcp",
+    )
+
+    assert evidence["error"] is None
+    assert evidence["runtime_closure_verified"] is True
+    assert evidence["launcher_copy_verified"] is True
+    assert (
+        evidence["external_launcher_identity"]["sha256"]
+        == evidence["distribution_console_script"]["sha256"]
+    )
+    assert evidence["distribution_console_script"]["path"] == str(record_launcher.resolve())
+
+
+def test_windows_uv_trampoline_rejects_nonmatching_record_launcher(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    runner = _load_runner()
+    provider = tmp_path / "tool" / "Scripts" / "python.exe"
+    provider.parent.mkdir(parents=True)
+    provider.write_bytes(b"provider")
+    public_launcher = tmp_path / "science-mcp.exe"
+    public_bytes = _write_uv_windows_trampoline(public_launcher, provider=provider)
+    record_launcher = provider.parent / public_launcher.name
+    record_launcher.write_bytes(public_bytes + b"different")
+
+    def run_probe(
+        command: list[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps({"matches": []}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(cast(Any, runner).subprocess, "run", run_probe)
+
+    evidence = cast(Any, runner)._external_python_console_distribution_identity(
+        public_launcher,
+        command_name="science-mcp",
+    )
+
+    assert evidence["runtime_closure_verified"] is False
+    assert evidence["launcher_copy_verified"] is False
+    assert (
+        evidence["error"]
+        == "persistent tool launcher has no unique installed console-script distribution"
+    )
+
+
+def test_windows_uv_trampoline_requires_unique_bounded_main_script(tmp_path: Path) -> None:
+    runner = _load_runner()
+    launcher = tmp_path / "science-mcp.exe"
+    launcher.write_bytes(b"MZ-test-stub")
+    with zipfile.ZipFile(launcher, "a") as archive:
+        archive.writestr("not-main.py", b"print('wrong')\n")
+
+    with raises(ValueError, match="no unique __main__"):
+        cast(Any, runner)._persistent_tool_launcher_shebang(
+            launcher.read_bytes(),
+            executable_name=launcher.name,
+        )
+
+    duplicate = tmp_path / "duplicate-science-mcp.exe"
+    duplicate.write_bytes(b"MZ-test-stub")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        with zipfile.ZipFile(duplicate, "a") as archive:
+            archive.writestr("__main__.py", b"#!/first/python\n")
+            archive.writestr("__main__.py", b"#!/second/python\n")
+    with raises(ValueError, match="no unique __main__"):
+        cast(Any, runner)._persistent_tool_launcher_shebang(
+            duplicate.read_bytes(),
+            executable_name=duplicate.name,
+        )
 
 
 def test_mcp_call_runner_supports_server_arguments(
@@ -643,12 +800,17 @@ def test_mcp_call_runner_supports_server_arguments(
 
 def test_mcp_call_runner_verifies_locked_clio_kit_child_runtime(
     tmp_path: Path,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     runner = _load_runner()
     uvx = tmp_path / ("uvx.exe" if os.name == "nt" else "uvx")
-    uv = tmp_path / ("uv.exe" if os.name == "nt" else "uv")
+    uv_bin = tmp_path / "uv-bin"
+    uv_bin.mkdir()
+    uv = uv_bin / ("uv.exe" if os.name == "nt" else "uv")
     uvx.write_bytes(b"pinned-uv-launcher")
     uv.write_bytes(b"pinned-uv-runtime")
+    uv.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{uv_bin}{os.pathsep}{os.environ.get('PATH', '')}")
     wheel = tmp_path / "clio_kit-2.3.1-py3-none-any.whl"
     prefix = "clio_kit-2.3.1.data/data/clio-kit-mcp-servers/spack/"
     launcher_source = _locked_clio_kit_v4_launcher_source()
@@ -684,7 +846,7 @@ def test_mcp_call_runner_verifies_locked_clio_kit_child_runtime(
     assert identity["nested_runtime"]["runtime_file_count"] == len(project)
     assert identity["nested_runtime"]["runtime_bytes"] == sum(map(len, project.values()))
     assert identity["nested_runtime"]["contract_source_verified"] is True
-    assert identity["nested_runtime"]["uv_executable"]["sha256"]
+    assert identity["nested_runtime"]["uv_executable"]["path"] == str(uv.resolve())
     assert identity["nested_runtime"]["locked_runtime_verified"] is True
     assert identity["server_process_artifact_verified"] is True
     assert identity["verified"] is True
@@ -939,10 +1101,20 @@ def test_mcp_call_runner_refuses_unverified_builtin_jarvis_launcher_before_launc
     artifact = _verified_jarvis_server_artifact()
     artifact["verified"] = False
     artifact["identity_error"] = "launcher digest did not verify"
+
+    def server_artifact_identity(
+        _server: str,
+        _server_args: list[str],
+        *,
+        verify_relay_jarvis_cd_lock: bool = False,
+    ) -> dict[str, Any]:
+        del verify_relay_jarvis_cd_lock
+        return artifact
+
     monkeypatch.setattr(
         runner,
         "_server_artifact_identity",
-        lambda *_args, **_kwargs: artifact,
+        server_artifact_identity,
     )
     opened = False
 
@@ -2677,8 +2849,21 @@ def test_registered_jarvis_execution_query_keeps_operator_result_schema(
         {"operator_contract": "custom", "status": "ready"},
     )
     artifact = _verified_jarvis_server_artifact()
-    monkeypatch.setattr(runner, "_server_artifact_identity", lambda *_args: artifact)
-    monkeypatch.setattr(runner, "_server_artifact_digest", lambda _artifact: "a" * 64)
+
+    def server_artifact_identity(
+        _server: str,
+        _server_args: list[str],
+        *,
+        verify_relay_jarvis_cd_lock: bool = False,
+    ) -> dict[str, Any]:
+        del verify_relay_jarvis_cd_lock
+        return artifact
+
+    def server_artifact_digest(_artifact: dict[str, Any]) -> str:
+        return "a" * 64
+
+    monkeypatch.setattr(runner, "_server_artifact_identity", server_artifact_identity)
+    monkeypatch.setattr(runner, "_server_artifact_digest", server_artifact_digest)
 
     returncode = cast(Any, runner).run_mcp_call_from_params(
         {
@@ -3156,6 +3341,17 @@ def _minimal_console_wheel(tmp_path: Path) -> Path:
             archive.writestr(name, content)
         archive.writestr(record_name, "\n".join(record_lines) + "\n")
     return wheel
+
+
+def _write_uv_windows_trampoline(path: Path, *, provider: Path) -> bytes:
+    """Write a representative uv PE-plus-ZIP console trampoline."""
+    path.write_bytes(b"MZ-test-uv-trampoline")
+    with zipfile.ZipFile(path, "a", compression=zipfile.ZIP_STORED) as archive:
+        archive.writestr(
+            "__main__.py",
+            f"#!{provider.resolve()}\nfrom science_mcp import main\nmain()\n".encode(),
+        )
+    return path.read_bytes()
 
 
 def _load_runner() -> ModuleType:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1446,7 +1446,10 @@ def test_generic_mcp_default_idempotency_key_excludes_builtin_jarvis_marker(
         "timeout_seconds": None,
     }
     assert job.idempotency_key == (
-        "mcp:mcp-call:" + mcp_server_module._stable_digest(expected_identity)
+        "mcp:mcp-call:"
+        + mcp_server_module._stable_digest(  # pyright: ignore[reportPrivateUsage]
+            expected_identity
+        )
     )
 
 

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.10"
+    assert version == "1.3.11"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1944,7 +1944,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.3.10"
+    assert policy.release_version == "1.3.11"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.10"
+version = "1.3.11"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- verify Windows `uv tool` PE+ZIP trampolines by extracting the bounded provider shebang and binding the public launcher to exactly one digest-equal RECORD-owned console script
- preserve full installed-distribution closure and JARVIS lock verification, and resolve the nested `uv` executable using the same PATH semantics as clio-kit
- add fail-closed trampoline, alias-mismatch, PATH-resolution, release-matrix, and tag-Pyright coverage
- bump clio-relay to 1.3.11

## Focused validation

- Ruff check and format on changed Python files
- Pyright: 0 errors, 0 warnings
- focused Windows-trampoline, distribution-closure, locked-runtime, release-version, and acceptance-matrix tests
- live source-tree identity probe against the installed clio-kit 2.5.3 Windows uv tool: 490 RECORD members verified