### PR TITLE
fix(runtime): allocate relay-owned desktop ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.11` uses a release-first patch process. A maintainer builds the
+> Version `1.3.12` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.11"
+$Version = "1.3.12"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.11"
+release_version: "1.3.12"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 7b03e2db8b71acb0736ab476b39141715aea1b4841163f13e57eb7464af4483f
+acceptance_matrix_sha256: 2774b40d7f122775ca01b17bb7f94226a9d99af0a81eb58f0f3876b3dc5e6dc7
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.11"
+$Tag = "v1.3.12"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.11" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.12" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.11",
-  "matrix_sha256": "7b03e2db8b71acb0736ab476b39141715aea1b4841163f13e57eb7464af4483f",
+  "release_version": "1.3.12",
+  "matrix_sha256": "2774b40d7f122775ca01b17bb7f94226a9d99af0a81eb58f0f3876b3dc5e6dc7",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.11"
+version = "1.3.12"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.11"
+__version__ = "1.3.12"

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -1182,7 +1182,8 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                 "Bind local relay connectors to one ready service reported by a completed, "
                 "artifact-bound JARVIS execution query with service runtimes included. "
                 "Runtime host, paths, scheduler identity, and dataset metadata are read "
-                "only from the durable JARVIS result."
+                "only from the durable JARVIS result. The relay allocates the desktop "
+                "loopback port."
             ),
             "inputSchema": {
                 "type": "object",
@@ -1196,11 +1197,6 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                     "package_id": {"type": "string", "minLength": 1, "maxLength": 256},
                     "package_name": {"type": "string", "minLength": 1, "maxLength": 256},
                     "name": {"type": "string", "minLength": 1, "maxLength": 256},
-                    "desktop_bind_port": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": 65535,
-                    },
                     "readiness_timeout_seconds": {
                         "type": "number",
                         "exclusiveMinimum": 0,
@@ -4129,7 +4125,6 @@ def _bind_jarvis_runtime(
         "package_id",
         "package_name",
         "name",
-        "desktop_bind_port",
         "readiness_timeout_seconds",
         "poll_seconds",
     }
@@ -4150,14 +4145,6 @@ def _bind_jarvis_runtime(
         package_id=_required_str(arguments, "package_id"),
         package_name=_required_str(arguments, "package_name"),
     )
-    raw_desktop_bind_port = arguments.get("desktop_bind_port")
-    if raw_desktop_bind_port is not None and (
-        isinstance(raw_desktop_bind_port, bool) or not isinstance(raw_desktop_bind_port, int)
-    ):
-        raise ValueError("desktop_bind_port must be an integer")
-    desktop_bind_port = raw_desktop_bind_port
-    if desktop_bind_port is not None and not 1 <= desktop_bind_port <= 65_535:
-        raise ValueError("desktop_bind_port must be between 1 and 65535")
     readiness_timeout_seconds = _positive_float_argument(
         arguments,
         "readiness_timeout_seconds",
@@ -4190,7 +4177,6 @@ def _bind_jarvis_runtime(
     started = supervisor.bind_verified_jarvis_runtime(
         name=runtime_name,
         verified=verified,
-        desktop_bind_port=desktop_bind_port,
         owner_session_id=settings.owner_session_id,
         owner_session_generation_id=settings.owner_session_generation_id,
         readiness_timeout_seconds=readiness_timeout_seconds,

--- a/src/clio_relay/service_runtime.py
+++ b/src/clio_relay/service_runtime.py
@@ -1028,7 +1028,11 @@ class ServiceRuntimeSupervisor:
         readiness_timeout_seconds: float = 300.0,
         poll_seconds: float = 2.0,
     ) -> ServiceRuntimeStartResult:
-        """Bind connectors to a ready JARVIS-owned service without submitting work."""
+        """Bind connectors to a ready JARVIS-owned service without submitting work.
+
+        ``desktop_bind_port`` is an internal operator override. Agent-facing calls
+        omit it so the relay allocates a distinct free loopback port.
+        """
         runtime = verified.runtime
         binding = verified.binding
         if runtime.lifecycle != "ready":
@@ -1050,9 +1054,11 @@ class ServiceRuntimeSupervisor:
                 raise ConfigurationError(
                     "scheduler-backed JARVIS services must advertise a loopback-only endpoint"
                 )
-        local_port = desktop_bind_port or runtime.port
-        if local_port < 1 or local_port > 65_535:
-            raise ConfigurationError("desktop bind port must be between 1 and 65535")
+        local_port = (
+            _available_loopback_port(exclude={runtime.port})
+            if desktop_bind_port is None
+            else _validated_available_loopback_port(desktop_bind_port)
+        )
         scheduler = binding.scheduler_provider or "external"
         spec = ServiceRuntimeSpec(
             kind="jarvis-service-runtime",
@@ -4083,7 +4089,21 @@ def _available_loopback_port(*, exclude: set[int] | None = None) -> int:
             port = cast(int, listener.getsockname()[1])
         if port not in excluded:
             return port
-    raise RelayError("could not select a distinct loopback port for browser attachment")
+    raise RelayError("could not select a distinct loopback port")
+
+
+def _validated_available_loopback_port(port: object) -> int:
+    """Validate and availability-test an explicit operator-selected loopback port."""
+    if isinstance(port, bool) or not isinstance(port, int):
+        raise ConfigurationError("desktop bind port must be an integer")
+    if port < 1 or port > 65_535:
+        raise ConfigurationError("desktop bind port must be between 1 and 65535")
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+            listener.bind(("127.0.0.1", port))
+    except OSError as exc:
+        raise ConfigurationError(f"desktop bind port is already occupied: {port}") from exc
+    return port
 
 
 def _validate_jarvis_service_state(

--- a/tests/test_jarvis_service_runtime.py
+++ b/tests/test_jarvis_service_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import socket
 import urllib.parse
 from collections.abc import Callable
 from pathlib import Path
@@ -501,7 +502,6 @@ def test_agent_bind_persists_urls_and_rejects_runtime_commands(
                     "source_artifact_id": artifact.artifact_id,
                     "package_id": "paraview-1",
                     "package_name": "builtin.paraview",
-                    "desktop_bind_port": 28777,
                 },
             },
         },
@@ -511,13 +511,17 @@ def test_agent_bind_persists_urls_and_rejects_runtime_commands(
     )
 
     assert response is not None and "error" not in response
-    result = response["result"]["structuredContent"]
-    assert result["connect_url"] == "http://127.0.0.1:28777"
-    assert result["health_url"] == "http://127.0.0.1:28777/healthz"
-    assert result["stream_url"] == "http://127.0.0.1:28777/live-data"
-    assert result["events_url"] == "http://127.0.0.1:28777/events"
-    assert result["state_url"] == "http://127.0.0.1:28777/state"
-    assert result["command_url"] == "http://127.0.0.1:28777/commands"
+    result = cast(dict[str, Any], response["result"]["structuredContent"])
+    connect_url = cast(str, result["connect_url"])
+    local_port = urllib.parse.urlparse(connect_url).port
+    assert local_port is not None
+    assert local_port != 18777
+    assert result["connect_url"] == f"http://127.0.0.1:{local_port}"
+    assert result["health_url"] == f"http://127.0.0.1:{local_port}/healthz"
+    assert result["stream_url"] == f"http://127.0.0.1:{local_port}/live-data"
+    assert result["events_url"] == f"http://127.0.0.1:{local_port}/events"
+    assert result["state_url"] == f"http://127.0.0.1:{local_port}/state"
+    assert result["command_url"] == f"http://127.0.0.1:{local_port}/commands"
     assert result["scheduler_cancel_requested"] is False
     gateway = result["gateway_session"]
     assert gateway["state"] == "ready"
@@ -533,6 +537,9 @@ def test_agent_bind_persists_urls_and_rejects_runtime_commands(
     assert owner_tokens
     assert all(token not in public_document for token in owner_tokens)
     assert "?capability=" not in public_document
+    runtime_spec = ServiceRuntimeSpec.model_validate(persisted.gateway["runtime_spec"])
+    assert runtime_spec.desktop_bind_port == local_port
+    assert runtime_spec.service_port == 18777
     persisted_transport = cast(dict[str, Any], persisted.gateway["transport"])
     for connector_name in ("remote_connector", "desktop_connector"):
         persisted_connector = cast(dict[str, Any], persisted_transport[connector_name])
@@ -548,10 +555,34 @@ def test_agent_bind_persists_urls_and_rejects_runtime_commands(
             gateway["gateway"]["ownership_intents"][connector_name]["owner_token"] == "<redacted>"
         )
 
-    refused = handle_request(
+    port_refused = handle_request(
         {
             "jsonrpc": "2.0",
             "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_bind_jarvis_runtime",
+                "arguments": {
+                    "cluster": definition.name,
+                    "source_job_id": job.job_id,
+                    "source_artifact_id": artifact.artifact_id,
+                    "package_id": "paraview-1",
+                    "package_name": "builtin.paraview",
+                    "desktop_bind_port": 28777,
+                },
+            },
+        },
+        queue=queue,
+        settings=settings,
+        profile="user",
+    )
+    assert port_refused is not None
+    assert "does not accept caller-supplied runtime metadata" in port_refused["error"]["message"]
+
+    refused = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
             "method": "tools/call",
             "params": {
                 "name": "relay_bind_jarvis_runtime",
@@ -575,7 +606,7 @@ def test_agent_bind_persists_urls_and_rejects_runtime_commands(
     replaced = handle_request(
         {
             "jsonrpc": "2.0",
-            "id": 3,
+            "id": 4,
             "method": "tools/call",
             "params": {
                 "name": "relay_update_gateway_session",
@@ -592,7 +623,7 @@ def test_agent_bind_persists_urls_and_rejects_runtime_commands(
     closed = handle_request(
         {
             "jsonrpc": "2.0",
-            "id": 4,
+            "id": 5,
             "method": "tools/call",
             "params": {
                 "name": "relay_close_gateway_session",
@@ -608,6 +639,45 @@ def test_agent_bind_persists_urls_and_rejects_runtime_commands(
     assert closed is not None
     assert "must be closed with stop-runtime" in closed["error"]["message"]
     assert queue.get_gateway_session(gateway["session_id"]).gateway["jarvis_runtime_binding"]
+
+
+def test_internal_bind_override_rejects_occupied_loopback_port(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An internal/operator override must fail before creating connector state on collision."""
+    queue, definition, job, artifact, envelope = _source_result(tmp_path)
+    monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
+    verified = resolve_jarvis_service_runtime(
+        queue=queue,
+        definition=definition,
+        source_job_id=job.job_id,
+        source_artifact_id=artifact.artifact_id,
+        package_id="paraview-1",
+        package_name="builtin.paraview",
+    )
+    supervisor = ServiceRuntimeSupervisor(
+        settings=RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool"),
+        queue=queue,
+        cluster=definition.name,
+        definition=definition,
+        token="token",
+        secret_key="secret",
+    )
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        listener.listen()
+        occupied_port = cast(int, listener.getsockname()[1])
+        with pytest.raises(
+            ConfigurationError,
+            match=f"desktop bind port is already occupied: {occupied_port}",
+        ):
+            supervisor.bind_verified_jarvis_runtime(
+                name="paraview-live",
+                verified=verified,
+                desktop_bind_port=occupied_port,
+            )
 
 
 def test_bound_runtime_detach_and_teardown_preserve_scheduler_by_default(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -166,6 +166,7 @@ def test_mcp_lists_relay_tools(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
         "relay_queue_stale",
         "relay_storage_status",
         "relay_bind_jarvis_runtime",
+        "relay_artifact_lineage",
         "jarvis_create_pipeline",
         "jarvis_describe",
         "jarvis_add_step",
@@ -174,6 +175,10 @@ def test_mcp_lists_relay_tools(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
         "jarvis_run",
     }
     assert "jarvis_create_pipeline" in tool_names
+    bind_runtime_tool = next(
+        tool for tool in response["result"]["tools"] if tool["name"] == "relay_bind_jarvis_runtime"
+    )
+    assert "desktop_bind_port" not in bind_runtime_tool["inputSchema"]["properties"]
     create_pipeline_tool = next(
         tool for tool in response["result"]["tools"] if tool["name"] == "jarvis_create_pipeline"
     )

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.11"
+    assert version == "1.3.12"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1944,7 +1944,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.3.11"
+    assert policy.release_version == "1.3.12"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.11"
+version = "1.3.12"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- remove `desktop_bind_port` from the agent-facing JARVIS runtime bind schema
- reject raw MCP attempts to bypass that schema
- allocate a free desktop loopback port owned by clio-relay and distinct from the remote service port
- retain a validated internal operator override that rejects invalid or occupied ports before connector creation
- release the fix as clio-relay 1.3.12

## Root cause

The previous optional argument invited the agent to copy or choose an infrastructure port. When omitted, relay reused the remote runtime port, which could collide locally and violated the intended boundary that agents provide scientific identity while relay owns connector placement.

## Validation

- schema, raw refusal, automatic allocation, collision, and detach focused tests: 4 passed
- release identity and policy digest tests: 2 passed
- scoped Ruff and Pyright passed
