### PR TITLE
fix: validate cleanup worker release source

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.12` uses a release-first patch process. A maintainer builds the
+> Version `1.3.13` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.12"
+$Version = "1.3.13"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.12"
+release_version: "1.3.13"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 2774b40d7f122775ca01b17bb7f94226a9d99af0a81eb58f0f3876b3dc5e6dc7
+acceptance_matrix_sha256: 6f788d7bd9c49848f82d4097eb25f51877a1b137984de6dff62425336852f5d0
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,11 +82,11 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.12"
+$Tag = "v1.3.13"
 $Commit = (git rev-parse HEAD).Trim()
 git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.12" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.13" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.12",
-  "matrix_sha256": "2774b40d7f122775ca01b17bb7f94226a9d99af0a81eb58f0f3876b3dc5e6dc7",
+  "release_version": "1.3.13",
+  "matrix_sha256": "6f788d7bd9c49848f82d4097eb25f51877a1b137984de6dff62425336852f5d0",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.12"
+version = "1.3.13"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.12"
+__version__ = "1.3.13"

--- a/src/clio_relay/installation.py
+++ b/src/clio_relay/installation.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, Literal, cast
 from urllib.parse import unquote, urlsplit
 
+from packaging.utils import InvalidWheelFilename, canonicalize_name, parse_wheel_filename
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from clio_relay.errors import ConfigurationError
@@ -1048,23 +1049,79 @@ def verify_remote_worker_info(
     return current_receipt
 
 
-def attach_verified_worker_identity(
+def _verify_release_worker_install_source(receipt: InstallReceipt) -> str:
+    """Validate the worker's own release-pinned installation source.
+
+    The desktop operator and persistent cluster worker may obtain the same
+    released wheel through different transports.  For example, an operator can
+    run a GitHub-release wheel while cluster bootstrap downloads the exact
+    version-pinned PyPI wheel.  Artifact, version, and software identity remain
+    exact; this check validates the worker receipt's source semantics instead
+    of incorrectly requiring it to equal the desktop launcher's source kind.
+    """
+    filename = receipt.artifact_filename
+    if not isinstance(filename, str) or not filename:
+        raise ConfigurationError("remote worker install receipt omitted its wheel filename")
+    try:
+        project, version, _build, _tags = parse_wheel_filename(filename)
+    except InvalidWheelFilename as exc:
+        raise ConfigurationError("remote worker install receipt wheel filename is invalid") from exc
+    if project != canonicalize_name("clio-relay") or str(version) != receipt.distribution_version:
+        raise ConfigurationError(
+            "remote worker install receipt wheel does not match its distribution version"
+        )
+
+    requested_source = receipt.requested_source
+    if requested_source == InstallSourceKind.PYPI.value:
+        expected_spec = f"clio-relay=={receipt.distribution_version}"
+        if receipt.install_spec != expected_spec:
+            raise ConfigurationError(
+                "remote worker PyPI install source is not pinned to the exact release version"
+            )
+    elif requested_source == InstallSourceKind.WHEEL.value:
+        parsed = urlsplit(receipt.install_spec)
+        if parsed.query or parsed.fragment:
+            raise ConfigurationError("remote worker wheel install source is not immutable")
+        install_filename = unquote(parsed.path).replace("\\", "/").rsplit("/", 1)[-1]
+        if install_filename != filename:
+            raise ConfigurationError(
+                "remote worker wheel install source does not match its receipt artifact"
+            )
+    else:
+        raise ConfigurationError(
+            "remote worker install source is not a release-pinned PyPI or wheel source"
+        )
+    return requested_source
+
+
+def _verify_report_worker_receipt(
     report: LiveValidationReport,
     info: dict[str, object],
 ) -> InstallReceipt:
-    """Verify and attach remote worker identity checks to a canonical report."""
+    """Bind a report to the exact worker artifact and its own pinned source."""
     receipt = verify_remote_worker_info(
         info,
         expected_cluster=report.cluster,
         expected_version=report.install_source.distribution_version,
         expected_software=report.software,
         expected_artifact_sha256=report.install_source.artifact_sha256,
-        expected_source=report.install_source.kind.value,
+        expected_source=None,
     )
+    _verify_release_worker_install_source(receipt)
+    return receipt
+
+
+def attach_verified_worker_identity(
+    report: LiveValidationReport,
+    info: dict[str, object],
+) -> InstallReceipt:
+    """Verify and attach remote worker identity checks to a canonical report."""
+    receipt = _verify_report_worker_receipt(report, info)
     now = datetime.now(UTC)
     checks = {
         "worker.artifact-version": receipt.distribution_version,
         "worker.artifact-sha256": receipt.artifact_sha256 or "none",
+        "worker.install-source": receipt.requested_source,
         "worker.source-identity": (
             f"{receipt.software.commit or 'none'}:"
             f"{receipt.software.tag or 'none'}:{receipt.software.dirty}"

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import sys
 from collections.abc import Callable
+from datetime import UTC, datetime
 from importlib import metadata
 from pathlib import Path
 from types import SimpleNamespace
@@ -20,6 +21,7 @@ from clio_relay.installation import (
     INSTALL_RECEIPT_PATH_ENV,
     INSTALL_RECEIPT_SCHEMA,
     ComponentArtifactIdentity,
+    InstallReceipt,
     NativeJarvisExecutionCapability,
     PersistentUvToolIdentity,
     installation_info,
@@ -38,7 +40,12 @@ from clio_relay.jarvis_mcp import (
     jarvis_mcp_command,
     jarvis_user_contract,
 )
-from clio_relay.validation_report import InstallSource, InstallSourceKind, SoftwareIdentity
+from clio_relay.validation_report import (
+    InstallSource,
+    InstallSourceKind,
+    LiveValidationReport,
+    SoftwareIdentity,
+)
 
 
 def _verified_locked_jarvis_runtime() -> dict[str, object]:
@@ -785,6 +792,97 @@ def test_remote_worker_identity_is_bound_to_fresh_running_endpoint(tmp_path: Pat
             expected_software=SoftwareIdentity.model_validate(installation["software"]),
             expected_artifact_sha256=receipt.artifact_sha256,
             expected_source="wheel",
+        )
+
+
+def test_cleanup_report_accepts_exact_pypi_worker_for_wheel_operator() -> None:
+    version = "1.3.12"
+    digest = "d" * 64
+    software = SoftwareIdentity(
+        version=version,
+        commit="8" * 40,
+        tag=f"v{version}",
+        dirty=False,
+    )
+    receipt = InstallReceipt(
+        installed_at=datetime.now(UTC),
+        install_spec=f"clio-relay=={version}",
+        requested_source="pypi",
+        artifact_filename=f"clio_relay-{version}-py3-none-any.whl",
+        artifact_sha256=digest,
+        distribution_version=version,
+        software=software,
+    )
+
+    def worker_info(worker_receipt: InstallReceipt) -> dict[str, object]:
+        installation = {
+            "schema_version": "clio-relay.installation-info.v1",
+            "distribution_version": version,
+            "software": software.model_dump(mode="json"),
+            "receipt": worker_receipt.model_dump(mode="json"),
+            "receipt_origin": "bootstrap",
+            "install_source": None,
+            "receipt_matches_install": True,
+            "component_runtime": {},
+        }
+        return {
+            "schema_version": "clio-relay.worker-runtime-info.v1",
+            "cluster": "ares",
+            "fresh": True,
+            "process_running": True,
+            "identity_matches_current": True,
+            "running": True,
+            "scheduler_provider": "slurm",
+            "endpoint": {
+                "role": "worker",
+                "cluster": "ares",
+                "pid": 123,
+                "metadata": {"scheduler_provider": "slurm"},
+            },
+            "installation": installation,
+            "endpoint_installation": installation,
+            "target_identity": {"verified": True},
+        }
+
+    wheel_url = (
+        "https://github.com/iowarp/clio-relay/releases/download/"
+        f"v{version}/clio_relay-{version}-py3-none-any.whl"
+    )
+    cleanup_report = LiveValidationReport(
+        scenario="cleanup",
+        cluster="ares",
+        software=software,
+        install_source=InstallSource(
+            kind=InstallSourceKind.WHEEL,
+            detected_kind=InstallSourceKind.WHEEL,
+            reference=wheel_url,
+            package_path="/desktop/uv/tools/clio-relay",
+            distribution_version=version,
+            artifact_sha256=digest,
+            direct_url={"url": wheel_url, "archive_info": {}},
+        ),
+    )
+
+    verified = installation_module._verify_report_worker_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        cleanup_report,
+        worker_info(receipt),
+    )
+
+    assert verified.requested_source == "pypi"
+    assert verified.artifact_sha256 == cleanup_report.install_source.artifact_sha256
+
+    unpinned = receipt.model_copy(update={"install_spec": f"clio-relay>={version}"})
+    with pytest.raises(ConfigurationError, match="not pinned to the exact release version"):
+        installation_module._verify_report_worker_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            cleanup_report,
+            worker_info(unpinned),
+        )
+
+    changed_artifact = receipt.model_copy(update={"artifact_sha256": "e" * 64})
+    with pytest.raises(ConfigurationError, match="wheel SHA-256 does not match"):
+        installation_module._verify_report_worker_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            cleanup_report,
+            worker_info(changed_artifact),
         )
 
 

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.12"
+    assert version == "1.3.13"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1944,7 +1944,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.3.12"
+    assert policy.release_version == "1.3.13"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.12"
+version = "1.3.13"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- validate the persistent worker's own exact release-pinned source independently from the desktop operator's install transport
- retain strict cluster, version, software identity, target identity, and wheel SHA-256 checks
- emit explicit `worker.install-source` evidence in machine-readable validation reports
- release the fix as clio-relay 1.3.13

## Root cause and impact

Attempt 10 completed preserve-jobs teardown successfully, including stopping the remote API and closing the owned session while retaining Slurm job 21954. Report finalization then failed because the desktop operator came from the GitHub release wheel while the supported Ares bootstrap receipt described the byte-identical version-pinned PyPI wheel. Source transport equality is not an artifact-identity invariant. The corrected boundary accepts either exact pinned release source and still rejects unpinned versions, invalid wheel receipts, or changed digests.

## Validation

- production-shaped wheel-operator/PyPI-worker cleanup regression
- existing fresh-running worker identity regression
- release identity and machine-readable gate policy tests
- Ruff, Pyright, uv lock check, and diff check
