### PR TITLE
fix: bind release artifacts to exact tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.14` uses a release-first patch process. A maintainer builds the
+> Version `1.3.15` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.14"
+$Version = "1.3.15"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.14"
+release_version: "1.3.15"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 9bf15c0c129ef463652eef27d0b0eec01f38132898c53a8fb20d75ad2637d6d7
+acceptance_matrix_sha256: a1a5e44d240a72848c044bc274619cecaffb0767c1dff8ab03604944081ef0fc
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -49,13 +49,42 @@ Formatting or package construction required by the changed surface is not a
 substitute for the focused behavioral test. Do not run the full regression
 suite locally as part of the patch release loop.
 
+## Merge and create the exact local tag
+
+Push and merge the focused patch, then update the local `main` checkout and
+create the package-version tag locally. The tag must exist before Hatch builds
+the release artifacts because the build hook embeds the exact tag in both
+distributions.
+
+```powershell
+git push -u origin HEAD
+gh pr create --title "fix: ..." --body-file PR.md
+gh pr merge --squash --delete-branch
+git switch main
+git pull --ff-only origin main
+$Tag = "v1.3.15"
+$Commit = (git rev-parse HEAD).Trim()
+if (git status --porcelain) { throw "release checkout is dirty" }
+if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
+git tag $Tag $Commit
+```
+
+Do not push the tag yet. Building before the local tag exists produces an
+artifact without an exact source-tag identity.
+
 ## Build exact distributions
 
 Build once from the merged release commit:
 
 ```powershell
 Remove-Item -Recurse -Force dist -ErrorAction SilentlyContinue
-uv build --out-dir dist
+$env:CLIO_RELAY_RELEASE_BUILD = "1"
+try {
+  uv build --out-dir dist
+  if ($LASTEXITCODE -ne 0) { throw "release distribution build failed" }
+} finally {
+  Remove-Item Env:CLIO_RELAY_RELEASE_BUILD -ErrorAction SilentlyContinue
+}
 uv run twine check dist/*
 $files = Get-ChildItem dist -File | Where-Object {
   $_.Name.EndsWith(".whl") -or $_.Name.EndsWith(".tar.gz")
@@ -68,25 +97,24 @@ $lines = foreach ($file in $files | Sort-Object Name) {
 Set-Content -Encoding ascii -Path dist/SHA256SUMS -Value $lines
 ```
 
+`CLIO_RELAY_RELEASE_BUILD=1` makes the build hook require a commit, a clean
+tree, and the exact `v<project.version>` tag. An untagged, differently tagged,
+or dirty source tree fails the build instead of creating a release artifact
+with incomplete provenance. Ordinary untagged CI candidate builds remain
+supported because they do not set release-build mode.
+
 Do not rebuild between GitHub publication and PyPI publication. PyPI receives
 the distributions downloaded from the published GitHub Release, not a second
 CI build.
 
-## Push, merge, tag, and publish
+## Push the tag and publish
 
-The normal order is:
+After the exact distributions have passed their local checks, push the tag and
+publish those already-built bytes:
 
 ```powershell
-git push -u origin HEAD
-gh pr create --title "fix: ..." --body-file PR.md
-gh pr merge --squash --delete-branch
-git switch main
-git pull --ff-only origin main
-$Tag = "v1.3.14"
-$Commit = (git rev-parse HEAD).Trim()
-git tag $Tag $Commit
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.14" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.15" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.14",
-  "matrix_sha256": "9bf15c0c129ef463652eef27d0b0eec01f38132898c53a8fb20d75ad2637d6d7",
+  "release_version": "1.3.15",
+  "matrix_sha256": "a1a5e44d240a72848c044bc274619cecaffb0767c1dff8ab03604944081ef0fc",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import tomllib
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
+from hatchling.builders.config import BuilderConfig
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
 
-class CustomBuildHook(BuildHookInterface):
+class CustomBuildHook(BuildHookInterface[BuilderConfig]):
     """Include commit, exact tag, and cleanliness in wheel and sdist artifacts."""
 
     PLUGIN_NAME = "custom"
@@ -29,6 +31,10 @@ class CustomBuildHook(BuildHookInterface):
         }
         if payload["commit"] is None:
             payload.update(_source_archive_identity(root))
+        _validate_release_build_identity(
+            payload,
+            release_mode=os.environ.get("CLIO_RELAY_RELEASE_BUILD"),
+        )
         generated.write_text(
             json.dumps(payload, indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
@@ -39,6 +45,35 @@ class CustomBuildHook(BuildHookInterface):
             force_include[str(generated)] = "src/clio_relay/_build_info.json"
         elif not (root / "src" / "clio_relay" / "_build_info.json").exists():
             force_include[str(generated)] = "clio_relay/_build_info.json"
+
+
+def _validate_release_build_identity(
+    payload: dict[str, object],
+    *,
+    release_mode: str | None,
+) -> None:
+    """Reject release distributions that cannot prove their exact source tag."""
+    if release_mode is None:
+        return
+    if release_mode != "1":
+        raise RuntimeError("CLIO_RELAY_RELEASE_BUILD must be exactly '1' when set")
+
+    version = payload.get("version")
+    if not isinstance(version, str) or not version:
+        raise RuntimeError("release build identity has no package version")
+    commit = payload.get("commit")
+    if not isinstance(commit, str) or not commit:
+        raise RuntimeError("release build identity has no source commit")
+    expected_tag = f"v{version}"
+    if payload.get("tag") != expected_tag:
+        raise RuntimeError(
+            "release build must run from the exact package-version tag: "
+            f"expected {expected_tag}, got {payload.get('tag')!r}"
+        )
+    if payload.get("dirty") is not False:
+        raise RuntimeError(
+            f"release build must run from a clean source tree: dirty={payload.get('dirty')!r}"
+        )
 
 
 def _git_output(root: Path, *args: str) -> str | None:
@@ -68,20 +103,25 @@ def _source_archive_identity(root: Path) -> dict[str, object]:
     embedded = root / "src" / "clio_relay" / "_build_info.json"
     if not embedded.exists():
         return {"commit": None, "tag": None, "dirty": None}
-    loaded = json.loads(embedded.read_text(encoding="utf-8"))
+    loaded: object = json.loads(embedded.read_text(encoding="utf-8"))
     if not isinstance(loaded, dict):
         return {"commit": None, "tag": None, "dirty": None}
+    document = cast(dict[str, object], loaded)
     return {
-        "commit": loaded.get("commit"),
-        "tag": loaded.get("tag"),
-        "dirty": loaded.get("dirty"),
+        "commit": document.get("commit"),
+        "tag": document.get("tag"),
+        "dirty": document.get("dirty"),
     }
 
 
 def _project_version(root: Path) -> str:
     with (root / "pyproject.toml").open("rb") as stream:
-        document = tomllib.load(stream)
-    project = document.get("project")
-    if not isinstance(project, dict) or not isinstance(project.get("version"), str):
+        document = cast(dict[str, object], tomllib.load(stream))
+    project_value = document.get("project")
+    if not isinstance(project_value, dict):
         raise RuntimeError("pyproject.toml does not define project.version")
-    return project["version"]
+    project = cast(dict[str, object], project_value)
+    version = project.get("version")
+    if not isinstance(version, str):
+        raise RuntimeError("pyproject.toml does not define project.version")
+    return version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.14"
+version = "1.3.15"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.14"
+__version__ = "1.3.15"

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1696,7 +1696,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "9bf15c0c129ef463652eef27d0b0eec01f38132898c53a8fb20d75ad2637d6d7"
+        "a1a5e44d240a72848c044bc274619cecaffb0767c1dff8ab03604944081ef0fc"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -6189,26 +6189,17 @@ def test_worker_refuses_runtime_identity_when_result_arguments_do_not_match(
 def test_worker_refuses_stdout_only_jarvis_mcp_runtime_identity(
     monkeypatch: MonkeyPatch,
 ) -> None:
-    server_args = [
-        "--from",
-        "clio-kit==2.3.1",
-        "clio-kit",
-        "mcp-server",
-        "jarvis",
-    ]
-    digest = "e" * 64
-    monkeypatch.setattr(
-        endpoint_module,
-        "jarvis_mcp_command",
-        lambda: ["uvx", *server_args],
-    )
+    command = ["clio-kit", "mcp-server", "jarvis"]
+    server_artifact = verified_jarvis_server_artifact()
+    digest = remote_mcp_server_artifact_digest(server_artifact)
+    monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
     arguments = {"pipeline_id": "owned"}
     job = RelayJob(
         cluster="research-cluster",
         kind=JobKind.MCP_CALL,
         spec=McpCallSpec(
-            server="uvx",
-            server_args=server_args,
+            server=command[0],
+            server_args=command[1:],
             expected_server_artifact_digest=digest,
             expected_jarvis_cd_lock_binding=(endpoint_module.jarvis_cd_lock_binding_expectation()),
             tool="jarvis_run",
@@ -6220,14 +6211,15 @@ def test_worker_refuses_stdout_only_jarvis_mcp_runtime_identity(
     trusted, reason = cast(Any, endpoint_module)._trusted_jarvis_mcp_result(
         job,
         {
-            "server": "uvx",
-            "server_args": server_args,
+            "server": command[0],
+            "server_args": command[1:],
             "env_from": {},
             "expected_server_artifact_digest": digest,
             "expected_jarvis_cd_lock_binding": (
                 endpoint_module.jarvis_cd_lock_binding_expectation()
             ),
             "observed_server_artifact_digest": digest,
+            "server_artifact": server_artifact,
             "operation": "tools/call",
             "tool": "jarvis_run",
             "arguments": arguments,

--- a/tests/test_hatch_build.py
+++ b/tests/test_hatch_build.py
@@ -1,0 +1,122 @@
+"""Focused tests for distribution source-identity embedding."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+import hatch_build
+from hatch_build import CustomBuildHook
+
+
+def _hook(root: Path, *, target_name: str = "wheel") -> CustomBuildHook:
+    hook = CustomBuildHook.__new__(CustomBuildHook)
+    object.__setattr__(hook, "_BuildHookInterface__root", str(root))
+    object.__setattr__(hook, "_BuildHookInterface__target_name", target_name)
+    return hook
+
+
+def _write_project(root: Path, *, version: str = "1.3.15") -> None:
+    (root / "pyproject.toml").write_text(
+        f'[project]\nname = "clio-relay"\nversion = "{version}"\n',
+        encoding="utf-8",
+    )
+
+
+def _clean_git_output(_root: Path, *args: str) -> str | None:
+    """Return a stable clean tagged identity for build-hook tests."""
+    return "a" * 40 if args == ("rev-parse", "HEAD") else "v1.3.15"
+
+
+def _untagged_git_output(_root: Path, *args: str) -> str | None:
+    """Return a stable commit with no exact tag for build-hook tests."""
+    return "a" * 40 if args == ("rev-parse", "HEAD") else None
+
+
+def _clean_git_status(_root: Path) -> bool:
+    """Report a clean synthetic source tree."""
+    return False
+
+
+def test_release_build_embeds_exact_clean_tagged_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_project(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_RELEASE_BUILD", "1")
+    monkeypatch.setattr(
+        hatch_build,
+        "_git_output",
+        _clean_git_output,
+    )
+    monkeypatch.setattr(hatch_build, "_git_dirty", _clean_git_status)
+    build_data: dict[str, object] = {}
+
+    _hook(tmp_path).initialize("1.3.15", build_data)
+
+    embedded = json.loads(
+        (tmp_path / ".clio-relay" / "build" / "_build_info.json").read_text(encoding="utf-8")
+    )
+    assert embedded == {
+        "commit": "a" * 40,
+        "dirty": False,
+        "tag": "v1.3.15",
+        "version": "1.3.15",
+    }
+    assert build_data["force_include"] == {
+        str(tmp_path / ".clio-relay" / "build" / "_build_info.json"): (
+            "clio_relay/_build_info.json"
+        )
+    }
+
+
+def test_release_build_rejects_source_without_exact_version_tag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_project(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_RELEASE_BUILD", "1")
+    monkeypatch.setattr(
+        hatch_build,
+        "_git_output",
+        _untagged_git_output,
+    )
+    monkeypatch.setattr(hatch_build, "_git_dirty", _clean_git_status)
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"release build must run from the exact package-version tag: "
+        r"expected v1\.3\.15, got None",
+    ):
+        _hook(tmp_path).initialize("1.3.15", {})
+
+
+@pytest.mark.parametrize(
+    ("identity", "message"),
+    [
+        (
+            {"version": "1.3.15", "commit": None, "tag": "v1.3.15", "dirty": False},
+            "release build identity has no source commit",
+        ),
+        (
+            {"version": "1.3.15", "commit": "a" * 40, "tag": "v1.3.15", "dirty": True},
+            "release build must run from a clean source tree",
+        ),
+    ],
+)
+def test_release_build_rejects_incomplete_or_dirty_identity(
+    identity: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(RuntimeError, match=message):
+        cast(Any, hatch_build)._validate_release_build_identity(identity, release_mode="1")
+
+
+def test_non_release_candidate_build_may_remain_untagged() -> None:
+    cast(Any, hatch_build)._validate_release_build_identity(
+        {"version": "1.3.15", "commit": "a" * 40, "tag": None, "dirty": False},
+        release_mode=None,
+    )

--- a/tests/test_mcp_call_runner.py
+++ b/tests/test_mcp_call_runner.py
@@ -125,15 +125,15 @@ def _jarvis_cd_lock_expectation() -> dict[str, str]:
     }
 
 
-def _verified_jarvis_server_artifact() -> dict[str, Any]:
+def _verified_jarvis_server_artifact(*, executable_path: str = "clio-kit") -> dict[str, Any]:
     """Return the minimal verified built-in JARVIS artifact boundary."""
     expected = _jarvis_cd_lock_expectation()
     return {
         "verified": True,
-        "resolved_executable": "clio-kit",
+        "resolved_executable": executable_path,
         "executable": {
-            "path": "clio-kit",
-            "filename": "clio-kit",
+            "path": executable_path,
+            "filename": Path(executable_path).name,
             "sha256": "d" * 64,
             "size_bytes": 1,
         },
@@ -3116,7 +3116,7 @@ def test_mcp_call_runner_persists_query_validation_in_durable_result(
         tmp_path,
         _jarvis_execution_query_result(include_progress=True, include_artifacts=True),
     )
-    artifact = _verified_jarvis_server_artifact()
+    artifact = _verified_jarvis_server_artifact(executable_path=sys.executable)
 
     def server_identity(
         _server: str,
@@ -3168,7 +3168,7 @@ def test_registered_jarvis_execution_query_keeps_operator_result_schema(
         tmp_path,
         {"operator_contract": "custom", "status": "ready"},
     )
-    artifact = _verified_jarvis_server_artifact()
+    artifact = _verified_jarvis_server_artifact(executable_path=sys.executable)
 
     def server_artifact_identity(
         _server: str,

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.14"
+    assert version == "1.3.15"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -89,6 +89,21 @@ def test_tag_push_uploads_exact_release_distributions_asynchronously() -> None:
     assert "github.event.release" not in text
 
 
+def test_release_build_requires_local_exact_tag_before_distribution_construction() -> None:
+    process = (ROOT / "docs" / "release.md").read_text(encoding="utf-8")
+
+    tag = process.index("git tag $Tag $Commit")
+    release_mode = process.index('$env:CLIO_RELAY_RELEASE_BUILD = "1"')
+    build = process.index("uv build --out-dir dist")
+    push = process.index("git push origin $Tag")
+
+    assert tag < release_mode < build < push
+    assert "Remove-Item Env:CLIO_RELAY_RELEASE_BUILD" in process
+    assert "An untagged, differently tagged, or dirty source tree fails the build" in " ".join(
+        process.split()
+    )
+
+
 def test_same_tag_release_stages_share_one_non_canceling_concurrency_group() -> None:
     workflows = (
         ("release.yml", "${{ github.ref_name }}"),

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1944,7 +1944,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.3.14"
+    assert policy.release_version == "1.3.15"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.14"
+version = "1.3.15"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- require release-mode builds to come from a clean commit carrying the exact `v<version>` tag
- update the patch release runbook so the local tag exists before Hatch builds either distribution
- correct stale trust-boundary fixtures exposed by the completed v1.3.14 tag CI
- bump the patch release identity to 1.3.15

## Root cause

v1.3.14 was built before its tag existed, so the wheel correctly embedded the commit but recorded `tag: null`. The release preflight therefore rejected the published artifact. The asynchronous tag suite also exposed test fixtures that no longer supplied the exact verified server identity or executable they intended to exercise.

## Validation

- Ruff check and format on all changed Python files
- Pyright: 0 errors
- 12 focused build-hook, release-policy, endpoint, and MCP runner tests passed