### PR TITLE
fix(jarvis): expose exact service runtime handoffs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,13 @@ jobs:
       - name: stage exact clio-kit release wheel
         shell: bash
         env:
-          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.5.4-py3-none-any.whl
-          CLIO_KIT_WHEEL_SHA256: 8e29cdde8abc669ca700aec09b38b6954322e924ac175cfcdf16a7f41a32374f
-          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.5.4/clio_kit-2.5.4-py3-none-any.whl
+          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.5.5-py3-none-any.whl
+          CLIO_KIT_WHEEL_SHA256: 622344b951d39f35b0952d2bf056d83040b81ad52e4aca4794fa486026eab278
+          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.5.5/clio_kit-2.5.5-py3-none-any.whl
         run: |
           set -euo pipefail
           umask 077
-          wheel_dir="$RUNNER_TEMP/clio-kit-v2.5.4"
+          wheel_dir="$RUNNER_TEMP/clio-kit-v2.5.5"
           mkdir "$wheel_dir"
           wheel="$wheel_dir/$CLIO_KIT_WHEEL_FILENAME"
           curl --fail --show-error --silent --location \
@@ -160,13 +160,13 @@ jobs:
       - name: stage exact clio-kit release wheel
         shell: bash
         env:
-          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.5.4-py3-none-any.whl
-          CLIO_KIT_WHEEL_SHA256: 8e29cdde8abc669ca700aec09b38b6954322e924ac175cfcdf16a7f41a32374f
-          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.5.4/clio_kit-2.5.4-py3-none-any.whl
+          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.5.5-py3-none-any.whl
+          CLIO_KIT_WHEEL_SHA256: 622344b951d39f35b0952d2bf056d83040b81ad52e4aca4794fa486026eab278
+          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.5.5/clio_kit-2.5.5-py3-none-any.whl
         run: |
           set -euo pipefail
           umask 077
-          wheel_dir="$RUNNER_TEMP/clio-kit-v2.5.4"
+          wheel_dir="$RUNNER_TEMP/clio-kit-v2.5.5"
           mkdir "$wheel_dir"
           wheel="$wheel_dir/$CLIO_KIT_WHEEL_FILENAME"
           curl --fail --show-error --silent --location \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.15` uses a release-first patch process. A maintainer builds the
+> Version `1.3.16` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do
@@ -140,7 +140,10 @@ These generic gateway operations manage ordinary endpoint metadata only. They ca
 When JARVIS already owns a live application, agents use the user-profile
 `relay_bind_jarvis_runtime` MCP tool instead of supplying a runtime specification.
 The relay verifies a completed `jarvis_get_execution` MCP result produced with
-`include_service_runtimes=true`, persists its execution, service, scheduler, and
+`include_service_runtimes=true`. A waited query returns compact
+`service_runtime_bindings`; the agent passes one entry unchanged as
+`relay_bind_jarvis_runtime.binding` instead of guessing opaque job, artifact, or
+service identifiers. The relay persists its execution, service, scheduler, and
 dataset identities, starts only
 the connector path, and returns local connect, health, stream, events, state, and
 command URLs. Detach and stop retain the scheduler job unless cancellation is

--- a/docs/ai/interface-context.md
+++ b/docs/ai/interface-context.md
@@ -156,15 +156,16 @@ pair. Submission tools accept `used_artifact_refs` as unique artifact-id/SHA-256
 pairs, and owned-session routes enforce an exact producer/consumer session
 generation match.
 
-`relay_bind_jarvis_runtime` is in the user profile. It takes a configured cluster,
-one completed relay-routed `jarvis_get_execution` source job with
-`include_service_runtimes=true`, its `mcp_result` artifact, and an exact package
-id/name. Its output includes the
+`relay_bind_jarvis_runtime` is in the user profile. A waited
+`jarvis_get_execution(include_service_runtimes=true)` response supplies compact
+`service_runtime_bindings`; pass one exact entry unchanged as `binding`. It carries
+the configured cluster, completed source job and `mcp_result` artifact, exact
+package id/name, and service-instance id. Its output includes the
 durable gateway session and six local URLs: connect, health, stream, events, state,
 and command. The gateway stores the immutable source job/artifact digest,
 execution and scheduler identities, service revision/report digest, and exact
 dataset descriptor/digest. The tool does not accept submit, status, cancel, host,
-port, path, or descriptor overrides.
+port, path, descriptor overrides, or mixed compact/legacy selectors.
 
 Normal bind and gateway-get results never contain a browser capability. A trusted
 desktop viewer calls `gateway browser-attach` only after exact binding verification

--- a/docs/ai/system-context.md
+++ b/docs/ai/system-context.md
@@ -104,7 +104,10 @@ from an authenticated completed relay-routed MCP result and persists
 `gateway.jarvis_runtime_binding`. That record binds the source relay job and
 artifact SHA-256 to the JARVIS execution, optional scheduler provider/native id,
 package/service revision, and exact dataset descriptor. Caller-provided runtime
-metadata and lifecycle commands are rejected. Binding starts no application or
+metadata and lifecycle commands are rejected. A waited execution query emits a
+compact selector-only `service_runtime_bindings` handoff which is copied unchanged
+into the bind call; the source artifact is still re-read and fully verified.
+Binding starts no application or
 scheduler work; it starts only the relay connectors. Any later explicit scheduler
 cancellation re-verifies the immutable source before invoking the provider.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -258,7 +258,7 @@ For the legacy clio-kit 2.2.6 compatibility path, a successful synchronous
 `jarvis_run` MCP return is normalized to a terminal `completed` record even
 though that release labels the result `status=running`; the original status and
 completion basis remain in `details.completion_normalization` for auditability.
-The pinned clio-kit 2.5.4 production path removes that ambiguity upstream and
+The pinned clio-kit 2.5.5 production path removes that ambiguity upstream and
 returns a structured completed result directly. The legacy normalization is
 diagnostic compatibility evidence and cannot satisfy the 1.0 gate. Scheduler
 submissions remain non-terminal unless JARVIS was asked to wait.
@@ -493,7 +493,7 @@ Install the cluster-side server once, then launch its persistent executable:
 
 ```bash
 uv tool install --python 3.12 --no-config \
-  https://github.com/iowarp/clio-kit/releases/download/v2.5.4/clio_kit-2.5.4-py3-none-any.whl
+  https://github.com/iowarp/clio-kit/releases/download/v2.5.5/clio_kit-2.5.5-py3-none-any.whl
 clio-kit mcp-server jarvis
 ```
 
@@ -712,23 +712,27 @@ clio-relay gateway stop-runtime <session-id> --cluster my-cluster --keep-schedul
 
 When JARVIS already owns the application execution, an agent must not construct a
 second runtime specification or submit another scheduler job. The user MCP profile
-exposes `relay_bind_jarvis_runtime` for this case. Give it the configured cluster,
-the completed relay-routed `jarvis_get_execution` job, called with
-`include_service_runtimes=true`, its result artifact, and the exact JARVIS package
-identity:
+exposes `relay_bind_jarvis_runtime` for this case. Call
+`jarvis_get_execution` with `include_service_runtimes=true` and
+`wait_for_terminal=true`, then pass one returned `service_runtime_bindings` entry
+unchanged as `binding`:
 
 ```json
 {
-  "cluster": "my-cluster",
-  "source_job_id": "<relay-job-id>",
-  "source_artifact_id": "<mcp-result-artifact-id>",
-  "package_id": "paraview-1",
-  "package_name": "builtin.paraview",
+  "binding": {
+    "cluster": "my-cluster",
+    "source_job_id": "<relay-job-id>",
+    "source_artifact_id": "<mcp-result-artifact-id>",
+    "package_id": "paraview-1",
+    "package_name": "builtin.paraview",
+    "service_instance_id": "paraview-live-1"
+  },
   "name": "paraview-live"
 }
 ```
 
-The bind operation accepts no host, port, endpoint path, dataset descriptor,
+The compact binding contains selectors only. The bind operation accepts no host,
+port, endpoint path, dataset descriptor,
 scheduler identity, or lifecycle command from the caller. It verifies the exact
 completed relay job, artifact SHA-256, installed MCP-server artifact digest,
 structured protocol result, native JARVIS execution identity, scheduler-provider

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.15"
+$Version = "1.3.16"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.15"
+release_version: "1.3.16"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: a1a5e44d240a72848c044bc274619cecaffb0767c1dff8ab03604944081ef0fc
+acceptance_matrix_sha256: d50533ec932b8c4d45b5a7e9ca6e4e85ad2b767c8a6d2e41395a60308cce35a7
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true
@@ -110,16 +110,16 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.5.4"
+            clio-kit: "2.5.5"
             jarvis-cd: "1.3.12"
             jarvis-util: c91bfdc9bba802e4b03bfb1babe614ffa3e09644
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.5.4"
-              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.4/clio_kit-2.5.4-py3-none-any.whl
+              distribution_version: "2.5.5"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.5/clio_kit-2.5.5-py3-none-any.whl
               requested_source: github_release
-              artifact_sha256: 8e29cdde8abc669ca700aec09b38b6954322e924ac175cfcdf16a7f41a32374f
+              artifact_sha256: 622344b951d39f35b0952d2bf056d83040b81ad52e4aca4794fa486026eab278
               native_execution:
                 schema_version: clio-relay.jarvis-native-execution-capability.v1
                 handle_schema: jarvis.execution.handle.v1
@@ -220,14 +220,14 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.5.4"
+            clio-kit: "2.5.5"
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.5.4"
-              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.4/clio_kit-2.5.4-py3-none-any.whl
+              distribution_version: "2.5.5"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.5/clio_kit-2.5.5-py3-none-any.whl
               requested_source: github_release
-              artifact_sha256: 8e29cdde8abc669ca700aec09b38b6954322e924ac175cfcdf16a7f41a32374f
+              artifact_sha256: 622344b951d39f35b0952d2bf056d83040b81ad52e4aca4794fa486026eab278
       - kind: scheduler_job
         roles: [queue-preservation-fixture]
         states: [completed]
@@ -288,24 +288,24 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.5.4"
+            clio-kit: "2.5.5"
             jarvis-cd: "1.3.12"
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.5.4"
-              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.4/clio_kit-2.5.4-py3-none-any.whl
+              distribution_version: "2.5.5"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.5/clio_kit-2.5.5-py3-none-any.whl
               requested_source: github_release
-              artifact_filename: clio_kit-2.5.4-py3-none-any.whl
-              artifact_sha256: 8e29cdde8abc669ca700aec09b38b6954322e924ac175cfcdf16a7f41a32374f
+              artifact_filename: clio_kit-2.5.5-py3-none-any.whl
+              artifact_sha256: 622344b951d39f35b0952d2bf056d83040b81ad52e4aca4794fa486026eab278
               persistent_tool:
                 manager: uv
                 uv_version: "0.11.28"
                 pyvenv_uv_version: "0.11.28"
                 distribution: clio-kit
-                distribution_version: "2.5.4"
+                distribution_version: "2.5.5"
                 entry_point: clio-kit
-                source_artifact_sha256: 8e29cdde8abc669ca700aec09b38b6954322e924ac175cfcdf16a7f41a32374f
+                source_artifact_sha256: 622344b951d39f35b0952d2bf056d83040b81ad52e4aca4794fa486026eab278
               native_execution:
                 schema_version: clio-relay.jarvis-native-execution-capability.v1
                 handle_schema: jarvis.execution.handle.v1
@@ -364,10 +364,10 @@ requirements:
         states: [verified]
         metadata_equals:
           install_source: uv-tool
-          install_artifact_sha256: 8e29cdde8abc669ca700aec09b38b6954322e924ac175cfcdf16a7f41a32374f
+          install_artifact_sha256: 622344b951d39f35b0952d2bf056d83040b81ad52e4aca4794fa486026eab278
           python_distribution_runtime:
             distribution: clio-kit
-            distribution_version: "2.5.4"
+            distribution_version: "2.5.5"
             entry_point: clio-kit
             runtime_closure_verified: true
           nested_runtime:
@@ -649,7 +649,7 @@ requirements:
         states: [verified]
         metadata_equals:
           install_source: wheel
-          install_artifact_sha256: 8e29cdde8abc669ca700aec09b38b6954322e924ac175cfcdf16a7f41a32374f
+          install_artifact_sha256: 622344b951d39f35b0952d2bf056d83040b81ad52e4aca4794fa486026eab278
           server_process_artifact_verified: true
           verified: true
 
@@ -748,7 +748,7 @@ requirements:
           remote_tool_names: [spack_find, spack_install, spack_locate]
           allowlisted_tool_names: [spack_find, spack_install, spack_locate]
           install_source: wheel
-          install_artifact_sha256: 8e29cdde8abc669ca700aec09b38b6954322e924ac175cfcdf16a7f41a32374f
+          install_artifact_sha256: 622344b951d39f35b0952d2bf056d83040b81ad52e4aca4794fa486026eab278
           contract_id: clio-kit-spack-user-v2
           contract_sha256: 3c5412148c770f4844e98eb893c4db0d0afdbf13afe967df67bd5f7d25e1f7db
           server_process_artifact_verified: true
@@ -853,7 +853,7 @@ requirements:
           remote_tool_names: [spack_find, spack_install, spack_locate]
           allowlisted_tool_names: [spack_find, spack_install, spack_locate]
           install_source: wheel
-          install_artifact_sha256: 8e29cdde8abc669ca700aec09b38b6954322e924ac175cfcdf16a7f41a32374f
+          install_artifact_sha256: 622344b951d39f35b0952d2bf056d83040b81ad52e4aca4794fa486026eab278
           contract_id: clio-kit-spack-user-v2
           contract_sha256: 3c5412148c770f4844e98eb893c4db0d0afdbf13afe967df67bd5f7d25e1f7db
           server_process_artifact_verified: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.15"
+$Tag = "v1.3.16"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.15" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.16" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/docs/remote-mcp-federation.md
+++ b/docs/remote-mcp-federation.md
@@ -264,7 +264,7 @@ Virtual JARVIS mutations and runs receive a fresh relay job by default. Supply
 an explicit `idempotency_key` only when retry de-duplication is intentional; an
 identical second `jarvis_run` is otherwise a new execution.
 
-The released clio-kit 2.5.4 artifact is the pinned six-tool JARVIS v3.2 contract.
+The released clio-kit 2.5.5 artifact is the pinned six-tool JARVIS v3.2 contract.
 Bootstrap
 downloads and hashes the exact coordinated wheel, installs it once with
 `uv tool install`, and persists the wheel plus the direct JARVIS command in the
@@ -283,13 +283,13 @@ relay's exact JARVIS-CD release pin. That dependency edge is recorded in the
 install receipt and call result. Operator-registered MCP servers remain bound
 by their own discovery artifact and are not constrained to the relay's
 JARVIS-CD version.
-The release gate requires that exact 2.5.4 artifact to be rerun on every target
+The release gate requires that exact 2.5.5 artifact to be rerun on every target
 selected by the release policy. Other servers use the operator registry and
 generated `remote_...` aliases.
 
 The exact release wheel is
-`clio_kit-2.5.4-py3-none-any.whl` with SHA-256
-`8e29cdde8abc669ca700aec09b38b6954322e924ac175cfcdf16a7f41a32374f`.
+`clio_kit-2.5.5-py3-none-any.whl` with SHA-256
+`622344b951d39f35b0952d2bf056d83040b81ad52e4aca4794fa486026eab278`.
 Its canonical contract is `clio-kit-jarvis-user-v3.2`, with contract SHA-256
 `12f6d349c9d44d8ce3594943dcd4018ec9b6e01ebb0e59d468bb1bb783a1ad5d`
 and canonical tools-wire SHA-256
@@ -308,7 +308,7 @@ operator-defined and do not select behavior.
 
 ## Register the scientific catalog MCP
 
-clio-kit 2.5.4 also ships the two-tool
+clio-kit 2.5.5 also ships the two-tool
 `clio-kit-scientific-catalog-user-v1` contract. It separates dataset discovery
 from visualization control: `scientific_dataset_search` finds operator catalog
 records and `scientific_dataset_describe` returns one exact

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.15",
-  "matrix_sha256": "a1a5e44d240a72848c044bc274619cecaffb0767c1dff8ab03604944081ef0fc",
+  "release_version": "1.3.16",
+  "matrix_sha256": "d50533ec932b8c4d45b5a7e9ca6e4e85ad2b767c8a6d2e41395a60308cce35a7",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.15"
+version = "1.3.16"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.15"
+__version__ = "1.3.16"

--- a/src/clio_relay/jarvis_mcp.py
+++ b/src/clio_relay/jarvis_mcp.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
+from clio_relay.identifiers import durable_record_id_json_schema
 from clio_relay.remote_mcp import (
     VIRTUAL_REMOTE_MCP_JOB_OUTPUT_SCHEMA,
     RemoteMcpSchemaCache,
@@ -22,14 +23,14 @@ from clio_relay.remote_mcp import (
 if TYPE_CHECKING:
     from clio_relay.installation import ComponentArtifactIdentity, InstallReceipt
 
-CLIO_KIT_JARVIS_MCP_VERSION = "2.5.4"
+CLIO_KIT_JARVIS_MCP_VERSION = "2.5.5"
 CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME = f"clio_kit-{CLIO_KIT_JARVIS_MCP_VERSION}-py3-none-any.whl"
 CLIO_KIT_JARVIS_MCP_WHEEL_URL = (
     "https://github.com/iowarp/clio-kit/releases/download/"
     f"v{CLIO_KIT_JARVIS_MCP_VERSION}/{CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME}"
 )
 CLIO_KIT_JARVIS_MCP_WHEEL_SHA256 = (
-    "8e29cdde8abc669ca700aec09b38b6954322e924ac175cfcdf16a7f41a32374f"
+    "622344b951d39f35b0952d2bf056d83040b81ad52e4aca4794fa486026eab278"
 )
 CLIO_KIT_JARVIS_USER_CONTRACT_ID = "clio-kit-jarvis-user-v3.2"
 DEFAULT_JARVIS_MCP_COMMAND = [
@@ -530,6 +531,18 @@ def virtual_jarvis_tool_definitions(*, clusters: list[str] | None = None) -> lis
         }
         required = cast(list[str], input_schema.get("required", []))
         input_schema["required"] = ["cluster", *required]
+        output_schema = deepcopy(VIRTUAL_REMOTE_MCP_JOB_OUTPUT_SCHEMA)
+        if remote_tool == "jarvis_get_execution":
+            output_properties = cast(JSON, output_schema["properties"])
+            output_properties["service_runtime_bindings"] = {
+                "type": "array",
+                "description": (
+                    "Ready-service handoffs derived from the verified durable MCP result. "
+                    "Pass one item unchanged as relay_bind_jarvis_runtime.binding."
+                ),
+                "items": jarvis_service_runtime_handoff_json_schema(clusters=clusters),
+                "maxItems": 4_096,
+            }
         tools.append(
             {
                 "name": virtual_jarvis_tool_name(remote_tool),
@@ -538,11 +551,47 @@ def virtual_jarvis_tool_definitions(*, clusters: list[str] | None = None) -> lis
                     "clio-kit JARVIS MCP and returned as a durable relay job."
                 ),
                 "inputSchema": input_schema,
-                "outputSchema": deepcopy(VIRTUAL_REMOTE_MCP_JOB_OUTPUT_SCHEMA),
+                "outputSchema": output_schema,
                 "annotations": deepcopy(cast(JSON, definition["annotations"])),
             }
         )
     return tools
+
+
+def jarvis_service_runtime_handoff_json_schema(
+    *,
+    clusters: list[str] | None = None,
+) -> JSON:
+    """Return the exact agent-facing JARVIS service handoff schema."""
+    return {
+        "type": "object",
+        "properties": {
+            "cluster": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 256,
+                **({"enum": sorted(clusters)} if clusters is not None else {}),
+            },
+            "source_job_id": durable_record_id_json_schema(),
+            "source_artifact_id": durable_record_id_json_schema(),
+            "package_id": {"type": "string", "minLength": 1, "maxLength": 256},
+            "package_name": {"type": "string", "minLength": 1, "maxLength": 256},
+            "service_instance_id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 512,
+            },
+        },
+        "required": [
+            "cluster",
+            "source_job_id",
+            "source_artifact_id",
+            "package_id",
+            "package_name",
+            "service_instance_id",
+        ],
+        "additionalProperties": False,
+    }
 
 
 def jarvis_user_contract() -> dict[str, JSON]:
@@ -667,6 +716,9 @@ def render_virtual_jarvis_agent_context() -> str:
         "selected canonical package name. "
         "When wait_for_terminal=true, the same JARVIS tool returns a bounded, "
         "artifact-bound mcp_result instead of requiring a second status or log call. "
+        "A completed jarvis_get_execution call with include_service_runtimes=true also "
+        "returns service_runtime_bindings. Pass one item unchanged as the binding argument "
+        "to relay_bind_jarvis_runtime; jarvis_run does not produce these handoffs. "
         "For later job queries, preserve cluster, job_id, and the opaque 64-character "
         "route_revision from one receipt as a single handle; never substitute a catalog "
         "or dataset revision. "

--- a/src/clio_relay/jarvis_service_runtime.py
+++ b/src/clio_relay/jarvis_service_runtime.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from clio_relay.cluster_config import ClusterDefinition
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
+from clio_relay.identifiers import DurableRecordId
 from clio_relay.jarvis_mcp import (
     jarvis_cd_lock_binding_expectation,
     jarvis_mcp_server_artifact_binding_verified,
@@ -79,17 +80,6 @@ class JarvisDatasetMember(BaseModel):
     location: str
     timestep: float | int | None = Field(default=None, exclude_if=lambda value: value is None)
 
-    @model_validator(mode="before")
-    @classmethod
-    def reject_null_timestep(cls, value: object) -> object:
-        """Require an optional timestep to be omitted instead of serialized as null."""
-        if not isinstance(value, dict):
-            return value
-        typed = cast(dict[str, object], value)
-        if "timestep" in typed and typed["timestep"] is None:
-            raise ValueError("dataset member timestep must be omitted when absent")
-        return typed
-
     @model_validator(mode="after")
     def validate_member(self) -> JarvisDatasetMember:
         """Require one normalized absolute location and a finite optional timestep."""
@@ -108,17 +98,6 @@ class JarvisDatasetArray(BaseModel):
     association: Literal["point", "cell", "field"]
     components: int = Field(ge=1, le=64)
     units: str | None = Field(default=None, exclude_if=lambda value: value is None)
-
-    @model_validator(mode="before")
-    @classmethod
-    def reject_null_units(cls, value: object) -> object:
-        """Require optional units to be omitted instead of serialized as null."""
-        if not isinstance(value, dict):
-            return value
-        typed = cast(dict[str, object], value)
-        if "units" in typed and typed["units"] is None:
-            raise ValueError("dataset array units must be omitted when absent")
-        return typed
 
     @model_validator(mode="after")
     def validate_array(self) -> JarvisDatasetArray:
@@ -333,6 +312,19 @@ class JarvisServiceRuntimeBinding(BaseModel):
         return _canonical_sha256(value, "binding digest")
 
 
+class JarvisServiceRuntimeHandoff(BaseModel):
+    """Agent-facing selectors copied unchanged into a relay runtime bind call."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    cluster: str = Field(min_length=1, max_length=256)
+    source_job_id: DurableRecordId
+    source_artifact_id: DurableRecordId
+    package_id: str = Field(min_length=1, max_length=256)
+    package_name: str = Field(min_length=1, max_length=256)
+    service_instance_id: str = Field(min_length=1, max_length=512)
+
+
 class VerifiedJarvisServiceRuntime(BaseModel):
     """Validated runtime and its immutable relay provenance."""
 
@@ -352,6 +344,7 @@ def resolve_jarvis_service_runtime(
     source_artifact_id: str,
     package_id: str,
     package_name: str,
+    service_instance_id: str | None = None,
 ) -> VerifiedJarvisServiceRuntime:
     """Resolve one ready service solely from a verified durable JARVIS MCP result."""
     job, artifact, document = _load_source(
@@ -361,7 +354,7 @@ def resolve_jarvis_service_runtime(
         source_job_id=source_job_id,
         source_artifact_id=source_artifact_id,
     )
-    spec = _validate_source_job(job, definition=definition)
+    spec = _validate_source_job(job, cluster=definition.name)
     query = _validate_mcp_result(document, job=job, spec=spec)
     native = native_execution_documents(query.model_dump(mode="json"))
     if native is None:
@@ -372,6 +365,7 @@ def resolve_jarvis_service_runtime(
         snapshot,
         package_id=package_id,
         package_name=package_name,
+        service_instance_id=service_instance_id,
     )
     _validate_runtime_package(native, runtime=runtime)
     scheduler_provider = native.execution_handle.scheduler_provider
@@ -404,6 +398,49 @@ def resolve_jarvis_service_runtime(
     return VerifiedJarvisServiceRuntime(binding=binding, runtime=runtime, native_execution=native)
 
 
+def derive_jarvis_service_runtime_handoffs(
+    *,
+    cluster: str,
+    source_job: RelayJob,
+    source_artifact: ArtifactRef,
+    document: JSON,
+) -> list[JarvisServiceRuntimeHandoff]:
+    """Derive ready-service selectors from one SHA-verified durable MCP artifact.
+
+    The caller verifies the artifact envelope and payload digest before passing
+    the decoded document. The same route, release, execution, and package checks
+    used by the eventual bind operation are then applied here.
+    """
+    if source_artifact.job_id != source_job.job_id or source_artifact.kind != "mcp_result":
+        raise ValueError("JARVIS service handoff artifact identity did not match its source job")
+    if source_artifact.sha256 is None:
+        raise ValueError("JARVIS service handoff artifact has no durable SHA-256")
+    _canonical_sha256(source_artifact.sha256, "handoff artifact digest")
+    spec = _validate_source_job(source_job, cluster=cluster)
+    query = _validate_mcp_result(document, job=source_job, spec=spec)
+    native = native_execution_documents(query.model_dump(mode="json"))
+    if native is None:
+        raise ValueError("JARVIS service runtime result omitted native execution documents")
+    snapshot = query.service_runtimes
+    _validate_snapshot_execution(snapshot, native=native)
+    handoffs: list[JarvisServiceRuntimeHandoff] = []
+    for runtime in snapshot.service_runtimes:
+        _validate_runtime_package(native, runtime=runtime)
+        if runtime.lifecycle != "ready":
+            continue
+        handoffs.append(
+            JarvisServiceRuntimeHandoff(
+                cluster=cluster,
+                source_job_id=source_job.job_id,
+                source_artifact_id=source_artifact.artifact_id,
+                package_id=runtime.package_id,
+                package_name=runtime.package_name,
+                service_instance_id=runtime.service_instance_id,
+            )
+        )
+    return handoffs
+
+
 def reverify_jarvis_service_runtime(
     *,
     queue: ClioCoreQueue,
@@ -421,6 +458,7 @@ def reverify_jarvis_service_runtime(
         source_artifact_id=expected.source_relay_artifact_id,
         package_id=expected.package_id,
         package_name=expected.package_name,
+        service_instance_id=expected.service_instance_id,
     )
     if not hmac.compare_digest(
         _canonical_json_bytes(observed.binding.model_dump(mode="json")),
@@ -503,8 +541,8 @@ def _load_source(
     return job, artifact, cast(JSON, document)
 
 
-def _validate_source_job(job: RelayJob, *, definition: ClusterDefinition) -> McpCallSpec:
-    if job.cluster != definition.name:
+def _validate_source_job(job: RelayJob, *, cluster: str) -> McpCallSpec:
+    if job.cluster != cluster:
         raise ValueError("JARVIS service source job belongs to a different cluster")
     if job.state is not JobState.SUCCEEDED:
         raise ValueError("JARVIS service source job must have completed successfully")
@@ -601,11 +639,14 @@ def _select_ready_runtime(
     *,
     package_id: str,
     package_name: str,
+    service_instance_id: str | None = None,
 ) -> JarvisServiceRuntime:
     matches = [
         runtime
         for runtime in snapshot.service_runtimes
-        if runtime.package_id == package_id and runtime.package_name == package_name
+        if runtime.package_id == package_id
+        and runtime.package_name == package_name
+        and (service_instance_id is None or runtime.service_instance_id == service_instance_id)
     ]
     if len(matches) != 1:
         raise ValueError(

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -40,12 +40,18 @@ from clio_relay.jarvis_mcp import (
     jarvis_mcp_artifact_binding_from_entry,
     jarvis_mcp_server,
     jarvis_mcp_server_args,
+    jarvis_service_runtime_handoff_json_schema,
     render_virtual_jarvis_agent_context,
     virtual_jarvis_call_arguments,
     virtual_jarvis_tool_definitions,
 )
-from clio_relay.jarvis_service_runtime import resolve_jarvis_service_runtime
+from clio_relay.jarvis_service_runtime import (
+    JarvisServiceRuntimeHandoff,
+    derive_jarvis_service_runtime_handoffs,
+    resolve_jarvis_service_runtime,
+)
 from clio_relay.models import (
+    ArtifactRef,
     ArtifactUse,
     Cursor,
     GatewaySession,
@@ -209,6 +215,14 @@ class McpSessionState:
                 "route_revision from the intended receipt"
             )
         return next(iter(routes))
+
+
+@dataclass(frozen=True)
+class _VerifiedMcpResult:
+    """SHA-verified full MCP artifact plus its bounded public projection."""
+
+    document: JSON
+    public: JSON
 
 
 def serve_stdio(
@@ -1231,6 +1245,8 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
             "description": (
                 "Bind local relay connectors to one ready service reported by a completed, "
                 "artifact-bound JARVIS execution query with service runtimes included. "
+                "Pass one service_runtime_bindings item from a waited jarvis_get_execution "
+                "call unchanged as binding. jarvis_run is not a valid binding source. "
                 "Runtime host, paths, scheduler identity, and dataset metadata are read "
                 "only from the durable JARVIS result. The relay allocates the desktop "
                 "loopback port."
@@ -1238,6 +1254,7 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
             "inputSchema": {
                 "type": "object",
                 "properties": {
+                    "binding": jarvis_service_runtime_handoff_json_schema(clusters=clusters),
                     "cluster": {
                         "type": "string",
                         **({"enum": sorted(clusters)} if clusters is not None else {}),
@@ -1260,12 +1277,29 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                         "default": 2,
                     },
                 },
-                "required": [
-                    "cluster",
-                    "source_job_id",
-                    "source_artifact_id",
-                    "package_id",
-                    "package_name",
+                "oneOf": [
+                    {
+                        "required": ["binding"],
+                        "not": {
+                            "anyOf": [
+                                {"required": ["cluster"]},
+                                {"required": ["source_job_id"]},
+                                {"required": ["source_artifact_id"]},
+                                {"required": ["package_id"]},
+                                {"required": ["package_name"]},
+                            ]
+                        },
+                    },
+                    {
+                        "required": [
+                            "cluster",
+                            "source_job_id",
+                            "source_artifact_id",
+                            "package_id",
+                            "package_name",
+                        ],
+                        "not": {"required": ["binding"]},
+                    },
                 ],
                 "additionalProperties": False,
             },
@@ -1719,10 +1753,17 @@ def _call_tool(
     if session is not None:
         session.observe_remote_job_result(result)
     return {
-        "content": [{"type": "text", "text": json.dumps(result, sort_keys=True)}],
+        "content": [{"type": "text", "text": _serialize_tool_result(result)}],
         "structuredContent": result,
         "isError": False,
     }
+
+
+def _serialize_tool_result(result: JSON) -> str:
+    """Keep compact service handoffs ahead of a potentially large MCP result."""
+    if "service_runtime_bindings" in result:
+        return json.dumps(result)
+    return json.dumps(result, sort_keys=True)
 
 
 def _restore_session_remote_job_route(
@@ -2743,7 +2784,7 @@ def _verified_mcp_result(
     definition: ClusterDefinition,
     job_id: str,
     artifacts: list[JSON],
-) -> JSON | None:
+) -> _VerifiedMcpResult | None:
     artifact = next(
         (
             item
@@ -2769,7 +2810,7 @@ def _verified_owned_mcp_result(
     client: OwnedSessionApiClient,
     job_id: str,
     artifacts: list[JSON],
-) -> JSON | None:
+) -> _VerifiedMcpResult | None:
     artifact = next(
         (
             item
@@ -2792,7 +2833,10 @@ def _verified_owned_mcp_result(
     return _decode_verified_mcp_result(envelope, artifact=artifact, job_id=job_id)
 
 
-def _verified_local_mcp_result(queue: ClioCoreQueue, job_id: str) -> JSON | None:
+def _verified_local_mcp_result(
+    queue: ClioCoreQueue,
+    job_id: str,
+) -> _VerifiedMcpResult | None:
     artifact = next(
         (
             item
@@ -2814,7 +2858,12 @@ def _verified_local_mcp_result(queue: ClioCoreQueue, job_id: str) -> JSON | None
     )
 
 
-def _decode_verified_mcp_result(envelope: JSON, *, artifact: JSON, job_id: str) -> JSON:
+def _decode_verified_mcp_result(
+    envelope: JSON,
+    *,
+    artifact: JSON,
+    job_id: str,
+) -> _VerifiedMcpResult:
     envelope_artifact = envelope.get("artifact")
     if not isinstance(envelope_artifact, dict):
         raise ValueError("MCP result artifact envelope is missing durable metadata")
@@ -2844,7 +2893,7 @@ def _decode_verified_mcp_result(envelope: JSON, *, artifact: JSON, job_id: str) 
     if not isinstance(document, dict):
         raise ValueError("MCP result artifact must contain a JSON object")
     typed = cast(JSON, document)
-    return {
+    public = {
         key: typed.get(key)
         for key in (
             "operation",
@@ -2859,6 +2908,7 @@ def _decode_verified_mcp_result(envelope: JSON, *, artifact: JSON, job_id: str) 
             "result_validation",
         )
     }
+    return _VerifiedMcpResult(document=typed, public=public)
 
 
 def _mcp_result_artifact(artifacts: list[JSON], *, job_id: str) -> JSON | None:
@@ -2940,21 +2990,37 @@ def _public_mcp_result_artifact(artifact: JSON) -> JSON:
 def _attach_terminal_mcp_evidence(
     receipt: JSON,
     *,
-    job_id: str,
+    source_job: RelayJob,
     last_error: str | None,
     artifacts: list[JSON],
-    parsed_result: JSON | None,
+    parsed_result: _VerifiedMcpResult | None,
 ) -> None:
     """Attach bounded terminal MCP evidence to a waited submission receipt."""
 
     receipt["last_error"] = last_error
     if parsed_result is None:
         return
-    artifact = _mcp_result_artifact(artifacts, job_id=job_id)
+    artifact = _mcp_result_artifact(artifacts, job_id=source_job.job_id)
     if artifact is None:
-        raise ValueError(f"verified MCP result for {job_id} has no durable artifact")
-    receipt["mcp_result"] = _bounded_mcp_result(parsed_result)
+        raise ValueError(f"verified MCP result for {source_job.job_id} has no durable artifact")
     receipt["mcp_result_artifact"] = _public_mcp_result_artifact(artifact)
+    if (
+        source_job.state is JobState.SUCCEEDED
+        and isinstance(source_job.spec, McpCallSpec)
+        and source_job.spec.tool == "jarvis_get_execution"
+        and source_job.spec.arguments.get("include_service_runtimes") is True
+    ):
+        source_artifact = ArtifactRef.model_validate(artifact)
+        receipt["service_runtime_bindings"] = [
+            handoff.model_dump(mode="json")
+            for handoff in derive_jarvis_service_runtime_handoffs(
+                cluster=source_job.cluster,
+                source_job=source_job,
+                source_artifact=source_artifact,
+                document=parsed_result.document,
+            )
+        ]
+    receipt["mcp_result"] = _bounded_mcp_result(parsed_result.public)
 
 
 def _render_remote_mcp_context(catalog: VirtualRemoteMcpCatalog) -> str:
@@ -3172,7 +3238,7 @@ def _wait_job(arguments: JSON, *, queue: ClioCoreQueue, settings: RelaySettings)
                 result["artifacts"] = artifact_records
                 parsed_result = _verified_owned_mcp_result(client, job_id, artifact_records)
                 if parsed_result is not None:
-                    result["mcp_result"] = parsed_result
+                    result["mcp_result"] = parsed_result.public
             result["cluster"] = target.name
             result["route_revision"] = _route_revision(target)
             return result
@@ -3204,7 +3270,7 @@ def _wait_job(arguments: JSON, *, queue: ClioCoreQueue, settings: RelaySettings)
         result["artifacts"] = artifact_records
         parsed_result = _verified_mcp_result(target, job_id, artifact_records)
         if parsed_result is not None:
-            result["mcp_result"] = parsed_result
+            result["mcp_result"] = parsed_result.public
         result["cluster"] = target.name
         result["route_revision"] = _route_revision(target)
         return result
@@ -3226,7 +3292,7 @@ def _wait_job(arguments: JSON, *, queue: ClioCoreQueue, settings: RelaySettings)
     result["artifacts"] = _complete_local_artifacts(queue, job.job_id)
     parsed_result = _verified_local_mcp_result(queue, job.job_id)
     if parsed_result is not None:
-        result["mcp_result"] = parsed_result
+        result["mcp_result"] = parsed_result.public
     if target is not None:
         result["cluster"] = target.name
         result["route_revision"] = _route_revision(target)
@@ -3817,9 +3883,10 @@ def _remote_mcp_submission_result(
     last_error = job.get("last_error")
     if last_error is not None and not isinstance(last_error, str):
         raise ValueError("remote MCP job returned an invalid last_error")
+    source_job = RelayJob.model_validate(job)
     _attach_terminal_mcp_evidence(
         result,
-        job_id=job_id,
+        source_job=source_job,
         last_error=last_error,
         artifacts=artifacts,
         parsed_result=parsed_result,
@@ -3841,7 +3908,7 @@ def _owned_session_submission_result(
 ) -> JSON:
     """Return an owned receipt, optionally waiting through the same protected API."""
     artifacts: list[JSON] = []
-    parsed_result: JSON | None = None
+    parsed_result: _VerifiedMcpResult | None = None
     logs: JSON | None = None
     if wait_for_terminal_result:
         with OwnedSessionApiClient(definition=definition, settings=settings) as client:
@@ -3894,7 +3961,7 @@ def _owned_session_submission_result(
     if wait_for_terminal_result and include_terminal_mcp_result:
         _attach_terminal_mcp_evidence(
             result,
-            job_id=job.job_id,
+            source_job=job,
             last_error=job.last_error,
             artifacts=artifacts,
             parsed_result=parsed_result,
@@ -4117,7 +4184,7 @@ def _submission_result(
         artifacts = _complete_local_artifacts(queue, job.job_id)
         _attach_terminal_mcp_evidence(
             result,
-            job_id=job.job_id,
+            source_job=job,
             last_error=job.last_error,
             artifacts=artifacts,
             parsed_result=_verified_local_mcp_result(queue, job.job_id),
@@ -4220,6 +4287,7 @@ def _bind_jarvis_runtime(
 ) -> JSON:
     """Bind only connector resources derived from one verified JARVIS result."""
     allowed = {
+        "binding",
         "cluster",
         "source_job_id",
         "source_artifact_id",
@@ -4235,16 +4303,24 @@ def _bind_jarvis_runtime(
             "relay_bind_jarvis_runtime does not accept caller-supplied runtime metadata: "
             + ", ".join(unexpected)
         )
-    cluster = _required_str(arguments, "cluster")
+    (
+        cluster,
+        source_job_id,
+        source_artifact_id,
+        package_id,
+        package_name,
+        service_instance_id,
+    ) = _jarvis_runtime_binding_selectors(arguments)
     definition = _remote_cluster_definition(cluster)
     verified = resolve_jarvis_service_runtime(
         queue=queue,
         definition=definition,
         settings=settings,
-        source_job_id=_required_durable_record_id(arguments, "source_job_id"),
-        source_artifact_id=_required_durable_record_id(arguments, "source_artifact_id"),
-        package_id=_required_str(arguments, "package_id"),
-        package_name=_required_str(arguments, "package_name"),
+        source_job_id=source_job_id,
+        source_artifact_id=source_artifact_id,
+        package_id=package_id,
+        package_name=package_name,
+        service_instance_id=service_instance_id,
     )
     readiness_timeout_seconds = _positive_float_argument(
         arguments,
@@ -4303,6 +4379,46 @@ def _bind_jarvis_runtime(
         "command_url": started.command_url,
         "scheduler_cancel_requested": False,
     }
+
+
+def _jarvis_runtime_binding_selectors(
+    arguments: JSON,
+) -> tuple[str, str, str, str, str, str | None]:
+    """Accept one exact handoff object or the legacy scalar selector contract."""
+    scalar_fields = {
+        "cluster",
+        "source_job_id",
+        "source_artifact_id",
+        "package_id",
+        "package_name",
+    }
+    if "binding" in arguments:
+        mixed = sorted(scalar_fields.intersection(arguments))
+        if mixed:
+            raise ValueError(
+                "relay_bind_jarvis_runtime binding cannot be mixed with legacy selectors: "
+                + ", ".join(mixed)
+            )
+        try:
+            handoff = JarvisServiceRuntimeHandoff.model_validate(arguments["binding"])
+        except ValidationError as exc:
+            raise ValueError(f"relay_bind_jarvis_runtime binding is invalid: {exc}") from exc
+        return (
+            handoff.cluster,
+            validate_durable_record_id(handoff.source_job_id),
+            validate_durable_record_id(handoff.source_artifact_id),
+            handoff.package_id,
+            handoff.package_name,
+            handoff.service_instance_id,
+        )
+    return (
+        _required_str(arguments, "cluster"),
+        _required_durable_record_id(arguments, "source_job_id"),
+        _required_durable_record_id(arguments, "source_artifact_id"),
+        _required_str(arguments, "package_id"),
+        _required_str(arguments, "package_name"),
+        None,
+    )
 
 
 def _update_gateway_session(arguments: JSON, *, queue: ClioCoreQueue) -> JSON:

--- a/src/clio_relay/remote_mcp.py
+++ b/src/clio_relay/remote_mcp.py
@@ -74,7 +74,7 @@ MAX_VIRTUAL_REMOTE_MCP_ALIAS_LENGTH = 64
 MAX_VIRTUAL_REMOTE_MCP_LOG_BYTES = 32_768
 REMOTE_MCP_REPLACE_ATTEMPTS = 25
 REMOTE_MCP_REPLACE_RETRY_SECONDS = 0.02
-CLIO_KIT_SPACK_USER_WHEEL_VERSION = "2.5.4"
+CLIO_KIT_SPACK_USER_WHEEL_VERSION = "2.5.5"
 CLIO_KIT_SPACK_USER_CONTRACT_ID = "clio-kit-spack-user-v2"
 # Digest the MCP wire ``tools/list`` result. FastMCP's in-process FunctionTool
 # schemas retain ``$defs`` that its protocol serializer dereferences, so their

--- a/tests/test_ci_clio_kit_wheel.py
+++ b/tests/test_ci_clio_kit_wheel.py
@@ -17,14 +17,14 @@ from clio_relay.jarvis_mcp import (
 ROOT = Path(__file__).resolve().parents[1]
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
-WHEEL_FILENAME = "clio_kit-2.5.4-py3-none-any.whl"
-WHEEL_SHA256 = "8e29cdde8abc669ca700aec09b38b6954322e924ac175cfcdf16a7f41a32374f"
-WHEEL_URL = f"https://github.com/iowarp/clio-kit/releases/download/v2.5.4/{WHEEL_FILENAME}"
+WHEEL_FILENAME = "clio_kit-2.5.5-py3-none-any.whl"
+WHEEL_SHA256 = "622344b951d39f35b0952d2bf056d83040b81ad52e4aca4794fa486026eab278"
+WHEEL_URL = f"https://github.com/iowarp/clio-kit/releases/download/v2.5.5/{WHEEL_FILENAME}"
 
 
 def test_runtime_and_ci_share_one_exact_clio_kit_release_pin() -> None:
     """Keep bootstrap, JARVIS MCP, and CI on the same exact release wheel bytes."""
-    assert CLIO_KIT_JARVIS_MCP_VERSION == "2.5.4"
+    assert CLIO_KIT_JARVIS_MCP_VERSION == "2.5.5"
     assert CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME == WHEEL_FILENAME
     assert CLIO_KIT_JARVIS_MCP_WHEEL_SHA256 == WHEEL_SHA256
     assert CLIO_KIT_JARVIS_MCP_WHEEL_URL == WHEEL_URL

--- a/tests/test_jarvis_service_runtime.py
+++ b/tests/test_jarvis_service_runtime.py
@@ -13,6 +13,7 @@ import pytest
 from typer.testing import CliRunner
 
 import clio_relay.jarvis_service_runtime as runtime_binding
+import clio_relay.mcp_server as mcp_server_module
 import clio_relay.service_runtime as service_runtime_module
 from clio_relay.browser_gateway import BrowserAttachmentGrant, BrowserDetachmentResult
 from clio_relay.cli import app
@@ -27,6 +28,7 @@ from clio_relay.errors import ConfigurationError
 from clio_relay.jarvis_mcp import jarvis_cd_lock_binding_expectation
 from clio_relay.jarvis_service_runtime import (
     RELAY_JARVIS_RUNTIME_BINDING_SCHEMA,
+    JarvisDatasetDescriptor,
     JarvisServiceRuntime,
     resolve_jarvis_service_runtime,
     reverify_jarvis_service_runtime,
@@ -80,6 +82,176 @@ def test_resolve_jarvis_service_runtime_binds_only_exact_durable_result(
     ]
     assert len(verified.binding.service_report_sha256) == 64
     assert len(verified.binding.dataset_descriptor_sha256) == 64
+
+
+def test_waited_execution_exposes_compact_verified_binding_before_large_result(
+    tmp_path: Path,
+) -> None:
+    """A waited query exposes the exact bind input before its bounded MCP payload."""
+    _queue, _definition, job, _artifact, envelope = _source_result(tmp_path)
+    document = json.loads(base64.b64decode(envelope["data"], validate=True).decode("utf-8"))
+    document["structured_result"]["runtime_metadata"] = {"padding": "x" * 90_000}
+    document["protocol_result"]["structuredContent"] = document["structured_result"]
+    _replace_envelope_document(envelope, document)
+    artifact = ArtifactRef.model_validate(envelope["artifact"])
+    parsed = mcp_server_module._decode_verified_mcp_result(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        envelope,
+        artifact=artifact.model_dump(mode="json"),
+        job_id=job.job_id,
+    )
+    receipt: dict[str, Any] = {
+        "cluster": job.cluster,
+        "job_id": job.job_id,
+        "state": "succeeded",
+    }
+
+    mcp_server_module._attach_terminal_mcp_evidence(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        receipt,
+        source_job=job,
+        last_error=None,
+        artifacts=[artifact.model_dump(mode="json")],
+        parsed_result=parsed,
+    )
+
+    expected = {
+        "cluster": job.cluster,
+        "source_job_id": job.job_id,
+        "source_artifact_id": artifact.artifact_id,
+        "package_id": "paraview-1",
+        "package_name": "builtin.paraview",
+        "service_instance_id": "paraview-live-1",
+    }
+    assert receipt["service_runtime_bindings"] == [expected]
+    keys = list(receipt)
+    assert keys.index("mcp_result_artifact") < keys.index("service_runtime_bindings")
+    assert keys.index("service_runtime_bindings") < keys.index("mcp_result")
+    serialized = mcp_server_module._serialize_tool_result(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        receipt
+    )
+    assert serialized.index('"mcp_result_artifact":') < serialized.index(
+        '"service_runtime_bindings":'
+    )
+    assert serialized.index('"service_runtime_bindings":') < serialized.index('"mcp_result":')
+
+
+def test_multiple_ready_services_have_exact_unchanged_bindings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated package services remain individually selectable by their handoff."""
+    queue, definition, job, _artifact, envelope = _source_result(tmp_path)
+    document = json.loads(base64.b64decode(envelope["data"], validate=True).decode("utf-8"))
+    services = document["structured_result"]["service_runtimes"]["service_runtimes"]
+    second = dict(services[0])
+    second.update(
+        {
+            "service_instance_id": "paraview-live-2",
+            "revision": 1,
+            "port": 18778,
+        }
+    )
+    services.append(second)
+    document["protocol_result"]["structuredContent"] = document["structured_result"]
+    _replace_envelope_document(envelope, document)
+    artifact = ArtifactRef.model_validate(envelope["artifact"])
+    parsed = mcp_server_module._decode_verified_mcp_result(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        envelope,
+        artifact=artifact.model_dump(mode="json"),
+        job_id=job.job_id,
+    )
+    receipt: dict[str, Any] = {}
+    mcp_server_module._attach_terminal_mcp_evidence(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        receipt,
+        source_job=job,
+        last_error=None,
+        artifacts=[artifact.model_dump(mode="json")],
+        parsed_result=parsed,
+    )
+    bindings = cast(list[dict[str, Any]], receipt["service_runtime_bindings"])
+    assert [item["service_instance_id"] for item in bindings] == [
+        "paraview-live-1",
+        "paraview-live-2",
+    ]
+
+    registry_path = tmp_path / "clusters.json"
+    ClusterRegistry(clusters={definition.name: definition}).save(registry_path)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+    monkeypatch.setenv("CLIO_RELAY_FRP_TOKEN", "token")
+    monkeypatch.setenv("CLIO_RELAY_STCP_SECRET", "secret")
+    monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
+    _patch_connector_start(monkeypatch)
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_bind_jarvis_runtime",
+                "arguments": {"binding": bindings[1]},
+            },
+        },
+        queue=queue,
+        settings=RelaySettings(
+            core_dir=tmp_path / "core",
+            spool_dir=tmp_path / "spool",
+            frpc_bin="frpc-test",
+        ),
+        profile="user",
+    )
+
+    assert response is not None and "error" not in response, response
+    gateway = response["result"]["structuredContent"]["gateway_session"]
+    persisted_binding = gateway["gateway"]["jarvis_runtime_binding"]
+    assert persisted_binding["service_instance_id"] == "paraview-live-2"
+    assert persisted_binding["source_relay_artifact_id"] == artifact.artifact_id
+
+
+def test_bind_rejects_mixed_or_invalid_handoff_forms(tmp_path: Path) -> None:
+    binding = {
+        "cluster": "test-cluster",
+        "source_job_id": "job-source",
+        "source_artifact_id": "artifact-result",
+        "package_id": "paraview-1",
+        "package_name": "builtin.paraview",
+        "service_instance_id": "paraview-live-1",
+    }
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+
+    mixed = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_bind_jarvis_runtime",
+                "arguments": {"binding": binding, "cluster": "other-cluster"},
+            },
+        },
+        queue=queue,
+        settings=settings,
+        profile="user",
+    )
+    invalid = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_bind_jarvis_runtime",
+                "arguments": {"binding": {**binding, "host": "caller.example"}},
+            },
+        },
+        queue=queue,
+        settings=settings,
+        profile="user",
+    )
+
+    assert mixed is not None
+    assert "cannot be mixed with legacy selectors: cluster" in mixed["error"]["message"]
+    assert invalid is not None
+    assert "binding is invalid" in invalid["error"]["message"]
+    assert "host" in invalid["error"]["message"]
 
 
 def test_owned_remote_source_uses_identity_bound_api_for_every_verification(
@@ -339,6 +511,46 @@ def test_service_runtime_uses_exact_jarvis_epoch_observation_contract(
     fictional.pop("observed_at_epoch")
     with pytest.raises(ValueError, match="observed_at"):
         JarvisServiceRuntime.model_validate(fictional)
+
+
+def test_dataset_descriptor_accepts_producer_null_optionals_but_canonicalizes_them() -> None:
+    """clio-kit may serialize optional timestep and units as null on the wire."""
+    canonical = {
+        "schema_version": "jarvis.dataset-descriptor.v1",
+        "dataset_id": "asteroid-first-five",
+        "kind": "temporal-volume",
+        "format": "vti-series",
+        "members": [{"index": 0, "location": "/datasets/asteroid/frame-000.vti"}],
+        "arrays": [
+            {
+                "name": "density",
+                "association": "point",
+                "components": 1,
+            }
+        ],
+        "bounds": None,
+        "source_artifact": None,
+    }
+    digest = hashlib.sha256(
+        json.dumps(
+            canonical,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()
+    wire = json.loads(json.dumps(canonical))
+    wire["members"][0]["timestep"] = None
+    wire["arrays"][0]["units"] = None
+    wire["fingerprint"] = {"algorithm": "sha256", "digest": digest}
+
+    descriptor = JarvisDatasetDescriptor.model_validate(wire)
+    dumped = descriptor.model_dump(mode="json")
+
+    assert "timestep" not in dumped["members"][0]
+    assert "units" not in dumped["arrays"][0]
+    assert dumped["fingerprint"]["digest"] == digest
 
 
 @pytest.mark.parametrize("include_service_runtimes", [None, False])

--- a/tests/test_mcp_call_runner_lifecycle.py
+++ b/tests/test_mcp_call_runner_lifecycle.py
@@ -26,7 +26,7 @@ def test_mcp_call_refuses_artifact_drift_before_launch(
     artifact: dict[str, Any] = {
         "requested_command": "science-mcp",
         "resolved_executable": "/opt/science-mcp",
-        "executable": {"sha256": "a" * 64},
+        "executable": {"path": "/opt/science-mcp", "sha256": "a" * 64},
         "install_spec": "/opt/science.whl",
         "install_source": "wheel",
         "install_artifact_sha256": "b" * 64,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7,7 +7,7 @@ from dataclasses import replace
 from datetime import timedelta
 from io import StringIO
 from pathlib import Path
-from typing import Protocol, cast
+from typing import Any, Protocol, cast
 
 import pytest
 from jsonschema import Draft202012Validator
@@ -22,6 +22,7 @@ from clio_relay.cluster_config import (
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.filesystem_paths import internal_filesystem_path
+from clio_relay.identifiers import durable_record_id_json_schema
 from clio_relay.mcp_server import (
     McpSessionState,
     handle_request,
@@ -263,6 +264,18 @@ def test_mcp_lists_relay_tools(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
         tool for tool in response["result"]["tools"] if tool["name"] == "relay_bind_jarvis_runtime"
     )
     assert "desktop_bind_port" not in bind_runtime_tool["inputSchema"]["properties"]
+    binding_schema = bind_runtime_tool["inputSchema"]["properties"]["binding"]
+    assert binding_schema["required"] == [
+        "cluster",
+        "source_job_id",
+        "source_artifact_id",
+        "package_id",
+        "package_name",
+        "service_instance_id",
+    ]
+    assert len(bind_runtime_tool["inputSchema"]["oneOf"]) == 2
+    assert binding_schema["properties"]["source_job_id"] == durable_record_id_json_schema()
+    assert binding_schema["properties"]["source_artifact_id"] == durable_record_id_json_schema()
     create_pipeline_tool = next(
         tool for tool in response["result"]["tools"] if tool["name"] == "jarvis_create_pipeline"
     )
@@ -336,6 +349,10 @@ def test_mcp_lists_relay_tools(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
         "type": "string",
         "const": "mcp_call",
     }
+    assert (
+        query_tool["outputSchema"]["properties"]["service_runtime_bindings"]["items"]
+        == binding_schema
+    )
     diagnose_tool = next(
         tool for tool in response["result"]["tools"] if tool["name"] == "relay_queue_diagnose"
     )
@@ -2065,6 +2082,11 @@ def test_direct_remote_waited_mcp_submission_returns_artifact_bound_result(
                         "cluster": "ares",
                         "kind": "mcp_call",
                         "state": "succeeded",
+                        "spec": {
+                            "server": "jarvis",
+                            "tool": "jarvis_describe",
+                        },
+                        "idempotency_key": "direct-waited-fixture",
                         "last_error": None,
                     },
                     "terminal": True,
@@ -2495,13 +2517,20 @@ def test_virtual_remote_mcp_wait_envelope_returns_same_call_result_without_leaki
             }
         ]
 
-    def verified_result(_queue: ClioCoreQueue, _job_id: str) -> dict[str, object]:
-        return {
+    def verified_result(
+        _queue: ClioCoreQueue,
+        _job_id: str,
+    ) -> mcp_server_module._VerifiedMcpResult:  # pyright: ignore[reportPrivateUsage]
+        document: dict[str, Any] = {
             "operation": "tools/call",
             "tool": "scientific_dataset_search",
             "returncode": 0,
             "structured_result": {"datasets": [{"dataset_id": "asteroid-first-five"}]},
         }
+        return mcp_server_module._VerifiedMcpResult(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            document=document,
+            public=document,
+        )
 
     def bounded_logs(
         selected_queue: ClioCoreQueue,

--- a/tests/test_mcp_stdio_validation.py
+++ b/tests/test_mcp_stdio_validation.py
@@ -21,6 +21,7 @@ from clio_relay.remote_mcp import (
     RemoteMcpToolSchema,
     remote_mcp_server_artifact_digest,
 )
+from tests.jarvis_mcp_fakes import verified_jarvis_server_artifact
 
 
 def test_packaged_stdio_session_initializes_lists_and_calls_virtual_jarvis(
@@ -36,11 +37,7 @@ def test_packaged_stdio_session_initializes_lists_and_calls_virtual_jarvis(
     ClusterRegistry(clusters={"alpha": ClusterDefinition(name="alpha", ssh_host="localhost")}).save(
         tmp_path / ".clio-relay" / "clusters.json"
     )
-    server_artifact = {
-        "verified": True,
-        "server_process_artifact_verified": True,
-        "executable": {"path": "/opt/bin/uvx", "sha256": "a" * 64},
-    }
+    server_artifact = verified_jarvis_server_artifact()
     contract = jarvis_user_contract()
     now = datetime.now(UTC)
     RemoteMcpSchemaCache.update_entry(
@@ -79,6 +76,7 @@ def test_packaged_stdio_session_initializes_lists_and_calls_virtual_jarvis(
 
     initialize = session.initialize_response["result"]
     listed = session.tools_list_response["result"]["tools"]
+    assert "result" in session.tools_call_response, session.evidence()
     call = session.tools_call_response["result"]["structuredContent"]
     job = ClioCoreQueue(tmp_path / "core").get_job(call["job_id"])
     assert initialize["serverInfo"]["name"] == "clio-relay"

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.15"
+    assert version == "1.3.16"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -337,11 +337,11 @@ def test_jarvis_release_requirement_enforces_unified_gray_scott_contract() -> No
         if resource["kind"] == "relay_worker"
     )
     clio_kit_component = worker["metadata_equals"]["component_artifacts"]["clio-kit"]
-    assert clio_kit_component["distribution_version"] == "2.5.4"
+    assert clio_kit_component["distribution_version"] == "2.5.5"
     assert clio_kit_component["persistent_tool"]["manager"] == "uv"
     assert clio_kit_component["persistent_tool"]["uv_version"] == "0.11.28"
     assert clio_kit_component["persistent_tool"]["source_artifact_sha256"] == (
-        "8e29cdde8abc669ca700aec09b38b6954322e924ac175cfcdf16a7f41a32374f"
+        "622344b951d39f35b0952d2bf056d83040b81ad52e4aca4794fa486026eab278"
     )
     jarvis_component = worker["metadata_equals"]["component_artifacts"]["jarvis-cd"]
     assert jarvis_component["distribution_version"] == "1.3.12"
@@ -505,7 +505,7 @@ def test_spack_release_requirements_split_existing_resolution_from_fresh_install
     )
     assert fresh_server["metadata_equals"]["server_name"] == "spack-fresh"
     assert fresh_server["metadata_equals"]["install_artifact_sha256"] == (
-        "8e29cdde8abc669ca700aec09b38b6954322e924ac175cfcdf16a7f41a32374f"
+        "622344b951d39f35b0952d2bf056d83040b81ad52e4aca4794fa486026eab278"
     )
     assert fresh_server["metadata_equals"]["contract_id"] == "clio-kit-spack-user-v2"
     assert fresh_server["metadata_equals"]["contract_sha256"] == (

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1944,7 +1944,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.3.15"
+    assert policy.release_version == "1.3.16"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.15"
+version = "1.3.16"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Waited `jarvis_get_execution(include_service_runtimes=true)` calls now return compact, artifact-derived `service_runtime_bindings` before the potentially large execution result. Agents pass one binding unchanged into `relay_bind_jarvis_runtime`; relay still re-reads and verifies the exact durable artifact and accepts no caller-supplied runtime host, port, path, scheduler, or dataset metadata.

The patch also selects repeated same-package services by exact service instance, accepts producer-side null optional dataset metadata while canonicalizing it out for fingerprints, repairs two stale security fixtures from the v1.3.15 tag CI, and pins the released clio-kit 2.5.5 / JARVIS MCP 3.2.3 wheel (`622344b9…eab278`). Focused verification: 113 relay tests plus 17 final behavior checks passed; Ruff and Pyright are clean.