### PR TITLE
fix(jarvis): preserve runtime bindings across relay waits

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.16` uses a release-first patch process. A maintainer builds the
+> Version `1.3.17` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.16"
+$Version = "1.3.17"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.16"
+release_version: "1.3.17"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: d50533ec932b8c4d45b5a7e9ca6e4e85ad2b767c8a6d2e41395a60308cce35a7
+acceptance_matrix_sha256: c8a4c30c2de822b4889917227c1206d68623cf7149d5196cbd350522b343c523
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.16"
+$Tag = "v1.3.17"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.16" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.17" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.16",
-  "matrix_sha256": "d50533ec932b8c4d45b5a7e9ca6e4e85ad2b767c8a6d2e41395a60308cce35a7",
+  "release_version": "1.3.17",
+  "matrix_sha256": "c8a4c30c2de822b4889917227c1206d68623cf7149d5196cbd350522b343c523",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.16"
+version = "1.3.17"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.16"
+__version__ = "1.3.17"

--- a/src/clio_relay/jarvis_mcp.py
+++ b/src/clio_relay/jarvis_mcp.py
@@ -543,12 +543,28 @@ def virtual_jarvis_tool_definitions(*, clusters: list[str] | None = None) -> lis
                 "items": jarvis_service_runtime_handoff_json_schema(clusters=clusters),
                 "maxItems": 4_096,
             }
+        tool_guidance = ""
+        if remote_tool == "jarvis_get_execution":
+            tool_guidance = (
+                " If this call returns queued, call relay_wait with its exact cluster, job_id, "
+                "and route_revision. The terminal wait returns service_runtime_bindings when "
+                "include_service_runtimes=true; bind one with relay_bind_jarvis_runtime before "
+                "opening a viewer. Never use execution_id as gateway_session_id."
+            )
+        elif remote_tool == "jarvis_add_step":
+            tool_guidance = (
+                " package_search is discovery only. Before add_step, call jarvis_describe with "
+                "target='package' and package_name set to the selected canonical name, then use "
+                "that package-owned settings contract rather than guessing settings."
+            )
         tools.append(
             {
                 "name": virtual_jarvis_tool_name(remote_tool),
                 "description": (
                     f"{definition['description']} Routed through the verified cluster-local "
-                    "clio-kit JARVIS MCP and returned as a durable relay job."
+                    "clio-kit JARVIS MCP and returned as a durable relay job. Preserve the "
+                    "returned cluster, job_id, and route_revision unchanged for every remote "
+                    f"follow-up.{tool_guidance}"
                 ),
                 "inputSchema": input_schema,
                 "outputSchema": output_schema,
@@ -716,9 +732,12 @@ def render_virtual_jarvis_agent_context() -> str:
         "selected canonical package name. "
         "When wait_for_terminal=true, the same JARVIS tool returns a bounded, "
         "artifact-bound mcp_result instead of requiring a second status or log call. "
-        "A completed jarvis_get_execution call with include_service_runtimes=true also "
-        "returns service_runtime_bindings. Pass one item unchanged as the binding argument "
-        "to relay_bind_jarvis_runtime; jarvis_run does not produce these handoffs. "
+        "If a JARVIS call returns queued, call relay_wait with its exact cluster, job_id, and "
+        "route_revision. A completed jarvis_get_execution call with "
+        "include_service_runtimes=true returns service_runtime_bindings either directly or "
+        "from that terminal relay_wait. Pass one item unchanged as the binding argument to "
+        "relay_bind_jarvis_runtime before opening a viewer; jarvis_run does not produce these "
+        "handoffs, and a JARVIS execution_id is never a gateway_session_id. "
         "For later job queries, preserve cluster, job_id, and the opaque 64-character "
         "route_revision from one receipt as a single handle; never substitute a catalog "
         "or dataset revision. "

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -461,9 +461,10 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
         {
             "name": "relay_status",
             "description": (
-                "Read relay job state, relay queue position, and scheduler status. A remote "
-                "job_id returned earlier on this MCP connection is self-routing; after a "
-                "reconnect, also pass cluster and route_revision from its receipt."
+                "Read relay job state, relay queue position, and scheduler status. For a "
+                "remote job, copy cluster, job_id, and route_revision unchanged from its "
+                "submission receipt on every follow-up call, including on the same MCP "
+                "connection. job_id alone is only for a local relay job."
             ),
             "inputSchema": {
                 "type": "object",
@@ -483,9 +484,10 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
         {
             "name": "relay_cancel",
             "description": (
-                "Request cancellation for a relay job. A remote job_id returned earlier on "
-                "this MCP connection is self-routing; after a reconnect, also pass cluster "
-                "and route_revision from its receipt."
+                "Request cancellation for a relay job. For a remote job, copy cluster, "
+                "job_id, and route_revision unchanged from its submission receipt on every "
+                "follow-up call, including on the same MCP connection. job_id alone is only "
+                "for a local relay job."
             ),
             "inputSchema": {
                 "type": "object",
@@ -507,9 +509,10 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
             "name": "relay_observe",
             "description": (
                 "Read job events from a cursor and optionally return when a regex pattern "
-                "matches stdout, stderr, or event text. A remote job_id returned earlier on "
-                "this MCP connection is self-routing; after a reconnect, also pass cluster "
-                "and route_revision from its receipt."
+                "matches stdout, stderr, or event text. For a remote job, copy cluster, "
+                "job_id, and route_revision unchanged from its submission receipt on every "
+                "follow-up call, including on the same MCP connection. job_id alone is only "
+                "for a local relay job."
             ),
             "inputSchema": {
                 "type": "object",
@@ -544,9 +547,14 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
         {
             "name": "relay_wait",
             "description": (
-                "Wait for a relay job to finish and return final status and logs. A remote "
-                "job_id returned earlier on this MCP connection is self-routing; after a "
-                "reconnect, also pass cluster and route_revision from its receipt."
+                "Wait for a relay job to finish and return final status, verified MCP result "
+                "evidence, and optional logs. For a remote job, copy cluster, job_id, and "
+                "route_revision unchanged from its submission receipt on every follow-up "
+                "call, including on the same MCP connection. job_id alone is only for a "
+                "local relay job. A terminal jarvis_get_execution requested with "
+                "include_service_runtimes=true returns service_runtime_bindings; pass one "
+                "unchanged to relay_bind_jarvis_runtime, then use that bind result's "
+                "gateway_session_id. Never use a JARVIS execution_id as gateway_session_id."
             ),
             "inputSchema": {
                 "type": "object",
@@ -1245,8 +1253,10 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
             "description": (
                 "Bind local relay connectors to one ready service reported by a completed, "
                 "artifact-bound JARVIS execution query with service runtimes included. "
-                "Pass one service_runtime_bindings item from a waited jarvis_get_execution "
-                "call unchanged as binding. jarvis_run is not a valid binding source. "
+                "Pass one service_runtime_bindings item returned either by a "
+                "wait_for_terminal jarvis_get_execution call or by relay_wait for its exact "
+                "remote job handle unchanged as binding. jarvis_run is not a valid binding "
+                "source, and a JARVIS execution_id is not a gateway_session_id. "
                 "Runtime host, paths, scheduler identity, and dataset metadata are read "
                 "only from the durable JARVIS result. The relay allocates the desktop "
                 "loopback port."
@@ -1762,7 +1772,30 @@ def _call_tool(
 def _serialize_tool_result(result: JSON) -> str:
     """Keep compact service handoffs ahead of a potentially large MCP result."""
     if "service_runtime_bindings" in result:
-        return json.dumps(result)
+        compact_keys = (
+            "service_runtime_bindings",
+            "mcp_result_artifact",
+            "cluster",
+            "job_id",
+            "route_revision",
+            "state",
+            "kind",
+            "terminal",
+            "remote",
+            "last_error",
+        )
+        bulk_keys = ("job", "mcp_result", "logs", "artifacts")
+        ordered: JSON = {}
+        for key in compact_keys:
+            if key in result:
+                ordered[key] = result[key]
+        for key, value in result.items():
+            if key not in compact_keys and key not in bulk_keys:
+                ordered[key] = value
+        for key in bulk_keys:
+            if key in result:
+                ordered[key] = result[key]
+        return json.dumps(ordered)
     return json.dumps(result, sort_keys=True)
 
 
@@ -2836,11 +2869,16 @@ def _verified_owned_mcp_result(
 def _verified_local_mcp_result(
     queue: ClioCoreQueue,
     job_id: str,
+    *,
+    artifacts: list[JSON] | None = None,
 ) -> _VerifiedMcpResult | None:
+    artifact_records = (
+        artifacts if artifacts is not None else _complete_local_artifacts(queue, job_id)
+    )
     artifact = next(
         (
             item
-            for item in _complete_local_artifacts(queue, job_id)
+            for item in artifact_records
             if item.get("kind") == "mcp_result" and item.get("job_id") == job_id
         ),
         None,
@@ -3197,6 +3235,7 @@ def _observe_job(arguments: JSON, *, queue: ClioCoreQueue, settings: RelaySettin
 def _wait_job(arguments: JSON, *, queue: ClioCoreQueue, settings: RelaySettings) -> JSON:
     job_id = _required_durable_record_id(arguments, "job_id")
     target = _job_target(arguments)
+    logs: JSON | None = None
     if target is not None and should_execute_on_cluster(target):
         if settings.owner_session_id is not None:
             with OwnedSessionApiClient(definition=target, settings=settings) as client:
@@ -3223,8 +3262,13 @@ def _wait_job(arguments: JSON, *, queue: ClioCoreQueue, settings: RelaySettings)
                     label="owned remote job status",
                 )
                 _validate_owned_job_status(result, job_id=job_id, cluster=target.name)
+                source_job = _terminal_remote_wait_job(
+                    result,
+                    job_id=job_id,
+                    cluster=target.name,
+                )
                 if arguments.get("include_logs", True) is not False:
-                    result["logs"] = _owned_job_logs(
+                    logs = _owned_job_logs(
                         client,
                         job_id,
                         limit=_log_limit(arguments),
@@ -3235,68 +3279,96 @@ def _wait_job(arguments: JSON, *, queue: ClioCoreQueue, settings: RelaySettings)
                     record_key="artifacts",
                     label=f"owned remote artifacts for {job_id}",
                 )
-                result["artifacts"] = artifact_records
                 parsed_result = _verified_owned_mcp_result(client, job_id, artifact_records)
-                if parsed_result is not None:
-                    result["mcp_result"] = parsed_result.public
-            result["cluster"] = target.name
-            result["route_revision"] = _route_revision(target)
-            return result
-        run_remote_clio(
-            target,
-            [
-                "job",
-                "wait",
-                job_id,
-                "--timeout-seconds",
-                str(float(arguments.get("timeout_seconds", 600))),
-                "--poll-seconds",
-                str(float(arguments.get("poll_seconds", 2))),
-            ],
-        )
-        result = _remote_json(target, ["job", "status", job_id], "remote job status")
-        if arguments.get("include_logs", True) is not False:
-            result["logs"] = _remote_job_logs(
+        else:
+            run_remote_clio(
                 target,
-                job_id,
+                [
+                    "job",
+                    "wait",
+                    job_id,
+                    "--timeout-seconds",
+                    str(float(arguments.get("timeout_seconds", 600))),
+                    "--poll-seconds",
+                    str(float(arguments.get("poll_seconds", 2))),
+                ],
+            )
+            result = _remote_json(target, ["job", "status", job_id], "remote job status")
+            source_job = _terminal_remote_wait_job(
+                result,
+                job_id=job_id,
+                cluster=target.name,
+            )
+            if arguments.get("include_logs", True) is not False:
+                logs = _remote_job_logs(
+                    target,
+                    job_id,
+                    limit=_log_limit(arguments),
+                )
+            artifact_records = _complete_remote_collection(
+                target,
+                ["job", "list-artifacts", job_id],
+                record_key="artifacts",
+                label=f"remote artifacts for {job_id}",
+            )
+            parsed_result = _verified_mcp_result(target, job_id, artifact_records)
+    else:
+        _require_local_job_cluster(queue, job_id, target)
+        source_job = wait_for_terminal(
+            queue,
+            job_id,
+            timeout_seconds=float(arguments.get("timeout_seconds", 600)),
+            poll_seconds=float(arguments.get("poll_seconds", 2)),
+        )
+        result = job_status(queue, source_job.job_id)
+        if arguments.get("include_logs", True) is not False:
+            logs = _job_logs(
+                queue,
+                settings,
+                source_job.job_id,
                 limit=_log_limit(arguments),
             )
-        artifact_records = _complete_remote_collection(
-            target,
-            ["job", "list-artifacts", job_id],
-            record_key="artifacts",
-            label=f"remote artifacts for {job_id}",
-        )
-        result["artifacts"] = artifact_records
-        parsed_result = _verified_mcp_result(target, job_id, artifact_records)
-        if parsed_result is not None:
-            result["mcp_result"] = parsed_result.public
-        result["cluster"] = target.name
-        result["route_revision"] = _route_revision(target)
-        return result
-    _require_local_job_cluster(queue, job_id, target)
-    job = wait_for_terminal(
-        queue,
-        job_id,
-        timeout_seconds=float(arguments.get("timeout_seconds", 600)),
-        poll_seconds=float(arguments.get("poll_seconds", 2)),
-    )
-    result = job_status(queue, job.job_id)
-    if arguments.get("include_logs", True) is not False:
-        result["logs"] = _job_logs(
+        artifact_records = _complete_local_artifacts(queue, source_job.job_id)
+        parsed_result = _verified_local_mcp_result(
             queue,
-            settings,
-            job.job_id,
-            limit=_log_limit(arguments),
+            source_job.job_id,
+            artifacts=artifact_records,
         )
-    result["artifacts"] = _complete_local_artifacts(queue, job.job_id)
-    parsed_result = _verified_local_mcp_result(queue, job.job_id)
-    if parsed_result is not None:
-        result["mcp_result"] = parsed_result.public
+
     if target is not None:
         result["cluster"] = target.name
         result["route_revision"] = _route_revision(target)
+    if parsed_result is not None:
+        _attach_terminal_mcp_evidence(
+            result,
+            source_job=source_job,
+            last_error=source_job.last_error,
+            artifacts=artifact_records,
+            parsed_result=parsed_result,
+        )
+    if logs is not None:
+        result["logs"] = logs
+    result["artifacts"] = artifact_records
     return result
+
+
+def _terminal_remote_wait_job(
+    result: JSON,
+    *,
+    job_id: str,
+    cluster: str,
+) -> RelayJob:
+    """Validate the exact terminal remote job backing a generic wait result."""
+
+    source_job = RelayJob.model_validate(_object(result.get("job")))
+    if source_job.job_id != job_id or source_job.cluster != cluster:
+        raise ValueError("remote wait returned a different job")
+    if (
+        source_job.state not in {JobState.SUCCEEDED, JobState.FAILED, JobState.CANCELED}
+        or result.get("terminal") is not True
+    ):
+        raise ValueError("remote wait did not return one terminal job")
+    return source_job
 
 
 def _job_logs(
@@ -3874,8 +3946,9 @@ def _remote_mcp_submission_result(
     )
     parsed_result = _verified_mcp_result(definition, job_id, artifacts)
     result.update({"state": state, "terminal": True})
+    logs: JSON | None = None
     if arguments.get("include_logs", False) is True:
-        result["logs"] = _remote_job_logs(
+        logs = _remote_job_logs(
             definition,
             job_id,
             limit=_log_limit(arguments),
@@ -3891,6 +3964,8 @@ def _remote_mcp_submission_result(
         artifacts=artifacts,
         parsed_result=parsed_result,
     )
+    if logs is not None:
+        result["logs"] = logs
     return result
 
 

--- a/tests/test_jarvis_service_runtime.py
+++ b/tests/test_jarvis_service_runtime.py
@@ -128,10 +128,334 @@ def test_waited_execution_exposes_compact_verified_binding_before_large_result(
     serialized = mcp_server_module._serialize_tool_result(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
         receipt
     )
-    assert serialized.index('"mcp_result_artifact":') < serialized.index(
-        '"service_runtime_bindings":'
+    assert serialized.index('"service_runtime_bindings":') < serialized.index(
+        '"mcp_result_artifact":'
     )
+    assert serialized.index('"mcp_result_artifact":') < serialized.index('"mcp_result":')
+
+
+def test_async_relay_wait_exposes_same_compact_verified_service_binding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A later relay_wait preserves the same artifact-bound bind handoff as an inline wait."""
+    queue, _definition, job, _artifact, envelope = _source_result(tmp_path)
+    queue.update_job_metadata(job.job_id, {"padding": "j" * 90_000})
+    document = json.loads(base64.b64decode(envelope["data"], validate=True).decode("utf-8"))
+    document["structured_result"]["runtime_metadata"] = {"padding": "x" * 90_000}
+    document["protocol_result"]["structuredContent"] = document["structured_result"]
+    _replace_envelope_document(envelope, document)
+    artifact = ArtifactRef.model_validate(envelope["artifact"])
+    artifact_record = artifact.model_dump(mode="json")
+    parsed = mcp_server_module._decode_verified_mcp_result(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        envelope,
+        artifact=artifact_record,
+        job_id=job.job_id,
+    )
+
+    def complete_artifacts(
+        _queue: ClioCoreQueue,
+        _job_id: str,
+    ) -> list[dict[str, Any]]:
+        return [artifact_record]
+
+    def verified_result(
+        _queue: ClioCoreQueue,
+        _job_id: str,
+        *,
+        artifacts: list[dict[str, Any]] | None = None,
+    ) -> mcp_server_module._VerifiedMcpResult:  # pyright: ignore[reportPrivateUsage]
+        del artifacts
+        return parsed
+
+    def large_logs(
+        _queue: ClioCoreQueue,
+        _settings: RelaySettings,
+        _job_id: str,
+        *,
+        limit: int,
+    ) -> dict[str, Any]:
+        assert limit == 32_768
+        return {
+            "stdout": {"text": "l" * limit, "eof": True},
+            "stderr": {"text": "", "eof": True},
+        }
+
+    monkeypatch.setattr(
+        mcp_server_module,
+        "_complete_local_artifacts",
+        complete_artifacts,
+    )
+    monkeypatch.setattr(
+        mcp_server_module,
+        "_verified_local_mcp_result",
+        verified_result,
+    )
+    monkeypatch.setattr(mcp_server_module, "_job_logs", large_logs)
+
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_wait",
+                "arguments": {"job_id": job.job_id, "include_logs": True},
+            },
+        },
+        queue=queue,
+        settings=RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool"),
+        profile="user",
+    )
+
+    assert response is not None and "error" not in response, response
+    receipt = response["result"]["structuredContent"]
+    expected = {
+        "cluster": job.cluster,
+        "source_job_id": job.job_id,
+        "source_artifact_id": artifact.artifact_id,
+        "package_id": "paraview-1",
+        "package_name": "builtin.paraview",
+        "service_instance_id": "paraview-live-1",
+    }
+    assert receipt["service_runtime_bindings"] == [expected]
+    assert receipt["mcp_result_artifact"]["artifact_id"] == artifact.artifact_id
+    assert receipt["artifacts"] == [artifact_record]
+    keys = list(receipt)
+    assert keys.index("service_runtime_bindings") < keys.index("mcp_result")
+    assert keys.index("mcp_result") < keys.index("artifacts")
+    serialized = response["result"]["content"][0]["text"]
+    assert serialized.count('"mcp_result":') == 1
+    assert serialized.startswith('{"service_runtime_bindings":')
+    assert serialized.index('"service_runtime_bindings":') < serialized.index('"job":')
     assert serialized.index('"service_runtime_bindings":') < serialized.index('"mcp_result":')
+    assert serialized.index('"service_runtime_bindings":') < serialized.index('"logs":')
+    assert serialized.index('"service_runtime_bindings":') < serialized.index('"artifacts":')
+    assert serialized.index('"mcp_result_artifact":') < serialized.index('"job":')
+    assert serialized.index('"mcp_result":') < serialized.index('"artifacts":')
+
+
+def test_ssh_remote_async_relay_wait_exposes_verified_service_binding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The SSH transport returns the same exact bind handoff from a later relay_wait."""
+    queue, source_definition, job, _artifact, envelope = _source_result(tmp_path)
+    definition = source_definition.model_copy(update={"ssh_host": "cluster-login"})
+    registry_path = tmp_path / "clusters.json"
+    ClusterRegistry(clusters={definition.name: definition}).save(registry_path)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+    artifact = ArtifactRef.model_validate(envelope["artifact"])
+    artifact_record = artifact.model_dump(mode="json")
+    parsed = mcp_server_module._decode_verified_mcp_result(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        envelope,
+        artifact=artifact_record,
+        job_id=job.job_id,
+    )
+    wait_commands: list[list[str]] = []
+
+    def run_remote(_definition: ClusterDefinition, command: list[str]) -> str:
+        wait_commands.append(command)
+        return ""
+
+    def remote_json(
+        _definition: ClusterDefinition,
+        command: list[str],
+        _label: str,
+    ) -> dict[str, Any]:
+        assert command == ["job", "status", job.job_id]
+        return {
+            "job": job.model_dump(mode="json"),
+            "relay_queue": {},
+            "scheduler": [],
+            "terminal": True,
+        }
+
+    def complete_remote_collection(
+        _definition: ClusterDefinition,
+        command: list[str],
+        *,
+        record_key: str,
+        label: str,
+    ) -> list[dict[str, Any]]:
+        assert command == ["job", "list-artifacts", job.job_id]
+        assert record_key == "artifacts"
+        assert label == f"remote artifacts for {job.job_id}"
+        return [artifact_record]
+
+    def verified_result(
+        _definition: ClusterDefinition,
+        selected_job_id: str,
+        artifacts: list[dict[str, Any]],
+    ) -> mcp_server_module._VerifiedMcpResult:  # pyright: ignore[reportPrivateUsage]
+        assert selected_job_id == job.job_id
+        assert artifacts == [artifact_record]
+        return parsed
+
+    monkeypatch.setattr(mcp_server_module, "run_remote_clio", run_remote)
+    monkeypatch.setattr(mcp_server_module, "_remote_json", remote_json)
+    monkeypatch.setattr(
+        mcp_server_module,
+        "_complete_remote_collection",
+        complete_remote_collection,
+    )
+    monkeypatch.setattr(mcp_server_module, "_verified_mcp_result", verified_result)
+
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_wait",
+                "arguments": {
+                    "cluster": definition.name,
+                    "job_id": job.job_id,
+                    "route_revision": mcp_server_module._route_revision(definition),  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+                    "include_logs": False,
+                },
+            },
+        },
+        queue=queue,
+        settings=RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool"),
+        profile="user",
+    )
+
+    assert response is not None and "error" not in response, response
+    receipt = response["result"]["structuredContent"]
+    assert receipt["service_runtime_bindings"][0]["source_job_id"] == job.job_id
+    assert receipt["service_runtime_bindings"][0]["source_artifact_id"] == artifact.artifact_id
+    assert receipt["mcp_result_artifact"]["artifact_id"] == artifact.artifact_id
+    assert list(receipt).index("service_runtime_bindings") < list(receipt).index("artifacts")
+    assert wait_commands == [
+        [
+            "job",
+            "wait",
+            job.job_id,
+            "--timeout-seconds",
+            "600.0",
+            "--poll-seconds",
+            "2.0",
+        ]
+    ]
+
+
+def test_owned_remote_async_relay_wait_exposes_verified_service_binding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The owned-session transport returns the same exact bind handoff from relay_wait."""
+    queue, source_definition, job, _artifact, envelope = _source_result(tmp_path)
+    definition = source_definition.model_copy(update={"ssh_host": "cluster-login"})
+    registry_path = tmp_path / "clusters.json"
+    ClusterRegistry(clusters={definition.name: definition}).save(registry_path)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+    artifact = ArtifactRef.model_validate(envelope["artifact"])
+    artifact_record = artifact.model_dump(mode="json")
+    parsed = mcp_server_module._decode_verified_mcp_result(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        envelope,
+        artifact=artifact_record,
+        job_id=job.job_id,
+    )
+    requests: list[tuple[str, str]] = []
+
+    class FakeOwnedSessionApiClient:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        def __enter__(self) -> FakeOwnedSessionApiClient:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def request_json(
+            self,
+            *,
+            method: str,
+            path: str,
+            query: dict[str, object] | None = None,
+            body: dict[str, object] | None = None,
+            response_timeout_seconds: float | None = None,
+        ) -> object:
+            del query, body, response_timeout_seconds
+            requests.append((method, path))
+            if method == "POST" and path == f"/jobs/{job.job_id}/wait":
+                return job.model_dump(mode="json")
+            if method == "GET" and path == f"/jobs/{job.job_id}/status":
+                return {
+                    "job": job.model_dump(mode="json"),
+                    "relay_queue": {},
+                    "scheduler": [],
+                    "terminal": True,
+                }
+            raise AssertionError(f"unexpected owned request: {method} {path}")
+
+    def complete_owned_collection(
+        _client: object,
+        *,
+        path: str,
+        record_key: str,
+        label: str,
+    ) -> list[dict[str, Any]]:
+        assert path == f"/jobs/{job.job_id}/artifacts"
+        assert record_key == "artifacts"
+        assert label == f"owned remote artifacts for {job.job_id}"
+        return [artifact_record]
+
+    def verified_result(
+        _client: object,
+        selected_job_id: str,
+        artifacts: list[dict[str, Any]],
+    ) -> mcp_server_module._VerifiedMcpResult:  # pyright: ignore[reportPrivateUsage]
+        assert selected_job_id == job.job_id
+        assert artifacts == [artifact_record]
+        return parsed
+
+    monkeypatch.setattr(mcp_server_module, "OwnedSessionApiClient", FakeOwnedSessionApiClient)
+    monkeypatch.setattr(
+        mcp_server_module,
+        "_complete_owned_collection",
+        complete_owned_collection,
+    )
+    monkeypatch.setattr(mcp_server_module, "_verified_owned_mcp_result", verified_result)
+
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_wait",
+                "arguments": {
+                    "cluster": definition.name,
+                    "job_id": job.job_id,
+                    "route_revision": mcp_server_module._route_revision(definition),  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+                    "include_logs": False,
+                },
+            },
+        },
+        queue=queue,
+        settings=RelaySettings(
+            core_dir=tmp_path / "core",
+            spool_dir=tmp_path / "spool",
+            api_token="owner-token",
+            owner_session_id="desktop-session",
+            owner_session_generation_id="generation-1",
+        ),
+        profile="user",
+    )
+
+    assert response is not None and "error" not in response, response
+    receipt = response["result"]["structuredContent"]
+    assert receipt["service_runtime_bindings"][0]["source_job_id"] == job.job_id
+    assert receipt["service_runtime_bindings"][0]["source_artifact_id"] == artifact.artifact_id
+    assert receipt["mcp_result_artifact"]["artifact_id"] == artifact.artifact_id
+    assert list(receipt).index("service_runtime_bindings") < list(receipt).index("artifacts")
+    assert requests == [
+        ("POST", f"/jobs/{job.job_id}/wait"),
+        ("GET", f"/jobs/{job.job_id}/status"),
+    ]
 
 
 def test_multiple_ready_services_have_exact_unchanged_bindings(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -374,6 +374,23 @@ def test_mcp_lists_relay_tools(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     for name in ("relay_observe", "relay_wait"):
         log_tool = next(tool for tool in response["result"]["tools"] if tool["name"] == name)
         assert log_tool["inputSchema"]["properties"]["log_limit"]["maximum"] == 32_768
+    for name in ("relay_status", "relay_cancel", "relay_observe", "relay_wait"):
+        followup_tool = next(tool for tool in response["result"]["tools"] if tool["name"] == name)
+        description = followup_tool["description"]
+        assert "cluster, job_id, and route_revision unchanged" in description
+        assert "on every follow-up call" in description
+        assert "job_id alone is only for a local relay job" in description
+    wait_tool = next(tool for tool in response["result"]["tools"] if tool["name"] == "relay_wait")
+    assert "service_runtime_bindings" in wait_tool["description"]
+    assert "Never use a JARVIS execution_id as gateway_session_id" in wait_tool["description"]
+    assert "JARVIS execution_id is not a gateway_session_id" in bind_runtime_tool["description"]
+    assert "Never use execution_id as gateway_session_id" in query_tool["description"]
+    add_step_tool = next(
+        tool for tool in response["result"]["tools"] if tool["name"] == "jarvis_add_step"
+    )
+    assert "package_search is discovery only" in add_step_tool["description"]
+    assert "target='package'" in add_step_tool["description"]
+    assert "package-owned settings contract rather than guessing" in add_step_tool["description"]
 
 
 def test_mcp_admin_profile_lists_operational_tools(tmp_path: Path) -> None:
@@ -893,6 +910,14 @@ def test_mcp_compact_job_handle_routes_remote_lifecycle_and_verifies_result(
     queue = ClioCoreQueue(tmp_path / "desktop-core")
     settings = RelaySettings(core_dir=tmp_path / "desktop-core", spool_dir=tmp_path / "spool")
     job_id = "remote-job-1"
+    remote_job = RelayJob(
+        job_id=job_id,
+        cluster="ares",
+        kind=JobKind.MCP_CALL,
+        state=JobState.SUCCEEDED,
+        spec=McpCallSpec(server="science", tool="inspect"),
+        idempotency_key="remote-science-inspect",
+    )
     payload = json.dumps(
         {
             "operation": "tools/call",
@@ -922,12 +947,7 @@ def test_mcp_compact_job_handle_routes_remote_lifecycle_and_verifies_result(
         if args[:2] == ["job", "status"]:
             return json.dumps(
                 {
-                    "job": {
-                        "job_id": job_id,
-                        "cluster": "ares",
-                        "kind": "mcp_call",
-                        "state": "succeeded",
-                    },
+                    "job": remote_job.model_dump(mode="json"),
                     "terminal": True,
                 }
             )

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.16"
+    assert version == "1.3.17"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1944,7 +1944,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.3.16"
+    assert policy.release_version == "1.3.17"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.16"
+version = "1.3.17"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- make queued relay_wait return the same verified JARVIS service-runtime binding as inline waits
- validate terminal remote job identity across local, SSH, and owned-session transports
- prioritize compact binding evidence before oversized results and teach bind-before-viewer/package-description semantics
- bump release identity to 1.3.17

## Focused validation
- 10 targeted relay/JARVIS tests passed
- 2 release identity and policy tests passed
- Ruff clean on changed implementation and focused tests
- Pyright: 0 errors