### PR TITLE
fix: make runtime binding and cleanup receipts explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.17` uses a release-first patch process. A maintainer builds the
+> Version `1.3.18` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.17"
+$Version = "1.3.18"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.17"
+release_version: "1.3.18"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: c8a4c30c2de822b4889917227c1206d68623cf7149d5196cbd350522b343c523
+acceptance_matrix_sha256: dd9d86c1dc8308040c9dde3da9071bd7bdae8d1cd9385a4583420bf3faf91ee3
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.17"
+$Tag = "v1.3.18"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.17" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.18" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.17",
-  "matrix_sha256": "c8a4c30c2de822b4889917227c1206d68623cf7149d5196cbd350522b343c523",
+  "release_version": "1.3.18",
+  "matrix_sha256": "dd9d86c1dc8308040c9dde3da9071bd7bdae8d1cd9385a4583420bf3faf91ee3",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.17"
+version = "1.3.18"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.17"
+__version__ = "1.3.18"

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -3416,7 +3416,7 @@ def session_detach(
             update={"report_id": seed_report.report_id, "started_at": seed_report.started_at}
         )
         canonical_report[0] = canonical
-        _write_cleanup_validation_report(
+        provenance_warning = _write_cleanup_validation_report(
             canonical,
             definition,
             canonical_report_path,
@@ -3424,9 +3424,11 @@ def session_detach(
             worker_observation_error=cleanup_worker_error,
         )
         payload["validation_report"] = str(canonical_report_path.resolve())
+        payload["validation_status"] = canonical.status.value
+        payload["validation_provenance_warning"] = provenance_warning
         typer.echo(_public_json(payload))
         canonical_ok = canonical.status is ValidationStatus.PASSED
-        if payload.get("ok") is not True or not canonical_ok:
+        if payload.get("ok") is not True or (not canonical_ok and not provenance_warning):
             raise typer.Exit(code=1)
 
     def guarded_action() -> None:
@@ -4100,7 +4102,7 @@ def session_teardown(
                     state="canceled",
                 )
             )
-        _write_cleanup_validation_report(
+        provenance_warning = _write_cleanup_validation_report(
             canonical,
             definition,
             canonical_report_path,
@@ -4108,9 +4110,11 @@ def session_teardown(
             worker_observation_error=cleanup_worker_error,
         )
         payload["validation_report"] = str(canonical_report_path.resolve())
+        payload["validation_status"] = canonical.status.value
+        payload["validation_provenance_warning"] = provenance_warning
         typer.echo(_public_json(payload))
         canonical_ok = canonical.status is ValidationStatus.PASSED
-        if payload.get("ok") is not True or not canonical_ok:
+        if payload.get("ok") is not True or (not canonical_ok and not provenance_warning):
             raise typer.Exit(code=1)
 
     def guarded_action() -> None:
@@ -12046,7 +12050,7 @@ def _write_cleanup_validation_report(
     *,
     observed_worker_info: dict[str, object] | None = None,
     worker_observation_error: Exception | None = None,
-) -> None:
+) -> bool:
     """Persist operational cleanup without manufacturing release provenance.
 
     Ordinary detach and teardown commands do not require a candidate wheel.  When
@@ -12055,10 +12059,25 @@ def _write_cleanup_validation_report(
     without verified-worker checks.  The release gate therefore cannot consume it
     as released-artifact evidence.  If a digest is supplied, remote worker
     verification remains strict and any mismatch still fails the acceptance run.
+
+    A bounded pre-cleanup worker observation is optional operational metadata.  Its
+    failure is recorded as failed provenance evidence, but it must not hide a
+    completed cleanup receipt or change the cleanup command's operational result.
+    Return ``True`` only when that optional provenance warning was recorded.
     """
     if report.install_source.artifact_sha256 is None:
         write_validation_report(report, path)
-        return
+        return False
+    if worker_observation_error is not None:
+        recorder = ValidationRecorder(report)
+        recorder.record_failure(
+            "worker.installation-info",
+            "verify remote worker installation identity",
+            worker_observation_error,
+        )
+        recorder.finish(worker_observation_error)
+        recorder.write(path)
+        return True
     _write_remote_verified_report(
         report,
         definition,
@@ -12066,6 +12085,7 @@ def _write_cleanup_validation_report(
         observed_worker_info=observed_worker_info,
         worker_observation_error=worker_observation_error,
     )
+    return False
 
 
 def _new_cleanup_acceptance_report(

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -1259,7 +1259,9 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                 "source, and a JARVIS execution_id is not a gateway_session_id. "
                 "Runtime host, paths, scheduler identity, and dataset metadata are read "
                 "only from the durable JARVIS result. The relay allocates the desktop "
-                "loopback port."
+                "loopback port. On success, copy the top-level gateway_session_id "
+                "unchanged into the viewer-opening tool; service_instance_id is not a "
+                "gateway identity."
             ),
             "inputSchema": {
                 "type": "object",
@@ -1316,6 +1318,14 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
             "outputSchema": {
                 "type": "object",
                 "properties": {
+                    "gateway_session_id": {
+                        **durable_record_id_json_schema(),
+                        "pattern": r"^gateway_[0-9a-f]{32}$",
+                        "description": (
+                            "Exact relay gateway identity to pass unchanged to a viewer-opening "
+                            "tool. It is equal to gateway_session.session_id."
+                        ),
+                    },
                     "gateway_session": {"type": "object"},
                     "connect_url": {"type": "string"},
                     "health_url": {"type": "string"},
@@ -1326,6 +1336,7 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                     "scheduler_cancel_requested": {"const": False},
                 },
                 "required": [
+                    "gateway_session_id",
                     "gateway_session",
                     "connect_url",
                     "health_url",
@@ -4444,8 +4455,13 @@ def _bind_jarvis_runtime(
         )
     ):
         raise ValueError("verified JARVIS runtime did not produce the complete URL contract")
+    gateway_session = public_gateway_session(started.session)
+    gateway_session_id = gateway_session.get("session_id")
+    if gateway_session_id != started.session.session_id:
+        raise ValueError("public gateway session identity did not match the bound runtime")
     return {
-        "gateway_session": public_gateway_session(started.session),
+        "gateway_session_id": gateway_session_id,
+        "gateway_session": gateway_session,
         "connect_url": started.connect_url,
         "health_url": started.health_url,
         "stream_url": started.stream_url,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1647,6 +1647,83 @@ def test_cli_session_detach_never_records_owner_session_closure(
     assert queue.get_owner_session_closed("session-1") is None
 
 
+def test_cli_session_detach_reports_success_when_optional_worker_observation_times_out(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_test_cluster(tmp_path)
+    core_dir = tmp_path / "core"
+    report_path = tmp_path / "detach-worker-timeout.json"
+    monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(core_dir))
+    monkeypatch.setenv("CLIO_RELAY_VALIDATION_ARTIFACT_SHA256", "a" * 64)
+    _activate_owner_session(ClioCoreQueue(core_dir))
+
+    def retained_session(**_kwargs: object) -> SessionLifecycleReport:
+        return SessionLifecycleReport(
+            cluster="ares",
+            session_id="session-1",
+            session_generation_id="generation-1",
+            mode="detach",
+            resources=[
+                CleanupResource(
+                    kind="remote_relay_api",
+                    resource_id="123",
+                    location="ares",
+                    action="retain",
+                    ownership_verified=True,
+                    outcome="retained",
+                    verified_after_operation=True,
+                )
+            ],
+        )
+
+    def timed_out_worker_observation(
+        _definition: ClusterDefinition,
+    ) -> tuple[None, RelayError]:
+        return None, RelayError("remote command timed out after 20 seconds: ares")
+
+    monkeypatch.setattr(cli, "detach_remote_session", retained_session)
+    monkeypatch.setattr(cli, "_cleanup_owned_runtime_sessions", _fake_empty_runtime_cleanup)
+    monkeypatch.setattr(cli, "_observe_worker_before_cleanup", timed_out_worker_observation)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "session",
+            "detach",
+            "--cluster",
+            "ares",
+            "--session-id",
+            "session-1",
+            "--validation-report",
+            str(report_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert payload["validation_status"] == "failed"
+    assert payload["validation_provenance_warning"] is True
+    assert payload["residual_resources"] == []
+    assert payload["resources"][0]["action"] == "retain"
+    assert payload["resources"][0]["outcome"] == "retained"
+    queue = ClioCoreQueue(core_dir)
+    assert queue.owner_session_is_closing("session-1") is False
+    assert queue.get_owner_session_closed("session-1") is None
+
+    validation_report = json.loads(report_path.read_text(encoding="utf-8"))
+    worker_check = next(
+        check
+        for check in validation_report["checks"]
+        if check["check_id"] == "worker.installation-info"
+    )
+    assert validation_report["status"] == "failed"
+    assert worker_check["status"] == "failed"
+    assert "timed out after 20 seconds" in worker_check["error"]
+
+
 def test_cli_session_detach_default_report_failure_controls_exit(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -2077,12 +2154,130 @@ def test_cli_session_teardown_retries_same_policy_after_closure(
 
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
+    assert payload["validation_status"] == "passed"
+    assert payload["validation_provenance_warning"] is False
     assert payload["cleanup_operation_id"] == intent["operation_id"]
     assert payload["cleanup_policy"] == {
         "stop_worker": False,
         "cancel_jobs": False,
         "cancel_scheduler_jobs": False,
     }
+
+
+def test_cli_session_teardown_reports_success_when_optional_worker_observation_times_out(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_test_cluster(tmp_path, scheduler_provider="slurm")
+    core_dir = tmp_path / "core"
+    report_path = tmp_path / "teardown-worker-timeout.json"
+    monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(core_dir))
+    monkeypatch.setenv("CLIO_RELAY_VALIDATION_ARTIFACT_SHA256", "a" * 64)
+    queue = ClioCoreQueue(core_dir)
+    _activate_owner_session(queue)
+    kept_job = cli._OwnedRelayJob(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        job_id="job-kept",
+        relay_state=JobState.SUCCEEDED,
+        scheduler_job_ids=("21958",),
+        scheduler_provider="slurm",
+        owner_session_generation_id="generation-1",
+    )
+
+    def list_owned_jobs(
+        *_args: object,
+        owner_session_generation_id: str | None = None,
+        **_kwargs: object,
+    ) -> list[object]:
+        return [] if owner_session_generation_id is None else [kept_job]
+
+    def running_scheduler_job(
+        _definition: ClusterDefinition,
+        scheduler_job_id: str,
+        *,
+        provider: str,
+    ) -> tuple[str, None]:
+        assert scheduler_job_id == "21958"
+        assert provider == "slurm"
+        return "running", None
+
+    def timed_out_worker_observation(
+        _definition: ClusterDefinition,
+    ) -> tuple[None, RelayError]:
+        return None, RelayError("remote command timed out after 20 seconds: ares")
+
+    def forbid_cancellation(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("default teardown must not request cancellation")
+
+    monkeypatch.setattr(cli, "status_remote_session", _fake_owned_session_status)
+    monkeypatch.setattr(cli, "teardown_remote_session", _fake_verified_teardown)
+    monkeypatch.setattr(cli, "_cleanup_owned_runtime_sessions", _fake_empty_runtime_cleanup)
+    monkeypatch.setattr(cli, "_list_owned_active_cluster_jobs", list_owned_jobs)
+    monkeypatch.setattr(cli, "_scheduler_phase_after_operation", running_scheduler_job)
+    monkeypatch.setattr(cli, "_observe_worker_before_cleanup", timed_out_worker_observation)
+    monkeypatch.setattr(cli, "_cancel_local_owned_jobs", forbid_cancellation)
+    monkeypatch.setattr(cli, "_cancel_owned_scheduler_jobs", forbid_cancellation)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "session",
+            "teardown",
+            "--cluster",
+            "ares",
+            "--session-id",
+            "session-1",
+            "--no-stop-worker",
+            "--keep-jobs",
+            "--keep-scheduler-jobs",
+            "--validation-report",
+            str(report_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    scheduler_resource = next(
+        resource for resource in payload["resources"] if resource["kind"] == "scheduler_job"
+    )
+    owner_resource = next(
+        resource for resource in payload["resources"] if resource["kind"] == "owner_session"
+    )
+    assert payload["ok"] is True
+    assert payload["validation_status"] == "failed"
+    assert payload["validation_provenance_warning"] is True
+    assert payload["residual_resources"] == []
+    assert payload["cleanup_policy"] == {
+        "stop_worker": False,
+        "cancel_jobs": False,
+        "cancel_scheduler_jobs": False,
+    }
+    assert payload["relay_cancel_requested"] is False
+    assert payload["scheduler_cancel_requested"] is False
+    assert scheduler_resource["resource_id"] == "21958"
+    assert scheduler_resource["action"] == "retain"
+    assert scheduler_resource["outcome"] == "retained"
+    assert scheduler_resource["observed_state"] == "running"
+    assert scheduler_resource["residual"] is False
+    assert owner_resource["outcome"] == "closed"
+    closure = queue.get_owner_session_closed(
+        "session-1",
+        session_generation_id="generation-1",
+    )
+    assert closure is not None
+    assert closure.residual_resource_ids == []
+
+    validation_report = json.loads(report_path.read_text(encoding="utf-8"))
+    worker_check = next(
+        check
+        for check in validation_report["checks"]
+        if check["check_id"] == "worker.installation-info"
+    )
+    assert validation_report["status"] == "failed"
+    assert validation_report["cleanup"]["remaining_resources"] == []
+    assert worker_check["status"] == "failed"
+    assert "timed out after 20 seconds" in worker_check["error"]
+    assert not any(check["check_id"] == "session.teardown" for check in validation_report["checks"])
 
 
 def test_cli_session_teardown_failure_preserves_stopped_api_evidence(
@@ -5323,6 +5518,37 @@ def test_cleanup_with_artifact_digest_keeps_worker_identity_verification_strict(
     assert saved["status"] == "failed"
     assert saved["install_source"]["artifact_sha256"] == "a" * 64
     assert saved["checks"][-1]["check_id"] == "worker.installation-info"
+
+
+def test_cleanup_with_artifact_digest_records_optional_worker_observation_failure(
+    tmp_path: Path,
+) -> None:
+    report = new_live_validation_report(
+        scenario="cleanup",
+        cluster="ares",
+        artifact_sha256="a" * 64,
+    )
+    recorder = ValidationRecorder(report)
+    with recorder.check("cleanup.relay-session", "remote API stopped") as evidence:
+        evidence.append(EvidenceReference(kind="cleanup", excerpt="remote API stopped"))
+    recorder.finish()
+    report_path = tmp_path / "optional-worker-observation.json"
+    observation_error = RelayError("remote command timed out after 20 seconds: ares")
+
+    provenance_warning = cli._write_cleanup_validation_report(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        report,
+        ClusterDefinition(name="ares", ssh_host="ares"),
+        report_path,
+        worker_observation_error=observation_error,
+    )
+
+    saved = json.loads(report_path.read_text(encoding="utf-8"))
+    assert provenance_warning is True
+    assert saved["status"] == "failed"
+    assert saved["checks"][0]["status"] == "passed"
+    assert saved["checks"][-1]["check_id"] == "worker.installation-info"
+    assert saved["checks"][-1]["status"] == "failed"
+    assert "timed out after 20 seconds" in saved["checks"][-1]["error"]
 
 
 def test_cli_cluster_add_persists_direct_transport_optimization(

--- a/tests/test_jarvis_service_runtime.py
+++ b/tests/test_jarvis_service_runtime.py
@@ -1060,6 +1060,10 @@ def test_agent_bind_persists_urls_and_rejects_runtime_commands(
     assert result["command_url"] == f"http://127.0.0.1:{local_port}/commands"
     assert result["scheduler_cancel_requested"] is False
     gateway = result["gateway_session"]
+    assert result["gateway_session_id"] == gateway["session_id"]
+    agent_visible = json.loads(response["result"]["content"][0]["text"])
+    assert agent_visible["gateway_session_id"] == gateway["session_id"]
+    assert agent_visible["gateway_session_id"] == agent_visible["gateway_session"]["session_id"]
     assert gateway["state"] == "ready"
     assert gateway["gateway"]["jarvis_runtime_binding"]["source_relay_job_id"] == job.job_id
     assert (

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -276,6 +276,28 @@ def test_mcp_lists_relay_tools(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     assert len(bind_runtime_tool["inputSchema"]["oneOf"]) == 2
     assert binding_schema["properties"]["source_job_id"] == durable_record_id_json_schema()
     assert binding_schema["properties"]["source_artifact_id"] == durable_record_id_json_schema()
+    bind_output_schema = bind_runtime_tool["outputSchema"]
+    assert bind_output_schema["properties"]["gateway_session_id"] == {
+        **durable_record_id_json_schema(),
+        "pattern": r"^gateway_[0-9a-f]{32}$",
+        "description": (
+            "Exact relay gateway identity to pass unchanged to a viewer-opening tool. "
+            "It is equal to gateway_session.session_id."
+        ),
+    }
+    assert bind_output_schema["required"] == [
+        "gateway_session_id",
+        "gateway_session",
+        "connect_url",
+        "health_url",
+        "stream_url",
+        "events_url",
+        "state_url",
+        "command_url",
+        "scheduler_cancel_requested",
+    ]
+    assert "top-level gateway_session_id" in bind_runtime_tool["description"]
+    assert "service_instance_id is not a gateway identity" in bind_runtime_tool["description"]
     create_pipeline_tool = next(
         tool for tool in response["result"]["tools"] if tool["name"] == "jarvis_create_pipeline"
     )

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.17"
+    assert version == "1.3.18"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1944,7 +1944,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.3.17"
+    assert policy.release_version == "1.3.18"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.17"
+version = "1.3.18"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Adds an exact top-level gateway_session_id to the JARVIS runtime bind result and preserves successful machine-readable detach/teardown receipts when optional pre-cleanup provenance observation times out. Canonical validation remains honestly failed for provenance warnings; scheduler cancellation remains opt-in. Focused tests: 9 passed; Ruff clean; Pyright 0.