### PR TITLE
fix(mcp): keep composed schemas agent-callable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.20` uses a release-first patch process. A maintainer builds the
+> Version `1.3.21` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.20"
+$Version = "1.3.21"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.20"
+release_version: "1.3.21"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 3d5e5a20e60be2c76dd69516f5d374c48f0897b30afd25bf6a6a27076bb19f64
+acceptance_matrix_sha256: 8393f94a4b161d7b279f8b0bdb740ee7a38250af637eb7580f5c27381b5d773c
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.20"
+$Tag = "v1.3.21"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.20" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.21" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.20",
-  "matrix_sha256": "3d5e5a20e60be2c76dd69516f5d374c48f0897b30afd25bf6a6a27076bb19f64",
+  "release_version": "1.3.21",
+  "matrix_sha256": "8393f94a4b161d7b279f8b0bdb740ee7a38250af637eb7580f5c27381b5d773c",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.20"
+version = "1.3.21"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.20"
+__version__ = "1.3.21"

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -888,10 +888,9 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                         "maximum": MAX_RESPONSE_PAGE_RECORDS,
                     },
                 },
-                "oneOf": [
-                    {"required": ["job_id"]},
-                    {"required": ["artifact_id"]},
-                ],
+                "if": {"required": ["job_id"]},
+                "then": {"not": {"required": ["artifact_id"]}},
+                "else": {"required": ["artifact_id"]},
                 "dependentRequired": {
                     "cluster": ["route_revision"],
                     "route_revision": ["cluster"],
@@ -1291,30 +1290,27 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                         "default": 2,
                     },
                 },
-                "oneOf": [
-                    {
-                        "required": ["binding"],
-                        "not": {
-                            "anyOf": [
-                                {"required": ["cluster"]},
-                                {"required": ["source_job_id"]},
-                                {"required": ["source_artifact_id"]},
-                                {"required": ["package_id"]},
-                                {"required": ["package_name"]},
-                            ]
-                        },
-                    },
-                    {
-                        "required": [
-                            "cluster",
-                            "source_job_id",
-                            "source_artifact_id",
-                            "package_id",
-                            "package_name",
-                        ],
-                        "not": {"required": ["binding"]},
-                    },
-                ],
+                "if": {"required": ["binding"]},
+                "then": {
+                    "not": {
+                        "anyOf": [
+                            {"required": ["cluster"]},
+                            {"required": ["source_job_id"]},
+                            {"required": ["source_artifact_id"]},
+                            {"required": ["package_id"]},
+                            {"required": ["package_name"]},
+                        ]
+                    }
+                },
+                "else": {
+                    "required": [
+                        "cluster",
+                        "source_job_id",
+                        "source_artifact_id",
+                        "package_id",
+                        "package_name",
+                    ]
+                },
                 "additionalProperties": False,
             },
             "outputSchema": {

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1696,7 +1696,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "3ff47f2835f38d7bbab2572efb001fade41a1970327c160fddd115db565e4510"
+        "8393f94a4b161d7b279f8b0bdb740ee7a38250af637eb7580f5c27381b5d773c"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -11,6 +11,7 @@ from typing import Any, Protocol, cast
 
 import pytest
 from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
 
 from clio_relay import mcp_server as mcp_server_module
 from clio_relay.cluster_config import (
@@ -273,7 +274,7 @@ def test_mcp_lists_relay_tools(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
         "package_name",
         "service_instance_id",
     ]
-    assert len(bind_runtime_tool["inputSchema"]["oneOf"]) == 2
+    assert bind_runtime_tool["inputSchema"]["if"] == {"required": ["binding"]}
     assert binding_schema["properties"]["source_job_id"] == durable_record_id_json_schema()
     assert binding_schema["properties"]["source_artifact_id"] == durable_record_id_json_schema()
     bind_output_schema = bind_runtime_tool["outputSchema"]
@@ -418,6 +419,80 @@ def test_mcp_lists_relay_tools(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     assert "package_search is discovery only" in add_step_tool["description"]
     assert "target='package'" in add_step_tool["description"]
     assert "package-owned settings contract rather than guessing" in add_step_tool["description"]
+
+
+def test_user_mcp_schemas_avoid_root_unions_and_preserve_exclusive_forms(
+    tmp_path: Path,
+) -> None:
+    """Keep agent-facing schemas visible to SDK clients without weakening validation."""
+
+    response = handle_request(
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        queue=ClioCoreQueue(tmp_path / "core"),
+        profile="user",
+    )
+
+    assert response is not None
+    tools = {tool["name"]: tool for tool in response["result"]["tools"]}
+    unsafe_root_unions = {"oneOf", "anyOf", "allOf"}
+    assert {
+        name: sorted(unsafe_root_unions.intersection(tool["inputSchema"]))
+        for name, tool in tools.items()
+        if unsafe_root_unions.intersection(tool["inputSchema"])
+    } == {}
+
+    lineage = cast(
+        _SchemaValidator,
+        Draft202012Validator(tools["relay_artifact_lineage"]["inputSchema"]),
+    )
+    for accepted in (
+        {"job_id": "job-source"},
+        {"artifact_id": "artifact-result"},
+        {
+            "artifact_id": "artifact-result",
+            "cluster": "ares",
+            "route_revision": "a" * 64,
+        },
+    ):
+        lineage.validate(accepted)
+    for rejected in (
+        {},
+        {"job_id": "job-source", "artifact_id": "artifact-result"},
+        {"artifact_id": "artifact-result", "cluster": "ares"},
+    ):
+        with pytest.raises(ValidationError):
+            lineage.validate(rejected)
+
+    handoff = {
+        "cluster": "ares",
+        "source_job_id": "job-source",
+        "source_artifact_id": "artifact-result",
+        "package_id": "paraview-1",
+        "package_name": "builtin.paraview",
+        "service_instance_id": "paraview-live-1",
+    }
+    bind_runtime = cast(
+        _SchemaValidator,
+        Draft202012Validator(tools["relay_bind_jarvis_runtime"]["inputSchema"]),
+    )
+    legacy_selectors = {
+        key: value for key, value in handoff.items() if key != "service_instance_id"
+    }
+    for accepted in (
+        {"binding": handoff},
+        {"binding": handoff, "readiness_timeout_seconds": 30},
+        legacy_selectors,
+        {**legacy_selectors, "name": "asteroid-viewer"},
+    ):
+        bind_runtime.validate(accepted)
+    for rejected in (
+        {},
+        {"binding": handoff, "cluster": "ares"},
+        {key: value for key, value in legacy_selectors.items() if key != "package_name"},
+        {"binding": {key: value for key, value in handoff.items() if key != "package_name"}},
+    ):
+        with pytest.raises(ValidationError):
+            bind_runtime.validate(rejected)
 
 
 def test_mcp_admin_profile_lists_operational_tools(tmp_path: Path) -> None:

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.20"
+    assert version == "1.3.21"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1944,7 +1944,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.3.20"
+    assert policy.release_version == "1.3.21"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.20"
+version = "1.3.21"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
﻿## Summary
- preserve exact artifact-lineage and runtime-binding exclusivity without root JSON Schema unions
- keep relay user tools callable through SDK clients that filter root combinators
- bump the patch release identity to 1.3.21

## Verification
- focused MCP schema and behavior tests
- focused release identity and acceptance-matrix tests
- Ruff and Pyright on the changed implementation/tests
- live SDK initialization probe exposes all 25 expected Host tools
