### PR TITLE
fix(session): bind owned runtimes to exact admissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.21` uses a release-first patch process. A maintainer builds the
+> Version `1.3.22` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.21"
+$Version = "1.3.22"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.21"
+release_version: "1.3.22"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 8393f94a4b161d7b279f8b0bdb740ee7a38250af637eb7580f5c27381b5d773c
+acceptance_matrix_sha256: 8f3d7f03d4e04d7fc9e79147cefe78fab3beaf51e6083486298fe6b7a4769cd6
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.21"
+$Tag = "v1.3.22"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.21" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.22" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.21",
-  "matrix_sha256": "8393f94a4b161d7b279f8b0bdb740ee7a38250af637eb7580f5c27381b5d773c",
+  "release_version": "1.3.22",
+  "matrix_sha256": "8f3d7f03d4e04d7fc9e79147cefe78fab3beaf51e6083486298fe6b7a4769cd6",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.21"
+version = "1.3.22"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.21"
+__version__ = "1.3.22"

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -59,8 +59,10 @@ from clio_relay.errors import ConfigurationError, NotFoundError, RelayError
 from clio_relay.frp_check import run_frpc_connection_check
 from clio_relay.identifiers import validate_durable_record_id
 from clio_relay.installation import (
+    InstallReceipt,
     attach_verified_worker_identity,
     installation_info,
+    verify_remote_worker_info,
     worker_runtime_info,
 )
 from clio_relay.jarvis_mcp import (
@@ -102,6 +104,17 @@ from clio_relay.models import (
     ServiceRuntimeSpec,
     TaskEventStatus,
     TaskTimelineEvent,
+)
+from clio_relay.owner_session_admission import (
+    assert_no_unscoped_desktop_admission_state as _assert_no_unscoped_desktop_admission_state,
+)
+from clio_relay.owner_session_admission import (
+    desktop_owner_session_admission_id as _desktop_owner_session_admission_id,
+)
+from clio_relay.owner_session_admission import (
+    owner_session_admission_status,
+    owner_session_gateway_admission,
+    owner_session_transition_lock,
 )
 from clio_relay.pagination import (
     DEFAULT_RESPONSE_PAGE_RECORDS,
@@ -179,10 +192,11 @@ from clio_relay.scheduler_providers import (
     validation_provider_for_scheduler,
 )
 from clio_relay.scheduler_validation import run_scheduler_lifecycle_validation
-from clio_relay.service_runtime import ServiceRuntimeStartResult, ServiceRuntimeSupervisor
+from clio_relay.service_runtime import ServiceRuntimeSupervisor
 from clio_relay.session_api import submit_owned_session_job
 from clio_relay.session_lifecycle import (
     CleanupResource,
+    SessionApiReleaseIdentity,
     SessionLifecycleReport,
     cleanup_connectors_cover_gateways,
     detach_remote_session,
@@ -204,6 +218,7 @@ from clio_relay.validation_report import (
     CleanupEvidence,
     EvidenceReference,
     LiveValidationReport,
+    SoftwareIdentity,
     ValidationRecorder,
     ValidationResource,
     ValidationStatus,
@@ -3003,17 +3018,89 @@ def session_start(
 
     def action() -> None:
         with _session_transition_lock(cluster=cluster, session_id=session_id):
+            api_release_identity = _verify_session_start_worker_compatibility(definition)
             lines = start_remote_session(
                 cluster=cluster,
                 definition=definition,
                 session_id=session_id,
                 remote_api_port=remote_api_port,
                 api_token=settings.api_token if require_token else None,
+                expected_api_release_identity=api_release_identity,
                 replace=replace,
             )
             _echo_lines(lines)
 
     _run_or_exit(action)
+
+
+def _verify_session_start_worker_compatibility(
+    definition: ClusterDefinition,
+) -> SessionApiReleaseIdentity:
+    """Require one exact live worker/install identity before session mutation."""
+    local_identity = _session_api_release_identity_from_installation(
+        installation_info(),
+        label="local clio-relay",
+    )
+    remote_receipt = verify_remote_worker_info(
+        _remote_worker_info(definition),
+        expected_cluster=definition.name,
+        expected_version=local_identity.distribution_version,
+        expected_software=local_identity.software,
+        expected_artifact_sha256=local_identity.artifact_sha256,
+        expected_source=None,
+    )
+    artifact_sha256 = remote_receipt.artifact_sha256
+    if artifact_sha256 is None:
+        raise ConfigurationError("remote worker receipt omitted its artifact SHA-256")
+    return SessionApiReleaseIdentity(
+        distribution_version=remote_receipt.distribution_version,
+        artifact_sha256=artifact_sha256,
+        software=remote_receipt.software,
+    )
+
+
+def _session_api_release_identity_from_installation(
+    info: dict[str, object],
+    *,
+    label: str,
+) -> SessionApiReleaseIdentity:
+    """Validate installation evidence and return its session-API identity."""
+    if info.get("receipt_matches_install") is not True:
+        raise ConfigurationError(f"{label} installation receipt does not match the running package")
+    try:
+        receipt = InstallReceipt.model_validate(info.get("receipt"))
+        software = SoftwareIdentity.model_validate(info.get("software"))
+    except ValidationError as exc:
+        raise ConfigurationError(f"{label} installation identity is invalid: {exc}") from exc
+    version = info.get("distribution_version")
+    artifact_sha256 = receipt.artifact_sha256
+    if (
+        not isinstance(version, str)
+        or receipt.distribution_version != version
+        or receipt.software != software
+        or artifact_sha256 is None
+    ):
+        raise ConfigurationError(f"{label} installation receipt does not match the running package")
+    return SessionApiReleaseIdentity(
+        distribution_version=version,
+        artifact_sha256=artifact_sha256,
+        software=software,
+    )
+
+
+def _require_process_bound_session_api_release() -> None:
+    """Require the API process to match its release marker when one is present."""
+    expected_sha256 = os.environ.get("CLIO_RELAY_API_RELEASE_IDENTITY_SHA256")
+    if expected_sha256 is None:
+        return
+    if re.fullmatch(r"[0-9a-f]{64}", expected_sha256) is None:
+        raise ConfigurationError("session API release identity marker is invalid")
+    observed = _session_api_release_identity_from_installation(
+        installation_info(),
+        label="session API",
+    )
+    if observed.sha256() != expected_sha256:
+        raise ConfigurationError("session API release identity does not match running package")
 
 
 @session_app.command("status")
@@ -6760,89 +6847,26 @@ def gateway_start_runtime(
             ),
         )
 
-        def start_runtime() -> ServiceRuntimeStartResult:
-            if owner_session_id is None or owner_session_generation_id is None:
-                return supervisor.start(name=name, spec=spec)
-            remote_execution = should_execute_on_cluster(definition)
-            local_admission_id = _desktop_owner_session_admission_id(
+        if owner_session_id is None or owner_session_generation_id is None:
+            result = supervisor.start(name=name, spec=spec)
+        else:
+            with owner_session_gateway_admission(
+                queue=queue,
+                definition=definition,
                 cluster=cluster,
                 session_id=owner_session_id,
-            )
-            if remote_execution:
-                _assert_no_unscoped_desktop_admission_state(
-                    queue,
-                    cluster=cluster,
-                    session_id=owner_session_id,
-                    session_generation_id=owner_session_generation_id,
+                session_generation_id=owner_session_generation_id,
+                transition_lock_factory=_session_transition_lock,
+                session_status_reader=status_remote_session,
+                admission_status_reader=_owner_session_admission_status,
+            ) as admission:
+                result = supervisor.start(
+                    name=name,
+                    spec=spec,
+                    owner_session_id=admission.owner_session_id,
+                    owner_session_generation_id=admission.owner_session_generation_id,
+                    owner_session_admission_id=admission.owner_session_admission_id,
                 )
-            process_status = status_remote_session(
-                definition=definition,
-                session_id=owner_session_id,
-            )
-            _require_live_owner_session_for_gateway(
-                process_status,
-                session_id=owner_session_id,
-                session_generation_id=owner_session_generation_id,
-            )
-            authoritative_admission = _owner_session_admission_status(
-                queue=queue,
-                definition=definition,
-                remote_execution=remote_execution,
-                session_id=owner_session_id,
-                session_generation_id=owner_session_generation_id,
-            )
-            _require_owner_session_admission_open(
-                authoritative_admission,
-                session_id=owner_session_id,
-                session_generation_id=owner_session_generation_id,
-            )
-            local_admission = queue.mirror_owner_session_generation_open(
-                local_admission_id,
-                session_generation_id=owner_session_generation_id,
-            )
-            _require_owner_session_admission_open(
-                local_admission,
-                session_id=local_admission_id,
-                session_generation_id=owner_session_generation_id,
-            )
-
-            # Reverify the authoritative boundary immediately before the first
-            # durable gateway write. The desktop transition lock remains held
-            # through all scheduler and connector side effects and rollback.
-            process_status = status_remote_session(
-                definition=definition,
-                session_id=owner_session_id,
-            )
-            _require_live_owner_session_for_gateway(
-                process_status,
-                session_id=owner_session_id,
-                session_generation_id=owner_session_generation_id,
-            )
-            authoritative_admission = _owner_session_admission_status(
-                queue=queue,
-                definition=definition,
-                remote_execution=remote_execution,
-                session_id=owner_session_id,
-                session_generation_id=owner_session_generation_id,
-            )
-            _require_owner_session_admission_open(
-                authoritative_admission,
-                session_id=owner_session_id,
-                session_generation_id=owner_session_generation_id,
-            )
-            return supervisor.start(
-                name=name,
-                spec=spec,
-                owner_session_id=owner_session_id,
-                owner_session_generation_id=owner_session_generation_id,
-                owner_session_admission_id=local_admission_id,
-            )
-
-        if owner_session_id is not None:
-            with _session_transition_lock(cluster=cluster, session_id=owner_session_id):
-                result = start_runtime()
-        else:
-            result = start_runtime()
         canonical = result.to_live_validation_report(
             launcher=validation_launcher,
             install_source=validation_install_source,
@@ -7980,6 +8004,10 @@ def api_start(
     """Start the desktop-facing HTTP API."""
     if require_token and RelaySettings.from_env().api_token is None:
         raise typer.BadParameter("CLIO_RELAY_API_TOKEN is required with --require-token")
+    try:
+        _require_process_bound_session_api_release()
+    except ConfigurationError as exc:
+        raise typer.BadParameter(str(exc)) from exc
     uvicorn.run("clio_relay.http_api:app", host=host, port=port)
 
 
@@ -8611,85 +8639,15 @@ def _owner_session_admission_status(
     session_id: str,
     session_generation_id: str,
 ) -> dict[str, object]:
-    """Read and strictly validate exact local or remote owner-session intake state."""
-    if remote_execution:
-        raw_status = cast(
-            object,
-            json.loads(
-                run_remote_clio(
-                    definition,
-                    [
-                        "session",
-                        "admission-status",
-                        "--session-id",
-                        session_id,
-                        "--session-generation-id",
-                        session_generation_id,
-                    ],
-                )
-            ),
-        )
-        if not isinstance(raw_status, dict):
-            raise RelayError("remote owner-session admission status was not an object")
-        status = {str(key): value for key, value in cast(dict[object, object], raw_status).items()}
-    else:
-        status = queue.owner_session_generation_status(
-            session_id,
-            session_generation_id=session_generation_id,
-        )
-    if (
-        status.get("schema_version") != "clio-relay.owner-session-admission-status.v1"
-        or status.get("owner_session_id") != session_id
-        or status.get("session_generation_id") != session_generation_id
-        or not all(
-            isinstance(status.get(key), bool) for key in ("active", "closing", "closed", "open")
-        )
-    ):
-        raise RelayError("owner-session admission status identity or schema did not match")
-    raw_intent = status.get("cleanup_intent")
-    if status.get("closing") is True:
-        if not isinstance(raw_intent, dict):
-            raise RelayError("closing owner-session admission status omitted cleanup intent")
-        intent = cast(dict[str, object], raw_intent)
-        operation_id = intent.get("operation_id")
-        if (
-            intent.get("schema_version") != "clio-relay.owner-session-cleanup-intent.v1"
-            or intent.get("owner_session_id") != session_id
-            or intent.get("session_generation_id") != session_generation_id
-            or not isinstance(operation_id, str)
-            or re.fullmatch(r"cleanup_[A-Za-z0-9_.-]+", operation_id) is None
-            or not all(
-                isinstance(intent.get(key), bool)
-                for key in ("stop_worker", "cancel_jobs", "cancel_scheduler_jobs")
-            )
-        ):
-            raise RelayError("owner-session admission cleanup intent was invalid")
-    elif raw_intent is not None:
-        raise RelayError("open owner-session admission status contained a cleanup intent")
-    return status
-
-
-def _require_owner_session_admission_open(
-    status: dict[str, object],
-    *,
-    session_id: str,
-    session_generation_id: str,
-) -> None:
-    """Fail closed unless exact generation intake is authoritatively open."""
-    if not (
-        status.get("owner_session_id") == session_id
-        and status.get("session_generation_id") == session_generation_id
-        and status.get("active") is True
-        and status.get("closing") is False
-        and status.get("closed") is False
-        and status.get("open") is True
-        and status.get("active_generation_id") == session_generation_id
-        and status.get("closing_generation_id") is None
-    ):
-        raise RelayError(
-            "owned session generation is not open for gateway admission: "
-            f"{session_id}:{session_generation_id}"
-        )
+    """Read owner-session intake through the CLI's injectable remote runner."""
+    return owner_session_admission_status(
+        queue=queue,
+        definition=definition,
+        remote_execution=remote_execution,
+        session_id=session_id,
+        session_generation_id=session_generation_id,
+        remote_cli_runner=run_remote_clio,
+    )
 
 
 def _select_owner_session_cleanup_operation(
@@ -10217,50 +10175,6 @@ def _verified_owner_session_generation(
     if status.get("running") is True and status.get("ownership_verified") is not True:
         raise RelayError("running remote session failed process ownership verification")
     return generation_id
-
-
-def _require_live_owner_session_for_gateway(
-    status: dict[str, object],
-    *,
-    session_id: str,
-    session_generation_id: str,
-) -> None:
-    """Require a live, owned, exact-generation API before gateway side effects."""
-    if not (
-        status.get("session_id") == session_id
-        and status.get("owner") == "clio-relay"
-        and status.get("session_generation_id") == session_generation_id
-        and status.get("running") is True
-        and status.get("ownership_verified") is True
-    ):
-        raise RelayError(
-            "gateway admission requires a live owned session with the exact generation: "
-            f"{session_id}:{session_generation_id}"
-        )
-
-
-def _assert_no_unscoped_desktop_admission_state(
-    queue: ClioCoreQueue,
-    *,
-    cluster: str,
-    session_id: str,
-    session_generation_id: str,
-) -> None:
-    """Fail closed when legacy desktop state cannot be attributed to one cluster."""
-    legacy = queue.owner_session_generation_status(
-        session_id,
-        session_generation_id=session_generation_id,
-    )
-    if (
-        legacy.get("active_generation_id") is not None
-        or legacy.get("closing_generation_id") is not None
-        or legacy.get("closed") is True
-    ):
-        raise RelayError(
-            "legacy unscoped desktop owner-session admission state cannot be safely assigned "
-            f"to cluster {cluster!r} for session {session_id!r}; clean or migrate it before "
-            "cluster-scoped admission"
-        )
 
 
 def _verified_owner_session_detach(
@@ -12269,17 +12183,8 @@ def _require_cluster(cluster: str) -> ClusterDefinition:
 
 
 def _session_transition_lock(*, cluster: str, session_id: str) -> FileLock:
-    """Serialize start, detach, and teardown orchestration for one desktop session."""
-    directory = default_registry_path().parent / "session-transitions"
-    directory.mkdir(parents=True, exist_ok=True)
-    identity = hashlib.sha256(f"{cluster}\0{session_id}".encode()).hexdigest()
-    return FileLock(str(directory / f"{identity}.lock"), timeout=60)
-
-
-def _desktop_owner_session_admission_id(*, cluster: str, session_id: str) -> str:
-    """Return a cluster-scoped local admission key without exposing raw names in paths."""
-    identity = hashlib.sha256(f"{cluster}\0{session_id}".encode()).hexdigest()
-    return f"desktop_{identity}"
+    """Return the shared cluster-scoped owner-session transition lock."""
+    return owner_session_transition_lock(cluster=cluster, session_id=session_id)
 
 
 def _require_durable_session_identity(value: str, *, field: str) -> str:

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -68,6 +68,7 @@ from clio_relay.models import (
     TaskEventStatus,
     TaskTimelineEvent,
 )
+from clio_relay.owner_session_admission import owner_session_gateway_admission
 from clio_relay.pagination import (
     DEFAULT_RESPONSE_PAGE_RECORDS,
     MAX_RESPONSE_PAGE_RECORDS,
@@ -4436,14 +4437,37 @@ def _bind_jarvis_runtime(
             "stcp secret",
         ),
     )
-    started = supervisor.bind_verified_jarvis_runtime(
-        name=runtime_name,
-        verified=verified,
-        owner_session_id=settings.owner_session_id,
-        owner_session_generation_id=settings.owner_session_generation_id,
-        readiness_timeout_seconds=readiness_timeout_seconds,
-        poll_seconds=poll_seconds,
-    )
+    owner_session_id = settings.owner_session_id
+    owner_session_generation_id = settings.owner_session_generation_id
+    if owner_session_id is None or owner_session_generation_id is None:
+        started = supervisor.bind_verified_jarvis_runtime(
+            name=runtime_name,
+            verified=verified,
+            readiness_timeout_seconds=readiness_timeout_seconds,
+            poll_seconds=poll_seconds,
+        )
+    else:
+        if settings.resolved_owner_session_cluster() != cluster:
+            raise ConfigurationError(
+                "owned runtime binding requires CLIO_RELAY_OWNER_SESSION_CLUSTER to match "
+                "the selected route"
+            )
+        with owner_session_gateway_admission(
+            queue=queue,
+            definition=definition,
+            cluster=cluster,
+            session_id=owner_session_id,
+            session_generation_id=owner_session_generation_id,
+        ) as admission:
+            started = supervisor.bind_verified_jarvis_runtime(
+                name=runtime_name,
+                verified=verified,
+                owner_session_id=admission.owner_session_id,
+                owner_session_generation_id=admission.owner_session_generation_id,
+                owner_session_admission_id=admission.owner_session_admission_id,
+                readiness_timeout_seconds=readiness_timeout_seconds,
+                poll_seconds=poll_seconds,
+            )
     if any(
         value is None
         for value in (

--- a/src/clio_relay/owner_session_admission.py
+++ b/src/clio_relay/owner_session_admission.py
@@ -1,0 +1,417 @@
+"""Admission boundary for gateway writes owned by a desktop relay session."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Callable, Generator
+from contextlib import AbstractContextManager, contextmanager
+from dataclasses import dataclass
+from typing import cast
+
+from filelock import FileLock
+
+from clio_relay.cluster_config import ClusterDefinition, default_registry_path
+from clio_relay.core_queue import ClioCoreQueue
+from clio_relay.errors import RelayError
+from clio_relay.remote_cli import run_remote_clio, should_execute_on_cluster
+from clio_relay.session_lifecycle import status_remote_session
+
+SessionStatusReader = Callable[..., dict[str, object]]
+AdmissionStatusReader = Callable[..., dict[str, object]]
+TransitionLockFactory = Callable[..., AbstractContextManager[object]]
+RemoteCliRunner = Callable[[ClusterDefinition, list[str]], str]
+
+
+@dataclass(frozen=True, slots=True)
+class OwnerSessionGatewayAdmission:
+    """Exact owner-session identity authorizing one cluster-local gateway write."""
+
+    owner_session_id: str
+    owner_session_generation_id: str
+    owner_session_admission_id: str
+
+
+def owner_session_transition_lock(*, cluster: str, session_id: str) -> FileLock:
+    """Serialize desktop orchestration transitions for one cluster/session pair."""
+    directory = default_registry_path().parent / "session-transitions"
+    directory.mkdir(parents=True, exist_ok=True)
+    identity = hashlib.sha256(f"{cluster}\0{session_id}".encode()).hexdigest()
+    return FileLock(str(directory / f"{identity}.lock"), timeout=60)
+
+
+def desktop_owner_session_admission_id(*, cluster: str, session_id: str) -> str:
+    """Return the cluster-scoped desktop admission key for one remote session."""
+    identity = hashlib.sha256(f"{cluster}\0{session_id}".encode()).hexdigest()
+    return f"desktop_{identity}"
+
+
+def owner_session_admission_status(
+    *,
+    queue: ClioCoreQueue,
+    definition: ClusterDefinition,
+    remote_execution: bool,
+    session_id: str,
+    session_generation_id: str,
+    remote_cli_runner: RemoteCliRunner | None = None,
+) -> dict[str, object]:
+    """Read and strictly validate exact local or remote owner-session intake state."""
+    if remote_execution:
+        run_cli = remote_cli_runner or run_remote_clio
+        raw_status = cast(
+            object,
+            json.loads(
+                run_cli(
+                    definition,
+                    [
+                        "session",
+                        "admission-status",
+                        "--session-id",
+                        session_id,
+                        "--session-generation-id",
+                        session_generation_id,
+                    ],
+                )
+            ),
+        )
+        if not isinstance(raw_status, dict):
+            raise RelayError("remote owner-session admission status was not an object")
+        status = {str(key): value for key, value in cast(dict[object, object], raw_status).items()}
+    else:
+        status = queue.owner_session_generation_status(
+            session_id,
+            session_generation_id=session_generation_id,
+        )
+    if (
+        status.get("schema_version") != "clio-relay.owner-session-admission-status.v1"
+        or status.get("owner_session_id") != session_id
+        or status.get("session_generation_id") != session_generation_id
+        or not all(
+            isinstance(status.get(key), bool) for key in ("active", "closing", "closed", "open")
+        )
+    ):
+        raise RelayError("owner-session admission status identity or schema did not match")
+    raw_intent = status.get("cleanup_intent")
+    if status.get("closing") is True:
+        if not isinstance(raw_intent, dict):
+            raise RelayError("closing owner-session admission status omitted cleanup intent")
+        intent = cast(dict[str, object], raw_intent)
+        operation_id = intent.get("operation_id")
+        if (
+            intent.get("schema_version") != "clio-relay.owner-session-cleanup-intent.v1"
+            or intent.get("owner_session_id") != session_id
+            or intent.get("session_generation_id") != session_generation_id
+            or not isinstance(operation_id, str)
+            or re.fullmatch(r"cleanup_[A-Za-z0-9_.-]+", operation_id) is None
+            or not all(
+                isinstance(intent.get(key), bool)
+                for key in ("stop_worker", "cancel_jobs", "cancel_scheduler_jobs")
+            )
+        ):
+            raise RelayError("owner-session admission cleanup intent was invalid")
+    elif raw_intent is not None:
+        raise RelayError("open owner-session admission status contained a cleanup intent")
+    return status
+
+
+def require_owner_session_admission_open(
+    status: dict[str, object],
+    *,
+    session_id: str,
+    session_generation_id: str,
+) -> None:
+    """Fail closed unless exact generation intake is authoritatively open."""
+    if not (
+        status.get("owner_session_id") == session_id
+        and status.get("session_generation_id") == session_generation_id
+        and status.get("active") is True
+        and status.get("closing") is False
+        and status.get("closed") is False
+        and status.get("open") is True
+        and status.get("active_generation_id") == session_generation_id
+        and status.get("closing_generation_id") is None
+    ):
+        raise RelayError(
+            "owned session generation is not open for gateway admission: "
+            f"{session_id}:{session_generation_id}"
+        )
+
+
+def require_live_owner_session_for_gateway(
+    status: dict[str, object],
+    *,
+    session_id: str,
+    session_generation_id: str,
+) -> None:
+    """Require a live, owned, exact-generation API before gateway side effects."""
+    if not (
+        status.get("session_id") == session_id
+        and status.get("owner") == "clio-relay"
+        and status.get("session_generation_id") == session_generation_id
+        and status.get("running") is True
+        and status.get("ownership_verified") is True
+    ):
+        raise RelayError(
+            "gateway admission requires a live owned session with the exact generation: "
+            f"{session_id}:{session_generation_id}"
+        )
+
+
+def assert_no_unscoped_desktop_admission_state(
+    queue: ClioCoreQueue,
+    *,
+    cluster: str,
+    session_id: str,
+    session_generation_id: str,
+) -> None:
+    """Fail closed when legacy desktop state cannot be attributed to one cluster."""
+    legacy = queue.owner_session_generation_status(
+        session_id,
+        session_generation_id=session_generation_id,
+    )
+    if (
+        legacy.get("active_generation_id") is not None
+        or legacy.get("closing_generation_id") is not None
+        or legacy.get("closed") is True
+    ):
+        raise RelayError(
+            "legacy unscoped desktop owner-session admission state cannot be safely assigned "
+            f"to cluster {cluster!r} for session {session_id!r}; clean or migrate it before "
+            "cluster-scoped admission"
+        )
+
+
+@contextmanager
+def owner_session_gateway_admission(
+    *,
+    queue: ClioCoreQueue,
+    definition: ClusterDefinition,
+    cluster: str,
+    session_id: str,
+    session_generation_id: str,
+    transition_lock_factory: TransitionLockFactory | None = None,
+    session_status_reader: SessionStatusReader | None = None,
+    admission_status_reader: AdmissionStatusReader | None = None,
+) -> Generator[OwnerSessionGatewayAdmission, None, None]:
+    """Authorize one owned gateway operation and lock through all its side effects.
+
+    The authoritative process and intake state are checked once before creating
+    the desktop mirror and again immediately before the caller receives control.
+    Keeping the caller inside this context keeps the same transition lock held
+    through durable gateway writes, connector setup, and any rollback they need.
+    """
+    if definition.name != cluster:
+        raise RelayError("owner-session gateway admission cluster definition did not match")
+    lock_factory = transition_lock_factory or owner_session_transition_lock
+    read_session_status = session_status_reader or status_remote_session
+    read_admission_status = admission_status_reader or owner_session_admission_status
+    remote_execution = should_execute_on_cluster(definition)
+    local_admission_id = desktop_owner_session_admission_id(
+        cluster=cluster,
+        session_id=session_id,
+    )
+
+    with lock_factory(cluster=cluster, session_id=session_id):
+        if remote_execution:
+            assert_no_unscoped_desktop_admission_state(
+                queue,
+                cluster=cluster,
+                session_id=session_id,
+                session_generation_id=session_generation_id,
+            )
+        _verify_authoritative_gateway_admission(
+            queue=queue,
+            definition=definition,
+            remote_execution=remote_execution,
+            session_id=session_id,
+            session_generation_id=session_generation_id,
+            session_status_reader=read_session_status,
+            admission_status_reader=read_admission_status,
+        )
+        local_status_before_mirror = queue.owner_session_generation_status(
+            local_admission_id,
+            session_generation_id=session_generation_id,
+        )
+        local_mirror_preexisting = (
+            local_status_before_mirror.get("active_generation_id") == session_generation_id
+            and local_status_before_mirror.get("open") is True
+        )
+        local_admission = queue.mirror_owner_session_generation_open(
+            local_admission_id,
+            session_generation_id=session_generation_id,
+        )
+        require_owner_session_admission_open(
+            local_admission,
+            session_id=local_admission_id,
+            session_generation_id=session_generation_id,
+        )
+
+        # A teardown may have won before the mirror write. Re-read the remote
+        # authority before exposing the admission to any connector side effect.
+        authoritative_status: dict[str, object] | None = None
+        try:
+            authoritative_status = _read_authoritative_gateway_admission(
+                queue=queue,
+                definition=definition,
+                remote_execution=remote_execution,
+                session_id=session_id,
+                session_generation_id=session_generation_id,
+                session_status_reader=read_session_status,
+                admission_status_reader=read_admission_status,
+            )
+            require_owner_session_admission_open(
+                authoritative_status,
+                session_id=session_id,
+                session_generation_id=session_generation_id,
+            )
+        except RelayError as admission_error:
+            if not local_mirror_preexisting:
+                if authoritative_status is None:
+                    try:
+                        authoritative_status = read_admission_status(
+                            queue=queue,
+                            definition=definition,
+                            remote_execution=remote_execution,
+                            session_id=session_id,
+                            session_generation_id=session_generation_id,
+                        )
+                    except (RelayError, ValueError):
+                        authoritative_status = None
+                if authoritative_status is not None:
+                    try:
+                        _reconcile_new_local_mirror_after_authoritative_close(
+                            queue=queue,
+                            local_admission_id=local_admission_id,
+                            session_id=session_id,
+                            session_generation_id=session_generation_id,
+                            authoritative_status=authoritative_status,
+                        )
+                    except (RelayError, ValueError) as reconciliation_error:
+                        raise RelayError(
+                            f"{admission_error}; newly created local admission mirror "
+                            f"could not be reconciled: {reconciliation_error}"
+                        ) from reconciliation_error
+            raise
+        yield OwnerSessionGatewayAdmission(
+            owner_session_id=session_id,
+            owner_session_generation_id=session_generation_id,
+            owner_session_admission_id=local_admission_id,
+        )
+
+
+def _verify_authoritative_gateway_admission(
+    *,
+    queue: ClioCoreQueue,
+    definition: ClusterDefinition,
+    remote_execution: bool,
+    session_id: str,
+    session_generation_id: str,
+    session_status_reader: SessionStatusReader,
+    admission_status_reader: AdmissionStatusReader,
+) -> None:
+    """Verify exact live process identity and authoritative intake state together."""
+    authoritative_admission = _read_authoritative_gateway_admission(
+        queue=queue,
+        definition=definition,
+        remote_execution=remote_execution,
+        session_id=session_id,
+        session_generation_id=session_generation_id,
+        session_status_reader=session_status_reader,
+        admission_status_reader=admission_status_reader,
+    )
+    require_owner_session_admission_open(
+        authoritative_admission,
+        session_id=session_id,
+        session_generation_id=session_generation_id,
+    )
+
+
+def _read_authoritative_gateway_admission(
+    *,
+    queue: ClioCoreQueue,
+    definition: ClusterDefinition,
+    remote_execution: bool,
+    session_id: str,
+    session_generation_id: str,
+    session_status_reader: SessionStatusReader,
+    admission_status_reader: AdmissionStatusReader,
+) -> dict[str, object]:
+    """Read exact process and intake evidence without discarding denied status."""
+    process_status = session_status_reader(
+        definition=definition,
+        session_id=session_id,
+    )
+    require_live_owner_session_for_gateway(
+        process_status,
+        session_id=session_id,
+        session_generation_id=session_generation_id,
+    )
+    return admission_status_reader(
+        queue=queue,
+        definition=definition,
+        remote_execution=remote_execution,
+        session_id=session_id,
+        session_generation_id=session_generation_id,
+    )
+
+
+def _reconcile_new_local_mirror_after_authoritative_close(
+    *,
+    queue: ClioCoreQueue,
+    local_admission_id: str,
+    session_id: str,
+    session_generation_id: str,
+    authoritative_status: dict[str, object],
+) -> None:
+    """Close a mirror created by this attempt when remote closure is proven."""
+    if (
+        authoritative_status.get("owner_session_id") != session_id
+        or authoritative_status.get("session_generation_id") != session_generation_id
+        or authoritative_status.get("open") is not False
+    ):
+        return
+    raw_intent = authoritative_status.get("cleanup_intent")
+    if authoritative_status.get("closing") is True:
+        if not isinstance(raw_intent, dict):
+            return
+        intent = cast(dict[str, object], raw_intent)
+        operation_id = intent.get("operation_id")
+        if (
+            intent.get("schema_version") != "clio-relay.owner-session-cleanup-intent.v1"
+            or intent.get("owner_session_id") != session_id
+            or intent.get("session_generation_id") != session_generation_id
+            or not isinstance(operation_id, str)
+            or re.fullmatch(r"cleanup_[A-Za-z0-9_.-]+", operation_id) is None
+            or not all(
+                isinstance(intent.get(key), bool)
+                for key in ("stop_worker", "cancel_jobs", "cancel_scheduler_jobs")
+            )
+        ):
+            return
+        stop_worker = cast(bool, intent["stop_worker"])
+        cancel_jobs = cast(bool, intent["cancel_jobs"])
+        cancel_scheduler_jobs = cast(bool, intent["cancel_scheduler_jobs"])
+    elif authoritative_status.get("closed") is True:
+        identity = hashlib.sha256(
+            f"{local_admission_id}\0{session_generation_id}".encode()
+        ).hexdigest()
+        operation_id = f"cleanup_admission_reconcile_{identity}"
+        stop_worker = False
+        cancel_jobs = False
+        cancel_scheduler_jobs = False
+    else:
+        return
+    queue.set_owner_session_closing(
+        local_admission_id,
+        session_generation_id=session_generation_id,
+        operation_id=operation_id,
+        stop_worker=stop_worker,
+        cancel_jobs=cancel_jobs,
+        cancel_scheduler_jobs=cancel_scheduler_jobs,
+    )
+    queue.set_owner_session_closed(
+        local_admission_id,
+        session_generation_id=session_generation_id,
+        residual_resource_ids=[],
+    )

--- a/src/clio_relay/service_runtime.py
+++ b/src/clio_relay/service_runtime.py
@@ -50,6 +50,7 @@ from clio_relay.models import (
     ServiceRuntimeSpec,
     utc_now,
 )
+from clio_relay.owner_session_admission import desktop_owner_session_admission_id
 from clio_relay.public_records import public_gateway_payload
 from clio_relay.relay_host import (
     FrpcConfig,
@@ -1024,6 +1025,7 @@ class ServiceRuntimeSupervisor:
         desktop_bind_port: int | None = None,
         owner_session_id: str | None = None,
         owner_session_generation_id: str | None = None,
+        owner_session_admission_id: str | None = None,
         transport_mode: str = "frp-stcp-wss",
         readiness_timeout_seconds: float = 300.0,
         poll_seconds: float = 2.0,
@@ -1040,6 +1042,24 @@ class ServiceRuntimeSupervisor:
         if (owner_session_id is None) != (owner_session_generation_id is None):
             raise ConfigurationError(
                 "owner_session_id and owner_session_generation_id must be provided together"
+            )
+        if owner_session_admission_id is not None and owner_session_id is None:
+            raise ConfigurationError(
+                "owner_session_admission_id requires owner_session_id and generation"
+            )
+        if owner_session_id is not None and owner_session_admission_id is None:
+            raise ConfigurationError(
+                "owned JARVIS runtime binding requires owner_session_admission_id"
+            )
+        if owner_session_id is not None and owner_session_admission_id != (
+            desktop_owner_session_admission_id(
+                cluster=self.cluster,
+                session_id=owner_session_id,
+            )
+        ):
+            raise ConfigurationError(
+                "owned JARVIS runtime binding admission id does not match its "
+                "cluster/session identity"
             )
         if readiness_timeout_seconds <= 0 or poll_seconds <= 0:
             raise ConfigurationError("runtime readiness intervals must be positive")
@@ -1100,6 +1120,8 @@ class ServiceRuntimeSupervisor:
                     "owner_session_generation_id": owner_session_generation_id,
                 }
             )
+            if owner_session_admission_id is not None:
+                owner_metadata["owner_session_admission_id"] = owner_session_admission_id
         self.queue.initialize()
         session = self.queue.create_gateway_session(
             GatewaySession(

--- a/src/clio_relay/session_lifecycle.py
+++ b/src/clio_relay/session_lifecycle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import shlex
 import subprocess
@@ -16,6 +17,7 @@ from clio_relay.cluster_config import ClusterDefinition
 from clio_relay.errors import RelayError
 from clio_relay.identifiers import DurableRecordId, validate_durable_record_id
 from clio_relay.remote_cli import remote_env
+from clio_relay.validation_report import SoftwareIdentity
 
 if TYPE_CHECKING:
     from clio_relay.validation_report import (
@@ -44,6 +46,31 @@ class RemoteSession:
     session_id: str
     remote_api_port: int
     api_token: str | None
+
+
+class SessionApiReleaseIdentity(BaseModel):
+    """Exact released artifact identity bound to an owned session API process."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["clio-relay.session-api-release.v1"] = (
+        "clio-relay.session-api-release.v1"
+    )
+    distribution_version: str = Field(min_length=1)
+    artifact_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    software: SoftwareIdentity
+
+    def canonical_json(self) -> str:
+        """Return the canonical JSON representation used for process attestation."""
+        return json.dumps(
+            self.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    def sha256(self) -> str:
+        """Return the canonical release-identity digest."""
+        return hashlib.sha256(self.canonical_json().encode("utf-8")).hexdigest()
 
 
 class CleanupResource(BaseModel):
@@ -640,6 +667,7 @@ def start_remote_session(
     session_id: str,
     remote_api_port: int,
     api_token: str | None,
+    expected_api_release_identity: SessionApiReleaseIdentity | None = None,
     replace: bool = False,
 ) -> list[str]:
     """Start a cluster-side relay API owned by a session id."""
@@ -652,6 +680,7 @@ def start_remote_session(
             session_id=session_id,
             remote_api_port=remote_api_port,
             api_token=api_token,
+            expected_api_release_identity=expected_api_release_identity,
             replace=replace,
         ),
     )
@@ -807,6 +836,7 @@ def _start_script(
     session_id: str,
     remote_api_port: int,
     api_token: str | None,
+    expected_api_release_identity: SessionApiReleaseIdentity | None,
     replace: bool,
 ) -> str:
     token_export = ""
@@ -815,6 +845,14 @@ def _start_script(
         token_export = f"export CLIO_RELAY_API_TOKEN={_shell_single_quote(api_token)}"
         require_token = " --require-token"
     replace_flag = "1" if replace else "0"
+    expected_release_json = (
+        expected_api_release_identity.canonical_json()
+        if expected_api_release_identity is not None
+        else ""
+    )
+    expected_release_sha256 = (
+        expected_api_release_identity.sha256() if expected_api_release_identity is not None else ""
+    )
     return f"""set -euo pipefail
 umask 077
 {remote_env(definition)}
@@ -827,6 +865,82 @@ flock -w 10 -x 9 || {{ echo "session transition lock timed out" >&2; exit 75; }}
 pid_file="$session_dir/api.pid"
 log_file="$session_dir/api.log"
 metadata_file="$session_dir/metadata.json"
+expected_api_release_identity_json={_shell_single_quote(expected_release_json)}
+expected_api_release_identity_sha256={shlex.quote(expected_release_sha256)}
+api_release_identity_json="$(python3 - \
+  "$expected_api_release_identity_json" "$expected_api_release_identity_sha256" \
+  <<'__CLIO_RELAY_CURRENT_API_RELEASE__'
+import hashlib
+import json
+import re
+import subprocess
+import sys
+
+expected_identity = json.loads(sys.argv[1]) if sys.argv[1] else None
+expected_sha256 = sys.argv[2]
+try:
+    completed = subprocess.run(
+        ["clio-relay", "installation-info"],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=20,
+    )
+except (OSError, subprocess.TimeoutExpired) as exc:
+    raise SystemExit(f"cannot attest the session API installation: {{exc}}") from exc
+if completed.returncode != 0:
+    raise SystemExit(
+        "cannot attest the session API installation: "
+        + (completed.stderr.strip() or completed.stdout.strip())
+    )
+try:
+    installation = json.loads(completed.stdout)
+except json.JSONDecodeError as exc:
+    raise SystemExit("session API installation identity is not valid JSON") from exc
+receipt = installation.get("receipt")
+software = installation.get("software")
+distribution_version = installation.get("distribution_version")
+artifact_sha256 = receipt.get("artifact_sha256") if isinstance(receipt, dict) else None
+if (
+    installation.get("schema_version") != "clio-relay.installation-info.v1"
+    or installation.get("receipt_matches_install") is not True
+    or not isinstance(receipt, dict)
+    or not isinstance(software, dict)
+    or receipt.get("schema_version") != "clio-relay.install-receipt.v1"
+    or receipt.get("distribution_version") != distribution_version
+    or receipt.get("software") != software
+    or not isinstance(distribution_version, str)
+    or not distribution_version
+    or not isinstance(software.get("version"), str)
+    or not software.get("version")
+    or not isinstance(artifact_sha256, str)
+    or re.fullmatch(r"[0-9a-f]{{64}}", artifact_sha256) is None
+):
+    raise SystemExit("session API installation receipt does not match the running package")
+identity = {{
+    "schema_version": "clio-relay.session-api-release.v1",
+    "distribution_version": distribution_version,
+    "artifact_sha256": artifact_sha256,
+    "software": software,
+}}
+canonical = json.dumps(identity, sort_keys=True, separators=(",", ":"))
+observed_sha256 = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+if expected_identity is not None and (
+    identity != expected_identity or observed_sha256 != expected_sha256
+):
+    raise SystemExit("session API installation changed after worker compatibility verification")
+print(canonical)
+__CLIO_RELAY_CURRENT_API_RELEASE__
+)"
+expected_api_release_identity_json="$api_release_identity_json"
+expected_api_release_identity_sha256="$(python3 - "$api_release_identity_json" \
+  <<'__CLIO_RELAY_CURRENT_API_RELEASE_DIGEST__'
+import hashlib
+import sys
+
+print(hashlib.sha256(sys.argv[1].encode("utf-8")).hexdigest())
+__CLIO_RELAY_CURRENT_API_RELEASE_DIGEST__
+)"
 is_owned_api_pid() {{
   python3 - "$metadata_file" "$1" "$session_id" <<'__CLIO_RELAY_PID_OWNER__'
 import json
@@ -908,6 +1022,41 @@ elif [ -n "$recorded_api_pgid" ] \
   && kill -0 -- "-$recorded_api_pgid" 2>/dev/null; then
   echo "refusing to replace an active session API group without a PID record" >&2
   exit 1
+fi
+if [ -n "$existing_owned_pid" ] && [ "{replace_flag}" != "1" ]; then
+  python3 - \
+    "$metadata_file" "$existing_owned_pid" \
+    "$expected_api_release_identity_json" "$expected_api_release_identity_sha256" \
+    <<'__CLIO_RELAY_EXISTING_API_RELEASE__'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+metadata_path, pid, expected_json, expected_sha256 = sys.argv[1:]
+metadata = json.loads(Path(metadata_path).read_text(encoding="utf-8"))
+expected_identity = json.loads(expected_json)
+observed_identity = metadata.get("api_release_identity")
+observed_sha256 = metadata.get("api_release_identity_sha256")
+if not isinstance(observed_identity, dict) or not isinstance(observed_sha256, str):
+    raise SystemExit("existing owned session API has no release identity; use --replace")
+canonical = json.dumps(observed_identity, sort_keys=True, separators=(",", ":"))
+if (
+    observed_identity != expected_identity
+    or observed_sha256 != expected_sha256
+    or hashlib.sha256(canonical.encode("utf-8")).hexdigest() != observed_sha256
+):
+    raise SystemExit("existing owned session API release identity differs; use --replace")
+try:
+    environment = (Path("/proc") / pid / "environ").read_bytes().split(bytes([0]))
+except OSError as exc:
+    raise SystemExit(f"cannot verify existing session API release identity: {{exc}}") from exc
+marker = f"CLIO_RELAY_API_RELEASE_IDENTITY_SHA256={{observed_sha256}}".encode()
+if marker not in environment:
+    raise SystemExit(
+        "existing owned session API release identity is not process-bound; use --replace"
+    )
+__CLIO_RELAY_EXISTING_API_RELEASE__
 fi
 recorded_generation_id="$(python3 - "$metadata_file" "$session_id" \
   <<'__CLIO_RELAY_RECORDED_GENERATION__'
@@ -1054,6 +1203,7 @@ trap cleanup_incomplete_start EXIT
 nohup setsid env \\
   "CLIO_RELAY_SESSION_OWNER_TOKEN=$owner_token" \\
   "CLIO_RELAY_SESSION_GENERATION_ID=$session_generation_id" \\
+  "CLIO_RELAY_API_RELEASE_IDENTITY_SHA256=$expected_api_release_identity_sha256" \\
   "CLIO_RELAY_OWNER_SESSION_ID=$session_id" \\
   "CLIO_RELAY_OWNER_SESSION_CLUSTER={shlex.quote(cluster)}" \\
   "${{api_command[@]}}" \\
@@ -1062,6 +1212,7 @@ api_pid="$!"
 echo "$api_pid" > "$pid_file"
 python3 - \
   "$metadata_file" "$api_pid" "$owner_token" "$session_generation_id" \
+  "$api_release_identity_json" "$expected_api_release_identity_sha256" \
   <<'__CLIO_RELAY_METADATA__'
 import json
 import os
@@ -1072,6 +1223,8 @@ path = sys.argv[1]
 api_pid = int(sys.argv[2])
 owner_token = sys.argv[3]
 session_generation_id = sys.argv[4]
+api_release_identity = json.loads(sys.argv[5])
+api_release_identity_sha256 = sys.argv[6]
 for _ in range(40):
     try:
         api_pgid = os.getpgid(api_pid)
@@ -1084,6 +1237,8 @@ for _ in range(40):
         api_pgid == api_pid
         and f"CLIO_RELAY_SESSION_OWNER_TOKEN={{owner_token}}".encode() in environment
         and f"CLIO_RELAY_SESSION_GENERATION_ID={{session_generation_id}}".encode()
+        in environment
+        and f"CLIO_RELAY_API_RELEASE_IDENTITY_SHA256={{api_release_identity_sha256}}".encode()
         in environment
     ):
         break
@@ -1100,6 +1255,8 @@ metadata = {{
     "api_pgid": api_pgid,
     "owner_token": owner_token,
     "session_generation_id": session_generation_id,
+    "api_release_identity": api_release_identity,
+    "api_release_identity_sha256": api_release_identity_sha256,
     "process_start_ticks": process_start_ticks,
     "started_at": datetime.now(timezone.utc).isoformat(),
     "owner": "clio-relay",
@@ -1282,6 +1439,7 @@ def _owned_status_script(*, session_id: str) -> str:
 session_id={shlex.quote(session_id)}
 metadata_file="$HOME/.local/share/clio-relay/sessions/$session_id/metadata.json"
 python3 - "$metadata_file" "$session_id" <<'__CLIO_RELAY_OWNED_STATUS__'
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -1301,6 +1459,7 @@ if not isinstance(pid, int):
         pid = None
 running = False
 ownership_verified = False
+environment = []
 try:
     proc = Path("/proc") / str(pid)
     stat = (proc / "stat").read_text(encoding="utf-8")
@@ -1330,8 +1489,23 @@ try:
 except (OSError, IndexError, TypeError):
     pass
 
+release_identity = metadata.get("api_release_identity")
+release_sha256 = metadata.get("api_release_identity_sha256")
+api_release_identity_verified = False
+if isinstance(release_identity, dict) and isinstance(release_sha256, str):
+    canonical_release = json.dumps(
+        release_identity,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    release_marker = f"CLIO_RELAY_API_RELEASE_IDENTITY_SHA256={{release_sha256}}".encode()
+    api_release_identity_verified = (
+        hashlib.sha256(canonical_release.encode("utf-8")).hexdigest() == release_sha256
+        and release_marker in environment
+    )
 metadata["running"] = running
 metadata["ownership_verified"] = ownership_verified
+metadata["api_release_identity_verified"] = api_release_identity_verified
 metadata["api_pid"] = pid if isinstance(pid, int) else None
 metadata["ownership_token_present"] = bool(metadata.pop("owner_token", None))
 print(json.dumps(metadata))

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1696,7 +1696,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "8393f94a4b161d7b279f8b0bdb740ee7a38250af637eb7580f5c27381b5d773c"
+        "8f3d7f03d4e04d7fc9e79147cefe78fab3beaf51e6083486298fe6b7a4769cd6"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,7 @@ from _pytest.monkeypatch import MonkeyPatch
 from click import unstyle
 from typer.testing import CliRunner
 
-from clio_relay import cli
+from clio_relay import __version__, cli
 from clio_relay.cli import app
 from clio_relay.cluster_config import (
     ClusterDefinition,
@@ -54,6 +54,7 @@ from clio_relay.service_runtime import ServiceRuntimeSupervisor
 from clio_relay.session_lifecycle import (
     CleanupResource,
     RemoteSessionStateEvidence,
+    SessionApiReleaseIdentity,
     SessionLifecycleReport,
 )
 from clio_relay.validation_report import (
@@ -156,6 +157,79 @@ def _owned_session_status(
         "running": running,
         "ownership_verified": running,
     }
+
+
+def _installation_identity(
+    *,
+    version: str = __version__,
+    artifact_sha256: str = "a" * 64,
+) -> dict[str, object]:
+    software: dict[str, object] = {
+        "version": version,
+        "commit": "1" * 40,
+        "tag": f"v{version}",
+        "dirty": False,
+    }
+    receipt: dict[str, object] = {
+        "schema_version": "clio-relay.install-receipt.v1",
+        "installed_at": datetime.now(UTC).isoformat(),
+        "install_spec": f"clio-relay=={version}",
+        "requested_source": "pypi",
+        "artifact_filename": f"clio_relay-{version}-py3-none-any.whl",
+        "artifact_sha256": artifact_sha256,
+        "distribution_version": version,
+        "software": software,
+        "components": {},
+        "component_artifacts": {},
+    }
+    return {
+        "schema_version": "clio-relay.installation-info.v1",
+        "distribution_version": version,
+        "software": software,
+        "receipt": receipt,
+        "receipt_origin": "uv-tool",
+        "install_source": None,
+        "receipt_matches_install": True,
+        "component_runtime": {},
+    }
+
+
+def _worker_runtime_identity(
+    installation: dict[str, object],
+    *,
+    fresh: bool = True,
+    process_running: bool = True,
+) -> dict[str, object]:
+    return {
+        "schema_version": "clio-relay.worker-runtime-info.v1",
+        "cluster": "ares",
+        "fresh": fresh,
+        "process_running": process_running,
+        "identity_matches_current": True,
+        "running": fresh and process_running,
+        "scheduler_provider": "external",
+        "endpoint": {
+            "role": "worker",
+            "cluster": "ares",
+            "pid": 123,
+            "metadata": {"scheduler_provider": "external"},
+        },
+        "installation": installation,
+        "endpoint_installation": installation,
+        "target_identity": {"verified": True},
+    }
+
+
+def _session_api_release_identity() -> SessionApiReleaseIdentity:
+    installation = _installation_identity()
+    receipt = cast(dict[str, object], installation["receipt"])
+    return SessionApiReleaseIdentity.model_validate(
+        {
+            "distribution_version": installation["distribution_version"],
+            "artifact_sha256": receipt["artifact_sha256"],
+            "software": installation["software"],
+        }
+    )
 
 
 def _verified_teardown_report(
@@ -1449,10 +1523,18 @@ def test_cli_session_lifecycle_commands(tmp_path: Path, monkeypatch: MonkeyPatch
         remote_calls.append(arguments)
         return "{}"
 
+    def accept_worker_compatibility(
+        _definition: ClusterDefinition,
+    ) -> SessionApiReleaseIdentity:
+        return _session_api_release_identity()
+
     monkeypatch.setattr("clio_relay.cli.start_remote_session", fake_start)
     monkeypatch.setattr("clio_relay.cli.status_remote_session", fake_status)
     monkeypatch.setattr("clio_relay.cli.teardown_remote_session", fake_teardown)
     monkeypatch.setattr("clio_relay.cli.run_remote_clio", fake_run_remote_clio)
+    monkeypatch.setattr(
+        cli, "_verify_session_start_worker_compatibility", accept_worker_compatibility
+    )
     monkeypatch.setenv("CLIO_RELAY_API_TOKEN", "api-token")
     monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(tmp_path / "core"))
     _activate_owner_session(ClioCoreQueue(tmp_path / "core"))
@@ -1520,8 +1602,16 @@ def test_cli_session_start_does_not_reopen_intake_when_process_start_fails(
         remote_calls.append(arguments)
         return "{}"
 
+    def accept_worker_compatibility(
+        _definition: ClusterDefinition,
+    ) -> SessionApiReleaseIdentity:
+        return _session_api_release_identity()
+
     monkeypatch.setattr(cli, "start_remote_session", fail_start)
     monkeypatch.setattr(cli, "run_remote_clio", record_remote)
+    monkeypatch.setattr(
+        cli, "_verify_session_start_worker_compatibility", accept_worker_compatibility
+    )
 
     result = CliRunner().invoke(
         app,
@@ -1530,6 +1620,153 @@ def test_cli_session_start_does_not_reopen_intake_when_process_start_fails(
 
     assert result.exit_code == 1
     assert remote_calls == []
+
+
+@pytest.mark.parametrize(
+    ("remote_version", "fresh", "process_running", "error"),
+    [
+        ("1.3.21", True, True, "distribution version does not match"),
+        (__version__, False, True, "did not prove fresh"),
+        (__version__, True, False, "did not prove process_running"),
+    ],
+)
+def test_cli_session_start_rejects_incompatible_worker_before_remote_mutation(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    remote_version: str,
+    fresh: bool,
+    process_running: bool,
+    error: str,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_test_cluster(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_API_TOKEN", "api-token")
+    local_installation = _installation_identity()
+    remote_installation = _installation_identity(
+        version=remote_version,
+        artifact_sha256="a" * 64 if remote_version == __version__ else "b" * 64,
+    )
+    starts: list[dict[str, object]] = []
+
+    def record_start(**kwargs: object) -> list[str]:
+        starts.append(kwargs)
+        return ["session_started=session-1"]
+
+    def remote_worker_info(_definition: ClusterDefinition) -> dict[str, object]:
+        return _worker_runtime_identity(
+            remote_installation,
+            fresh=fresh,
+            process_running=process_running,
+        )
+
+    monkeypatch.setattr(cli, "installation_info", lambda: local_installation)
+    monkeypatch.setattr(cli, "_remote_worker_info", remote_worker_info)
+    monkeypatch.setattr(cli, "start_remote_session", record_start)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "session",
+            "start",
+            "--cluster",
+            "ares",
+            "--session-id",
+            "session-1",
+            "--replace",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert error in result.output
+    assert starts == []
+
+
+def test_cli_session_start_verifies_exact_worker_inside_lock_before_mutation(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_test_cluster(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_API_TOKEN", "api-token")
+    installation = _installation_identity()
+    events: list[str] = []
+
+    class RecordingLock:
+        def __enter__(self) -> RecordingLock:
+            events.append("lock-enter")
+            return self
+
+        def __exit__(
+            self,
+            _exc_type: object,
+            _exc: object,
+            _traceback: object,
+        ) -> None:
+            events.append("lock-exit")
+
+    def transition_lock(*, cluster: str, session_id: str) -> RecordingLock:
+        assert cluster == "ares"
+        assert session_id == "session-1"
+        return RecordingLock()
+
+    def local_info() -> dict[str, object]:
+        events.append("local-installation")
+        return installation
+
+    def remote_info(_definition: ClusterDefinition) -> dict[str, object]:
+        events.append("remote-worker")
+        return _worker_runtime_identity(installation)
+
+    def start(**kwargs: object) -> list[str]:
+        assert isinstance(kwargs["expected_api_release_identity"], SessionApiReleaseIdentity)
+        events.append("start-remote-session")
+        return ["session_started=session-1", "session_generation_id=generation-1"]
+
+    monkeypatch.setattr(cli, "_session_transition_lock", transition_lock)
+    monkeypatch.setattr(cli, "installation_info", local_info)
+    monkeypatch.setattr(cli, "_remote_worker_info", remote_info)
+    monkeypatch.setattr(cli, "start_remote_session", start)
+
+    result = CliRunner().invoke(
+        app,
+        ["session", "start", "--cluster", "ares", "--session-id", "session-1"],
+    )
+
+    assert result.exit_code == 0
+    assert events == [
+        "lock-enter",
+        "local-installation",
+        "remote-worker",
+        "start-remote-session",
+        "lock-exit",
+    ]
+
+
+def test_cli_api_start_verifies_process_bound_release_identity(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    installation = _installation_identity()
+    identity = _session_api_release_identity()
+    launches: list[tuple[str, int]] = []
+
+    def launch(_application: str, *, host: str, port: int) -> None:
+        launches.append((host, port))
+
+    monkeypatch.setattr(cli, "installation_info", lambda: installation)
+    monkeypatch.setattr(cli.uvicorn, "run", launch)
+    monkeypatch.setenv("CLIO_RELAY_API_RELEASE_IDENTITY_SHA256", identity.sha256())
+
+    accepted = CliRunner().invoke(app, ["api", "start", "--port", "9001"])
+
+    assert accepted.exit_code == 0, accepted.output
+    assert launches == [("127.0.0.1", 9001)]
+
+    monkeypatch.setenv("CLIO_RELAY_API_RELEASE_IDENTITY_SHA256", "b" * 64)
+    rejected = CliRunner().invoke(app, ["api", "start", "--port", "9002"])
+
+    assert rejected.exit_code == 2
+    assert "release identity does not match running package" in rejected.output
+    assert launches == [("127.0.0.1", 9001)]
 
 
 def test_cli_session_submit_jarvis_uses_identity_proven_client(

--- a/tests/test_jarvis_service_runtime.py
+++ b/tests/test_jarvis_service_runtime.py
@@ -14,6 +14,7 @@ from typer.testing import CliRunner
 
 import clio_relay.jarvis_service_runtime as runtime_binding
 import clio_relay.mcp_server as mcp_server_module
+import clio_relay.owner_session_admission as owner_session_admission_module
 import clio_relay.service_runtime as service_runtime_module
 from clio_relay.browser_gateway import BrowserAttachmentGrant, BrowserDetachmentResult
 from clio_relay.cli import app
@@ -24,7 +25,7 @@ from clio_relay.cluster_config import (
 )
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
-from clio_relay.errors import ConfigurationError
+from clio_relay.errors import ConfigurationError, QueueConflictError
 from clio_relay.jarvis_mcp import jarvis_cd_lock_binding_expectation
 from clio_relay.jarvis_service_runtime import (
     RELAY_JARVIS_RUNTIME_BINDING_SCHEMA,
@@ -1219,6 +1220,185 @@ def test_agent_bind_persists_urls_and_rejects_runtime_commands(
     assert queue.get_gateway_session(gateway["session_id"]).gateway["jarvis_runtime_binding"]
 
 
+def test_owned_agent_bind_uses_shared_cluster_scoped_gateway_admission(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The MCP bind path mirrors owner intake and locks through connector setup."""
+    queue, definition, job, artifact, envelope = _source_result(tmp_path)
+    remote_definition = definition.model_copy(update={"ssh_host": "relay.example.test"})
+    registry_path = tmp_path / "clusters.json"
+    ClusterRegistry(clusters={definition.name: remote_definition}).save(registry_path)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+    monkeypatch.setenv("CLIO_RELAY_FRP_TOKEN", "token")
+    monkeypatch.setenv("CLIO_RELAY_STCP_SECRET", "secret")
+    monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
+    verified = resolve_jarvis_service_runtime(
+        queue=queue,
+        definition=definition,
+        source_job_id=job.job_id,
+        source_artifact_id=artifact.artifact_id,
+        package_id="paraview-1",
+        package_name="builtin.paraview",
+    )
+    monkeypatch.setenv("CLIO_RELAY_CLI_MODE", "ssh")
+
+    with pytest.raises(
+        QueueConflictError,
+        match="owner session generation has no active admission state",
+    ):
+        queue.create_gateway_session(
+            GatewaySession(
+                cluster=definition.name,
+                name="pre-fix-owned-bind",
+                metadata={
+                    "owner": "clio-relay",
+                    "owner_session_id": "desktop-session",
+                    "owner_session_generation_id": "generation-1",
+                },
+            )
+        )
+
+    def resolved_runtime(**_kwargs: object) -> Any:
+        return verified
+
+    monkeypatch.setattr(mcp_server_module, "resolve_jarvis_service_runtime", resolved_runtime)
+    _patch_connector_start(monkeypatch)
+    events: list[str] = []
+    lock_held = False
+
+    class RecordingLock:
+        def __enter__(self) -> RecordingLock:
+            nonlocal lock_held
+            assert lock_held is False
+            lock_held = True
+            events.append("enter")
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            nonlocal lock_held
+            assert lock_held is True
+            lock_held = False
+            events.append("exit")
+
+    def transition_lock(*, cluster: str, session_id: str) -> RecordingLock:
+        assert (cluster, session_id) == (definition.name, "desktop-session")
+        return RecordingLock()
+
+    def remote_session_status(**_kwargs: object) -> dict[str, object]:
+        assert lock_held is True
+        events.append("session")
+        return {
+            "owner": "clio-relay",
+            "session_id": "desktop-session",
+            "session_generation_id": "generation-1",
+            "running": True,
+            "ownership_verified": True,
+        }
+
+    def remote_admission_status(
+        _definition: ClusterDefinition,
+        args: list[str],
+    ) -> str:
+        assert lock_held is True
+        assert args[:2] == ["session", "admission-status"]
+        events.append("admission")
+        return json.dumps(
+            {
+                "schema_version": "clio-relay.owner-session-admission-status.v1",
+                "owner_session_id": "desktop-session",
+                "session_generation_id": "generation-1",
+                "active_generation_id": "generation-1",
+                "closing_generation_id": None,
+                "active": True,
+                "closing": False,
+                "closed": False,
+                "open": True,
+                "cleanup_intent": None,
+            }
+        )
+
+    monkeypatch.setattr(
+        owner_session_admission_module,
+        "owner_session_transition_lock",
+        transition_lock,
+    )
+    monkeypatch.setattr(
+        owner_session_admission_module,
+        "status_remote_session",
+        remote_session_status,
+    )
+    monkeypatch.setattr(
+        owner_session_admission_module,
+        "run_remote_clio",
+        remote_admission_status,
+    )
+    original_bind = ServiceRuntimeSupervisor.bind_verified_jarvis_runtime
+
+    def bind_while_locked(self: ServiceRuntimeSupervisor, **kwargs: Any) -> Any:
+        assert lock_held is True
+        assert kwargs["owner_session_admission_id"].startswith("desktop_")
+        events.append("bind")
+        return original_bind(self, **kwargs)
+
+    monkeypatch.setattr(
+        ServiceRuntimeSupervisor,
+        "bind_verified_jarvis_runtime",
+        bind_while_locked,
+    )
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        frpc_bin="frpc-test",
+        api_token="api-token",
+        owner_session_id="desktop-session",
+        owner_session_generation_id="generation-1",
+        owner_session_cluster=definition.name,
+        remote_cluster=definition.name,
+    )
+
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_bind_jarvis_runtime",
+                "arguments": {
+                    "cluster": definition.name,
+                    "source_job_id": job.job_id,
+                    "source_artifact_id": artifact.artifact_id,
+                    "package_id": "paraview-1",
+                    "package_name": "builtin.paraview",
+                },
+            },
+        },
+        queue=queue,
+        settings=settings,
+        profile="user",
+    )
+
+    assert response is not None and "error" not in response, response
+    result = cast(dict[str, Any], response["result"]["structuredContent"])
+    gateway = cast(dict[str, Any], result["gateway_session"])
+    persisted = queue.get_gateway_session(cast(str, gateway["session_id"]))
+    admission_id = cast(str, persisted.metadata["owner_session_admission_id"])
+    assert admission_id.startswith("desktop_")
+    assert persisted.metadata["owner_session_id"] == "desktop-session"
+    assert persisted.metadata["owner_session_generation_id"] == "generation-1"
+    assert gateway["metadata"]["owner_session_admission_id"] == admission_id
+    assert result["scheduler_cancel_requested"] is False
+    assert events == [
+        "enter",
+        "session",
+        "admission",
+        "session",
+        "admission",
+        "bind",
+        "exit",
+    ]
+
+
 def test_internal_bind_override_rejects_occupied_loopback_port(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1256,6 +1436,93 @@ def test_internal_bind_override_rejects_occupied_loopback_port(
                 verified=verified,
                 desktop_bind_port=occupied_port,
             )
+
+
+def test_owned_bind_rejects_missing_cluster_scoped_admission_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct callers cannot regress an owned bind to the raw session key."""
+    queue, definition, job, artifact, envelope = _source_result(tmp_path)
+    monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
+    verified = resolve_jarvis_service_runtime(
+        queue=queue,
+        definition=definition,
+        source_job_id=job.job_id,
+        source_artifact_id=artifact.artifact_id,
+        package_id="paraview-1",
+        package_name="builtin.paraview",
+    )
+    supervisor = ServiceRuntimeSupervisor(
+        settings=RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool"),
+        queue=queue,
+        cluster=definition.name,
+        definition=definition,
+        token="token",
+        secret_key="secret",
+    )
+
+    with pytest.raises(
+        ConfigurationError,
+        match="owned JARVIS runtime binding requires owner_session_admission_id",
+    ):
+        supervisor.bind_verified_jarvis_runtime(
+            name="paraview-live",
+            verified=verified,
+            owner_session_id="desktop-session",
+            owner_session_generation_id="generation-1",
+        )
+
+    assert queue.list_gateway_sessions() == []
+
+
+@pytest.mark.parametrize("wrong_admission", ["raw", "other-cluster"])
+def test_owned_bind_rejects_wrong_cluster_scoped_admission_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    wrong_admission: str,
+) -> None:
+    """Direct callers cannot substitute raw or cross-cluster admission state."""
+    queue, definition, job, artifact, envelope = _source_result(tmp_path)
+    monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
+    verified = resolve_jarvis_service_runtime(
+        queue=queue,
+        definition=definition,
+        source_job_id=job.job_id,
+        source_artifact_id=artifact.artifact_id,
+        package_id="paraview-1",
+        package_name="builtin.paraview",
+    )
+    supervisor = ServiceRuntimeSupervisor(
+        settings=RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool"),
+        queue=queue,
+        cluster=definition.name,
+        definition=definition,
+        token="token",
+        secret_key="secret",
+    )
+    admission_id = (
+        "desktop-session"
+        if wrong_admission == "raw"
+        else owner_session_admission_module.desktop_owner_session_admission_id(
+            cluster="another-cluster",
+            session_id="desktop-session",
+        )
+    )
+
+    with pytest.raises(
+        ConfigurationError,
+        match="admission id does not match its cluster/session identity",
+    ):
+        supervisor.bind_verified_jarvis_runtime(
+            name="paraview-live",
+            verified=verified,
+            owner_session_id="desktop-session",
+            owner_session_generation_id="generation-1",
+            owner_session_admission_id=admission_id,
+        )
+
+    assert queue.list_gateway_sessions() == []
 
 
 def test_bound_runtime_detach_and_teardown_preserve_scheduler_by_default(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -423,8 +423,11 @@ def test_mcp_lists_relay_tools(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
 
 def test_user_mcp_schemas_avoid_root_unions_and_preserve_exclusive_forms(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Keep agent-facing schemas visible to SDK clients without weakening validation."""
+
+    monkeypatch.setattr(mcp_server_module, "_configured_cluster_names", lambda: ["ares"])
 
     response = handle_request(
         {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},

--- a/tests/test_owner_session_admission.py
+++ b/tests/test_owner_session_admission.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from clio_relay.cluster_config import ClusterDefinition
+from clio_relay.core_queue import ClioCoreQueue
+from clio_relay.errors import QueueConflictError, RelayError
+from clio_relay.models import GatewaySession
+from clio_relay.owner_session_admission import (
+    desktop_owner_session_admission_id,
+    owner_session_gateway_admission,
+)
+
+
+def test_gateway_admission_reproduces_raw_owner_failure_then_mirrors_cluster_scope(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shared boundary fixes the exact missing local admission seen live."""
+    queue = ClioCoreQueue(tmp_path / "core")
+    queue.initialize()
+    definition = ClusterDefinition(name="test-cluster", ssh_host="relay.example.test")
+    monkeypatch.setenv("CLIO_RELAY_CLI_MODE", "ssh")
+
+    with pytest.raises(
+        QueueConflictError,
+        match="owner session generation has no active admission state",
+    ):
+        queue.create_gateway_session(
+            GatewaySession(
+                cluster=definition.name,
+                name="raw-owner-session",
+                metadata={
+                    "owner": "clio-relay",
+                    "owner_session_id": "desktop-session",
+                    "owner_session_generation_id": "generation-1",
+                },
+            )
+        )
+
+    events: list[str] = []
+    lock_held = False
+
+    class RecordingLock(AbstractContextManager[object]):
+        def __enter__(self) -> object:
+            nonlocal lock_held
+            assert lock_held is False
+            lock_held = True
+            events.append("enter")
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            nonlocal lock_held
+            assert lock_held is True
+            lock_held = False
+            events.append("exit")
+
+    def lock_factory(*, cluster: str, session_id: str) -> RecordingLock:
+        assert (cluster, session_id) == ("test-cluster", "desktop-session")
+        return RecordingLock()
+
+    def session_status(**_kwargs: object) -> dict[str, object]:
+        assert lock_held is True
+        events.append("session")
+        return _live_session_status()
+
+    def admission_status(**_kwargs: object) -> dict[str, object]:
+        assert lock_held is True
+        events.append("admission")
+        return _open_admission_status()
+
+    with owner_session_gateway_admission(
+        queue=queue,
+        definition=definition,
+        cluster=definition.name,
+        session_id="desktop-session",
+        session_generation_id="generation-1",
+        transition_lock_factory=lock_factory,
+        session_status_reader=session_status,
+        admission_status_reader=admission_status,
+    ) as admission:
+        assert lock_held is True
+        events.append("gateway-write")
+        gateway = queue.create_gateway_session(
+            GatewaySession(
+                cluster=definition.name,
+                name="admitted-owner-session",
+                metadata={
+                    "owner": "clio-relay",
+                    "owner_session_id": admission.owner_session_id,
+                    "owner_session_generation_id": admission.owner_session_generation_id,
+                    "owner_session_admission_id": admission.owner_session_admission_id,
+                },
+            )
+        )
+
+    assert events == [
+        "enter",
+        "session",
+        "admission",
+        "session",
+        "admission",
+        "gateway-write",
+        "exit",
+    ]
+    assert gateway.metadata["owner_session_admission_id"].startswith("desktop_")
+    assert gateway.metadata["owner_session_admission_id"] != "desktop-session"
+
+
+def test_gateway_admission_teardown_race_fails_before_gateway_side_effects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cleanup intent appearing after mirroring wins before gateway creation."""
+    queue = ClioCoreQueue(tmp_path / "core")
+    queue.initialize()
+    definition = ClusterDefinition(name="test-cluster", ssh_host="relay.example.test")
+    monkeypatch.setenv("CLIO_RELAY_CLI_MODE", "ssh")
+    admission_reads = 0
+
+    def admission_status(**_kwargs: object) -> dict[str, object]:
+        nonlocal admission_reads
+        admission_reads += 1
+        if admission_reads == 1:
+            return _open_admission_status()
+        return {
+            **_open_admission_status(),
+            "closing": True,
+            "open": False,
+            "closing_generation_id": "generation-1",
+            "cleanup_intent": {
+                "schema_version": "clio-relay.owner-session-cleanup-intent.v1",
+                "operation_id": "cleanup_race",
+                "owner_session_id": "desktop-session",
+                "session_generation_id": "generation-1",
+                "stop_worker": False,
+                "cancel_jobs": False,
+                "cancel_scheduler_jobs": False,
+            },
+        }
+
+    def session_status(**_kwargs: object) -> dict[str, object]:
+        return _live_session_status()
+
+    entered = False
+    with (
+        pytest.raises(RelayError, match="is not open for gateway admission"),
+        owner_session_gateway_admission(
+            queue=queue,
+            definition=definition,
+            cluster=definition.name,
+            session_id="desktop-session",
+            session_generation_id="generation-1",
+            session_status_reader=session_status,
+            admission_status_reader=admission_status,
+        ),
+    ):
+        entered = True
+
+    assert entered is False
+    assert admission_reads == 2
+    assert queue.list_gateway_sessions() == []
+    local_admission_id = desktop_owner_session_admission_id(
+        cluster=definition.name,
+        session_id="desktop-session",
+    )
+    reconciled = queue.owner_session_generation_status(
+        local_admission_id,
+        session_generation_id="generation-1",
+    )
+    assert reconciled["active_generation_id"] is None
+    assert reconciled["closing"] is True
+    assert reconciled["closed"] is True
+    assert reconciled["open"] is False
+    cleanup_intent = reconciled["cleanup_intent"]
+    assert isinstance(cleanup_intent, dict)
+    cleanup_intent = cast(dict[str, object], cleanup_intent)
+    assert cleanup_intent.get("schema_version") == ("clio-relay.owner-session-cleanup-intent.v1")
+    assert cleanup_intent.get("operation_id") == "cleanup_race"
+    assert cleanup_intent.get("owner_session_id") == local_admission_id
+    assert cleanup_intent.get("session_generation_id") == "generation-1"
+    assert cleanup_intent.get("stop_worker") is False
+    assert cleanup_intent.get("cancel_jobs") is False
+    assert cleanup_intent.get("cancel_scheduler_jobs") is False
+    assert isinstance(cleanup_intent.get("created_at"), str)
+    reopened = queue.mirror_owner_session_generation_open(
+        local_admission_id,
+        session_generation_id="generation-2",
+    )
+    assert reopened["active_generation_id"] == "generation-2"
+    assert reopened["open"] is True
+
+
+def _live_session_status() -> dict[str, object]:
+    return {
+        "owner": "clio-relay",
+        "session_id": "desktop-session",
+        "session_generation_id": "generation-1",
+        "running": True,
+        "ownership_verified": True,
+    }
+
+
+def _open_admission_status() -> dict[str, object]:
+    return {
+        "schema_version": "clio-relay.owner-session-admission-status.v1",
+        "owner_session_id": "desktop-session",
+        "session_generation_id": "generation-1",
+        "active_generation_id": "generation-1",
+        "closing_generation_id": None,
+        "active": True,
+        "closing": False,
+        "closed": False,
+        "open": True,
+        "cleanup_intent": None,
+    }

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.21"
+    assert version == "1.3.22"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -9,6 +9,7 @@ import pytest
 from pytest import MonkeyPatch
 
 import clio_relay.session_lifecycle as session_lifecycle
+from clio_relay import __version__
 from clio_relay.cluster_config import ClusterDefinition
 from clio_relay.errors import RelayError
 from clio_relay.session_lifecycle import (
@@ -18,6 +19,7 @@ from clio_relay.session_lifecycle import (
     SESSION_WORKER_CHECK_ID,
     CleanupResource,
     RemoteSessionStateEvidence,
+    SessionApiReleaseIdentity,
     SessionLifecycleReport,
     challenge_remote_session_identity,
     detach_remote_session,
@@ -25,6 +27,21 @@ from clio_relay.session_lifecycle import (
     status_remote_session,
     teardown_remote_session,
 )
+
+
+def _api_release_identity() -> SessionApiReleaseIdentity:
+    return SessionApiReleaseIdentity.model_validate(
+        {
+            "distribution_version": __version__,
+            "artifact_sha256": "a" * 64,
+            "software": {
+                "version": __version__,
+                "commit": "1" * 40,
+                "tag": f"v{__version__}",
+                "dirty": False,
+            },
+        }
+    )
 
 
 def test_scheduler_cancellation_evidence_rejects_an_extra_relay_link() -> None:
@@ -233,6 +250,7 @@ def test_start_remote_session_writes_owned_pid_and_metadata(monkeypatch: MonkeyP
         session_id="session-1",
         remote_api_port=9001,
         api_token="token",
+        expected_api_release_identity=_api_release_identity(),
     )
 
     assert "session_started=session-1" in lines
@@ -256,6 +274,16 @@ def test_start_remote_session_writes_owned_pid_and_metadata(monkeypatch: MonkeyP
     assert "trap cleanup_incomplete_start EXIT" in script
     assert "flock -w 10 -x 9" in script
     assert "CLIO_RELAY_SESSION_GENERATION_ID" in script
+    assert "CLIO_RELAY_API_RELEASE_IDENTITY_SHA256" in script
+    assert "clio-relay.session-api-release.v1" in script
+    assert "session API installation changed after worker compatibility verification" in script
+    assert "existing owned session API has no release identity; use --replace" in script
+    assert "existing owned session API release identity differs; use --replace" in script
+    assert (
+        "existing owned session API release identity is not process-bound; use --replace" in script
+    )
+    assert "api_release_identity" in script
+    assert "api_release_identity_sha256" in script
     assert "session_generation_id" in script
     assert "clio-relay session prepare-start" in script
     assert '--recorded-generation-id "$recorded_generation_id"' in script
@@ -276,6 +304,44 @@ def test_start_remote_session_writes_owned_pid_and_metadata(monkeypatch: MonkeyP
     assert "owned API did not become ready" in script
     assert "\x00" not in script
     assert "pkill" not in script
+
+
+def test_start_remote_session_checks_existing_api_release_before_reuse(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scripts: list[str] = []
+
+    def fake_run(
+        command: list[str],
+        *,
+        input: bytes,
+        capture_output: bool,
+        check: bool,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[bytes]:
+        del capture_output, check, timeout
+        scripts.append(input.decode("utf-8"))
+        return subprocess.CompletedProcess(command, 0, b"session_already_running=session-1\n", b"")
+
+    monkeypatch.setattr("clio_relay.session_lifecycle.subprocess.run", fake_run)
+
+    start_remote_session(
+        cluster="ares",
+        definition=ClusterDefinition(name="ares", ssh_host="ares"),
+        session_id="session-1",
+        remote_api_port=9001,
+        api_token="token",
+        expected_api_release_identity=_api_release_identity(),
+        replace=False,
+    )
+
+    script = scripts[0]
+    assert '[ -n "$existing_owned_pid" ] && [ "0" != "1" ]' in script
+    assert script.index("__CLIO_RELAY_EXISTING_API_RELEASE__") < script.index(
+        'echo "session_already_running=$session_id"'
+    )
+    assert '(Path("/proc") / pid / "environ")' in script
+    assert "CLIO_RELAY_API_RELEASE_IDENTITY_SHA256={observed_sha256}" in script
 
 
 def test_status_remote_session_returns_json(monkeypatch: MonkeyPatch) -> None:

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import zipfile
 from collections.abc import Callable
+from copy import deepcopy
 from datetime import UTC, datetime
 from importlib import metadata
 from pathlib import Path
@@ -1944,7 +1945,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.3.21"
+    assert policy.release_version == "1.3.22"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256
@@ -2257,6 +2258,21 @@ def test_native_application_progress_gate_rejects_legacy_adapter_only_evidence()
         for item in repository_policy.requirements
         if item.requirement_id == "ares-jarvis-lammps-package-progress"
     )
+    worker_requirement = next(
+        item for item in requirement.required_resources if item.kind == "relay_worker"
+    )
+    worker_metadata = deepcopy(worker_requirement.metadata_equals)
+    component_runtime = worker_metadata.get("component_runtime")
+    assert isinstance(component_runtime, dict)
+    jarvis_runtime = component_runtime.get("jarvis-cd")
+    assert isinstance(jarvis_runtime, dict)
+    jarvis_runtime.update(
+        {
+            "provider_interpreter_verified": True,
+            "provider_native_execution_capability_verified": True,
+            "extra_runtime_evidence": "preserved",
+        }
+    )
     policy = _without_acceptance_matrix(
         repository_policy.model_copy(
             update={
@@ -2302,30 +2318,6 @@ def test_native_application_progress_gate_rejects_legacy_adapter_only_evidence()
         "provider_validated": True,
         "acceptance_validated": True,
     }
-    native_capability = {
-        "schema_version": "clio-relay.jarvis-native-execution-capability.v1",
-        "handle_schema": "jarvis.execution.handle.v1",
-        "record_schema": "jarvis.execution.record.v1",
-        "progress_schema": "jarvis.execution.progress.v1",
-        "operations": [
-            "execution_handle.progress",
-            "pipeline.get_execution",
-            "pipeline.get_execution_progress",
-            "pipeline.run",
-        ],
-    }
-    jarvis_component = {
-        "distribution": "jarvis_cd",
-        "distribution_version": "1.3.12",
-        "install_spec": (
-            "https://github.com/grc-iit/jarvis-cd/releases/download/"
-            "v1.3.12/jarvis_cd-1.3.12-py3-none-any.whl"
-        ),
-        "requested_source": "github_release",
-        "artifact_filename": "jarvis_cd-1.3.12-py3-none-any.whl",
-        "artifact_sha256": "67541dde02e13842ab7a1581717a3577869f3d6ff7db4faf0238fd8c6319d3e3",
-        "native_execution": native_capability,
-    }
     report.resources = [
         ValidationResource(
             kind="relay_job",
@@ -2341,25 +2333,7 @@ def test_native_application_progress_gate_rejects_legacy_adapter_only_evidence()
             role="cluster_worker",
             cluster="ares",
             state="running",
-            metadata={
-                "components": {"jarvis-cd": "1.3.12"},
-                "component_artifacts": {"jarvis-cd": jarvis_component},
-                "component_runtime": {
-                    "jarvis-cd": {
-                        "verified": True,
-                        "artifact_sha256_verified": True,
-                        "provider_interpreter_verified": True,
-                        "execution_interpreter_verified": True,
-                        "execution_distribution_identity_verified": True,
-                        "execution_source_verified": True,
-                        "provider_native_execution_capability_verified": True,
-                        "execution_native_execution_capability_verified": True,
-                        "native_execution_capability_verified": True,
-                        "jarvis_executable_verified": True,
-                        "extra_runtime_evidence": "preserved",
-                    }
-                },
-            },
+            metadata=worker_metadata,
         ),
         ValidationResource(
             kind="package_progress_provider",

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.21"
+version = "1.3.22"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- authorize owned gateway/runtime writes through one cluster-scoped admission boundary held across connector side effects and rollback
- reconcile teardown races without leaking local admission state, and reject raw or cross-cluster admission IDs
- verify the exact live endpoint release before session mutation and bind owned session APIs to a process-attested release identity
- fix the two v1.3.21 tag-check fixture failures and advance release identity to v1.3.22

## Verification
- focused admission, session lifecycle, cleanup, MCP schema, release-gate, and transport tests passed
- Ruff check/format passed
- Pyright passed with zero errors
- generated remote start script passed Git Bash syntax validation
- all 12 embedded Python heredocs compiled successfully
- uv lock and staged diff checks passed

Scheduler cancellation remains opt-in; default cleanup preserves jobs.