### PR TITLE
fix(ci): type release gate metadata fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.22` uses a release-first patch process. A maintainer builds the
+> Version `1.3.23` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.22"
+$Version = "1.3.23"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.22"
+release_version: "1.3.23"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 8f3d7f03d4e04d7fc9e79147cefe78fab3beaf51e6083486298fe6b7a4769cd6
+acceptance_matrix_sha256: 020c854123be068df00468f604a903150434b0e5bab9638239760570c6a06133
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.22"
+$Tag = "v1.3.23"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.22" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.23" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.22",
-  "matrix_sha256": "8f3d7f03d4e04d7fc9e79147cefe78fab3beaf51e6083486298fe6b7a4769cd6",
+  "release_version": "1.3.23",
+  "matrix_sha256": "020c854123be068df00468f604a903150434b0e5bab9638239760570c6a06133",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.22"
+version = "1.3.23"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.22"
+__version__ = "1.3.23"

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1696,7 +1696,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "8f3d7f03d4e04d7fc9e79147cefe78fab3beaf51e6083486298fe6b7a4769cd6"
+        "020c854123be068df00468f604a903150434b0e5bab9638239760570c6a06133"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.22"
+    assert version == "1.3.23"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1945,7 +1945,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.3.22"
+    assert policy.release_version == "1.3.23"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256
@@ -2264,9 +2264,11 @@ def test_native_application_progress_gate_rejects_legacy_adapter_only_evidence()
     worker_metadata = deepcopy(worker_requirement.metadata_equals)
     component_runtime = worker_metadata.get("component_runtime")
     assert isinstance(component_runtime, dict)
-    jarvis_runtime = component_runtime.get("jarvis-cd")
+    typed_component_runtime = cast(dict[str, object], component_runtime)
+    jarvis_runtime = typed_component_runtime.get("jarvis-cd")
     assert isinstance(jarvis_runtime, dict)
-    jarvis_runtime.update(
+    typed_jarvis_runtime = cast(dict[str, object], jarvis_runtime)
+    typed_jarvis_runtime.update(
         {
             "provider_interpreter_verified": True,
             "provider_native_execution_capability_verified": True,

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.22"
+version = "1.3.23"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- add explicit typed narrowing for the policy-derived JARVIS worker metadata fixture
- advance the exact release identity to v1.3.23

## Verification
- full Pyright: 0 errors
- exact release-gate fixture and release identity tests: passed
- Ruff, uv lock, and diff checks: passed

This is the focused fix for the v1.3.22 asynchronous tag-check failure; production runtime code is unchanged.