### PR TITLE
fix(session): clean gateways before relay API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.23` uses a release-first patch process. A maintainer builds the
+> Version `1.3.24` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.23"
+$Version = "1.3.24"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.23"
+release_version: "1.3.24"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 020c854123be068df00468f604a903150434b0e5bab9638239760570c6a06133
+acceptance_matrix_sha256: d2c8c5592a2794cf254924c29128d08616d4300e336f1341a87ea5df81d085ba
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.23"
+$Tag = "v1.3.24"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.23" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.24" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.23",
-  "matrix_sha256": "020c854123be068df00468f604a903150434b0e5bab9638239760570c6a06133",
+  "release_version": "1.3.24",
+  "matrix_sha256": "d2c8c5592a2794cf254924c29128d08616d4300e336f1341a87ea5df81d085ba",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.23"
+version = "1.3.24"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.23"
+__version__ = "1.3.24"

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -3986,6 +3986,16 @@ def session_teardown(
                         }
                     )
             write_validation_report(partial, canonical_report_path)
+        gateway_reports = _cleanup_owned_runtime_sessions(
+            cluster=cluster,
+            definition=definition,
+            owner_session_id=session_id,
+            owner_session_generation_id=session_generation_id,
+            mode="teardown",
+            cancel_scheduler_jobs=cancel_scheduler_jobs,
+            scheduler_sentinel_ids=scheduler_sentinel_ids,
+            owned_jobs=owned_jobs,
+        )
         report = teardown_remote_session(
             definition=definition,
             session_id=session_id,
@@ -4050,17 +4060,6 @@ def session_teardown(
             scheduler_sentinel_ids,
             owned_jobs,
             gateway_scheduler_job_ids=gateway_scheduler_job_ids,
-        )
-
-        gateway_reports = _cleanup_owned_runtime_sessions(
-            cluster=cluster,
-            definition=definition,
-            owner_session_id=session_id,
-            owner_session_generation_id=session_generation_id,
-            mode="teardown",
-            cancel_scheduler_jobs=cancel_scheduler_jobs,
-            scheduler_sentinel_ids=scheduler_sentinel_ids,
-            owned_jobs=owned_jobs,
         )
 
         scheduler_jobs = list_owned_jobs(include_terminal=True)

--- a/src/clio_relay/service_runtime.py
+++ b/src/clio_relay/service_runtime.py
@@ -1901,7 +1901,10 @@ class ServiceRuntimeSupervisor:
             errors.append(unresolved_scheduler.detail or "scheduler submission is unresolved")
         if session.scheduler_job_id is not None:
             try:
-                verified_submission = self._verified_scheduler_submission(session)
+                verified_submission = self._verified_scheduler_submission(
+                    session,
+                    allow_quiesced_owner_source_recovery=not cancel_scheduler_job,
+                )
             except (ConfigurationError, RelayError) as exc:
                 scheduler_resource = CleanupResource(
                     kind="scheduler_job",
@@ -2837,6 +2840,8 @@ class ServiceRuntimeSupervisor:
     def _verified_scheduler_submission(
         self,
         session: GatewaySession,
+        *,
+        allow_quiesced_owner_source_recovery: bool = False,
     ) -> _VerifiedSchedulerSubmission:
         """Prove the exact provider and job ID from the relay-created remote sidecar."""
         scheduler_job_id = _optional_str(session.scheduler_job_id)
@@ -2855,6 +2860,23 @@ class ServiceRuntimeSupervisor:
                     settings=self.settings,
                     binding_document=binding_document,
                 )
+            except (ConfigurationError, RelayError):
+                if not (
+                    allow_quiesced_owner_source_recovery
+                    and self._quiesced_owner_source_recovery_is_authorized(session)
+                ):
+                    raise
+                try:
+                    verified = reverify_jarvis_service_runtime(
+                        queue=self.queue,
+                        definition=self.definition,
+                        settings=None,
+                        binding_document=binding_document,
+                    )
+                except ValueError as exc:
+                    raise RelayError(
+                        f"JARVIS service runtime binding re-verification failed: {exc}"
+                    ) from exc
             except ValueError as exc:
                 raise RelayError(
                     f"JARVIS service runtime binding re-verification failed: {exc}"
@@ -2946,6 +2968,51 @@ class ServiceRuntimeSupervisor:
             provider=canonical_provider,
             scheduler_job_id=scheduler_job_id,
             spec=spec,
+        )
+
+    def _quiesced_owner_source_recovery_is_authorized(
+        self,
+        session: GatewaySession,
+    ) -> bool:
+        """Authorize a non-canceling direct source read for an exact closing owner."""
+        teardown_intent = _object(session.gateway.get("teardown_intent", {}))
+        owner_session_id = _optional_str(session.metadata.get("owner_session_id"))
+        generation_id = _optional_str(session.metadata.get("owner_session_generation_id"))
+        admission_id = _optional_str(session.metadata.get("owner_session_admission_id"))
+        if owner_session_id is None or generation_id is None or admission_id is None:
+            return False
+        try:
+            expected_admission_id = desktop_owner_session_admission_id(
+                cluster=self.cluster,
+                session_id=owner_session_id,
+            )
+        except ValueError:
+            return False
+        if (
+            teardown_intent.get("schema_version") != "clio-relay.gateway-teardown-intent.v1"
+            or teardown_intent.get("gateway_session_id") != session.session_id
+            or teardown_intent.get("cancel_scheduler_job") is not False
+            or self.settings.owner_session_id != owner_session_id
+            or self.settings.owner_session_generation_id != generation_id
+            or self.settings.resolved_owner_session_cluster() != self.cluster
+            or admission_id != expected_admission_id
+        ):
+            return False
+        try:
+            cleanup_intent = self.queue.get_owner_session_cleanup_intent(
+                admission_id,
+                session_generation_id=generation_id,
+            )
+        except (OSError, QueueConflictError, ValueError):
+            return False
+        return bool(
+            cleanup_intent is not None
+            and cleanup_intent.get("schema_version") == "clio-relay.owner-session-cleanup-intent.v1"
+            and cleanup_intent.get("owner_session_id") == admission_id
+            and cleanup_intent.get("session_generation_id") == generation_id
+            and cleanup_intent.get("cancel_scheduler_jobs") is False
+            and isinstance(cleanup_intent.get("operation_id"), str)
+            and bool(cleanup_intent.get("operation_id"))
         )
 
     def _stop_local_connector(

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1696,7 +1696,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "020c854123be068df00468f604a903150434b0e5bab9638239760570c6a06133"
+        "d2c8c5592a2794cf254924c29128d08616d4300e336f1341a87ea5df81d085ba"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2517,6 +2517,45 @@ def test_cli_session_teardown_reports_success_when_optional_worker_observation_t
     assert not any(check["check_id"] == "session.teardown" for check in validation_report["checks"])
 
 
+def test_cli_session_teardown_cleans_jarvis_gateway_before_stopping_owned_api(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_test_cluster(tmp_path)
+    core_dir = tmp_path / "core"
+    monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(core_dir))
+    _activate_owner_session(ClioCoreQueue(core_dir))
+    api_running = True
+    lifecycle_events: list[str] = []
+
+    def clean_jarvis_gateway(**_kwargs: object) -> list[dict[str, object]]:
+        lifecycle_events.append("clean_jarvis_gateway")
+        if not api_running:
+            raise RelayError(
+                "JARVIS scheduler ownership source is unavailable after owned API shutdown"
+            )
+        return []
+
+    def stop_owned_api(**_kwargs: object) -> SessionLifecycleReport:
+        nonlocal api_running
+        lifecycle_events.append("stop_owned_api")
+        api_running = False
+        return _verified_teardown_report()
+
+    monkeypatch.setattr(cli, "status_remote_session", _fake_owned_session_status)
+    monkeypatch.setattr(cli, "_cleanup_owned_runtime_sessions", clean_jarvis_gateway)
+    monkeypatch.setattr(cli, "teardown_remote_session", stop_owned_api)
+
+    result = CliRunner().invoke(
+        app,
+        ["session", "teardown", "--cluster", "ares", "--session-id", "session-1"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert lifecycle_events == ["clean_jarvis_gateway", "stop_owned_api"]
+
+
 def test_cli_session_teardown_failure_preserves_stopped_api_evidence(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -2539,14 +2578,14 @@ def test_cli_session_teardown_failure_preserves_stopped_api_evidence(
             return []
         raise RelayError("post-API owner-session rescan failed")
 
-    def forbidden_gateway_cleanup(**_kwargs: object) -> list[dict[str, object]]:
+    def record_gateway_cleanup(**_kwargs: object) -> list[dict[str, object]]:
         gateway_cleanup_calls.append("gateway")
         return []
 
     monkeypatch.setattr(cli, "status_remote_session", _fake_owned_session_status)
     monkeypatch.setattr(cli, "teardown_remote_session", _fake_verified_teardown)
     monkeypatch.setattr(cli, "_list_owned_active_cluster_jobs", fail_after_api_stop)
-    monkeypatch.setattr(cli, "_cleanup_owned_runtime_sessions", forbidden_gateway_cleanup)
+    monkeypatch.setattr(cli, "_cleanup_owned_runtime_sessions", record_gateway_cleanup)
 
     result = CliRunner().invoke(
         app,
@@ -2577,7 +2616,7 @@ def test_cli_session_teardown_failure_preserves_stopped_api_evidence(
     assert process_resource["resource_id"] == "123"
     assert process_resource["state"] == "stopped"
     assert report["cleanup"]["actions"][0]["kind"] == "remote_relay_api"
-    assert gateway_cleanup_calls == []
+    assert gateway_cleanup_calls == ["gateway"]
     assert queue.owner_session_is_closing("session-1") is True
     assert queue.get_owner_session_closed("session-1") is None
 

--- a/tests/test_jarvis_service_runtime.py
+++ b/tests/test_jarvis_service_runtime.py
@@ -25,7 +25,7 @@ from clio_relay.cluster_config import (
 )
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
-from clio_relay.errors import ConfigurationError, QueueConflictError
+from clio_relay.errors import ConfigurationError, QueueConflictError, RelayError
 from clio_relay.jarvis_mcp import jarvis_cd_lock_binding_expectation
 from clio_relay.jarvis_service_runtime import (
     RELAY_JARVIS_RUNTIME_BINDING_SCHEMA,
@@ -1716,6 +1716,119 @@ def test_bound_runtime_detach_and_teardown_preserve_scheduler_by_default(
     assert sum("connector-step-cancel" in command for command in allocation_commands) == 1
     assert reverified == ["paraview-live-1", "paraview-live-1"]
     assert reverified_settings == [supervisor.settings, supervisor.settings]
+
+
+def test_quiesced_owner_keep_scheduler_recovery_reverifies_without_stopped_api(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue, definition, job, artifact, envelope = _source_result(tmp_path)
+    monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
+    verified = resolve_jarvis_service_runtime(
+        queue=queue,
+        definition=definition,
+        source_job_id=job.job_id,
+        source_artifact_id=artifact.artifact_id,
+        package_id="paraview-1",
+        package_name="builtin.paraview",
+    )
+    owner_session_id = "desktop-session"
+    generation_id = "generation-1"
+    admission_id = owner_session_admission_module.desktop_owner_session_admission_id(
+        cluster=definition.name,
+        session_id=owner_session_id,
+    )
+    queue.mirror_owner_session_generation_open(
+        admission_id,
+        session_generation_id=generation_id,
+    )
+    spec = ServiceRuntimeSpec(
+        kind="jarvis-service-runtime",
+        submit_command=None,
+        deployment_driver="jarvis-bound",
+        service_port=verified.runtime.port,
+        desktop_bind_port=28777,
+        scheduler="slurm",
+    )
+    session = queue.create_gateway_session(
+        GatewaySession(
+            cluster=definition.name,
+            name="quiesced-owner-recovery",
+            scheduler="slurm",
+            scheduler_job_id="12345",
+            gateway={
+                "runtime_spec": spec.model_dump(mode="json"),
+                "jarvis_runtime_binding": verified.binding.model_dump(mode="json"),
+                "teardown_intent": {
+                    "schema_version": "clio-relay.gateway-teardown-intent.v1",
+                    "operation_id": "gateway_cleanup_00000000000000000000000000000000",
+                    "gateway_session_id": "gateway_recovery",
+                    "cancel_scheduler_job": False,
+                    "created_at": "2026-07-18T03:00:00Z",
+                },
+            },
+            metadata={
+                "owner": "clio-relay",
+                "owner_session_id": owner_session_id,
+                "owner_session_generation_id": generation_id,
+                "owner_session_admission_id": admission_id,
+            },
+            session_id="gateway_recovery",
+        )
+    )
+    queue.set_owner_session_closing(
+        admission_id,
+        session_generation_id=generation_id,
+        stop_worker=False,
+        cancel_jobs=False,
+        cancel_scheduler_jobs=False,
+    )
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        api_token="api-token",
+        owner_session_id=owner_session_id,
+        owner_session_generation_id=generation_id,
+        owner_session_cluster=definition.name,
+    )
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster=definition.name,
+        definition=definition,
+        token="token",
+        secret_key="secret",
+    )
+    observed_settings: list[RelaySettings | None] = []
+
+    def stopped_api_then_direct_source(**kwargs: Any) -> Any:
+        source_settings = kwargs.get("settings")
+        observed_settings.append(source_settings)
+        if source_settings is not None:
+            raise RelayError("owned API generation is already stopped")
+        return verified
+
+    monkeypatch.setattr(
+        service_runtime_module,
+        "reverify_jarvis_service_runtime",
+        stopped_api_then_direct_source,
+    )
+
+    submission = supervisor._verified_scheduler_submission(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        session,
+        allow_quiesced_owner_source_recovery=True,
+    )
+
+    assert submission.provider == "slurm"
+    assert submission.scheduler_job_id == "12345"
+    assert observed_settings == [settings, None]
+    observed_settings.clear()
+    with pytest.raises(RelayError, match="already stopped"):
+        supervisor._verified_scheduler_submission(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            session,
+            allow_quiesced_owner_source_recovery=False,
+        )
+    assert observed_settings == [settings]
 
 
 def test_bound_runtime_scheduler_cancel_requires_fresh_binding_reverification(

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.23"
+    assert version == "1.3.24"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1945,7 +1945,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.3.23"
+    assert policy.release_version == "1.3.24"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.23"
+version = "1.3.24"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- clean owner-session JARVIS gateways before stopping their relay API
- permit a narrowly authorized keep-job recovery when an earlier teardown already stopped that API
- bump the patch release identity to 1.3.24

## Focused validation
- 16 focused cleanup/runtime tests passed during implementation
- 5 focused regression and release-identity tests passed after the version bump
- Ruff, focused Pyright, and git diff checks passed

Scheduler jobs remain preserved by default; the recovery path is unavailable when cancellation is requested.