### PR TITLE
fix(cleanup): accept provider-proven missing jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.24` uses a release-first patch process. A maintainer builds the
+> Version `1.3.25` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.24"
+$Version = "1.3.25"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.24"
+release_version: "1.3.25"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: d2c8c5592a2794cf254924c29128d08616d4300e336f1341a87ea5df81d085ba
+acceptance_matrix_sha256: 7c1e22c6826b5858c5d6782477d39a7e875d48c08a890337c50c8560a4a84544
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.24"
+$Tag = "v1.3.25"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.24" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.25" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.24",
-  "matrix_sha256": "d2c8c5592a2794cf254924c29128d08616d4300e336f1341a87ea5df81d085ba",
+  "release_version": "1.3.25",
+  "matrix_sha256": "7c1e22c6826b5858c5d6782477d39a7e875d48c08a890337c50c8560a4a84544",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.24"
+version = "1.3.25"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.24"
+__version__ = "1.3.25"

--- a/src/clio_relay/service_runtime.py
+++ b/src/clio_relay/service_runtime.py
@@ -46,6 +46,7 @@ from clio_relay.models import (
     SchedulerConnectorPlacement,
     SchedulerConnectorStepIdentity,
     SchedulerConnectorStepStatus,
+    SchedulerPhase,
     SchedulerStatus,
     ServiceRuntimeSpec,
     utc_now,
@@ -491,7 +492,7 @@ class ServiceRuntimeStopResult:
             )
         else:
             allowed_retention_outcomes = (
-                {"retained"} if self.mode == "detach" else {"retained", "terminal"}
+                {"retained"} if self.mode == "detach" else {"retained", "terminal", "missing"}
             )
             scheduler_check = (
                 RUNTIME_SCHEDULER_RETAINED_CHECK_ID,
@@ -509,7 +510,7 @@ class ServiceRuntimeStopResult:
                             resource.observed_state in _ACTIVE_RUNTIME_STATES
                             if self.mode == "detach"
                             else resource.observed_state
-                            not in {"missing", "not-found", "not_found", "unknown"}
+                            not in {"not-found", "not_found", "unknown"}
                         )
                         and not resource.residual
                         for resource in scheduler_resources
@@ -3234,11 +3235,43 @@ class ServiceRuntimeSupervisor:
         if scheduler_job_id is None:
             raise ConfigurationError("scheduler retention requires a scheduler job id")
         try:
-            observed_state = self._observe_scheduler_state(
-                scheduler=session.scheduler,
-                spec=spec,
-                scheduler_job_id=scheduler_job_id,
-            )
+            provider = provider_for_scheduler(session.scheduler)
+            if provider.name == "external":
+                observed_state = self._observe_runtime_state(
+                    spec=spec,
+                    scheduler_job_id=scheduler_job_id,
+                )
+            else:
+                provider_status = self._poll_scheduler_provider(
+                    provider=provider.name,
+                    scheduler_job_id=scheduler_job_id,
+                )
+                if (
+                    provider_status.phase is SchedulerPhase.UNKNOWN
+                    and provider_status.active_record_found is False
+                ):
+                    return CleanupResource(
+                        kind="scheduler_job",
+                        resource_id=scheduler_job_id,
+                        location=self.definition.ssh_host,
+                        provider=session.scheduler,
+                        action="retain",
+                        metadata={
+                            "gateway_session_id": session.session_id,
+                            "scheduler_status": provider_status.model_dump(mode="json"),
+                        },
+                        ownership_verified=True,
+                        outcome="missing",
+                        verified_after_operation=True,
+                        observed_state="missing",
+                        residual=False,
+                        detail=(
+                            "scheduler cancellation was not requested; the provider proved "
+                            "that no active scheduler record remained; no completed or "
+                            "canceled state is claimed"
+                        ),
+                    )
+                observed_state = provider_status.phase.value
         except RelayError as exc:
             return CleanupResource(
                 kind="scheduler_job",

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.24"
+    assert version == "1.3.25"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_service_runtime.py
+++ b/tests/test_service_runtime.py
@@ -23,7 +23,13 @@ from clio_relay.cluster_config import ClusterDefinition, ClusterRegistry, FrpTra
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.errors import RelayError
-from clio_relay.models import GatewaySession, GatewaySessionState, ServiceRuntimeSpec
+from clio_relay.models import (
+    GatewaySession,
+    GatewaySessionState,
+    SchedulerPhase,
+    SchedulerStatus,
+    ServiceRuntimeSpec,
+)
 from clio_relay.service_runtime import (
     CommandRunner,
     LocalConnectorIdentity,
@@ -368,6 +374,32 @@ class InvalidRetentionRunner(FakeRunner):
     ) -> subprocess.CompletedProcess[str]:
         if "jarvis runtime status 12345" in (input_text or ""):
             return subprocess.CompletedProcess(command, 0, '{"state":"banana"}\n', "")
+        return super().run(command, input_text=input_text, timeout_seconds=timeout_seconds)
+
+
+class ProviderRetentionRunner(FakeRunner):
+    def __init__(self) -> None:
+        super().__init__()
+        self.retention_status: SchedulerStatus | None = None
+
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        input_text: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        if self.retention_status is not None and "clio-relay scheduler status 12345" in (
+            input_text or ""
+        ):
+            self.commands.append(list(command))
+            self.inputs.append(input_text)
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                self.retention_status.model_dump_json(indent=2) + "\n",
+                "",
+            )
         return super().run(command, input_text=input_text, timeout_seconds=timeout_seconds)
 
 
@@ -763,6 +795,103 @@ def test_service_runtime_uses_explicit_slurm_provider_for_tracking_and_cancel(
     assert scheduler_resource.provider == "slurm"
     assert scheduler_resource.observed_state == "canceled"
     assert scheduler_resource.verified_after_operation is True
+
+
+def test_service_runtime_keep_scheduler_accepts_provider_proven_no_active_record(
+    tmp_path: Path,
+) -> None:
+    runner = ProviderRetentionRunner()
+    spec = _runtime_spec().model_copy(update={"scheduler": "slurm"})
+    queue, settings, definition, _runner, session_id = _started_session(
+        tmp_path,
+        runner=runner,
+        spec=spec,
+    )
+    runner.retention_status = SchedulerStatus(
+        scheduler="slurm",
+        scheduler_job_id="12345",
+        phase=SchedulerPhase.UNKNOWN,
+        record_found=False,
+        active_record_found=False,
+    )
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=definition,
+        token="",
+        secret_key="",
+        runner=runner,
+        sleep=lambda _seconds: None,
+    )
+
+    result = supervisor.stop(session_id=session_id)
+
+    scheduler = next(resource for resource in result.resources if resource.kind == "scheduler_job")
+    report = result.to_live_validation_report()
+    retention_check = next(
+        check for check in report.checks if check.check_id == "gateway.jobs-preserved-default"
+    )
+    assert result.session.state is GatewaySessionState.CLOSED
+    assert result.errors == []
+    assert result.canceled_scheduler_job is None
+    assert runner.provider_canceled_jobs == []
+    assert scheduler.action == "retain"
+    assert scheduler.outcome == "missing"
+    assert scheduler.ownership_verified is True
+    assert scheduler.verified_after_operation is True
+    assert scheduler.observed_state == "missing"
+    assert scheduler.residual is False
+    scheduler_status = cast(dict[str, object], scheduler.metadata["scheduler_status"])
+    assert scheduler_status["phase"] == "unknown"
+    assert scheduler_status["active_record_found"] is False
+    assert "no completed or canceled state is claimed" in (scheduler.detail or "")
+    assert retention_check.status is ValidationStatus.PASSED
+    assert report.status is ValidationStatus.PASSED
+
+
+def test_service_runtime_keep_scheduler_rejects_ambiguous_unknown_provider_state(
+    tmp_path: Path,
+) -> None:
+    runner = ProviderRetentionRunner()
+    spec = _runtime_spec().model_copy(update={"scheduler": "slurm"})
+    queue, settings, definition, _runner, session_id = _started_session(
+        tmp_path,
+        runner=runner,
+        spec=spec,
+    )
+    runner.retention_status = SchedulerStatus(
+        scheduler="slurm",
+        scheduler_job_id="12345",
+        phase=SchedulerPhase.UNKNOWN,
+        record_found=None,
+        active_record_found=None,
+    )
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=definition,
+        token="",
+        secret_key="",
+        runner=runner,
+        sleep=lambda _seconds: None,
+    )
+
+    result = supervisor.stop(session_id=session_id)
+
+    scheduler = next(resource for resource in result.resources if resource.kind == "scheduler_job")
+    assert result.session.state is GatewaySessionState.DEGRADED
+    assert result.canceled_scheduler_job is None
+    assert runner.provider_canceled_jobs == []
+    assert scheduler.action == "retain"
+    assert scheduler.outcome == "failed"
+    assert scheduler.ownership_verified is True
+    assert scheduler.verified_after_operation is False
+    assert scheduler.observed_state == "unknown"
+    assert scheduler.residual is True
+    assert "verification remained unresolved: unknown" in (scheduler.detail or "")
+    assert result.to_live_validation_report().status is ValidationStatus.FAILED
 
 
 @pytest.mark.parametrize("mutation", ["gateway_job_id", "intent_job_id", "provider"])

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1945,7 +1945,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.3.24"
+    assert policy.release_version == "1.3.25"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.24"
+version = "1.3.25"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Treat an exact SLURM status result with no active record as safely absent during keep-jobs teardown, without claiming completion or cancellation. Ambiguous provider state and every cancellation path remain fail-closed.\n\nFocused verification: the two new retention tests and two release-identity tests pass; Ruff, Pyright, and diff checks pass.