### PR TITLE
fix: preserve owned gateway provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.27` uses a release-first patch process. A maintainer builds the
+> Version `1.3.28` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.27"
+$Version = "1.3.28"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.27"
+release_version: "1.3.28"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 51ad060c4f2d806d5483a875c0a65374f2b29e3ca5e1c88e3f7ac7716df90509
+acceptance_matrix_sha256: e6145be8d5ff6ddba07b2217e66810bea9125fcc5bcee1d9b3a8cea925101f3d
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.27"
+$Tag = "v1.3.28"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.27" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.28" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.27",
-  "matrix_sha256": "51ad060c4f2d806d5483a875c0a65374f2b29e3ca5e1c88e3f7ac7716df90509",
+  "release_version": "1.3.28",
+  "matrix_sha256": "e6145be8d5ff6ddba07b2217e66810bea9125fcc5bcee1d9b3a8cea925101f3d",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.27"
+version = "1.3.28"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.27"
+__version__ = "1.3.28"

--- a/src/clio_relay/core_queue.py
+++ b/src/clio_relay/core_queue.py
@@ -9222,7 +9222,7 @@ class ClioCoreQueue:
                 relation_kind="direct",
                 relation_key=job_id,
             )
-        for artifact_id in set(session.artifacts):
+        for artifact_id in _gateway_direct_artifact_ids(session):
             self._write_gateway_reverse_ref_unlocked("artifact", artifact_id, session)
             artifact = self._read_optional(
                 self._storage_root / "artifacts" / f"{artifact_id}.json",
@@ -12590,7 +12590,28 @@ def _gateway_direct_job_ids(session: GatewaySession) -> set[str]:
         value = session.metadata.get(field)
         if isinstance(value, str) and value:
             job_ids.add(value)
+    for provenance in _gateway_source_provenance(session):
+        value = provenance.get("source_relay_job_id")
+        if isinstance(value, str) and value:
+            job_ids.add(value)
     return job_ids
+
+
+def _gateway_direct_artifact_ids(session: GatewaySession) -> set[str]:
+    artifact_ids = {artifact_id for artifact_id in session.artifacts if artifact_id}
+    for provenance in _gateway_source_provenance(session):
+        value = provenance.get("source_relay_artifact_id")
+        if isinstance(value, str) and value:
+            artifact_ids.add(value)
+    return artifact_ids
+
+
+def _gateway_source_provenance(session: GatewaySession) -> tuple[dict[str, Any], ...]:
+    provenance = [session.metadata]
+    runtime_binding = session.gateway.get("jarvis_runtime_binding")
+    if isinstance(runtime_binding, dict):
+        provenance.append(cast(dict[str, Any], runtime_binding))
+    return tuple(provenance)
 
 
 def _gateway_relation_is_preserved(
@@ -12604,7 +12625,7 @@ def _gateway_relation_is_preserved(
     if relation_kind == "direct":
         return relation_key in _gateway_direct_job_ids(session)
     if relation_kind == "artifact":
-        return relation_key in session.artifacts
+        return relation_key in _gateway_direct_artifact_ids(session)
     if relation_kind == "scheduler":
         return relation_key == session.scheduler_job_id
     raise QueueConflictError(f"unsupported gateway relation kind: {relation_kind}")

--- a/src/clio_relay/jarvis_service_runtime.py
+++ b/src/clio_relay/jarvis_service_runtime.py
@@ -476,36 +476,40 @@ def _load_source(
     source_job_id: str,
     source_artifact_id: str,
 ) -> tuple[RelayJob, ArtifactRef, JSON]:
-    if should_execute_on_cluster(definition):
-        if settings is not None and settings.owner_session_id is not None:
-            with OwnedSessionApiClient(definition=definition, settings=settings) as client:
-                status = _json_object(
-                    client.request_json(
-                        method="GET",
-                        path=f"/jobs/{source_job_id}/status",
-                    ),
-                    "JARVIS service source job",
-                )
-                envelope = _json_object(
-                    client.request_json(
-                        method="GET",
-                        path=f"/artifacts/{source_artifact_id}/content",
-                    ),
-                    "JARVIS service source artifact",
-                )
-            raw_job = status.get("job")
-        else:
-            status = _remote_json(
-                definition,
-                ["job", "status", source_job_id],
+    # The source receipt belongs to its exact owner-session generation, regardless of
+    # where the current operation executes.  In particular, browser attachment is a
+    # desktop-local operation, but it must re-verify the remote JARVIS receipt through
+    # the authenticated owner-session API rather than looking for that job in the
+    # desktop queue.  CLI locality controls command placement, not provenance storage.
+    if settings is not None and settings.owner_session_id is not None:
+        with OwnedSessionApiClient(definition=definition, settings=settings) as client:
+            status = _json_object(
+                client.request_json(
+                    method="GET",
+                    path=f"/jobs/{source_job_id}/status",
+                ),
                 "JARVIS service source job",
             )
-            raw_job = status.get("job")
-            envelope = _remote_json(
-                definition,
-                ["job", "read-artifact", source_artifact_id],
+            envelope = _json_object(
+                client.request_json(
+                    method="GET",
+                    path=f"/artifacts/{source_artifact_id}/content",
+                ),
                 "JARVIS service source artifact",
             )
+        raw_job = status.get("job")
+    elif should_execute_on_cluster(definition):
+        status = _remote_json(
+            definition,
+            ["job", "status", source_job_id],
+            "JARVIS service source job",
+        )
+        raw_job = status.get("job")
+        envelope = _remote_json(
+            definition,
+            ["job", "read-artifact", source_artifact_id],
+            "JARVIS service source artifact",
+        )
     else:
         raw_job = queue.get_job(source_job_id).model_dump(mode="json")
         envelope = cast(JSON, read_artifact_bytes(queue, source_artifact_id))

--- a/tests/test_core_retention.py
+++ b/tests/test_core_retention.py
@@ -553,6 +553,58 @@ def test_terminal_gc_uses_per_job_monitor_and_gateway_reference_indexes(
     assert queue.plan_terminal_job_gc(scheduler_job.job_id).eligible is True
 
 
+@pytest.mark.parametrize("provenance_location", ["metadata", "binding"])
+@pytest.mark.parametrize(
+    ("source_field", "source_kind"),
+    [
+        ("source_relay_job_id", "job"),
+        ("source_relay_artifact_id", "artifact"),
+    ],
+)
+def test_terminal_gc_protects_direct_live_gateway_source_provenance(
+    tmp_path: Path,
+    provenance_location: str,
+    source_field: str,
+    source_kind: str,
+) -> None:
+    queue = ClioCoreQueue(tmp_path)
+    _intent_record, job = _terminal_job(
+        queue,
+        f"gc-gateway-source-{provenance_location}-{source_kind}",
+    )
+    source_id = job.job_id
+    if source_kind == "artifact":
+        source_id = queue.append_artifact(
+            ArtifactRef(
+                job_id=job.job_id,
+                uri=(tmp_path / "gateway-source").as_uri(),
+                kind="runtime-binding",
+            )
+        ).artifact_id
+    metadata: dict[str, object] = {}
+    gateway: dict[str, object] = {}
+    if provenance_location == "metadata":
+        metadata[source_field] = source_id
+    else:
+        gateway["jarvis_runtime_binding"] = {source_field: source_id}
+
+    session = queue.create_gateway_session(
+        GatewaySession(
+            cluster="test-cluster",
+            name=f"source-{source_kind}-gateway",
+            gateway=gateway,
+            metadata=metadata,
+        )
+    )
+
+    plan = queue.plan_terminal_job_gc(job.job_id)
+    assert plan.eligible is False
+    assert "active_gateway_record" in plan.protections
+
+    queue.close_gateway_session(session.session_id)
+    assert queue.plan_terminal_job_gc(job.job_id).eligible is True
+
+
 def test_terminal_task_pending_cleanup_blocks_gc_until_acknowledged(tmp_path: Path) -> None:
     queue = ClioCoreQueue(tmp_path)
     _intent_record, job = _terminal_job(queue, "gc-pending-execution-cleanup")

--- a/tests/test_jarvis_service_runtime.py
+++ b/tests/test_jarvis_service_runtime.py
@@ -631,6 +631,10 @@ def test_owned_remote_source_uses_identity_bound_api_for_every_verification(
         owner_session_generation_id="generation-1",
         remote_cluster=definition.name,
     )
+    # Browser attachment is intentionally desktop-local. Its immutable source
+    # receipt still belongs to the remote owner session and must not be looked up
+    # in the desktop queue merely because command placement is local.
+    monkeypatch.setenv("CLIO_RELAY_CLI_MODE", "local")
     requests: list[tuple[str, str]] = []
     lifecycle: list[str] = []
 
@@ -670,10 +674,14 @@ def test_owned_remote_source_uses_identity_bound_api_for_every_verification(
     def local_artifact_forbidden(_queue: ClioCoreQueue, _artifact_id: str) -> dict[str, object]:
         raise AssertionError("owned remote source must not read desktop artifact storage")
 
-    def source_is_remote(_definition: ClusterDefinition) -> bool:
-        return True
+    def locality_must_not_select_provenance(_definition: ClusterDefinition) -> bool:
+        raise AssertionError("owner-session provenance must take precedence over CLI locality")
 
-    monkeypatch.setattr(runtime_binding, "should_execute_on_cluster", source_is_remote)
+    monkeypatch.setattr(
+        runtime_binding,
+        "should_execute_on_cluster",
+        locality_must_not_select_provenance,
+    )
     monkeypatch.setattr(runtime_binding, "OwnedSessionApiClient", FakeOwnedSessionApiClient)
     monkeypatch.setattr(runtime_binding, "run_remote_clio", direct_ssh_forbidden)
     monkeypatch.setattr(runtime_binding, "read_artifact_bytes", local_artifact_forbidden)

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.27"
+    assert version == "1.3.28"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1945,7 +1945,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.3.27"
+    assert policy.release_version == "1.3.28"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.27"
+version = "1.3.28"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- Re-verify remote JARVIS service receipts through the exact authenticated owner-session API even when the browser capability itself is created by a desktop-local relay command.
- Protect `source_relay_job_id` and `source_relay_artifact_id` while a same-core gateway remains active, then release those protections when the gateway closes.
- Advance the release identity and machine-readable acceptance policy to 1.3.28.

## Root cause

`CLIO_RELAY_CLI_MODE=local` correctly kept the short-lived browser proxy on the desktop, but it also selected the desktop queue for immutable JARVIS provenance. Remote MCP receipts live in the owned Ares session, so attachment failed with `job not found` even though the gateway and scheduler service were ready. The retention index also omitted the explicit source provenance field names used by JARVIS-bound gateways.

## Validation

- Focused owner-session browser-source and one-time capability tests pass.
- Four focused live-gateway source job/artifact retention cases pass.
- Release identity and machine-readable policy tests pass.
- Ruff and Pyright pass on all changed Python files.
