### PR TITLE
fix: close inherited connector handles on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.28` uses a release-first patch process. A maintainer builds the
+> Version `1.3.29` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -55,7 +55,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.28"
+$Version = "1.3.29"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.28"
+release_version: "1.3.29"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: e6145be8d5ff6ddba07b2217e66810bea9125fcc5bcee1d9b3a8cea925101f3d
+acceptance_matrix_sha256: f29cd3531821dccf58a19f43b4e6c840ace0702e060222566e3a87a3580b3405
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.28"
+$Tag = "v1.3.29"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.28" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.29" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.28",
-  "matrix_sha256": "e6145be8d5ff6ddba07b2217e66810bea9125fcc5bcee1d9b3a8cea925101f3d",
+  "release_version": "1.3.29",
+  "matrix_sha256": "f29cd3531821dccf58a19f43b4e6c840ace0702e060222566e3a87a3580b3405",
   "report_count_per_stage": 17,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.28"
+version = "1.3.29"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.28"
+__version__ = "1.3.29"

--- a/src/clio_relay/service_runtime.py
+++ b/src/clio_relay/service_runtime.py
@@ -232,7 +232,11 @@ class SubprocessCommandRunner:
                 list(command),
                 stdout=stdout_handle,
                 stderr=stderr_handle,
-                close_fds=os.name != "nt",
+                # The launched connector outlives this CLI process.  In particular, a relay
+                # command may itself be invoked with captured stdout/stderr by an MCP surface.
+                # Closing inherited descriptors on Windows prevents the connector grandchild
+                # from retaining those capture pipes and blocking the short-lived CLI forever.
+                close_fds=True,
                 env=env,
                 creationflags=creationflags,
                 start_new_session=start_new_session,

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.28"
+    assert version == "1.3.29"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_service_runtime.py
+++ b/tests/test_service_runtime.py
@@ -5,6 +5,7 @@ import shlex
 import signal
 import subprocess
 import sys
+import time
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -56,6 +57,89 @@ from tests.gateway_ownership_crash_fixture import (
 class FakeProcess:
     def __init__(self, pid: int) -> None:
         self.pid = pid
+
+
+def test_local_connector_does_not_retain_captured_cli_pipes(tmp_path: Path) -> None:
+    """A long-lived connector grandchild must not keep its captured CLI parent open."""
+
+    started_path = tmp_path / "grandchild-started"
+    stop_path = tmp_path / "grandchild-stop"
+    stopped_path = tmp_path / "grandchild-stopped"
+    stdout_path = tmp_path / "connector.out"
+    stderr_path = tmp_path / "connector.err"
+    grandchild = "\n".join(
+        (
+            "import os",
+            "import sys",
+            "import time",
+            "from pathlib import Path",
+            "started, stop, stopped = map(Path, sys.argv[1:4])",
+            "started.write_text(str(os.getpid()), encoding='utf-8')",
+            "deadline = time.monotonic() + 10.0",
+            "while not stop.exists() and time.monotonic() < deadline:",
+            "    time.sleep(0.05)",
+            "stopped.write_text('stopped', encoding='utf-8')",
+        )
+    )
+    captured_cli = "\n".join(
+        (
+            "import sys",
+            "from pathlib import Path",
+            "from clio_relay.service_runtime import SubprocessCommandRunner",
+            "started, stop, stopped, stdout, stderr = map(Path, sys.argv[1:6])",
+            "process = SubprocessCommandRunner().popen(",
+            "    [sys.executable, '-c', sys.argv[6], str(started), str(stop), str(stopped)],",
+            "    stdout_path=stdout,",
+            "    stderr_path=stderr,",
+            ")",
+            "print(process.pid, flush=True)",
+        )
+    )
+    cli = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            captured_cli,
+            str(started_path),
+            str(stop_path),
+            str(stopped_path),
+            str(stdout_path),
+            str(stderr_path),
+            grandchild,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    timed_out = False
+    stdout = ""
+    stderr = ""
+    try:
+        try:
+            stdout, stderr = cli.communicate(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            stop_path.touch()
+            stdout, stderr = cli.communicate(timeout=5.0)
+
+        assert not timed_out, (
+            "captured relay CLI waited for its long-lived connector grandchild to exit"
+        )
+        assert cli.returncode == 0, stderr
+        assert stdout.strip().isdigit()
+        deadline = time.monotonic() + 2.0
+        while not started_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert started_path.is_file()
+        assert not stopped_path.exists()
+    finally:
+        stop_path.touch()
+        deadline = time.monotonic() + 2.0
+        while not stopped_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        if cli.poll() is None:
+            cli.kill()
+            cli.wait(timeout=2.0)
 
 
 def _script_assignment(script: str, name: str) -> str:

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1945,7 +1945,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.3.28"
+    assert policy.release_version == "1.3.29"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 17
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.28"
+version = "1.3.29"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Live Ares browser attachment exposed a Windows inherited-handle leak: the long-lived browser proxy retained a captured CLI pipe, so the attachment became active but the MCP call never completed. This patch closes inherited descriptors for connector children on every platform and adds a real nested-process regression proving the short-lived CLI returns while its grandchild remains alive.

Focused validation:
- new Windows nested-process regression
- release identity/policy checks
- Ruff
- focused Pyright