### PR TITLE
fix(catalog): validate descriptor handoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,13 @@ jobs:
       - name: stage exact clio-kit release wheel
         shell: bash
         env:
-          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.5.10-py3-none-any.whl
-          CLIO_KIT_WHEEL_SHA256: 4911142152f476f973caa0c7f8050d88e8efa5f803651bda88685836ee3232f5
-          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.5.10/clio_kit-2.5.10-py3-none-any.whl
+          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.5.11-py3-none-any.whl
+          CLIO_KIT_WHEEL_SHA256: a0a2bbf8d23495dd4f43881d35a47bfb83bc2d1c016bd952bd7a1c88a43ca03e
+          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.5.11/clio_kit-2.5.11-py3-none-any.whl
         run: |
           set -euo pipefail
           umask 077
-          wheel_dir="$RUNNER_TEMP/clio-kit-v2.5.10"
+          wheel_dir="$RUNNER_TEMP/clio-kit-v2.5.11"
           mkdir "$wheel_dir"
           wheel="$wheel_dir/$CLIO_KIT_WHEEL_FILENAME"
           curl --fail --show-error --silent --location \
@@ -160,13 +160,13 @@ jobs:
       - name: stage exact clio-kit release wheel
         shell: bash
         env:
-          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.5.10-py3-none-any.whl
-          CLIO_KIT_WHEEL_SHA256: 4911142152f476f973caa0c7f8050d88e8efa5f803651bda88685836ee3232f5
-          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.5.10/clio_kit-2.5.10-py3-none-any.whl
+          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.5.11-py3-none-any.whl
+          CLIO_KIT_WHEEL_SHA256: a0a2bbf8d23495dd4f43881d35a47bfb83bc2d1c016bd952bd7a1c88a43ca03e
+          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.5.11/clio_kit-2.5.11-py3-none-any.whl
         run: |
           set -euo pipefail
           umask 077
-          wheel_dir="$RUNNER_TEMP/clio-kit-v2.5.10"
+          wheel_dir="$RUNNER_TEMP/clio-kit-v2.5.11"
           mkdir "$wheel_dir"
           wheel="$wheel_dir/$CLIO_KIT_WHEEL_FILENAME"
           curl --fail --show-error --silent --location \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.29` uses a release-first patch process. A maintainer builds the
+> Version `1.3.30` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -261,7 +261,7 @@ For the legacy clio-kit 2.2.6 compatibility path, a successful synchronous
 `jarvis_run` MCP return is normalized to a terminal `completed` record even
 though that release labels the result `status=running`; the original status and
 completion basis remain in `details.completion_normalization` for auditability.
-The pinned clio-kit 2.5.10 production path removes that ambiguity upstream and
+The pinned clio-kit 2.5.11 production path removes that ambiguity upstream and
 returns a structured completed result directly. The legacy normalization is
 diagnostic compatibility evidence and cannot satisfy the 1.0 gate. Scheduler
 submissions remain non-terminal unless JARVIS was asked to wait.
@@ -496,7 +496,7 @@ Install the cluster-side server once, then launch its persistent executable:
 
 ```bash
 uv tool install --python 3.12 --no-config \
-  https://github.com/iowarp/clio-kit/releases/download/v2.5.10/clio_kit-2.5.10-py3-none-any.whl
+  https://github.com/iowarp/clio-kit/releases/download/v2.5.11/clio_kit-2.5.11-py3-none-any.whl
 clio-kit mcp-server jarvis
 ```
 
@@ -645,6 +645,14 @@ locate prefix and canonical `/hash` load spec, or installed status with the
 requested reuse setting. The resulting `remote-mcp.structured-result` check and
 `structured_result_assertion` job metadata are suitable for release-policy
 constraints; successful text content cannot substitute for structured data.
+
+For clio-kit's scientific catalog, register the current
+`clio-kit-scientific-catalog-user-v1.1` contract. Its describe result exposes an
+exact top-level `dataset_descriptor` for direct handoff to
+`jarvis_add_step(config.dataset_descriptor=...)`; do not pass the surrounding
+catalog `dataset` record to JARVIS. Historical
+`clio-kit-scientific-catalog-user-v1` registrations remain valid against their
+own preserved digest, but do not claim this explicit handoff shape.
 
 The wheel path is an operator-supplied immutable artifact. A PyPI requirement
 string is insufficient for user-profile evidence. A direct console script is

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -13,7 +13,7 @@ instances without a core-code change.
 
 ## Required report matrix
 
-Each stage produces exactly these 17 policy reports. The tracked
+Each stage produces exactly these 18 policy reports. The tracked
 [`report-matrix-1.0.json`](../examples/release-gate/report-matrix-1.0.json) is the
 machine-readable inventory.
 
@@ -24,22 +24,23 @@ machine-readable inventory.
 | 3 | `ares-queue-management` | `queue validate` | must precede lifecycle fixtures |
 | 4 | `ares-jarvis-gray-scott` | `jarvis-mcp-validate` | bounded package search, Gray-Scott run, progress, query, and artifacts |
 | 5 | `ares-jarvis-lammps` | `jarvis-mcp-validate` | bounded package search and separate LAMMPS progress run |
-| 6 | `ares-spack-find` | `remote-mcp validate` | `spack_find` |
-| 7 | `ares-spack-locate` | `remote-mcp validate` | `spack_locate` |
-| 8 | `ares-spack-install` | `remote-mcp validate` | absent -> fresh install -> exact locate transition |
-| 9 | `ares-slurm-lifecycle` | `scheduler validate-lifecycle` | explicit SLURM provider |
-| 10 | `ares-cleanup-detach` | `session detach` | grouped with report 11 by relay session |
-| 11 | `ares-cleanup-teardown` | `session teardown` | explicit keep-jobs default proof |
-| 12 | `ares-explicit-cancel-teardown` | `session teardown` | separate owned job plus unowned sentinel |
-| 13 | `homelab-cleanup-detach` | `session detach` | grouped with report 14 by relay session |
-| 14 | `homelab-cleanup-teardown` | `session teardown` | explicit keep-jobs default proof |
-| 15 | `homelab-transport` | `live-test` | relay and owned SSH transport |
-| 16 | `ares-gateway-start` | `gateway start-runtime` | grouped with report 17 by gateway session |
-| 17 | `ares-gateway-stop` | `gateway stop-runtime` | keeps scheduler job by default |
+| 6 | `ares-scientific-catalog-describe` | `remote-mcp validate` | catalog v1.1 output schema, exact dataset identity, and JARVIS descriptor handoff |
+| 7 | `ares-spack-find` | `remote-mcp validate` | `spack_find` |
+| 8 | `ares-spack-locate` | `remote-mcp validate` | `spack_locate` |
+| 9 | `ares-spack-install` | `remote-mcp validate` | absent -> fresh install -> exact locate transition |
+| 10 | `ares-slurm-lifecycle` | `scheduler validate-lifecycle` | explicit SLURM provider |
+| 11 | `ares-cleanup-detach` | `session detach` | grouped with report 12 by relay session |
+| 12 | `ares-cleanup-teardown` | `session teardown` | explicit keep-jobs default proof |
+| 13 | `ares-explicit-cancel-teardown` | `session teardown` | separate owned job plus unowned sentinel |
+| 14 | `homelab-cleanup-detach` | `session detach` | grouped with report 15 by relay session |
+| 15 | `homelab-cleanup-teardown` | `session teardown` | explicit keep-jobs default proof |
+| 16 | `homelab-transport` | `live-test` | relay and owned SSH transport |
+| 17 | `ares-gateway-start` | `gateway start-runtime` | grouped with report 18 by gateway session |
+| 18 | `ares-gateway-stop` | `gateway stop-runtime` | keeps scheduler job by default |
 
 Bootstrap of the homelab target and creation of cleanup-owned gateway fixtures
 also write diagnostic reports. Store those outside the policy report directory
-and do not upload them as part of the 17-report set.
+and do not upload them as part of the 18-report set.
 
 ## Start one evidence stage
 
@@ -55,7 +56,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.29"
+$Version = "1.3.30"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }
@@ -264,7 +265,7 @@ The producer login and numeric GitHub id are resolved afresh for the stage but
 remain the real operator identity. The invocation id, report id, report path,
 pipeline id, relay-session id, and gateway-session id must be fresh for every
 operation. This helper guarantees a new invocation id, refuses report-path
-replacement, and tracks only the 17 policy reports:
+replacement, and tracks only the 18 policy reports:
 
 ```powershell
 $PolicyReports = [System.Collections.Generic.List[string]]::new()
@@ -401,6 +402,7 @@ the whole definition.
 ```powershell
 $AresSpack = [string]$AresDefinition.spack_executable
 $AresFreshBaseSpack = "$AresHome/spack/bin/spack"
+$AresScientificCatalogFile = [string]$env:CLIO_RELAY_VALIDATION_ARES_SCIENTIFIC_CATALOG_FILE
 if ($AresDefinition.scheduler_provider -ne "slurm") { throw "Ares must explicitly use slurm" }
 if ($AresSpack -notmatch '^/[A-Za-z0-9._+/-]+$' -or
     $AresSpack.StartsWith("//") -or
@@ -411,6 +413,16 @@ if ($AresSpack -notmatch '^/[A-Za-z0-9._+/-]+$' -or
 foreach ($Executable in @($AresSpack, $AresFreshBaseSpack)) {
   & $OpenSsh $AresSshHost "test -x '$Executable'"
   if ($LASTEXITCODE -ne 0) { throw "required Ares Spack executable is absent: $Executable" }
+}
+if ($AresScientificCatalogFile -notmatch '^/[A-Za-z0-9._+/-]+$' -or
+    $AresScientificCatalogFile.StartsWith("//") -or
+    $AresScientificCatalogFile.EndsWith("/") -or
+    $AresScientificCatalogFile -match '(^|/)\.\.(/|$)') {
+  throw "CLIO_RELAY_VALIDATION_ARES_SCIENTIFIC_CATALOG_FILE must name one canonical absolute remote path"
+}
+& $OpenSsh $AresSshHost "test -f '$AresScientificCatalogFile'"
+if ($LASTEXITCODE -ne 0) {
+  throw "the operator-configured Ares scientific catalog is absent: $AresScientificCatalogFile"
 }
 if ($HomelabDefinition.scheduler_provider -ne "external") { throw "homelab must explicitly use external" }
 foreach ($Name in @(
@@ -819,6 +831,48 @@ with latest timestep 20 and two observed members. The LAMMPS report must contain
 determinate JARVIS-native progress for package id `lammps`. Stdout parsing alone
 cannot satisfy either requirement.
 
+## Run the scientific catalog v1.1 contract
+
+Use the exact clio-kit 2.5.11 persistent executable installed and receipt-bound
+by bootstrap. The catalog file is operator-owned site metadata supplied through
+`CLIO_RELAY_VALIDATION_ARES_SCIENTIFIC_CATALOG_FILE`; it is not copied into the
+relay release. This policy uses
+`deep-water-impact-2018-yb31-first5` as concrete Ares release evidence, not as a
+runtime allowlist. Operators replace both the target and dataset evidence in a
+later policy without changing relay code.
+
+The describe validation checks the cached output schema and the actual
+`structuredContent`. It also proves that the requested dataset id, catalog
+record id, and both descriptor ids agree; that the top-level
+`dataset_descriptor` equals `dataset.descriptor`; and that
+`descriptor_sha256` is the canonical digest of that exact JARVIS handoff.
+
+```powershell
+$AresClioKit = "$AresHome/.local/bin/clio-kit"
+& $Relay remote-mcp register --cluster $AresCluster --name scientific-catalog `
+  --command $AresClioKit `
+  --arg=mcp-server --arg=scientific-catalog --arg=-- `
+  --arg=--catalog-file --arg=$AresScientificCatalogFile `
+  --contract clio-kit-scientific-catalog-user-v1.1 `
+  --allow-tool scientific_dataset_search `
+  --allow-tool scientific_dataset_describe `
+  --profile user --call-timeout-seconds 300 --replace
+if ($LASTEXITCODE -ne 0) { throw "scientific catalog MCP registration failed" }
+& $Relay remote-mcp refresh --cluster $AresCluster --name scientific-catalog
+if ($LASTEXITCODE -ne 0) { throw "scientific catalog MCP discovery failed" }
+
+$CatalogDescribeArguments = Write-JsonFile "ares-scientific-catalog-describe.json" @{
+  dataset_id = "deep-water-impact-2018-yb31-first5"
+}
+Invoke-RelayReport -Id "ares-scientific-catalog-describe" `
+  -ReportOption "--validation-report" -Command @(
+    "remote-mcp", "validate", "--cluster", $AresCluster,
+    "--name", "scientific-catalog", "--tool", "scientific_dataset_describe",
+    "--arguments-json-file", $CatalogDescribeArguments,
+    "--wait-timeout-seconds", "300", "--poll-seconds", "1"
+  )
+```
+
 ## Run the three-tool Spack contract
 
 Register exactly the three agent-facing user operations. The `--arg=...` form is
@@ -830,7 +884,6 @@ structured `not_installed` error. Relay still accepts the preserved
 it against its own v2 artifact and digest rather than the current contract.
 
 ```powershell
-$AresClioKit = "$AresHome/.local/bin/clio-kit"
 & $Relay remote-mcp register --cluster $AresCluster --name spack `
   --command $AresClioKit `
   --arg=mcp-server --arg=spack --arg=-- --arg=--spack-command --arg=$AresSpack `
@@ -1358,7 +1411,7 @@ Invoke-RelayReport -Id "homelab-transport" -ReportOption "--report" -Command @(
 
 ## Prove the dedicated gateway pair
 
-Reports 16 and 17 must refer to the exact same gateway session. Stop closes the
+Reports 17 and 18 must refer to the exact same gateway session. Stop closes the
 connectors and record while explicitly retaining the scheduler job; the bounded
 fixture exits by itself.
 
@@ -1508,7 +1561,7 @@ The release workflow order is fixed:
 
 After the candidate upload, dispatch `live-validation-attest.yml` and then
 `release-gate.yml` from protected `main`. After public PyPI publication, create
-a new released stage, install from the public index, rerun all 17 reports, upload
+a new released stage, install from the public index, rerun all 18 reports, upload
 the distinct `released-validation-*.json` files, and dispatch
 `released-validation-attest.yml`. Only then may `finalize-release.yml` publish
 the final GitHub release claims.

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.29"
+release_version: "1.3.30"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: f29cd3531821dccf58a19f43b4e6c840ace0702e060222566e3a87a3580b3405
+acceptance_matrix_sha256: 2c760f9cc33077d6f4e584fde49d93d2c2300ea2312adb281a4aff2a6b96ce25
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true
@@ -110,16 +110,16 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.5.10"
+            clio-kit: "2.5.11"
             jarvis-cd: "1.3.16"
             jarvis-util: c91bfdc9bba802e4b03bfb1babe614ffa3e09644
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.5.10"
-              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.10/clio_kit-2.5.10-py3-none-any.whl
+              distribution_version: "2.5.11"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.11/clio_kit-2.5.11-py3-none-any.whl
               requested_source: github_release
-              artifact_sha256: 4911142152f476f973caa0c7f8050d88e8efa5f803651bda88685836ee3232f5
+              artifact_sha256: a0a2bbf8d23495dd4f43881d35a47bfb83bc2d1c016bd952bd7a1c88a43ca03e
               native_execution:
                 schema_version: clio-relay.jarvis-native-execution-capability.v1
                 handle_schema: jarvis.execution.handle.v1
@@ -220,14 +220,14 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.5.10"
+            clio-kit: "2.5.11"
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.5.10"
-              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.10/clio_kit-2.5.10-py3-none-any.whl
+              distribution_version: "2.5.11"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.11/clio_kit-2.5.11-py3-none-any.whl
               requested_source: github_release
-              artifact_sha256: 4911142152f476f973caa0c7f8050d88e8efa5f803651bda88685836ee3232f5
+              artifact_sha256: a0a2bbf8d23495dd4f43881d35a47bfb83bc2d1c016bd952bd7a1c88a43ca03e
       - kind: scheduler_job
         roles: [queue-preservation-fixture]
         states: [completed]
@@ -288,24 +288,24 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.5.10"
+            clio-kit: "2.5.11"
             jarvis-cd: "1.3.16"
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.5.10"
-              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.10/clio_kit-2.5.10-py3-none-any.whl
+              distribution_version: "2.5.11"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.5.11/clio_kit-2.5.11-py3-none-any.whl
               requested_source: github_release
-              artifact_filename: clio_kit-2.5.10-py3-none-any.whl
-              artifact_sha256: 4911142152f476f973caa0c7f8050d88e8efa5f803651bda88685836ee3232f5
+              artifact_filename: clio_kit-2.5.11-py3-none-any.whl
+              artifact_sha256: a0a2bbf8d23495dd4f43881d35a47bfb83bc2d1c016bd952bd7a1c88a43ca03e
               persistent_tool:
                 manager: uv
                 uv_version: "0.11.28"
                 pyvenv_uv_version: "0.11.28"
                 distribution: clio-kit
-                distribution_version: "2.5.10"
+                distribution_version: "2.5.11"
                 entry_point: clio-kit
-                source_artifact_sha256: 4911142152f476f973caa0c7f8050d88e8efa5f803651bda88685836ee3232f5
+                source_artifact_sha256: a0a2bbf8d23495dd4f43881d35a47bfb83bc2d1c016bd952bd7a1c88a43ca03e
               native_execution:
                 schema_version: clio-relay.jarvis-native-execution-capability.v1
                 handle_schema: jarvis.execution.handle.v1
@@ -364,10 +364,10 @@ requirements:
         states: [verified]
         metadata_equals:
           install_source: uv-tool
-          install_artifact_sha256: 4911142152f476f973caa0c7f8050d88e8efa5f803651bda88685836ee3232f5
+          install_artifact_sha256: a0a2bbf8d23495dd4f43881d35a47bfb83bc2d1c016bd952bd7a1c88a43ca03e
           python_distribution_runtime:
             distribution: clio-kit
-            distribution_version: "2.5.10"
+            distribution_version: "2.5.11"
             entry_point: clio-kit
             runtime_closure_verified: true
           nested_runtime:
@@ -617,7 +617,7 @@ requirements:
               jarvis_executable_verified: true
 
   - requirement_id: ares-non-jarvis-virtual-mcp
-    description: discover and run a registered non-JARVIS clio-kit MCP on Ares
+    description: discover and run the released scientific catalog v1.1 contract on Ares, including its explicit JARVIS descriptor handoff
     cluster: ares
     scenarios:
       - remote-mcp
@@ -625,9 +625,11 @@ requirements:
       - remote-mcp.register
       - remote-mcp.discover
       - remote-mcp.tools-list
+      - remote-mcp.scientific-catalog-user-contract
       - remote-mcp.call
       - remote-mcp.server-artifact
       - remote-mcp.durable-result
+      - remote-mcp.scientific-catalog-result
       - worker.artifact-version
       - worker.artifact-sha256
       - worker.source-identity
@@ -641,6 +643,23 @@ requirements:
       - kind: relay_job
         roles: [virtual_remote_mcp_call]
         states: [succeeded]
+        metadata_equals:
+          remote_mcp_server_name: scientific-catalog
+          remote_mcp_tool_name: scientific_dataset_describe
+          spec:
+            arguments:
+              dataset_id: deep-water-impact-2018-yb31-first5
+          scientific_catalog_result_assertion:
+            contract: clio-kit-scientific-catalog-user-v1.1
+            tool: scientific_dataset_describe
+            requested_dataset_id: deep-water-impact-2018-yb31-first5
+            dataset_id: deep-water-impact-2018-yb31-first5
+            descriptor_dataset_id: deep-water-impact-2018-yb31-first5
+            nested_descriptor_dataset_id: deep-water-impact-2018-yb31-first5
+            schema_versions_match: true
+            dataset_identity_matches: true
+            dataset_descriptor_handoff_matches: true
+            descriptor_digest_matches: true
       - kind: relay_worker
         roles: [cluster_worker]
         states: [running]
@@ -648,10 +667,16 @@ requirements:
         roles: [remote_mcp_server]
         states: [verified]
         metadata_equals:
+          server_name: scientific-catalog
+          remote_tool_names: [scientific_dataset_describe, scientific_dataset_search]
+          allowlisted_tool_names: [scientific_dataset_describe, scientific_dataset_search]
           install_source: wheel
-          install_artifact_sha256: 4911142152f476f973caa0c7f8050d88e8efa5f803651bda88685836ee3232f5
+          install_artifact_sha256: a0a2bbf8d23495dd4f43881d35a47bfb83bc2d1c016bd952bd7a1c88a43ca03e
+          contract_id: clio-kit-scientific-catalog-user-v1.1
+          contract_sha256: 80a9b583c26a084ff07d638ddf0c2c7d4325dbc8d4299931d0c4f3627cb8674c
           server_process_artifact_verified: true
           verified: true
+    evidence_group_resource_kind: mcp_server
 
   - requirement_id: ares-spack-virtual-mcp
     description: discover the complete released Spack MCP user contract and resolve the existing LAMMPS installation on Ares
@@ -748,7 +773,7 @@ requirements:
           remote_tool_names: [spack_find, spack_install, spack_locate]
           allowlisted_tool_names: [spack_find, spack_install, spack_locate]
           install_source: wheel
-          install_artifact_sha256: 4911142152f476f973caa0c7f8050d88e8efa5f803651bda88685836ee3232f5
+          install_artifact_sha256: a0a2bbf8d23495dd4f43881d35a47bfb83bc2d1c016bd952bd7a1c88a43ca03e
           contract_id: clio-kit-spack-user-v2.1
           contract_sha256: cc90789227aa0baea99d0e0379b320811c1dbd40c7fa66877d372309201be1c2
           server_process_artifact_verified: true
@@ -853,7 +878,7 @@ requirements:
           remote_tool_names: [spack_find, spack_install, spack_locate]
           allowlisted_tool_names: [spack_find, spack_install, spack_locate]
           install_source: wheel
-          install_artifact_sha256: 4911142152f476f973caa0c7f8050d88e8efa5f803651bda88685836ee3232f5
+          install_artifact_sha256: a0a2bbf8d23495dd4f43881d35a47bfb83bc2d1c016bd952bd7a1c88a43ca03e
           contract_id: clio-kit-spack-user-v2.1
           contract_sha256: cc90789227aa0baea99d0e0379b320811c1dbd40c7fa66877d372309201be1c2
           server_process_artifact_verified: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.29"
+$Tag = "v1.3.30"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.29" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.30" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/docs/remote-mcp-federation.md
+++ b/docs/remote-mcp-federation.md
@@ -264,7 +264,7 @@ Virtual JARVIS mutations and runs receive a fresh relay job by default. Supply
 an explicit `idempotency_key` only when retry de-duplication is intentional; an
 identical second `jarvis_run` is otherwise a new execution.
 
-The released clio-kit 2.5.10 artifact is the pinned six-tool JARVIS v3.3 contract.
+The released clio-kit 2.5.11 artifact is the pinned six-tool JARVIS v3.3 contract.
 Bootstrap
 downloads and hashes the exact coordinated wheel, installs it once with
 `uv tool install`, and persists the wheel plus the direct JARVIS command in the
@@ -283,13 +283,13 @@ relay's exact JARVIS-CD release pin. That dependency edge is recorded in the
 install receipt and call result. Operator-registered MCP servers remain bound
 by their own discovery artifact and are not constrained to the relay's
 JARVIS-CD version.
-The release gate requires that exact 2.5.10 artifact to be rerun on every target
+The release gate requires that exact 2.5.11 artifact to be rerun on every target
 selected by the release policy. Other servers use the operator registry and
 generated `remote_...` aliases.
 
 The exact release wheel is
-`clio_kit-2.5.10-py3-none-any.whl` with SHA-256
-`4911142152f476f973caa0c7f8050d88e8efa5f803651bda88685836ee3232f5`.
+`clio_kit-2.5.11-py3-none-any.whl` with SHA-256
+`a0a2bbf8d23495dd4f43881d35a47bfb83bc2d1c016bd952bd7a1c88a43ca03e`.
 Its canonical contract is `clio-kit-jarvis-user-v3.3`, with contract SHA-256
 `0993ee9b2ee9b3c2b021a3967d9221199c3a6be50d726d4b125812e6b1148115`
 and canonical tools-wire SHA-256
@@ -315,13 +315,16 @@ against their distinct preserved contract digest.
 
 ## Register the scientific catalog MCP
 
-clio-kit 2.5.10 also ships the two-tool
-`clio-kit-scientific-catalog-user-v1` contract. It separates dataset discovery
+clio-kit 2.5.11 also ships the two-tool
+`clio-kit-scientific-catalog-user-v1.1` contract. It separates dataset discovery
 from visualization control: `scientific_dataset_search` finds operator catalog
-records and `scientific_dataset_describe` returns one exact
-`jarvis.dataset-descriptor.v1`. Register it through the same generic federation
-layer; the relay does not add dataset names, scene recipes, or site-specific
-semantics:
+records and `scientific_dataset_describe` returns the complete catalog record
+plus one exact top-level `dataset_descriptor` with schema
+`jarvis.dataset-descriptor.v1`. Pass only that top-level descriptor unchanged as
+`jarvis_add_step`'s `config.dataset_descriptor`; the surrounding `dataset`
+record is human discovery metadata and is not a JARVIS package argument. Register
+the server through the same generic federation layer; the relay does not add
+dataset names, scene recipes, or site-specific semantics:
 
 ```powershell
 clio-relay remote-mcp register `
@@ -332,13 +335,22 @@ clio-relay remote-mcp register `
   --arg scientific-catalog `
   --allow-tool scientific_dataset_search `
   --allow-tool scientific_dataset_describe `
+  --contract clio-kit-scientific-catalog-user-v1.1 `
   --profile user
 clio-relay remote-mcp refresh --cluster my-cluster --name scientific-catalog
 ```
 
-The released wheel contract and its hashes are checked by the relay release
-gate. At runtime, the operator registration and refreshed schema cache remain
-the authority, so adding a different catalog or cluster requires no relay code
+The relay checks the current contract SHA-256
+`80a9b583c26a084ff07d638ddf0c2c7d4325dbc8d4299931d0c4f3627cb8674c`,
+canonical tools-wire SHA-256
+`1c8df94a298f92b92126c953a7b8124d90b2fa12919de93738a40e563c3eaa28`,
+and exact contract artifact SHA-256
+`29cbbfe64eaa7bcf29531b3d28762b8ff47e89d291b0a5b66119da96c790135e`.
+Historical `clio-kit-scientific-catalog-user-v1` registrations remain accepted
+against their separately preserved contract, wire, and artifact digests; they
+do not claim the explicit top-level descriptor handoff added in v1.1. At
+runtime, the operator registration and refreshed schema cache remain the
+authority, so adding a different catalog or cluster requires no relay code
 change.
 
 For an unreleased candidate, use an exact wheel path for the remote command and

--- a/examples/release-gate/README.md
+++ b/examples/release-gate/README.md
@@ -19,7 +19,7 @@ The JSON and YAML templates use the following literal replacement tokens:
 
 Render into an ignored per-stage directory. Never edit a tracked template with
 live values, and never write token or shared-secret values into rendered files.
-`report-matrix-1.0.json` is the authoritative ordered inventory of the 17
+`report-matrix-1.0.json` is the authoritative ordered inventory of the 18
 non-local reports required for each evidence stage.
 
 The nonscheduler gateway driver is Linux-specific and stores private state with

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.29",
-  "matrix_sha256": "f29cd3531821dccf58a19f43b4e6c840ace0702e060222566e3a87a3580b3405",
-  "report_count_per_stage": 17,
+  "release_version": "1.3.30",
+  "matrix_sha256": "2c760f9cc33077d6f4e584fde49d93d2c2300ea2312adb281a4aff2a6b96ce25",
+  "report_count_per_stage": 18,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [
     {
@@ -61,6 +61,19 @@
     },
     {
       "ordinal": 6,
+      "id": "ares-scientific-catalog-describe",
+      "cluster": "ares",
+      "scenario": "remote-mcp",
+      "command": ["remote-mcp", "validate"],
+      "report_option": "--validation-report",
+      "remote_tool": "scientific_dataset_describe",
+      "arguments": {
+        "dataset_id": "deep-water-impact-2018-yb31-first5"
+      },
+      "evidence_group": "scientific-catalog"
+    },
+    {
+      "ordinal": 7,
       "id": "ares-spack-find",
       "cluster": "ares",
       "scenario": "remote-mcp",
@@ -71,7 +84,7 @@
       "evidence_group": "spack"
     },
     {
-      "ordinal": 7,
+      "ordinal": 8,
       "id": "ares-spack-locate",
       "cluster": "ares",
       "scenario": "remote-mcp",
@@ -82,7 +95,7 @@
       "evidence_group": "spack"
     },
     {
-      "ordinal": 8,
+      "ordinal": 9,
       "id": "ares-spack-install",
       "cluster": "ares",
       "scenario": "remote-mcp",
@@ -93,7 +106,7 @@
       "evidence_group": "spack-fresh"
     },
     {
-      "ordinal": 9,
+      "ordinal": 10,
       "id": "ares-slurm-lifecycle",
       "cluster": "ares",
       "scenario": "scheduler-lifecycle",
@@ -101,7 +114,7 @@
       "report_option": "--report"
     },
     {
-      "ordinal": 10,
+      "ordinal": 11,
       "id": "ares-cleanup-detach",
       "cluster": "ares",
       "scenario": "cleanup",
@@ -110,7 +123,7 @@
       "evidence_group": "ares-default-cleanup-session"
     },
     {
-      "ordinal": 11,
+      "ordinal": 12,
       "id": "ares-cleanup-teardown",
       "cluster": "ares",
       "scenario": "cleanup",
@@ -119,7 +132,7 @@
       "evidence_group": "ares-default-cleanup-session"
     },
     {
-      "ordinal": 12,
+      "ordinal": 13,
       "id": "ares-explicit-cancel-teardown",
       "cluster": "ares",
       "scenario": "cleanup",
@@ -128,7 +141,7 @@
       "evidence_group": "ares-explicit-cancel-session"
     },
     {
-      "ordinal": 13,
+      "ordinal": 14,
       "id": "homelab-cleanup-detach",
       "cluster": "homelab",
       "scenario": "cleanup",
@@ -137,7 +150,7 @@
       "evidence_group": "homelab-default-cleanup-session"
     },
     {
-      "ordinal": 14,
+      "ordinal": 15,
       "id": "homelab-cleanup-teardown",
       "cluster": "homelab",
       "scenario": "cleanup",
@@ -146,7 +159,7 @@
       "evidence_group": "homelab-default-cleanup-session"
     },
     {
-      "ordinal": 15,
+      "ordinal": 16,
       "id": "homelab-transport",
       "cluster": "homelab",
       "scenario": "transport",
@@ -154,7 +167,7 @@
       "report_option": "--report"
     },
     {
-      "ordinal": 16,
+      "ordinal": 17,
       "id": "ares-gateway-start",
       "cluster": "ares",
       "scenario": "gateway-runtime",
@@ -163,7 +176,7 @@
       "evidence_group": "ares-dedicated-gateway"
     },
     {
-      "ordinal": 17,
+      "ordinal": 18,
       "id": "ares-gateway-stop",
       "cluster": "ares",
       "scenario": "gateway-runtime",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.29"
+version = "1.3.30"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.29"
+__version__ = "1.3.30"

--- a/src/clio_relay/_contracts/scientific-catalog-user-v1.1.json
+++ b/src/clio_relay/_contracts/scientific-catalog-user-v1.1.json
@@ -1,0 +1,671 @@
+{
+  "canonicalization": "json-sort-keys-compact-utf8-v1",
+  "contract_id": "clio-kit-scientific-catalog-user-v1.1",
+  "contract_sha256": "80a9b583c26a084ff07d638ddf0c2c7d4325dbc8d4299931d0c4f3627cb8674c",
+  "profile": "user",
+  "projection": "mcp-agent-tool-schema-v1",
+  "schema_version": "clio-kit.mcp-user-contract.v1",
+  "server_name": "scientific-catalog",
+  "source": {
+    "method": "tools/list",
+    "protocol_version": "2024-11-05",
+    "transport": "stdio"
+  },
+  "tool_names": [
+    "scientific_dataset_describe",
+    "scientific_dataset_search"
+  ],
+  "tools": [
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "catalog",
+            "scientific-data",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Return one exact operator catalog record plus a top-level dataset_descriptor. Pass dataset_descriptor unchanged as jarvis_add_step config.dataset_descriptor; do not pass the surrounding dataset record.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "dataset_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "dataset_id"
+        ],
+        "type": "object"
+      },
+      "name": "scientific_dataset_describe",
+      "outputSchema": {
+        "additionalProperties": false,
+        "description": "Complete catalog record and exact JARVIS descriptor.",
+        "properties": {
+          "catalog_revision": {
+            "type": "string"
+          },
+          "catalog_sha256": {
+            "type": "string"
+          },
+          "dataset": {
+            "additionalProperties": false,
+            "description": "Human-discoverable metadata around one intrinsic dataset descriptor.",
+            "properties": {
+              "dataset_id": {
+                "type": "string"
+              },
+              "descriptor": {
+                "additionalProperties": false,
+                "description": "JARVIS-owned intrinsic dataset descriptor without visualization semantics.",
+                "properties": {
+                  "arrays": {
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Intrinsic array facts discovered for one dataset.",
+                      "properties": {
+                        "association": {
+                          "enum": [
+                            "point",
+                            "cell",
+                            "field"
+                          ],
+                          "type": "string"
+                        },
+                        "components": {
+                          "maximum": 64,
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "name": {
+                          "maxLength": 512,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "units": {
+                          "anyOf": [
+                            {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "association",
+                        "components"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 256,
+                    "type": "array"
+                  },
+                  "bounds": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "number"
+                        },
+                        "maxItems": 6,
+                        "minItems": 6,
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "dataset_id": {
+                    "type": "string"
+                  },
+                  "fingerprint": {
+                    "additionalProperties": false,
+                    "description": "Content or collection identity for one dataset descriptor.",
+                    "properties": {
+                      "algorithm": {
+                        "const": "sha256",
+                        "type": "string"
+                      },
+                      "digest": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "algorithm",
+                      "digest"
+                    ],
+                    "type": "object"
+                  },
+                  "format": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "kind": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "members": {
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "One ordered, cluster-local member in the bounded catalog view.",
+                      "properties": {
+                        "index": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "location": {
+                          "maxLength": 4096,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "timestep": {
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "required": [
+                        "index",
+                        "location"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 512,
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "schema_version": {
+                    "const": "jarvis.dataset-descriptor.v1",
+                    "type": "string"
+                  },
+                  "source_artifact": {
+                    "anyOf": [
+                      {
+                        "additionalProperties": false,
+                        "description": "Optional durable JARVIS artifact that owns a dataset.",
+                        "properties": {
+                          "artifact_id": {
+                            "pattern": "^art_[A-Za-z0-9_-]{22,86}$",
+                            "type": "string"
+                          },
+                          "sha256": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "artifact_id",
+                          "sha256"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "required": [
+                  "schema_version",
+                  "dataset_id",
+                  "kind",
+                  "format",
+                  "members",
+                  "fingerprint"
+                ],
+                "type": "object"
+              },
+              "summary": {
+                "maxLength": 4096,
+                "minLength": 1,
+                "type": "string"
+              },
+              "tags": {
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 64,
+                "type": "array"
+              },
+              "title": {
+                "maxLength": 512,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "dataset_id",
+              "title",
+              "summary",
+              "descriptor"
+            ],
+            "type": "object"
+          },
+          "dataset_descriptor": {
+            "additionalProperties": false,
+            "description": "JARVIS-owned intrinsic dataset descriptor without visualization semantics.",
+            "properties": {
+              "arrays": {
+                "items": {
+                  "additionalProperties": false,
+                  "description": "Intrinsic array facts discovered for one dataset.",
+                  "properties": {
+                    "association": {
+                      "enum": [
+                        "point",
+                        "cell",
+                        "field"
+                      ],
+                      "type": "string"
+                    },
+                    "components": {
+                      "maximum": 64,
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "name": {
+                      "maxLength": 512,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "units": {
+                      "anyOf": [
+                        {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "association",
+                    "components"
+                  ],
+                  "type": "object"
+                },
+                "maxItems": 256,
+                "type": "array"
+              },
+              "bounds": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "type": "number"
+                    },
+                    "maxItems": 6,
+                    "minItems": 6,
+                    "type": "array"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "dataset_id": {
+                "type": "string"
+              },
+              "fingerprint": {
+                "additionalProperties": false,
+                "description": "Content or collection identity for one dataset descriptor.",
+                "properties": {
+                  "algorithm": {
+                    "const": "sha256",
+                    "type": "string"
+                  },
+                  "digest": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "algorithm",
+                  "digest"
+                ],
+                "type": "object"
+              },
+              "format": {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "kind": {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "members": {
+                "items": {
+                  "additionalProperties": false,
+                  "description": "One ordered, cluster-local member in the bounded catalog view.",
+                  "properties": {
+                    "index": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "location": {
+                      "maxLength": 4096,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "timestep": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "required": [
+                    "index",
+                    "location"
+                  ],
+                  "type": "object"
+                },
+                "maxItems": 512,
+                "minItems": 1,
+                "type": "array"
+              },
+              "schema_version": {
+                "const": "jarvis.dataset-descriptor.v1",
+                "type": "string"
+              },
+              "source_artifact": {
+                "anyOf": [
+                  {
+                    "additionalProperties": false,
+                    "description": "Optional durable JARVIS artifact that owns a dataset.",
+                    "properties": {
+                      "artifact_id": {
+                        "pattern": "^art_[A-Za-z0-9_-]{22,86}$",
+                        "type": "string"
+                      },
+                      "sha256": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "artifact_id",
+                      "sha256"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "required": [
+              "schema_version",
+              "dataset_id",
+              "kind",
+              "format",
+              "members",
+              "fingerprint"
+            ],
+            "type": "object"
+          },
+          "descriptor_sha256": {
+            "type": "string"
+          },
+          "schema_version": {
+            "const": "clio-kit.scientific-dataset-description.v1",
+            "default": "clio-kit.scientific-dataset-description.v1",
+            "type": "string"
+          },
+          "site_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "site_id",
+          "catalog_revision",
+          "catalog_sha256",
+          "dataset",
+          "dataset_descriptor",
+          "descriptor_sha256"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "catalog",
+            "scientific-data",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Search operator-registered scientific datasets and return bounded intrinsic summaries.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "page_size": {
+            "default": 20,
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "query": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
+        },
+        "type": "object"
+      },
+      "name": "scientific_dataset_search",
+      "outputSchema": {
+        "additionalProperties": false,
+        "description": "Stable paginated response from scientific dataset search.",
+        "properties": {
+          "catalog_revision": {
+            "type": "string"
+          },
+          "catalog_sha256": {
+            "type": "string"
+          },
+          "datasets": {
+            "items": {
+              "additionalProperties": false,
+              "description": "Bounded discovery record returned by search.",
+              "properties": {
+                "dataset_fingerprint": {
+                  "type": "string"
+                },
+                "dataset_id": {
+                  "type": "string"
+                },
+                "descriptor_sha256": {
+                  "type": "string"
+                },
+                "first_timestep": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "format": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "last_timestep": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "member_count": {
+                  "type": "integer"
+                },
+                "summary": {
+                  "type": "string"
+                },
+                "tags": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "title": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "dataset_id",
+                "title",
+                "summary",
+                "tags",
+                "kind",
+                "format",
+                "member_count",
+                "first_timestep",
+                "last_timestep",
+                "dataset_fingerprint",
+                "descriptor_sha256"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema_version": {
+            "const": "clio-kit.scientific-dataset-search.v1",
+            "default": "clio-kit.scientific-dataset-search.v1",
+            "type": "string"
+          },
+          "site_id": {
+            "type": "string"
+          },
+          "total_matches": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "site_id",
+          "catalog_revision",
+          "catalog_sha256",
+          "datasets",
+          "total_matches",
+          "next_cursor"
+        ],
+        "type": "object"
+      }
+    }
+  ],
+  "wire_sha256": "1c8df94a298f92b92126c953a7b8124d90b2fa12919de93738a40e563c3eaa28"
+}

--- a/src/clio_relay/_contracts/scientific-catalog-user-v1.json
+++ b/src/clio_relay/_contracts/scientific-catalog-user-v1.json
@@ -1,0 +1,495 @@
+{
+  "canonicalization": "json-sort-keys-compact-utf8-v1",
+  "contract_id": "clio-kit-scientific-catalog-user-v1",
+  "contract_sha256": "a53006f24f4698f659f0a7c8bf61fc7bd7ad23274b06d2eed2ccfca68b9ecb0a",
+  "profile": "user",
+  "projection": "mcp-agent-tool-schema-v1",
+  "schema_version": "clio-kit.mcp-user-contract.v1",
+  "server_name": "scientific-catalog",
+  "source": {
+    "method": "tools/list",
+    "protocol_version": "2024-11-05",
+    "transport": "stdio"
+  },
+  "tool_names": [
+    "scientific_dataset_describe",
+    "scientific_dataset_search"
+  ],
+  "tools": [
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "catalog",
+            "scientific-data",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Return one exact operator catalog record and its jarvis.dataset-descriptor.v1.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "dataset_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "dataset_id"
+        ],
+        "type": "object"
+      },
+      "name": "scientific_dataset_describe",
+      "outputSchema": {
+        "additionalProperties": false,
+        "description": "Complete catalog record and exact JARVIS descriptor.",
+        "properties": {
+          "catalog_revision": {
+            "type": "string"
+          },
+          "catalog_sha256": {
+            "type": "string"
+          },
+          "dataset": {
+            "additionalProperties": false,
+            "description": "Human-discoverable metadata around one intrinsic dataset descriptor.",
+            "properties": {
+              "dataset_id": {
+                "type": "string"
+              },
+              "descriptor": {
+                "additionalProperties": false,
+                "description": "JARVIS-owned intrinsic dataset descriptor without visualization semantics.",
+                "properties": {
+                  "arrays": {
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Intrinsic array facts discovered for one dataset.",
+                      "properties": {
+                        "association": {
+                          "enum": [
+                            "point",
+                            "cell",
+                            "field"
+                          ],
+                          "type": "string"
+                        },
+                        "components": {
+                          "maximum": 64,
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "name": {
+                          "maxLength": 512,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "units": {
+                          "anyOf": [
+                            {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "association",
+                        "components"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 256,
+                    "type": "array"
+                  },
+                  "bounds": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "number"
+                        },
+                        "maxItems": 6,
+                        "minItems": 6,
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "dataset_id": {
+                    "type": "string"
+                  },
+                  "fingerprint": {
+                    "additionalProperties": false,
+                    "description": "Content or collection identity for one dataset descriptor.",
+                    "properties": {
+                      "algorithm": {
+                        "const": "sha256",
+                        "type": "string"
+                      },
+                      "digest": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "algorithm",
+                      "digest"
+                    ],
+                    "type": "object"
+                  },
+                  "format": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "kind": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "members": {
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "One ordered, cluster-local member in the bounded catalog view.",
+                      "properties": {
+                        "index": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "location": {
+                          "maxLength": 4096,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "timestep": {
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "required": [
+                        "index",
+                        "location"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 512,
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "schema_version": {
+                    "const": "jarvis.dataset-descriptor.v1",
+                    "type": "string"
+                  },
+                  "source_artifact": {
+                    "anyOf": [
+                      {
+                        "additionalProperties": false,
+                        "description": "Optional durable JARVIS artifact that owns a dataset.",
+                        "properties": {
+                          "artifact_id": {
+                            "pattern": "^art_[A-Za-z0-9_-]{22,86}$",
+                            "type": "string"
+                          },
+                          "sha256": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "artifact_id",
+                          "sha256"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "required": [
+                  "schema_version",
+                  "dataset_id",
+                  "kind",
+                  "format",
+                  "members",
+                  "fingerprint"
+                ],
+                "type": "object"
+              },
+              "summary": {
+                "maxLength": 4096,
+                "minLength": 1,
+                "type": "string"
+              },
+              "tags": {
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 64,
+                "type": "array"
+              },
+              "title": {
+                "maxLength": 512,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "dataset_id",
+              "title",
+              "summary",
+              "descriptor"
+            ],
+            "type": "object"
+          },
+          "descriptor_sha256": {
+            "type": "string"
+          },
+          "schema_version": {
+            "const": "clio-kit.scientific-dataset-description.v1",
+            "default": "clio-kit.scientific-dataset-description.v1",
+            "type": "string"
+          },
+          "site_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "site_id",
+          "catalog_revision",
+          "catalog_sha256",
+          "dataset",
+          "descriptor_sha256"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "catalog",
+            "scientific-data",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Search operator-registered scientific datasets and return bounded intrinsic summaries.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "page_size": {
+            "default": 20,
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "query": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
+        },
+        "type": "object"
+      },
+      "name": "scientific_dataset_search",
+      "outputSchema": {
+        "additionalProperties": false,
+        "description": "Stable paginated response from scientific dataset search.",
+        "properties": {
+          "catalog_revision": {
+            "type": "string"
+          },
+          "catalog_sha256": {
+            "type": "string"
+          },
+          "datasets": {
+            "items": {
+              "additionalProperties": false,
+              "description": "Bounded discovery record returned by search.",
+              "properties": {
+                "dataset_fingerprint": {
+                  "type": "string"
+                },
+                "dataset_id": {
+                  "type": "string"
+                },
+                "descriptor_sha256": {
+                  "type": "string"
+                },
+                "first_timestep": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "format": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "last_timestep": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "member_count": {
+                  "type": "integer"
+                },
+                "summary": {
+                  "type": "string"
+                },
+                "tags": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "title": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "dataset_id",
+                "title",
+                "summary",
+                "tags",
+                "kind",
+                "format",
+                "member_count",
+                "first_timestep",
+                "last_timestep",
+                "dataset_fingerprint",
+                "descriptor_sha256"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema_version": {
+            "const": "clio-kit.scientific-dataset-search.v1",
+            "default": "clio-kit.scientific-dataset-search.v1",
+            "type": "string"
+          },
+          "site_id": {
+            "type": "string"
+          },
+          "total_matches": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "site_id",
+          "catalog_revision",
+          "catalog_sha256",
+          "datasets",
+          "total_matches",
+          "next_cursor"
+        ],
+        "type": "object"
+      }
+    }
+  ],
+  "wire_sha256": "55bd04f45653c9117b8a1ae41cbc5e79dd6383e86a851b43caa071ae357bb2c4"
+}

--- a/src/clio_relay/ci_validation.py
+++ b/src/clio_relay/ci_validation.py
@@ -2214,7 +2214,7 @@ def validate_release_acceptance_matrix(
         "command",
         "report_option",
     }
-    optional_report_fields = {"package", "remote_tool", "evidence_group"}
+    optional_report_fields = {"package", "remote_tool", "arguments", "evidence_group"}
     normalized_reports: list[dict[str, object]] = []
     report_ids: set[str] = set()
     for ordinal, raw in enumerate(reports, start=1):
@@ -2251,6 +2251,31 @@ def validate_release_acceptance_matrix(
             raise ProvenanceError(
                 f"release acceptance matrix report option is invalid: {report_id}"
             )
+        if "arguments" in report:
+            arguments = _mapping(report.get("arguments"), "matrix report arguments")
+            if len(arguments) > 64 or any(
+                not key or len(key) > 256 or re.fullmatch(r"[A-Za-z0-9_.-]+", key) is None
+                for key in arguments
+            ):
+                raise ProvenanceError(
+                    f"release acceptance matrix arguments are invalid: {report_id}"
+                )
+            try:
+                encoded_arguments = json.dumps(
+                    arguments,
+                    allow_nan=False,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+            except (TypeError, ValueError) as exc:
+                raise ProvenanceError(
+                    f"release acceptance matrix arguments are not finite JSON: {report_id}"
+                ) from exc
+            if len(encoded_arguments) > 64 * 1024:
+                raise ProvenanceError(
+                    f"release acceptance matrix arguments are too large: {report_id}"
+                )
         normalized_reports.append(
             {
                 "ordinal": ordinal,

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -1448,7 +1448,8 @@ def remote_mcp_register(
             help=(
                 "Optional audited semantic contract. Supported: clio-kit-spack-user-v2.1 "
                 "(current), clio-kit-spack-user-v2 (compatibility), "
-                "clio-kit-scientific-catalog-user-v1."
+                "clio-kit-scientific-catalog-user-v1.1 (current), "
+                "clio-kit-scientific-catalog-user-v1 (compatibility)."
             )
         ),
     ] = None,

--- a/src/clio_relay/cluster_config.py
+++ b/src/clio_relay/cluster_config.py
@@ -259,6 +259,7 @@ RemoteMcpProfile = Literal["user", "admin", "operator"]
 RemoteMcpContract = Literal[
     "clio-kit-spack-user-v2.1",
     "clio-kit-spack-user-v2",
+    "clio-kit-scientific-catalog-user-v1.1",
     "clio-kit-scientific-catalog-user-v1",
 ]
 

--- a/src/clio_relay/jarvis_mcp.py
+++ b/src/clio_relay/jarvis_mcp.py
@@ -23,14 +23,14 @@ from clio_relay.remote_mcp import (
 if TYPE_CHECKING:
     from clio_relay.installation import ComponentArtifactIdentity, InstallReceipt
 
-CLIO_KIT_JARVIS_MCP_VERSION = "2.5.10"
+CLIO_KIT_JARVIS_MCP_VERSION = "2.5.11"
 CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME = f"clio_kit-{CLIO_KIT_JARVIS_MCP_VERSION}-py3-none-any.whl"
 CLIO_KIT_JARVIS_MCP_WHEEL_URL = (
     "https://github.com/iowarp/clio-kit/releases/download/"
     f"v{CLIO_KIT_JARVIS_MCP_VERSION}/{CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME}"
 )
 CLIO_KIT_JARVIS_MCP_WHEEL_SHA256 = (
-    "4911142152f476f973caa0c7f8050d88e8efa5f803651bda88685836ee3232f5"
+    "a0a2bbf8d23495dd4f43881d35a47bfb83bc2d1c016bd952bd7a1c88a43ca03e"
 )
 CLIO_KIT_JARVIS_USER_CONTRACT_ID = "clio-kit-jarvis-user-v3.3"
 DEFAULT_JARVIS_MCP_COMMAND = [

--- a/src/clio_relay/remote_mcp.py
+++ b/src/clio_relay/remote_mcp.py
@@ -60,6 +60,7 @@ MAX_REMOTE_MCP_CACHE_ENTRIES = 1_024
 MAX_REMOTE_MCP_TOOLS_PER_SERVER = 2_048
 MAX_REMOTE_MCP_TOOL_SCHEMA_BYTES = 1024 * 1024
 MAX_REMOTE_MCP_PROVENANCE_BYTES = 1024 * 1024
+MAX_REMOTE_MCP_SCIENTIFIC_CATALOG_STRUCTURED_BYTES = 1024 * 1024
 MAX_REMOTE_MCP_JSON_DEPTH = 64
 MAX_REMOTE_MCP_JSON_NODES = 100_000
 MAX_REMOTE_MCP_DIAGNOSTIC_CHARS = 4_096
@@ -74,7 +75,7 @@ MAX_VIRTUAL_REMOTE_MCP_ALIAS_LENGTH = 64
 MAX_VIRTUAL_REMOTE_MCP_LOG_BYTES = 32_768
 REMOTE_MCP_REPLACE_ATTEMPTS = 25
 REMOTE_MCP_REPLACE_RETRY_SECONDS = 0.02
-CLIO_KIT_SPACK_USER_WHEEL_VERSION = "2.5.10"
+CLIO_KIT_SPACK_USER_WHEEL_VERSION = "2.5.11"
 CLIO_KIT_SPACK_USER_CONTRACT_ID = "clio-kit-spack-user-v2.1"
 CLIO_KIT_SPACK_USER_LEGACY_CONTRACT_ID = "clio-kit-spack-user-v2"
 CLIO_KIT_SPACK_USER_CONTRACT_IDS = frozenset(
@@ -117,9 +118,47 @@ CLIO_KIT_SPACK_USER_CONTRACT_ARTIFACT_BY_ID = {
 CLIO_KIT_SPACK_USER_CONTRACT_SHA256 = CLIO_KIT_SPACK_USER_CONTRACT_SHA256_BY_ID[
     CLIO_KIT_SPACK_USER_CONTRACT_ID
 ]
-CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ID = "clio-kit-scientific-catalog-user-v1"
+CLIO_KIT_SCIENTIFIC_CATALOG_USER_WHEEL_VERSION = "2.5.11"
+CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ID = "clio-kit-scientific-catalog-user-v1.1"
+CLIO_KIT_SCIENTIFIC_CATALOG_USER_LEGACY_CONTRACT_ID = "clio-kit-scientific-catalog-user-v1"
+CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_IDS = frozenset(
+    {
+        CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ID,
+        CLIO_KIT_SCIENTIFIC_CATALOG_USER_LEGACY_CONTRACT_ID,
+    }
+)
+CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256_BY_ID = {
+    CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ID: (
+        "80a9b583c26a084ff07d638ddf0c2c7d4325dbc8d4299931d0c4f3627cb8674c"
+    ),
+    CLIO_KIT_SCIENTIFIC_CATALOG_USER_LEGACY_CONTRACT_ID: (
+        "a53006f24f4698f659f0a7c8bf61fc7bd7ad23274b06d2eed2ccfca68b9ecb0a"
+    ),
+}
+CLIO_KIT_SCIENTIFIC_CATALOG_USER_WIRE_SHA256_BY_ID = {
+    CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ID: (
+        "1c8df94a298f92b92126c953a7b8124d90b2fa12919de93738a40e563c3eaa28"
+    ),
+    CLIO_KIT_SCIENTIFIC_CATALOG_USER_LEGACY_CONTRACT_ID: (
+        "55bd04f45653c9117b8a1ae41cbc5e79dd6383e86a851b43caa071ae357bb2c4"
+    ),
+}
+CLIO_KIT_SCIENTIFIC_CATALOG_USER_ARTIFACT_SHA256_BY_ID = {
+    CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ID: (
+        "29cbbfe64eaa7bcf29531b3d28762b8ff47e89d291b0a5b66119da96c790135e"
+    ),
+    CLIO_KIT_SCIENTIFIC_CATALOG_USER_LEGACY_CONTRACT_ID: (
+        "86097ef70d5b4e740a93ae0cdd0eb723cae1ac8898cfd8cbbc1911835cb22d56"
+    ),
+}
+CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ARTIFACT_BY_ID = {
+    CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ID: "scientific-catalog-user-v1.1.json",
+    CLIO_KIT_SCIENTIFIC_CATALOG_USER_LEGACY_CONTRACT_ID: ("scientific-catalog-user-v1.json"),
+}
 CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256 = (
-    "a53006f24f4698f659f0a7c8bf61fc7bd7ad23274b06d2eed2ccfca68b9ecb0a"
+    CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256_BY_ID[
+        CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ID
+    ]
 )
 _COMPOSED_SCHEMA_KEYS = {
     "$dynamicRef",
@@ -928,6 +967,16 @@ class RemoteMcpAcceptanceReport(BaseModel):
             )
             if result_check is not None:
                 call_metadata["structured_result_assertion"] = result_check.evidence
+            catalog_result_check = next(
+                (
+                    check
+                    for check in self.checks
+                    if check.name == "remote-mcp.scientific-catalog-result"
+                ),
+                None,
+            )
+            if catalog_result_check is not None:
+                call_metadata["scientific_catalog_result_assertion"] = catalog_result_check.evidence
             report.resources.append(
                 ValidationResource(
                     kind="relay_job",
@@ -997,7 +1046,15 @@ class RemoteMcpAcceptanceReport(BaseModel):
             None,
         )
         contract_check = next(
-            (check for check in self.checks if check.name == "remote-mcp.spack-user-contract"),
+            (
+                check
+                for check in self.checks
+                if check.name
+                in {
+                    "remote-mcp.spack-user-contract",
+                    "remote-mcp.scientific-catalog-user-contract",
+                }
+            ),
             None,
         )
         contract_metadata: JSON = {}
@@ -2085,6 +2142,24 @@ def build_remote_mcp_acceptance_report(
             build_remote_mcp_structured_result_check(
                 expectation=result_expectation,
                 remote_tool_name=remote_tool_name,
+                arguments=spec.get("arguments", {}),
+                protocol_result=protocol_result,
+                output_schema=output_schema,
+            )
+        )
+    if (
+        registration is not None
+        and registration.contract == CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ID
+        and remote_tool_name == "scientific_dataset_describe"
+    ):
+        matching_tools = (
+            [tool for tool in entry.tools if tool.name == remote_tool_name]
+            if entry is not None
+            else []
+        )
+        output_schema = matching_tools[0].output_schema if len(matching_tools) == 1 else None
+        checks.append(
+            _scientific_catalog_structured_result_check(
                 arguments=spec.get("arguments", {}),
                 protocol_result=protocol_result,
                 output_schema=output_schema,
@@ -3187,6 +3262,237 @@ def _structured_result_schema_evidence(
     return evidence
 
 
+def _scientific_catalog_structured_result_check(
+    *,
+    arguments: object,
+    protocol_result: JSON | None,
+    output_schema: JSON | None,
+) -> RemoteMcpAcceptanceCheck:
+    """Verify the v1.1 catalog describe result and explicit JARVIS handoff."""
+    failures: list[str] = []
+    typed_arguments = _as_json(arguments) or {}
+    structured_value = (
+        protocol_result.get("structuredContent") if protocol_result is not None else None
+    )
+    structured = _as_json(structured_value)
+    output_schema_evidence = _scientific_catalog_structured_schema_evidence(
+        output_schema=output_schema,
+        structured_value=structured_value,
+    )
+    structured_content_safe = (
+        output_schema_evidence["structured_content_bounded"] is True
+        and output_schema_evidence["structured_content_finite"] is True
+    )
+    if not structured_content_safe:
+        failures.append("structuredContent is not bounded finite JSON")
+    elif output_schema_evidence["schema_present"] is not True:
+        failures.append("cached tool outputSchema is absent")
+    elif output_schema_evidence["schema_valid"] is not True:
+        failures.append("cached tool outputSchema is invalid")
+    elif output_schema_evidence["structured_content_valid"] is not True:
+        failures.append("structuredContent does not satisfy the cached tool outputSchema")
+
+    requested_dataset_id = _bounded_catalog_identity(typed_arguments.get("dataset_id"))
+    dataset: JSON | None = None
+    dataset_descriptor: JSON | None = None
+    nested_descriptor: JSON | None = None
+    computed_descriptor_sha256: str | None = None
+    descriptor_digest_error: str | None = None
+    if requested_dataset_id is None:
+        failures.append("call arguments do not contain one bounded dataset_id")
+    if structured is None:
+        failures.append("protocol result has no structuredContent object")
+    elif structured_content_safe:
+        dataset = _as_json(structured.get("dataset"))
+        dataset_descriptor = _as_json(structured.get("dataset_descriptor"))
+        nested_descriptor = _as_json(dataset.get("descriptor")) if dataset is not None else None
+        if dataset_descriptor is not None:
+            try:
+                computed_descriptor_sha256 = _scientific_catalog_descriptor_sha256(
+                    dataset_descriptor
+                )
+            except (RecursionError, TypeError, ValueError) as exc:
+                descriptor_digest_error = _bounded_diagnostic(str(exc))
+                failures.append("dataset_descriptor is not canonical finite JSON")
+
+    response_schema_version = (
+        structured.get("schema_version")
+        if structured is not None and structured_content_safe
+        else None
+    )
+    descriptor_schema_version = (
+        dataset_descriptor.get("schema_version") if dataset_descriptor is not None else None
+    )
+    nested_descriptor_schema_version = (
+        nested_descriptor.get("schema_version") if nested_descriptor is not None else None
+    )
+    schema_versions_match = (
+        response_schema_version == "clio-kit.scientific-dataset-description.v1"
+        and descriptor_schema_version == "jarvis.dataset-descriptor.v1"
+        and nested_descriptor_schema_version == "jarvis.dataset-descriptor.v1"
+    )
+    if not schema_versions_match:
+        failures.append("catalog result or descriptor schema_version does not match v1.1")
+
+    dataset_id = _bounded_catalog_identity(
+        dataset.get("dataset_id") if dataset is not None else None
+    )
+    descriptor_dataset_id = _bounded_catalog_identity(
+        dataset_descriptor.get("dataset_id") if dataset_descriptor is not None else None
+    )
+    nested_descriptor_dataset_id = _bounded_catalog_identity(
+        nested_descriptor.get("dataset_id") if nested_descriptor is not None else None
+    )
+    dataset_identity_matches = (
+        requested_dataset_id is not None
+        and requested_dataset_id == dataset_id
+        and requested_dataset_id == descriptor_dataset_id
+        and requested_dataset_id == nested_descriptor_dataset_id
+    )
+    if not dataset_identity_matches:
+        failures.append(
+            "requested dataset_id does not match the catalog record and both descriptors"
+        )
+
+    descriptor_handoff_matches = (
+        dataset_descriptor is not None
+        and nested_descriptor is not None
+        and dataset_descriptor == nested_descriptor
+    )
+    if not descriptor_handoff_matches:
+        failures.append("dataset_descriptor does not equal dataset.descriptor")
+
+    observed_descriptor_sha256 = (
+        structured.get("descriptor_sha256") if structured is not None else None
+    )
+    descriptor_digest_matches = (
+        _is_sha256(observed_descriptor_sha256)
+        and observed_descriptor_sha256 == computed_descriptor_sha256
+    )
+    if not descriptor_digest_matches:
+        failures.append("descriptor_sha256 does not match the canonical dataset_descriptor")
+
+    passed = not failures
+    return RemoteMcpAcceptanceCheck(
+        name="remote-mcp.scientific-catalog-result",
+        passed=passed,
+        message=(
+            "scientific catalog result proves the exact JARVIS descriptor handoff"
+            if passed
+            else "scientific catalog result does not prove the exact JARVIS descriptor handoff"
+        ),
+        evidence={
+            "contract": CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ID,
+            "tool": "scientific_dataset_describe",
+            "requested_dataset_id": requested_dataset_id,
+            "dataset_id": dataset_id,
+            "descriptor_dataset_id": descriptor_dataset_id,
+            "nested_descriptor_dataset_id": nested_descriptor_dataset_id,
+            "response_schema_version": _bounded_optional_string(response_schema_version, 128),
+            "descriptor_schema_version": _bounded_optional_string(descriptor_schema_version, 128),
+            "nested_descriptor_schema_version": _bounded_optional_string(
+                nested_descriptor_schema_version, 128
+            ),
+            "schema_versions_match": schema_versions_match,
+            "dataset_identity_matches": dataset_identity_matches,
+            "dataset_descriptor_handoff_matches": descriptor_handoff_matches,
+            "descriptor_sha256": (
+                observed_descriptor_sha256 if _is_sha256(observed_descriptor_sha256) else None
+            ),
+            "computed_descriptor_sha256": computed_descriptor_sha256,
+            "descriptor_digest_matches": descriptor_digest_matches,
+            "descriptor_digest_error": descriptor_digest_error,
+            "output_schema": output_schema_evidence,
+            "failures": failures,
+        },
+    )
+
+
+def _scientific_catalog_structured_schema_evidence(
+    *,
+    output_schema: JSON | None,
+    structured_value: object,
+) -> JSON:
+    """Bound and reject non-finite catalog content before schema evaluation."""
+    guard_evidence: JSON = {
+        "structured_content_bounded": False,
+        "structured_content_finite": False,
+        "structured_content_bytes": None,
+        "structured_content_bytes_limit": (MAX_REMOTE_MCP_SCIENTIFIC_CATALOG_STRUCTURED_BYTES),
+        "structured_content_guard_error": None,
+        "schema_evaluated": False,
+    }
+    try:
+        _require_bounded_json_structure(
+            structured_value,
+            label="scientific catalog structuredContent",
+        )
+        guard_evidence["structured_content_bounded"] = True
+        _require_finite_json(
+            structured_value,
+            label="scientific catalog structuredContent",
+        )
+        guard_evidence["structured_content_finite"] = True
+        encoded = json.dumps(
+            structured_value,
+            allow_nan=False,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        guard_evidence["structured_content_bytes"] = len(encoded)
+        if len(encoded) > MAX_REMOTE_MCP_SCIENTIFIC_CATALOG_STRUCTURED_BYTES:
+            guard_evidence["structured_content_bounded"] = False
+            raise ValueError(
+                "remote MCP scientific catalog structuredContent exceeds "
+                f"{MAX_REMOTE_MCP_SCIENTIFIC_CATALOG_STRUCTURED_BYTES} bytes"
+            )
+    except (RecursionError, TypeError, ValueError) as exc:
+        guard_evidence["structured_content_guard_error"] = _bounded_diagnostic(str(exc))
+        return {
+            "schema_present": output_schema is not None,
+            "schema_valid": False,
+            "schema_sha256": None,
+            "structured_content_valid": False,
+            "validation_errors": [guard_evidence["structured_content_guard_error"]],
+            "validation_errors_truncated": False,
+            **guard_evidence,
+        }
+    schema_evidence = _structured_result_schema_evidence(
+        output_schema=output_schema,
+        structured_value=structured_value,
+    )
+    guard_evidence["schema_evaluated"] = True
+    return {
+        **schema_evidence,
+        **guard_evidence,
+    }
+
+
+def _scientific_catalog_descriptor_sha256(descriptor: JSON) -> str:
+    """Hash a descriptor with the exact canonical JSON used by clio-kit."""
+    payload = json.dumps(
+        descriptor,
+        allow_nan=False,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _bounded_catalog_identity(value: object) -> str | None:
+    """Return one bounded printable catalog identity for release evidence."""
+    if (
+        not isinstance(value, str)
+        or not 1 <= len(value) <= 256
+        or not value.strip()
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        return None
+    return value
+
+
 def _validate_spack_find_result(
     structured: JSON,
     arguments: JSON,
@@ -3521,6 +3827,10 @@ def _scientific_catalog_user_contract_check(
         set(registration.allow_tools) if registration is not None else set()
     )
     observed_contract_digest = remote_mcp_schema_digest(list(tools.values()))
+    declared_contract = registration.contract if registration is not None else None
+    expected_contract_digest = CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256_BY_ID.get(
+        declared_contract or ""
+    )
 
     annotation_matches: dict[str, bool] = {}
     expected_annotations = {
@@ -3566,10 +3876,31 @@ def _scientific_catalog_user_contract_check(
     describe_output_properties = (
         _as_json(describe_output.get("properties")) if describe_output is not None else None
     ) or {}
+    describe_output_required_value: object = (
+        describe_output.get("required", []) if describe_output is not None else []
+    )
+    describe_output_required = (
+        cast(list[object], describe_output_required_value)
+        if isinstance(describe_output_required_value, list)
+        else []
+    )
     dataset_schema = _as_json(describe_output_properties.get("dataset")) or {}
     dataset_properties = _as_json(dataset_schema.get("properties")) or {}
     descriptor_schema = _as_json(dataset_properties.get("descriptor")) or {}
     descriptor_properties = _as_json(descriptor_schema.get("properties")) or {}
+    handoff_descriptor_schema = _as_json(describe_output_properties.get("dataset_descriptor")) or {}
+    descriptor_handoff_required = declared_contract == CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ID
+    descriptor_handoff_matches: bool | None = (
+        "dataset_descriptor" in describe_output_required
+        and handoff_descriptor_schema == descriptor_schema
+        if descriptor_handoff_required
+        else None
+    )
+    descriptor_handoff_accepted = (
+        descriptor_handoff_matches is True
+        if descriptor_handoff_required
+        else declared_contract == CLIO_KIT_SCIENTIFIC_CATALOG_USER_LEGACY_CONTRACT_ID
+    )
     describe_output_matches = (
         describe_output is not None
         and describe_output.get("type") == "object"
@@ -3584,6 +3915,7 @@ def _scientific_catalog_user_contract_check(
         and descriptor_schema.get("additionalProperties") is False
         and _as_json(descriptor_properties.get("schema_version"))
         == {"const": "jarvis.dataset-descriptor.v1", "type": "string"}
+        and descriptor_handoff_accepted
     )
 
     search_output = search.output_schema if search is not None else None
@@ -3615,11 +3947,11 @@ def _scientific_catalog_user_contract_check(
         actual_names == expected_names
         and allowlisted_names == expected_names
         and registration is not None
-        and registration.contract == CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ID
+        and registration.contract in CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_IDS
         and "user" in registration.profiles
         and all(annotation_matches.values())
         and all(schema_matches.values())
-        and observed_contract_digest == CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256
+        and observed_contract_digest == expected_contract_digest
     )
     return RemoteMcpAcceptanceCheck(
         name="remote-mcp.scientific-catalog-user-contract",
@@ -3634,11 +3966,24 @@ def _scientific_catalog_user_contract_check(
             "remote_tool_names": sorted(actual_names),
             "allowlisted_tool_names": sorted(allowlisted_names),
             "profiles": registration.profiles if registration is not None else [],
-            "declared_contract": registration.contract if registration is not None else None,
+            "declared_contract": declared_contract,
             "annotations_match": annotation_matches,
             "schemas_match": schema_matches,
-            "expected_contract_sha256": CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256,
-            "expected_clio_kit_version": CLIO_KIT_SPACK_USER_WHEEL_VERSION,
+            "dataset_descriptor_handoff_required": descriptor_handoff_required,
+            "dataset_descriptor_handoff_matches": descriptor_handoff_matches,
+            "expected_contract_sha256": expected_contract_digest,
+            "expected_wire_sha256": (
+                CLIO_KIT_SCIENTIFIC_CATALOG_USER_WIRE_SHA256_BY_ID.get(declared_contract or "")
+            ),
+            "expected_contract_artifact": (
+                CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ARTIFACT_BY_ID.get(
+                    declared_contract or ""
+                )
+            ),
+            "expected_contract_artifact_sha256": (
+                CLIO_KIT_SCIENTIFIC_CATALOG_USER_ARTIFACT_SHA256_BY_ID.get(declared_contract or "")
+            ),
+            "expected_clio_kit_version": (CLIO_KIT_SCIENTIFIC_CATALOG_USER_WHEEL_VERSION),
             "observed_contract_sha256": observed_contract_digest,
         },
     )
@@ -3651,7 +3996,7 @@ def _declared_contract_check(
     """Evaluate the semantic contract explicitly declared by an operator."""
     if registration.contract in CLIO_KIT_SPACK_USER_CONTRACT_IDS:
         return _spack_user_contract_check(entry, registration)
-    if registration.contract == CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ID:
+    if registration.contract in CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_IDS:
         return _scientific_catalog_user_contract_check(entry, registration)
     raise ValueError(f"unsupported remote MCP semantic contract: {registration.contract}")
 

--- a/tests/test_ci_clio_kit_wheel.py
+++ b/tests/test_ci_clio_kit_wheel.py
@@ -13,18 +13,24 @@ from clio_relay.jarvis_mcp import (
     CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
     CLIO_KIT_JARVIS_MCP_WHEEL_URL,
 )
+from clio_relay.remote_mcp import (
+    CLIO_KIT_SCIENTIFIC_CATALOG_USER_WHEEL_VERSION,
+    CLIO_KIT_SPACK_USER_WHEEL_VERSION,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
-WHEEL_FILENAME = "clio_kit-2.5.10-py3-none-any.whl"
-WHEEL_SHA256 = "4911142152f476f973caa0c7f8050d88e8efa5f803651bda88685836ee3232f5"
-WHEEL_URL = f"https://github.com/iowarp/clio-kit/releases/download/v2.5.10/{WHEEL_FILENAME}"
+WHEEL_FILENAME = "clio_kit-2.5.11-py3-none-any.whl"
+WHEEL_SHA256 = "a0a2bbf8d23495dd4f43881d35a47bfb83bc2d1c016bd952bd7a1c88a43ca03e"
+WHEEL_URL = f"https://github.com/iowarp/clio-kit/releases/download/v2.5.11/{WHEEL_FILENAME}"
 
 
 def test_runtime_and_ci_share_one_exact_clio_kit_release_pin() -> None:
     """Keep bootstrap, JARVIS MCP, and CI on the same exact release wheel bytes."""
-    assert CLIO_KIT_JARVIS_MCP_VERSION == "2.5.10"
+    assert CLIO_KIT_JARVIS_MCP_VERSION == "2.5.11"
+    assert CLIO_KIT_SPACK_USER_WHEEL_VERSION == "2.5.11"
+    assert CLIO_KIT_SCIENTIFIC_CATALOG_USER_WHEEL_VERSION == "2.5.11"
     assert CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME == WHEEL_FILENAME
     assert CLIO_KIT_JARVIS_MCP_WHEEL_SHA256 == WHEEL_SHA256
     assert CLIO_KIT_JARVIS_MCP_WHEEL_URL == WHEEL_URL

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1679,24 +1679,27 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     )
     raw_matrix = json.loads(matrix_path.read_text(encoding="utf-8"))
     raw_reports = cast(list[dict[str, object]], raw_matrix["reports"])
-    assert [item["id"] for item in raw_reports[5:8]] == [
+    assert raw_reports[5]["id"] == "ares-scientific-catalog-describe"
+    assert raw_reports[5]["remote_tool"] == "scientific_dataset_describe"
+    assert raw_reports[5]["arguments"] == {"dataset_id": "deep-water-impact-2018-yb31-first5"}
+    assert [item["id"] for item in raw_reports[6:9]] == [
         "ares-spack-find",
         "ares-spack-locate",
         "ares-spack-install",
     ]
-    assert [item["evidence_group"] for item in raw_reports[5:8]] == [
+    assert [item["evidence_group"] for item in raw_reports[6:9]] == [
         "spack",
         "spack",
         "spack-fresh",
     ]
-    assert [item["package"] for item in raw_reports[5:8]] == [
+    assert [item["package"] for item in raw_reports[6:9]] == [
         "lammps",
         "lammps",
         "libsigsegv@2.14",
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "51ad060c4f2d806d5483a875c0a65374f2b29e3ca5e1c88e3f7ac7716df90509"
+        "2c760f9cc33077d6f4e584fde49d93d2c2300ea2312adb281a4aff2a6b96ce25"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]
@@ -1713,7 +1716,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
 
     binding = cast(dict[str, object], manifest["acceptance_matrix"])
     assert binding["sha256"] == matrix["matrix_sha256"]
-    assert binding["report_count"] == 17
+    assert binding["report_count"] == 18
     manifest_assets = cast(list[dict[str, object]], manifest["assets"])
     assert [cast(str, item["name"]) for item in manifest_assets] == [
         "validation-local.json",

--- a/tests/test_clio_kit_mcp_contracts.py
+++ b/tests/test_clio_kit_mcp_contracts.py
@@ -36,7 +36,12 @@ from clio_relay.jarvis_mcp import (
     jarvis_user_contract,
 )
 from clio_relay.remote_mcp import (
+    CLIO_KIT_SCIENTIFIC_CATALOG_USER_ARTIFACT_SHA256_BY_ID,
+    CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ARTIFACT_BY_ID,
+    CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ID,
     CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256,
+    CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256_BY_ID,
+    CLIO_KIT_SCIENTIFIC_CATALOG_USER_WIRE_SHA256_BY_ID,
     CLIO_KIT_SPACK_USER_ARTIFACT_SHA256_BY_ID,
     CLIO_KIT_SPACK_USER_CONTRACT_ARTIFACT_BY_ID,
     CLIO_KIT_SPACK_USER_CONTRACT_ID,
@@ -120,10 +125,21 @@ EXPECTED_CONTRACTS = {
         "contract_sha256": CLIO_KIT_SPACK_USER_CONTRACT_SHA256,
         "tool_names": {"spack_find", "spack_install", "spack_locate"},
     },
+    "clio-kit-scientific-catalog-user-v1.1": {
+        "server_name": "scientific-catalog",
+        "artifact": "scientific-catalog-user-v1.1.json",
+        "contract_sha256": CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256,
+        "tool_names": {
+            "scientific_dataset_describe",
+            "scientific_dataset_search",
+        },
+    },
     "clio-kit-scientific-catalog-user-v1": {
         "server_name": "scientific-catalog",
         "artifact": "scientific-catalog-user-v1.json",
-        "contract_sha256": CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256,
+        "contract_sha256": CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256_BY_ID[
+            "clio-kit-scientific-catalog-user-v1"
+        ],
         "tool_names": {
             "scientific_dataset_describe",
             "scientific_dataset_search",
@@ -182,6 +198,7 @@ ACTIVE_CONTRACT_IDS = frozenset(EXPECTED_CONTRACTS) - {
     "clio-kit-jarvis-user-v3",
     "clio-kit-jarvis-user-v3.1",
     "clio-kit-jarvis-user-v3.2",
+    "clio-kit-scientific-catalog-user-v1",
     "clio-kit-spack-user-v2",
 }
 UV_TOOL_PROBE_VERSION = "0.0.0"
@@ -406,7 +423,9 @@ def test_relay_contract_pins_match_clio_kit_wheel_artifacts(
     legacy_spack_tools = _tools_by_name(shipped_contracts["clio-kit-spack-user-v2"])
     assert set(legacy_spack_tools) == set(spack_tools)
 
-    scientific_tools = _tools_by_name(shipped_contracts["clio-kit-scientific-catalog-user-v1"])
+    scientific_tools = _tools_by_name(
+        shipped_contracts[CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ID]
+    )
     assert set(scientific_tools) == {
         "scientific_dataset_describe",
         "scientific_dataset_search",
@@ -415,6 +434,16 @@ def test_relay_contract_pins_match_clio_kit_wheel_artifacts(
         cast(JSON, tool["annotations"])["readOnlyHint"] is True
         for tool in scientific_tools.values()
     )
+    describe_output = cast(JSON, scientific_tools["scientific_dataset_describe"]["outputSchema"])
+    describe_properties = cast(JSON, describe_output["properties"])
+    dataset_properties = cast(JSON, cast(JSON, describe_properties["dataset"])["properties"])
+    assert "dataset_descriptor" in cast(list[str], describe_output["required"])
+    assert describe_properties["dataset_descriptor"] == dataset_properties["descriptor"]
+
+    legacy_scientific_tools = _tools_by_name(
+        shipped_contracts["clio-kit-scientific-catalog-user-v1"]
+    )
+    assert set(legacy_scientific_tools) == set(scientific_tools)
 
 
 @pytest.mark.parametrize("contract_id", sorted(CLIO_KIT_SPACK_USER_CONTRACT_SHA256_BY_ID))
@@ -433,6 +462,38 @@ def test_relay_vendors_exact_spack_contract_artifacts(contract_id: str) -> None:
     assert artifact["contract_id"] == contract_id
     assert artifact["contract_sha256"] == CLIO_KIT_SPACK_USER_CONTRACT_SHA256_BY_ID[contract_id]
     assert artifact["wire_sha256"] == CLIO_KIT_SPACK_USER_WIRE_SHA256_BY_ID[contract_id]
+    assert (
+        hashlib.sha256(_canonical_json(_contract_projection(tools))).hexdigest()
+        == artifact["contract_sha256"]
+    )
+    assert hashlib.sha256(_canonical_json({"tools": tools})).hexdigest() == artifact["wire_sha256"]
+
+
+@pytest.mark.parametrize(
+    "contract_id", sorted(CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256_BY_ID)
+)
+def test_relay_vendors_exact_scientific_catalog_contract_artifacts(
+    contract_id: str,
+) -> None:
+    """Keep current and compatibility catalog artifacts immutable in relay wheels."""
+    artifact_name = CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ARTIFACT_BY_ID[contract_id]
+    path = Path(remote_mcp.__file__).with_name("_contracts") / artifact_name
+    payload = path.read_bytes()
+    artifact = _json_object(payload, label=contract_id)
+    tools = cast(list[JSON], artifact["tools"])
+
+    assert (
+        hashlib.sha256(payload).hexdigest()
+        == CLIO_KIT_SCIENTIFIC_CATALOG_USER_ARTIFACT_SHA256_BY_ID[contract_id]
+    )
+    assert artifact["contract_id"] == contract_id
+    assert (
+        artifact["contract_sha256"]
+        == CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256_BY_ID[contract_id]
+    )
+    assert (
+        artifact["wire_sha256"] == CLIO_KIT_SCIENTIFIC_CATALOG_USER_WIRE_SHA256_BY_ID[contract_id]
+    )
     assert (
         hashlib.sha256(_canonical_json(_contract_projection(tools))).hexdigest()
         == artifact["contract_sha256"]

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -32,7 +32,7 @@ def _matrix_reports() -> list[dict[str, object]]:
         dict[str, object],
         json.loads((FIXTURES / "report-matrix-1.0.json").read_text(encoding="utf-8")),
     )
-    assert document["report_count_per_stage"] == 17
+    assert document["report_count_per_stage"] == 18
     return cast(list[dict[str, object]], document["reports"])
 
 
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.29"
+    assert version == "1.3.30"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version
@@ -502,8 +502,8 @@ def test_gray_scott_helper_fails_closed_on_spack_and_config_discovery_errors(
 def test_release_acceptance_matrix_is_complete_ordered_and_unique() -> None:
     reports = _matrix_reports()
 
-    assert [report["ordinal"] for report in reports] == list(range(1, 18))
-    assert len({cast(str, report["id"]) for report in reports}) == 17
+    assert [report["ordinal"] for report in reports] == list(range(1, 19))
+    assert len({cast(str, report["id"]) for report in reports}) == 18
     assert reports[2]["id"] == "ares-queue-management"
     assert all(
         cast(int, report["ordinal"]) > 3
@@ -518,17 +518,35 @@ def test_release_acceptance_matrix_is_complete_ordered_and_unique() -> None:
         "builtin.lammps",
     ]
     assert [report.get("remote_tool") for report in reports if "remote_tool" in report] == [
+        "scientific_dataset_describe",
         "spack_find",
         "spack_locate",
         "spack_install",
     ]
+    catalog = next(
+        report for report in reports if report["id"] == "ares-scientific-catalog-describe"
+    )
+    assert catalog["arguments"] == {"dataset_id": "deep-water-impact-2018-yb31-first5"}
 
 
 def test_release_acceptance_upload_checks_derive_matrix_cardinality() -> None:
     runbook = RUNBOOK.read_text(encoding="utf-8")
 
-    assert "-ne 17" not in runbook
+    assert "-ne 18" not in runbook
     assert runbook.count("-ne $Matrix.report_count_per_stage") >= 3
+
+
+def test_release_acceptance_runs_released_catalog_v11_descriptor_proof() -> None:
+    """The operator runbook registers, refreshes, and validates the catalog handoff."""
+    runbook = RUNBOOK.read_text(encoding="utf-8")
+
+    assert "CLIO_RELAY_VALIDATION_ARES_SCIENTIFIC_CATALOG_FILE" in runbook
+    assert "--contract clio-kit-scientific-catalog-user-v1.1" in runbook
+    assert "remote-mcp refresh --cluster $AresCluster --name scientific-catalog" in runbook
+    assert 'Invoke-RelayReport -Id "ares-scientific-catalog-describe"' in runbook
+    assert '"--tool", "scientific_dataset_describe"' in runbook
+    assert 'dataset_id = "deep-water-impact-2018-yb31-first5"' in runbook
+    assert "concrete Ares release evidence, not as a" in runbook
 
 
 def test_release_acceptance_matrix_preserves_evidence_groups() -> None:

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -337,11 +337,11 @@ def test_jarvis_release_requirement_enforces_unified_gray_scott_contract() -> No
         if resource["kind"] == "relay_worker"
     )
     clio_kit_component = worker["metadata_equals"]["component_artifacts"]["clio-kit"]
-    assert clio_kit_component["distribution_version"] == "2.5.10"
+    assert clio_kit_component["distribution_version"] == "2.5.11"
     assert clio_kit_component["persistent_tool"]["manager"] == "uv"
     assert clio_kit_component["persistent_tool"]["uv_version"] == "0.11.28"
     assert clio_kit_component["persistent_tool"]["source_artifact_sha256"] == (
-        "4911142152f476f973caa0c7f8050d88e8efa5f803651bda88685836ee3232f5"
+        "a0a2bbf8d23495dd4f43881d35a47bfb83bc2d1c016bd952bd7a1c88a43ca03e"
     )
     native_execution = clio_kit_component["native_execution"]
     assert native_execution["contract_id"] == "clio-kit-jarvis-user-v3.3"
@@ -408,6 +408,54 @@ def test_jarvis_release_requirement_enforces_unified_gray_scott_contract() -> No
         == "c35f531e386cc9a5e728c1c67c1902b08e0776f07d95bdfb13c33cb00550310a"
     )
     assert lammps.get("evidence_group_resource_kind") is None
+
+    catalog = requirements["ares-non-jarvis-virtual-mcp"]
+    assert "remote-mcp.scientific-catalog-user-contract" in catalog["required_checks"]
+    assert "remote-mcp.scientific-catalog-result" in catalog["required_checks"]
+    catalog_call = next(
+        resource
+        for resource in cast(list[dict[str, Any]], catalog["required_resources"])
+        if resource["kind"] == "relay_job"
+    )
+    catalog_call_metadata = catalog_call["metadata_equals"]
+    assert catalog_call_metadata["remote_mcp_server_name"] == "scientific-catalog"
+    assert catalog_call_metadata["remote_mcp_tool_name"] == "scientific_dataset_describe"
+    assert catalog_call_metadata["spec"]["arguments"] == {
+        "dataset_id": "deep-water-impact-2018-yb31-first5"
+    }
+    assert catalog_call_metadata["scientific_catalog_result_assertion"] == {
+        "contract": "clio-kit-scientific-catalog-user-v1.1",
+        "tool": "scientific_dataset_describe",
+        "requested_dataset_id": "deep-water-impact-2018-yb31-first5",
+        "dataset_id": "deep-water-impact-2018-yb31-first5",
+        "descriptor_dataset_id": "deep-water-impact-2018-yb31-first5",
+        "nested_descriptor_dataset_id": "deep-water-impact-2018-yb31-first5",
+        "schema_versions_match": True,
+        "dataset_identity_matches": True,
+        "dataset_descriptor_handoff_matches": True,
+        "descriptor_digest_matches": True,
+    }
+    catalog_server = next(
+        resource
+        for resource in cast(list[dict[str, Any]], catalog["required_resources"])
+        if resource["kind"] == "mcp_server"
+    )
+    assert catalog_server["metadata_equals"]["server_name"] == "scientific-catalog"
+    assert catalog_server["metadata_equals"]["remote_tool_names"] == [
+        "scientific_dataset_describe",
+        "scientific_dataset_search",
+    ]
+    assert catalog_server["metadata_equals"]["allowlisted_tool_names"] == [
+        "scientific_dataset_describe",
+        "scientific_dataset_search",
+    ]
+    assert catalog_server["metadata_equals"]["contract_id"] == (
+        "clio-kit-scientific-catalog-user-v1.1"
+    )
+    assert catalog_server["metadata_equals"]["contract_sha256"] == (
+        "80a9b583c26a084ff07d638ddf0c2c7d4325dbc8d4299931d0c4f3627cb8674c"
+    )
+    assert catalog["evidence_group_resource_kind"] == "mcp_server"
 
     spack = requirements["ares-spack-virtual-mcp"]
     assert spack["evidence_group_resource_kind"] == "mcp_server"
@@ -510,7 +558,7 @@ def test_spack_release_requirements_split_existing_resolution_from_fresh_install
     )
     assert fresh_server["metadata_equals"]["server_name"] == "spack-fresh"
     assert fresh_server["metadata_equals"]["install_artifact_sha256"] == (
-        "4911142152f476f973caa0c7f8050d88e8efa5f803651bda88685836ee3232f5"
+        "a0a2bbf8d23495dd4f43881d35a47bfb83bc2d1c016bd952bd7a1c88a43ca03e"
     )
     assert fresh_server["metadata_equals"]["contract_id"] == "clio-kit-spack-user-v2.1"
     assert fresh_server["metadata_equals"]["contract_sha256"] == (
@@ -989,16 +1037,16 @@ def test_release_seals_decisions_and_claims_bind_the_exact_matrix() -> None:
     assert '"acceptance_matrix": matrix_binding' in candidate
     assert 'matrix_report_count = matrix_binding.get("report_count")' in candidate
     assert "len(expected_reports) != matrix_report_count" in candidate
-    assert 'matrix_binding.get("report_count") != 17' not in candidate
+    assert 'matrix_binding.get("report_count") != 18' not in candidate
     assert 'decision.get("acceptance_report_ids") == expected_ids' in gate
     assert '"acceptance_matrix": matrix_binding' in released
     assert 'matrix_report_count = matrix_binding.get("report_count")' in released
     assert "len(expected_reports) != matrix_report_count" in released
-    assert 'matrix_binding.get("report_count") != 17' not in released
+    assert 'matrix_binding.get("report_count") != 18' not in released
     assert "candidate-to-released matrix binding failed" in released
     assert 'matrix_report_count = matrix.get("report_count")' in finalization
     assert "len(expected_reports) == matrix_report_count" in finalization
-    assert 'matrix.get("report_count") == 17' not in finalization
+    assert 'matrix.get("report_count") == 18' not in finalization
     assert '"ordered_report_ids": released_matrix_ids' in finalization
     assert '"ordered_report_document_ids": ordered_document_ids' in finalization
 

--- a/tests/test_remote_mcp.py
+++ b/tests/test_remote_mcp.py
@@ -88,9 +88,14 @@ def test_remote_mcp_registration_is_deny_by_default_and_validated() -> None:
         command="clio-kit",
         allow_tools=["scientific_dataset_search", "scientific_dataset_describe"],
         profiles=["user"],
+        contract="clio-kit-scientific-catalog-user-v1.1",
+    )
+    legacy_catalog_registration = RemoteMcpServerConfig(
+        command="clio-kit",
         contract="clio-kit-scientific-catalog-user-v1",
     )
-    assert catalog_registration.contract == "clio-kit-scientific-catalog-user-v1"
+    assert catalog_registration.contract == "clio-kit-scientific-catalog-user-v1.1"
+    assert legacy_catalog_registration.contract == "clio-kit-scientific-catalog-user-v1"
 
     current_spack_registration = RemoteMcpServerConfig(
         command="clio-kit",
@@ -147,8 +152,16 @@ def test_remote_mcp_registration_is_deny_by_default_and_validated() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    "contract_id",
+    [
+        "clio-kit-scientific-catalog-user-v1.1",
+        "clio-kit-scientific-catalog-user-v1",
+    ],
+)
 def test_scientific_catalog_contract_is_read_only_and_exact(
     monkeypatch: MonkeyPatch,
+    contract_id: str,
 ) -> None:
     """The released catalog contract must be registrable and fail closed on drift."""
     expected_names = ["scientific_dataset_describe", "scientific_dataset_search"]
@@ -163,9 +176,9 @@ def test_scientific_catalog_contract_is_read_only_and_exact(
         ],
         allow_tools=expected_names,
         profiles=["user"],
-        contract="clio-kit-scientific-catalog-user-v1",
+        contract=cast(Any, contract_id),
     )
-    tools = [_scientific_catalog_tool(name) for name in expected_names]
+    tools = [_scientific_catalog_tool(name, contract_id=contract_id) for name in expected_names]
     entry = _entry(
         registration,
         cluster="alpha",
@@ -174,8 +187,11 @@ def test_scientific_catalog_contract_is_read_only_and_exact(
     )
     monkeypatch.setattr(
         remote_mcp,
-        "CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256",
-        entry.schema_digest,
+        "CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256_BY_ID",
+        {
+            **remote_mcp.CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256_BY_ID,
+            contract_id: entry.schema_digest,
+        },
     )
 
     exact = remote_mcp._declared_contract_check(  # pyright: ignore[reportPrivateUsage]
@@ -186,6 +202,13 @@ def test_scientific_catalog_contract_is_read_only_and_exact(
     assert exact.name == "remote-mcp.scientific-catalog-user-contract"
     assert exact.evidence["remote_tool_names"] == expected_names
     assert exact.evidence["allowlisted_tool_names"] == expected_names
+    assert exact.evidence["declared_contract"] == contract_id
+    if contract_id == "clio-kit-scientific-catalog-user-v1.1":
+        assert exact.evidence["dataset_descriptor_handoff_required"] is True
+        assert exact.evidence["dataset_descriptor_handoff_matches"] is True
+    else:
+        assert exact.evidence["dataset_descriptor_handoff_required"] is False
+        assert exact.evidence["dataset_descriptor_handoff_matches"] is None
 
     drifted_tools = deepcopy(tools)
     cast(dict[str, object], drifted_tools[1]["annotations"])["openWorldHint"] = True
@@ -197,8 +220,11 @@ def test_scientific_catalog_contract_is_read_only_and_exact(
     )
     monkeypatch.setattr(
         remote_mcp,
-        "CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256",
-        drifted_entry.schema_digest,
+        "CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256_BY_ID",
+        {
+            **remote_mcp.CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256_BY_ID,
+            contract_id: drifted_entry.schema_digest,
+        },
     )
 
     drifted = remote_mcp._declared_contract_check(  # pyright: ignore[reportPrivateUsage]
@@ -210,6 +236,321 @@ def test_scientific_catalog_contract_is_read_only_and_exact(
         "scientific_dataset_describe": True,
         "scientific_dataset_search": False,
     }
+
+
+def test_current_scientific_catalog_contract_requires_explicit_handoff(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The v1.1 declaration cannot pass with the ambiguous historical output shape."""
+    contract_id = "clio-kit-scientific-catalog-user-v1.1"
+    expected_names = ["scientific_dataset_describe", "scientific_dataset_search"]
+    registration = RemoteMcpServerConfig(
+        command="uvx",
+        args=[
+            "--from",
+            "/opt/wheels/clio_kit-2.5.11-py3-none-any.whl",
+            "clio-kit",
+            "mcp-server",
+            "scientific-catalog",
+        ],
+        allow_tools=expected_names,
+        profiles=["user"],
+        contract=contract_id,
+    )
+    tools = [
+        _scientific_catalog_tool(
+            name,
+            contract_id="clio-kit-scientific-catalog-user-v1",
+        )
+        for name in expected_names
+    ]
+    entry = _entry(
+        registration,
+        cluster="alpha",
+        server_name="scientific-catalog",
+        tools=tools,
+    )
+    monkeypatch.setattr(
+        remote_mcp,
+        "CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256_BY_ID",
+        {
+            **remote_mcp.CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_SHA256_BY_ID,
+            contract_id: entry.schema_digest,
+        },
+    )
+
+    check = remote_mcp._declared_contract_check(  # pyright: ignore[reportPrivateUsage]
+        entry, registration
+    )
+
+    assert check.passed is False
+    assert check.evidence["dataset_descriptor_handoff_matches"] is False
+
+
+def test_scientific_catalog_contract_projects_identity_to_live_report() -> None:
+    """A live describe call proves and projects the v1.1 descriptor handoff."""
+    contract_id = "clio-kit-scientific-catalog-user-v1.1"
+    contract_sha256 = "80a9b583c26a084ff07d638ddf0c2c7d4325dbc8d4299931d0c4f3627cb8674c"
+    dataset_id = "deep-water-impact-2018-yb31-first5"
+    registration = RemoteMcpServerConfig(
+        command="uvx",
+        args=[
+            "--from",
+            "/opt/wheels/clio_kit-2.5.11-py3-none-any.whl",
+            "clio-kit",
+            "mcp-server",
+            "scientific-catalog",
+        ],
+        allow_tools=["scientific_dataset_describe", "scientific_dataset_search"],
+        profiles=["user"],
+        contract=contract_id,
+    )
+    contract_artifact = json.loads(
+        (
+            Path(remote_mcp.__file__).with_name("_contracts") / "scientific-catalog-user-v1.1.json"
+        ).read_text(encoding="utf-8")
+    )
+    tools = cast(list[dict[str, object]], contract_artifact["tools"])
+    entry = _entry(
+        registration,
+        cluster="alpha",
+        server_name="scientific-catalog",
+        tools=tools,
+    )
+    registry = ClusterRegistry(
+        clusters={"alpha": _cluster("alpha", {"scientific-catalog": registration})}
+    )
+    server_artifact = _server_artifact(registration)
+    server_artifact_digest = remote_mcp_server_artifact_digest(server_artifact)
+    job_id = "job_catalog_describe"
+    arguments = {"dataset_id": dataset_id}
+    job: dict[str, object] = {
+        "job_id": job_id,
+        "cluster": "alpha",
+        "kind": "mcp_call",
+        "state": "succeeded",
+        "spec": {
+            "server": registration.command,
+            "server_args": registration.args,
+            "env_from": {},
+            "operation": "tools/call",
+            "tool": "scientific_dataset_describe",
+            "arguments": arguments,
+            "expected_server_artifact_digest": server_artifact_digest,
+        },
+    }
+    structured = _scientific_catalog_describe_result(dataset_id)
+    acceptance = build_remote_mcp_acceptance_report(
+        registry=registry,
+        cache=RemoteMcpSchemaCache(entries=[entry]),
+        cluster="alpha",
+        server_name="scientific-catalog",
+        remote_tool_name="scientific_dataset_describe",
+        profile="user",
+        call_job_id=job_id,
+        call_status={"job": job, "terminal": True},
+        artifacts=[
+            {
+                "artifact_id": f"artifact_{kind}",
+                "job_id": job_id,
+                "kind": kind,
+                "sha256": hashlib.sha256(kind.encode()).hexdigest(),
+            }
+            for kind in ("stdout", "stderr", "mcp_result", "provenance")
+        ],
+        mcp_result={
+            "server": registration.command,
+            "server_args": registration.args,
+            "env_from": {},
+            "operation": "tools/call",
+            "tool": "scientific_dataset_describe",
+            "arguments": arguments,
+            "returncode": 0,
+            "protocol_result": {"structuredContent": structured},
+            "server_artifact": server_artifact,
+            "expected_server_artifact_digest": server_artifact_digest,
+            "observed_server_artifact_digest": server_artifact_digest,
+            "protocol_error": None,
+        },
+        provenance={"job": job},
+        now=NOW,
+    )
+
+    assert acceptance.passed is True
+    catalog_result = next(
+        check for check in acceptance.checks if check.name == "remote-mcp.scientific-catalog-result"
+    )
+    assert catalog_result.passed is True
+    assert catalog_result.evidence["dataset_descriptor_handoff_matches"] is True
+    assert catalog_result.evidence["descriptor_digest_matches"] is True
+    report = acceptance.to_live_validation_report()
+
+    server_resource = next(
+        resource for resource in report.resources if resource.kind == "mcp_server"
+    )
+    assert server_resource.metadata["contract_id"] == contract_id
+    assert server_resource.metadata["contract_sha256"] == contract_sha256
+    call_resource = next(
+        resource for resource in report.resources if resource.role == "virtual_remote_mcp_call"
+    )
+    assert call_resource.metadata["scientific_catalog_result_assertion"] == (
+        catalog_result.evidence
+    )
+
+
+@pytest.mark.parametrize("drift", ["handoff", "digest"])
+def test_scientific_catalog_result_rejects_descriptor_drift(drift: str) -> None:
+    """Schema-valid output cannot substitute a divergent or unbound descriptor."""
+    dataset_id = "deep-water-impact-2018-yb31-first5"
+    structured = _scientific_catalog_describe_result(dataset_id)
+    if drift == "handoff":
+        nested_descriptor = cast(
+            dict[str, object],
+            cast(dict[str, object], structured["dataset"])["descriptor"],
+        )
+        cast(list[dict[str, object]], nested_descriptor["members"])[0]["location"] = (
+            "/mnt/common/datasets-staging/scivis/drifted.vti"
+        )
+    else:
+        structured["descriptor_sha256"] = "0" * 64
+    contract_artifact = json.loads(
+        (
+            Path(remote_mcp.__file__).with_name("_contracts") / "scientific-catalog-user-v1.1.json"
+        ).read_text(encoding="utf-8")
+    )
+    describe_tool = next(
+        tool
+        for tool in cast(list[dict[str, object]], contract_artifact["tools"])
+        if tool["name"] == "scientific_dataset_describe"
+    )
+
+    check = remote_mcp._scientific_catalog_structured_result_check(  # pyright: ignore[reportPrivateUsage]
+        arguments={"dataset_id": dataset_id},
+        protocol_result={"structuredContent": structured},
+        output_schema=cast(dict[str, object], describe_tool["outputSchema"]),
+    )
+
+    assert check.passed is False
+    assert check.evidence["output_schema"]["structured_content_valid"] is True
+    assert (
+        check.evidence[
+            "dataset_descriptor_handoff_matches"
+            if drift == "handoff"
+            else "descriptor_digest_matches"
+        ]
+        is False
+    )
+
+
+def test_scientific_catalog_result_rejects_nan_without_raising() -> None:
+    """A non-finite descriptor fails into bounded evidence before hashing."""
+    dataset_id = "deep-water-impact-2018-yb31-first5"
+    structured = _scientific_catalog_describe_result(dataset_id)
+    descriptor = cast(dict[str, object], structured["dataset_descriptor"])
+    cast(list[float], descriptor["bounds"])[0] = float("nan")
+    cast(dict[str, object], structured["dataset"])["descriptor"] = deepcopy(descriptor)
+
+    check = remote_mcp._scientific_catalog_structured_result_check(  # pyright: ignore[reportPrivateUsage]
+        arguments={"dataset_id": dataset_id},
+        protocol_result={"structuredContent": structured},
+        output_schema=_scientific_catalog_describe_output_schema(),
+    )
+
+    schema_evidence = cast(dict[str, object], check.evidence["output_schema"])
+    assert check.passed is False
+    assert schema_evidence["structured_content_bounded"] is True
+    assert schema_evidence["structured_content_finite"] is False
+    assert "non-finite JSON number" in cast(str, schema_evidence["structured_content_guard_error"])
+    assert check.evidence["computed_descriptor_sha256"] is None
+    assert check.evidence["descriptor_digest_matches"] is False
+
+
+def test_scientific_catalog_result_rejects_overdeep_content_without_traversing() -> None:
+    """Unsafe nesting fails before schema evaluation or descriptor comparison."""
+    dataset_id = "deep-water-impact-2018-yb31-first5"
+    structured = _scientific_catalog_describe_result(dataset_id)
+    nested: dict[str, object] = {"leaf": True}
+    for _ in range(remote_mcp.MAX_REMOTE_MCP_JSON_DEPTH + 1):
+        nested = {"child": nested}
+    descriptor = cast(dict[str, object], structured["dataset_descriptor"])
+    descriptor["unsafe_test_nesting"] = nested
+    cast(dict[str, object], structured["dataset"])["descriptor"] = deepcopy(descriptor)
+
+    check = remote_mcp._scientific_catalog_structured_result_check(  # pyright: ignore[reportPrivateUsage]
+        arguments={"dataset_id": dataset_id},
+        protocol_result={"structuredContent": structured},
+        output_schema=_scientific_catalog_describe_output_schema(),
+    )
+
+    schema_evidence = cast(dict[str, object], check.evidence["output_schema"])
+    assert check.passed is False
+    assert schema_evidence["structured_content_bounded"] is False
+    assert "nesting levels" in cast(str, schema_evidence["structured_content_guard_error"])
+    assert check.evidence["computed_descriptor_sha256"] is None
+    assert check.evidence["dataset_descriptor_handoff_matches"] is False
+
+
+def test_scientific_catalog_result_bounds_oversized_evidence() -> None:
+    """Oversized catalog strings fail without being copied into report evidence."""
+    dataset_id = "deep-water-impact-2018-yb31-first5"
+    structured = _scientific_catalog_describe_result(dataset_id)
+    structured["schema_version"] = "x" * (
+        remote_mcp.MAX_REMOTE_MCP_SCIENTIFIC_CATALOG_STRUCTURED_BYTES + 1
+    )
+
+    check = remote_mcp._scientific_catalog_structured_result_check(  # pyright: ignore[reportPrivateUsage]
+        arguments={"dataset_id": dataset_id},
+        protocol_result={"structuredContent": structured},
+        output_schema=_scientific_catalog_describe_output_schema(),
+    )
+
+    schema_evidence = cast(dict[str, object], check.evidence["output_schema"])
+    assert check.passed is False
+    assert schema_evidence["structured_content_bounded"] is False
+    assert schema_evidence["structured_content_finite"] is True
+    assert cast(int, schema_evidence["structured_content_bytes"]) > cast(
+        int, schema_evidence["structured_content_bytes_limit"]
+    )
+    assert "exceeds" in cast(str, schema_evidence["structured_content_guard_error"])
+    assert schema_evidence["schema_evaluated"] is False
+    assert check.evidence["response_schema_version"] is None
+    assert check.evidence["computed_descriptor_sha256"] is None
+    assert len(json.dumps(check.evidence, allow_nan=False)) < 16_384
+
+
+def test_scientific_catalog_result_hashes_unicode_like_clio_kit() -> None:
+    """Unicode descriptor bytes use clio-kit's unescaped canonical JSON."""
+    dataset_id = "deep-water-impact-2018-yb31-first5"
+    structured = _scientific_catalog_describe_result(dataset_id)
+    descriptor = cast(dict[str, object], structured["dataset_descriptor"])
+    arrays = cast(list[dict[str, object]], descriptor["arrays"])
+    arrays[0]["name"] = "temperature-Δ"
+    identity = {key: value for key, value in descriptor.items() if key != "fingerprint"}
+    fingerprint = cast(dict[str, object], descriptor["fingerprint"])
+    fingerprint["digest"] = _canonical_json_sha256(identity)
+    cast(dict[str, object], structured["dataset"])["descriptor"] = deepcopy(descriptor)
+    expected_digest = _canonical_json_sha256(descriptor)
+    ascii_escaped_digest = hashlib.sha256(
+        json.dumps(
+            descriptor,
+            allow_nan=False,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    structured["descriptor_sha256"] = expected_digest
+
+    check = remote_mcp._scientific_catalog_structured_result_check(  # pyright: ignore[reportPrivateUsage]
+        arguments={"dataset_id": dataset_id},
+        protocol_result={"structuredContent": structured},
+        output_schema=_scientific_catalog_describe_output_schema(),
+    )
+
+    assert expected_digest != ascii_escaped_digest
+    assert check.passed is True
+    assert check.evidence["computed_descriptor_sha256"] == expected_digest
+    assert check.evidence["descriptor_digest_matches"] is True
 
 
 def test_discovery_artifact_creates_fresh_provenance_cache_entry(tmp_path: Path) -> None:
@@ -2233,7 +2574,7 @@ def test_cli_registers_released_scientific_catalog_contract(
             "--profile",
             "user",
             "--contract",
-            "clio-kit-scientific-catalog-user-v1",
+            "clio-kit-scientific-catalog-user-v1.1",
         ],
     )
 
@@ -2243,7 +2584,7 @@ def test_cli_registers_released_scientific_catalog_contract(
         .require("alpha")
         .remote_mcp_servers["scientific-catalog"]
     )
-    assert registration.contract == "clio-kit-scientific-catalog-user-v1"
+    assert registration.contract == "clio-kit-scientific-catalog-user-v1.1"
     assert registration.args == [
         "mcp-server",
         "scientific-catalog",
@@ -4498,6 +4839,163 @@ def test_cli_validate_calls_virtual_alias_and_writes_report(
     assert json.loads(output_path.read_text(encoding="utf-8")) == report
 
 
+@pytest.mark.parametrize("complete", [True, False], ids=["durable-result", "nonterminal"])
+def test_cli_validate_catalog_waits_and_projects_automatic_assertion(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    complete: bool,
+) -> None:
+    """CLI validation waits on the queued call and projects catalog semantics."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_CLI_MODE", "local")
+    monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(tmp_path / "core"))
+    monkeypatch.setenv("CLIO_RELAY_SPOOL_DIR", str(tmp_path / "spool"))
+    dataset_id = "deep-water-impact-2018-yb31-first5"
+    registration = RemoteMcpServerConfig(
+        command="uvx",
+        args=[
+            "--from",
+            "/opt/wheels/clio_kit-2.5.11-py3-none-any.whl",
+            "clio-kit",
+            "mcp-server",
+            "scientific-catalog",
+        ],
+        allow_tools=["scientific_dataset_describe", "scientific_dataset_search"],
+        profiles=["user"],
+        contract="clio-kit-scientific-catalog-user-v1.1",
+    )
+    registry = ClusterRegistry(
+        clusters={"alpha": _cluster("alpha", {"scientific-catalog": registration})}
+    )
+    registry.save(tmp_path / ".clio-relay" / "clusters.json")
+    contract_artifact = json.loads(
+        (
+            Path(remote_mcp.__file__).with_name("_contracts") / "scientific-catalog-user-v1.1.json"
+        ).read_text(encoding="utf-8")
+    )
+    refreshed_at = datetime.now(UTC)
+    discovery_entry = _entry(
+        registration,
+        cluster="alpha",
+        server_name="scientific-catalog",
+        tools=cast(list[dict[str, object]], contract_artifact["tools"]),
+    ).model_copy(
+        update={
+            "discovered_at": refreshed_at,
+            "expires_at": refreshed_at + timedelta(hours=1),
+        }
+    )
+    RemoteMcpSchemaCache.update_entry(
+        tmp_path / ".clio-relay" / "remote-mcp-cache.json",
+        discovery_entry,
+    )
+    server_artifact = _server_artifact(registration)
+    server_artifact_digest = remote_mcp_server_artifact_digest(server_artifact)
+    observed_initial_states: list[JobState] = []
+
+    def finish_or_leave_queued(
+        queue: ClioCoreQueue,
+        job_id: str,
+        *,
+        timeout_seconds: float,
+        poll_seconds: float,
+    ) -> RelayJob:
+        del timeout_seconds, poll_seconds
+        job = queue.get_job(job_id)
+        observed_initial_states.append(job.state)
+        assert job.state == JobState.QUEUED
+        assert isinstance(job.spec, McpCallSpec)
+        assert job.spec.tool == "scientific_dataset_describe"
+        assert job.spec.arguments == {"dataset_id": dataset_id}
+        if not complete:
+            return job
+        spool = JobSpool(tmp_path / "spool", job)
+        spool.initialize()
+        mcp_result_path = spool.path / "mcp-result.json"
+        mcp_result_path.write_text(
+            json.dumps(
+                {
+                    "server": registration.command,
+                    "server_args": registration.args,
+                    "operation": "tools/call",
+                    "tool": "scientific_dataset_describe",
+                    "arguments": {"dataset_id": dataset_id},
+                    "returncode": 0,
+                    "protocol_result": {
+                        "structuredContent": _scientific_catalog_describe_result(dataset_id)
+                    },
+                    "server_artifact": server_artifact,
+                    "expected_server_artifact_digest": server_artifact_digest,
+                    "observed_server_artifact_digest": server_artifact_digest,
+                    "protocol_error": None,
+                    "timed_out": False,
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+        provenance_path = spool.path / "provenance.json"
+        provenance_path.write_text(
+            json.dumps({"job": job.model_dump(mode="json")}, default=str),
+            encoding="utf-8",
+        )
+        for kind, path in (
+            ("stdout", spool.path / "stdout.log"),
+            ("stderr", spool.path / "stderr.log"),
+            ("mcp_result", mcp_result_path),
+            ("provenance", provenance_path),
+        ):
+            queue.append_artifact(spool.artifact_for(path, kind=kind))
+        return queue.update_job_state(job_id, JobState.SUCCEEDED, message="call complete")
+
+    monkeypatch.setattr("clio_relay.cli.wait_for_terminal", finish_or_leave_queued)
+    output_path = tmp_path / "validation" / "catalog-domain.json"
+    canonical_path = tmp_path / "validation" / "catalog-live.json"
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "remote-mcp",
+            "validate",
+            "--cluster",
+            "alpha",
+            "--name",
+            "scientific-catalog",
+            "--tool",
+            "scientific_dataset_describe",
+            "--arguments-json",
+            json.dumps({"dataset_id": dataset_id}),
+            "--profile",
+            "user",
+            "--output-json",
+            str(output_path),
+            "--validation-report",
+            str(canonical_path),
+        ],
+    )
+
+    assert result.exit_code == (0 if complete else 1), result.output
+    assert observed_initial_states == [JobState.QUEUED]
+    domain_report = json.loads(output_path.read_text(encoding="utf-8"))
+    catalog_check = next(
+        check
+        for check in domain_report["checks"]
+        if check["name"] == "remote-mcp.scientific-catalog-result"
+    )
+    assert catalog_check["passed"] is complete
+    canonical_report = json.loads(canonical_path.read_text(encoding="utf-8"))
+    assert canonical_report["status"] == ("passed" if complete else "failed")
+    call_resource = next(
+        resource
+        for resource in canonical_report["resources"]
+        if resource.get("role") == "virtual_remote_mcp_call"
+    )
+    assertion = call_resource["metadata"]["scientific_catalog_result_assertion"]
+    assert assertion["contract"] == "clio-kit-scientific-catalog-user-v1.1"
+    assert assertion["requested_dataset_id"] == dataset_id
+    assert assertion["dataset_descriptor_handoff_matches"] is complete
+
+
 def test_cli_validate_preflight_failure_writes_canonical_report(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -4944,7 +5442,86 @@ def _spack_result_schema(name: str) -> dict[str, object]:
     raise AssertionError(f"unexpected Spack tool: {name}")
 
 
-def _scientific_catalog_tool(name: str) -> dict[str, object]:
+def _canonical_json_sha256(value: object) -> str:
+    """Return the compact unescaped canonical JSON digest used by clio-kit."""
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _scientific_catalog_describe_output_schema() -> dict[str, object]:
+    """Load the exact vendored v1.1 describe output schema."""
+    contract_artifact = json.loads(
+        (
+            Path(remote_mcp.__file__).with_name("_contracts") / "scientific-catalog-user-v1.1.json"
+        ).read_text(encoding="utf-8")
+    )
+    describe_tool = next(
+        tool
+        for tool in cast(list[dict[str, object]], contract_artifact["tools"])
+        if tool["name"] == "scientific_dataset_describe"
+    )
+    return cast(dict[str, object], describe_tool["outputSchema"])
+
+
+def _scientific_catalog_describe_result(dataset_id: str) -> dict[str, object]:
+    """Return one valid v1.1 describe result with canonical descriptor identity."""
+    descriptor_without_fingerprint: dict[str, object] = {
+        "schema_version": "jarvis.dataset-descriptor.v1",
+        "dataset_id": dataset_id,
+        "kind": "temporal-volume",
+        "format": "vti",
+        "members": [
+            {
+                "index": 0,
+                "location": "/mnt/common/datasets-staging/scivis/asteroid-000.vti",
+                "timestep": 0.0,
+            }
+        ],
+        "arrays": [
+            {
+                "name": "density",
+                "association": "point",
+                "components": 1,
+            }
+        ],
+        "bounds": [0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+        "source_artifact": None,
+    }
+    fingerprint = _canonical_json_sha256(descriptor_without_fingerprint)
+    descriptor = {
+        **descriptor_without_fingerprint,
+        "fingerprint": {"algorithm": "sha256", "digest": fingerprint},
+    }
+    descriptor_sha256 = _canonical_json_sha256(descriptor)
+    return {
+        "schema_version": "clio-kit.scientific-dataset-description.v1",
+        "site_id": "ares",
+        "catalog_revision": "release-v1",
+        "catalog_sha256": "a" * 64,
+        "dataset": {
+            "dataset_id": dataset_id,
+            "title": "2018 Deep Water Impact first five timesteps",
+            "summary": "Bounded release-acceptance dataset record.",
+            "tags": ["asteroid", "impact", "volume"],
+            "descriptor": deepcopy(descriptor),
+        },
+        "dataset_descriptor": deepcopy(descriptor),
+        "descriptor_sha256": descriptor_sha256,
+    }
+
+
+def _scientific_catalog_tool(
+    name: str,
+    *,
+    contract_id: str = "clio-kit-scientific-catalog-user-v1.1",
+) -> dict[str, object]:
     """Return the bounded schema shape required by the scientific catalog contract check."""
     annotations = {
         "readOnlyHint": True,
@@ -4953,6 +5530,34 @@ def _scientific_catalog_tool(name: str) -> dict[str, object]:
         "openWorldHint": False,
     }
     if name == "scientific_dataset_describe":
+        descriptor_schema: dict[str, object] = {
+            "type": "object",
+            "properties": {
+                "schema_version": {
+                    "const": "jarvis.dataset-descriptor.v1",
+                    "type": "string",
+                }
+            },
+            "additionalProperties": False,
+        }
+        output_properties: dict[str, object] = {
+            "schema_version": {
+                "const": "clio-kit.scientific-dataset-description.v1",
+                "default": "clio-kit.scientific-dataset-description.v1",
+                "type": "string",
+            },
+            "dataset": {
+                "type": "object",
+                "properties": {"descriptor": deepcopy(descriptor_schema)},
+                "additionalProperties": False,
+            },
+        }
+        output_required: list[str] = []
+        if contract_id == "clio-kit-scientific-catalog-user-v1.1":
+            output_properties["dataset_descriptor"] = deepcopy(descriptor_schema)
+            output_required.append("dataset_descriptor")
+        elif contract_id != "clio-kit-scientific-catalog-user-v1":
+            raise AssertionError(f"unsupported scientific catalog contract: {contract_id}")
         return {
             "name": name,
             "description": "Return one exact operator catalog record.",
@@ -4965,29 +5570,8 @@ def _scientific_catalog_tool(name: str) -> dict[str, object]:
             },
             "outputSchema": {
                 "type": "object",
-                "properties": {
-                    "schema_version": {
-                        "const": "clio-kit.scientific-dataset-description.v1",
-                        "default": "clio-kit.scientific-dataset-description.v1",
-                        "type": "string",
-                    },
-                    "dataset": {
-                        "type": "object",
-                        "properties": {
-                            "descriptor": {
-                                "type": "object",
-                                "properties": {
-                                    "schema_version": {
-                                        "const": "jarvis.dataset-descriptor.v1",
-                                        "type": "string",
-                                    }
-                                },
-                                "additionalProperties": False,
-                            }
-                        },
-                        "additionalProperties": False,
-                    },
-                },
+                "properties": output_properties,
+                "required": output_required,
                 "additionalProperties": False,
             },
         }

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1945,9 +1945,9 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.3.29"
+    assert policy.release_version == "1.3.30"
     assert policy.acceptance_matrix is not None
-    assert policy.acceptance_matrix["report_count_per_stage"] == 17
+    assert policy.acceptance_matrix["report_count_per_stage"] == 18
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256
     matrix_stages = cast(list[dict[str, object]], policy.acceptance_matrix["stages"])
     assert [stage["name"] for stage in matrix_stages] == [
@@ -1963,6 +1963,12 @@ def test_repository_release_policy_is_machine_readable() -> None:
     assert "ares-jarvis-native-application-progress" in requirement_ids
     assert "ares-jarvis-lammps-package-progress" in requirement_ids
     assert "homelab-owned-cleanup" in requirement_ids
+    catalog = next(
+        item for item in policy.requirements if item.requirement_id == "ares-non-jarvis-virtual-mcp"
+    )
+    assert "remote-mcp.scientific-catalog-user-contract" in catalog.required_checks
+    assert "remote-mcp.scientific-catalog-result" in catalog.required_checks
+    assert catalog.evidence_group_resource_kind == "mcp_server"
     ares_bootstrap = next(
         item for item in policy.requirements if item.requirement_id == "ares-released-bootstrap"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.29"
+version = "1.3.30"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- pin clio-kit 2.5.11 and vendor its current and historical scientific-catalog contracts
- expose and validate the v1.1 top-level `dataset_descriptor` handoff while preserving v1 compatibility
- validate a real describe result against the cached output schema, dataset identity, canonical digest, and bounded finite JSON rules
- add the dedicated machine-readable catalog acceptance report and update the 1.3.30 release matrix

## Why

The catalog previously returned the JARVIS-ready descriptor only inside a larger catalog record. Agents could accidentally forward that outer record to JARVIS, wasting a tool round trip and producing an avoidable validation failure. Relay acceptance also proved only the advertised schema, not the actual live result.

## Impact

Agents can now hand `dataset_descriptor` directly to JARVIS. The release gate proves that the live cluster result matches the released clio-kit contract without hardcoding cluster or dataset behavior into relay core. Historical v1 registrations remain valid.

## Validation

- 23 focused release, contract, matrix, and exact-wheel tests passed
- all 11 scientific-catalog focused tests passed, including queued wait/artifact integration
- NaN, excessive depth, oversized evidence, Unicode canonicalization, and descriptor drift regressions pass
- Ruff and Pyright pass with zero errors
- `git diff --check` and `uv lock --check` pass
