### PR TITLE
fix(gateway): preserve browser SSE reconnects

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 examples/release-gate/**/*.py text eol=lf
 examples/release-gate/**/*.in text eol=lf
 examples/release-gate/**/*.tmpl text eol=lf
+src/clio_relay/_contracts/*.json text eol=lf

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.30` uses a release-first patch process. A maintainer builds the
+> Version `1.3.31` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -56,7 +56,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.30"
+$Version = "1.3.31"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.30"
+release_version: "1.3.31"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 2c760f9cc33077d6f4e584fde49d93d2c2300ea2312adb281a4aff2a6b96ce25
+acceptance_matrix_sha256: ec85dc74e3f5f324fa9b5cccf8d57eec67f446f63ca706cdde31f0512647c075
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.30"
+$Tag = "v1.3.31"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.30" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.31" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.30",
-  "matrix_sha256": "2c760f9cc33077d6f4e584fde49d93d2c2300ea2312adb281a4aff2a6b96ce25",
+  "release_version": "1.3.31",
+  "matrix_sha256": "ec85dc74e3f5f324fa9b5cccf8d57eec67f446f63ca706cdde31f0512647c075",
   "report_count_per_stage": 18,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.30"
+version = "1.3.31"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.30"
+__version__ = "1.3.31"

--- a/src/clio_relay/browser_gateway.py
+++ b/src/clio_relay/browser_gateway.py
@@ -325,11 +325,19 @@ class CapabilityProxyHandler(BaseHTTPRequestHandler):
             response = connection.getresponse()
             if connection.sock is not None:
                 connection.sock.settimeout(UPSTREAM_IDLE_TIMEOUT_SECONDS)
+            media_type = response.getheader("Content-Type", "").partition(";")[0].strip()
+            close_downstream = (
+                media_type.casefold() == "text/event-stream"
+                or response.getheader("Content-Length") is None
+            )
             self.send_response(response.status, response.reason)
             for name, value in response.getheaders():
                 if name.casefold() not in _STRIPPED_RESPONSE_HEADERS:
                     self.send_header(name, value)
             self._cors_headers()
+            if close_downstream:
+                self.send_header("Connection", "close")
+                self.close_connection = True
             self.end_headers()
             response_started = True
             while True:
@@ -338,10 +346,15 @@ class CapabilityProxyHandler(BaseHTTPRequestHandler):
                     break
                 self.wfile.write(chunk)
                 self.wfile.flush()
+            if response.length not in {None, 0}:
+                self.close_connection = True
         except (BrokenPipeError, ConnectionResetError):
+            self.close_connection = True
             return
         except (TimeoutError, OSError, http.client.HTTPException):
-            if not response_started and not self.wfile.closed:
+            if response_started:
+                self.close_connection = True
+            elif not self.wfile.closed:
                 with suppress(BrokenPipeError, ConnectionResetError, OSError):
                     self._error(502, "upstream service is unavailable")
         finally:

--- a/tests/test_browser_gateway.py
+++ b/tests/test_browser_gateway.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import http.client
 import json
 import socket
 import threading
@@ -102,6 +103,119 @@ def test_browser_gateway_preflight_methods_stream_and_command_are_narrow(
             ]
 
 
+def test_browser_gateway_closes_ended_sse_and_reconnects_to_latest_revision(
+    tmp_path: Path,
+) -> None:
+    with _revision_sse_backend(keep_open_for_command=False) as (backend_port, requests):
+        capability = "r" * 43
+        with _capability_proxy(
+            backend_port=backend_port,
+            capability=capability,
+            revocation_path=tmp_path / "revoked",
+        ) as proxy_port:
+            query = urlencode({"capability": capability})
+            events_url = f"http://127.0.0.1:{proxy_port}/events?{query}"
+            command_url = f"http://127.0.0.1:{proxy_port}/commands?{query}"
+            with httpx.Client(timeout=2.0) as client:
+                with client.stream("GET", events_url, headers={"Origin": "null"}) as first:
+                    assert first.headers["connection"] == "close"
+                    assert b"".join(first.iter_bytes()) == b'data: {"revision":1}\n\n'
+
+                command = client.post(
+                    command_url,
+                    headers={"Origin": "null", "Content-Type": "application/json"},
+                    content=b'{"operation":"next-timestep"}',
+                )
+                assert command.status_code == 200
+
+                with client.stream("GET", events_url, headers={"Origin": "null"}) as latest:
+                    assert latest.headers["connection"] == "close"
+                    assert b"".join(latest.iter_bytes()) == b'data: {"revision":2}\n\n'
+
+            assert requests == [
+                ("GET", "/events", b""),
+                ("POST", "/commands", b'{"operation":"next-timestep"}'),
+                ("GET", "/events", b""),
+            ]
+
+
+def test_browser_gateway_streams_post_command_revision_before_sse_closes(
+    tmp_path: Path,
+) -> None:
+    with _revision_sse_backend(keep_open_for_command=True) as (backend_port, requests):
+        capability = "s" * 43
+        with _capability_proxy(
+            backend_port=backend_port,
+            capability=capability,
+            revocation_path=tmp_path / "revoked",
+        ) as proxy_port:
+            query = urlencode({"capability": capability})
+            events_url = f"http://127.0.0.1:{proxy_port}/events?{query}"
+            command_url = f"http://127.0.0.1:{proxy_port}/commands?{query}"
+            with (
+                httpx.Client(timeout=3.0) as stream_client,
+                stream_client.stream("GET", events_url, headers={"Origin": "null"}) as response,
+            ):
+                lines = response.iter_lines()
+                assert response.headers["connection"] == "close"
+                assert next(line for line in lines if line.startswith("data:")) == (
+                    'data: {"revision":1}'
+                )
+                command = httpx.post(
+                    command_url,
+                    headers={"Origin": "null", "Content-Type": "application/json"},
+                    content=b'{"operation":"next-timestep"}',
+                    timeout=2.0,
+                )
+                assert command.status_code == 200
+                assert next(line for line in lines if line.startswith("data:")) == (
+                    'data: {"revision":2}'
+                )
+                assert all(not line for line in lines)
+
+            assert requests == [
+                ("GET", "/events", b""),
+                ("POST", "/commands", b'{"operation":"next-timestep"}'),
+            ]
+
+
+def test_browser_gateway_keeps_finite_content_length_responses_alive(tmp_path: Path) -> None:
+    with _backend_server() as (backend_port, requests):
+        capability = "k" * 43
+        with _capability_proxy(
+            backend_port=backend_port,
+            capability=capability,
+            revocation_path=tmp_path / "revoked",
+        ) as proxy_port:
+            query = urlencode({"capability": capability})
+            connection = http.client.HTTPConnection("127.0.0.1", proxy_port, timeout=2.0)
+            try:
+                connection.request("GET", f"/healthz?{query}", headers={"Origin": "null"})
+                first = connection.getresponse()
+                assert first.getheader("Connection") is None
+                assert json.loads(first.read()) == {
+                    "schema_version": "jarvis.paraview.health.v1",
+                    "status": "ready",
+                    "service_instance_id": "service-1",
+                    "revision": 1,
+                }
+                downstream_socket = connection.sock
+                assert downstream_socket is not None
+
+                connection.request("GET", f"/state?{query}", headers={"Origin": "null"})
+                second = connection.getresponse()
+                assert second.getheader("Connection") is None
+                second.read()
+                assert connection.sock is downstream_socket
+            finally:
+                connection.close()
+
+            assert requests == [
+                ("GET", "/healthz", b""),
+                ("GET", "/state", b""),
+            ]
+
+
 def test_browser_gateway_revocation_and_expiry_fail_closed(tmp_path: Path) -> None:
     with _backend_server() as (backend_port, requests):
         capability = "z" * 43
@@ -194,6 +308,70 @@ def _backend_server() -> Generator[tuple[int, list[tuple[str, str, bytes]]]]:
             body = self.rfile.read(length)
             requests.append(("POST", self.path, body))
             payload = b'{"accepted":true}'
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, format: str, *args: Any) -> None:
+            del format, args
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), BackendHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield int(server.server_address[1]), requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@contextmanager
+def _revision_sse_backend(
+    *, keep_open_for_command: bool
+) -> Generator[tuple[int, list[tuple[str, str, bytes]]]]:
+    requests: list[tuple[str, str, bytes]] = []
+    condition = threading.Condition()
+    revision = 1
+
+    class BackendHandler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_GET(self) -> None:  # noqa: N802
+            nonlocal revision
+            requests.append(("GET", self.path, b""))
+            with condition:
+                initial_revision = revision
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+            if not keep_open_for_command:
+                self.send_header("Connection", "close")
+                self.close_connection = True
+            self.end_headers()
+            self.wfile.write(f'data: {{"revision":{initial_revision}}}\n\n'.encode())
+            self.wfile.flush()
+            if not keep_open_for_command:
+                return
+            with condition:
+                changed = condition.wait_for(lambda: revision > initial_revision, timeout=2.0)
+                latest_revision = revision
+            if changed:
+                self.wfile.write(f'data: {{"revision":{latest_revision}}}\n\n'.encode())
+                self.wfile.flush()
+            self.close_connection = True
+
+        def do_POST(self) -> None:  # noqa: N802
+            nonlocal revision
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length)
+            requests.append(("POST", self.path, body))
+            with condition:
+                revision += 1
+                current_revision = revision
+                condition.notify_all()
+            payload = json.dumps({"accepted": True, "revision": current_revision}).encode()
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(payload)))

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.30"
+    assert version == "1.3.31"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version
@@ -131,6 +131,12 @@ def test_remote_release_text_fixtures_are_lf_attributed_and_normalized_before_sc
     assert "$StagedBytes -contains [byte]0x00" in runbook
     assert "$Text = Read-LfUtf8TextFile $Source" in runbook
     assert '$Text = ConvertTo-LfText $Text "rendered template $Destination"' in runbook
+
+
+def test_vendored_contract_artifacts_are_lf_attributed() -> None:
+    attributes = (ROOT / ".gitattributes").read_text(encoding="utf-8").splitlines()
+
+    assert "src/clio_relay/_contracts/*.json text eol=lf" in attributes
 
 
 def test_lf_text_staging_and_rendering_normalize_windows_bytes_under_powershell(

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1945,7 +1945,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.3.30"
+    assert policy.release_version == "1.3.31"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 18
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.30"
+version = "1.3.31"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- frame browser-facing SSE and unbounded proxy responses by connection close so EventSource can reconnect after upstream FRP EOF, idle timeout, or failure
- preserve keep-alive for successfully completed finite Content-Length responses and close truncated finite responses
- prove forced SSE EOF/reconnect-to-latest, persistent post-command frame delivery, and finite response reuse
- force vendored MCP contract JSON to LF so exact artifact digests are stable on Windows and Linux
- prepare patch release 1.3.31

## Why

A live Ares ParaView command rendered and committed revision 2, but an ended upstream SSE transport left the browser-side HTTP/1.1 socket hung open. The viewer could neither receive revision 2 nor reconnect, so the production demo stalled despite a successful JARVIS command. Separately, the v1.3.30 asynchronous Windows tag matrix exposed CRLF conversion of byte-pinned contract artifacts.

## Validation

- 14 focused tests passed
- targeted Ruff and Pyright passed
- uv lock check and git diff check passed