### PR TITLE
fix(jarvis): accept relay-owned execution identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.3.32` uses a release-first patch process. A maintainer builds the
+> Version `1.3.33` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -56,7 +56,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.3.32"
+$Version = "1.3.33"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.3.32"
+release_version: "1.3.33"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 7169aa3406dcc8c97f398659d38b7c39ebf5b728dc8315a4a91b240fa01dc24c
+acceptance_matrix_sha256: fa3846b8cc07c7f98429da47abae109e4f35deee388bdb59934e41965f99ba3e
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.3.32"
+$Tag = "v1.3.33"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.32" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.3.33" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.3.32",
-  "matrix_sha256": "7169aa3406dcc8c97f398659d38b7c39ebf5b728dc8315a4a91b240fa01dc24c",
+  "release_version": "1.3.33",
+  "matrix_sha256": "fa3846b8cc07c7f98429da47abae109e4f35deee388bdb59934e41965f99ba3e",
   "report_count_per_stage": 18,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.3.32"
+version = "1.3.33"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.3.32"
+__version__ = "1.3.33"

--- a/src/clio_relay/session_api.py
+++ b/src/clio_relay/session_api.py
@@ -29,6 +29,8 @@ from clio_relay.models import (
     McpCallSpec,
     RelayJob,
     RemoteAgentTaskSpec,
+    deterministic_jarvis_execution_id,
+    is_owned_jarvis_run_spec,
 )
 from clio_relay.session_lifecycle import (
     challenge_remote_session_identity,
@@ -324,9 +326,10 @@ def _validate_submission_receipt(
     if path == "/jobs/jarvis-mcp-call":
         if job.kind is not JobKind.MCP_CALL or not isinstance(job.spec, McpCallSpec):
             raise RelayError("owned session API returned the wrong job kind")
+        expected_arguments = _expected_jarvis_mcp_arguments(job, payload=payload)
         if (
             job.spec.tool != payload.get("tool")
-            or job.spec.arguments != payload.get("arguments", {})
+            or job.spec.arguments != expected_arguments
             or job.spec.expected_server_artifact_digest
             != payload.get("expected_server_artifact_digest")
             or job.spec.timeout_seconds != payload.get("timeout_seconds")
@@ -367,6 +370,43 @@ def _validate_submission_receipt(
         }
         if observed_agent != expected_agent:
             raise RelayError("owned session API returned a different remote-agent task")
+
+
+def _expected_jarvis_mcp_arguments(
+    job: RelayJob,
+    *,
+    payload: dict[str, object],
+) -> dict[str, object]:
+    """Normalize only the server-owned identity added during JARVIS run admission.
+
+    The authenticated cluster API admits ``jarvis_run`` before returning its receipt. Admission
+    deterministically adds ``execution_id`` using the cluster, idempotency key, and server-owned
+    relay job ID. That field is intentionally absent from an ordinary caller request. Recompute
+    the one permitted normalization while retaining an exact comparison for every caller-owned
+    argument. An explicit execution ID is accepted only for an exact idempotent replay whose
+    returned job identity proves the same value.
+    """
+
+    raw_arguments = payload.get("arguments", {})
+    if not isinstance(raw_arguments, dict):
+        raise RelayError("owned session submission has invalid JARVIS MCP arguments")
+    expected_arguments = cast(dict[str, object], raw_arguments)
+    raw_tool = payload.get("tool")
+    normalized_tool = raw_tool.replace("-", "_").lower() if isinstance(raw_tool, str) else ""
+    if normalized_tool != "jarvis_run":
+        return expected_arguments
+    if not is_owned_jarvis_run_spec(job.kind, job.spec):
+        raise RelayError("owned session API returned an unbound JARVIS run")
+
+    expected_execution_id = deterministic_jarvis_execution_id(
+        cluster=job.cluster,
+        idempotency_key=job.idempotency_key,
+        job_id=job.job_id,
+    )
+    supplied_execution_id = expected_arguments.get("execution_id")
+    if supplied_execution_id is not None and supplied_execution_id != expected_execution_id:
+        raise RelayError("owned session JARVIS run used a different execution identity")
+    return {**expected_arguments, "execution_id": expected_execution_id}
 
 
 def _owned_session_credentials(

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.3.32"
+    assert version == "1.3.33"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_session_api.py
+++ b/tests/test_session_api.py
@@ -12,7 +12,12 @@ import pytest
 from clio_relay.cluster_config import ClusterDefinition
 from clio_relay.config import RelaySettings
 from clio_relay.errors import RelayError
-from clio_relay.models import JobKind, McpCallSpec, RelayJob
+from clio_relay.models import (
+    JobKind,
+    McpCallSpec,
+    RelayJob,
+    prepare_owned_jarvis_run_submission,
+)
 from clio_relay.session_api import (
     OWNER_SESSION_ID_HEADER,
     SESSION_GENERATION_ID_HEADER,
@@ -140,6 +145,39 @@ def _job(expected_digest: str) -> RelayJob:
     )
 
 
+def _admitted_jarvis_run_job(
+    expected_digest: str,
+    *,
+    pipeline_id: str = "science-pipeline",
+) -> RelayJob:
+    """Return the exact server-normalized receipt for an owned JARVIS run."""
+
+    submitted = RelayJob(
+        cluster="ares",
+        kind=JobKind.MCP_CALL,
+        spec=McpCallSpec(
+            server="clio-kit",
+            server_args=["mcp-server", "jarvis"],
+            expected_server_artifact_digest=expected_digest,
+            expected_jarvis_cd_lock_binding={
+                "schema_version": "clio-relay.jarvis-cd-lock-expectation.v1",
+                "version": "1.3.16",
+                "url": "https://example.invalid/jarvis-cd.whl",
+                "sha256": "b" * 64,
+            },
+            tool="jarvis_run",
+            arguments={"pipeline_id": pipeline_id},
+        ),
+        idempotency_key="owned-session-client",
+        metadata={
+            "owner": "clio-relay",
+            "owner_session_id": "desktop-session-1",
+            "owner_session_generation_id": "generation-1",
+        },
+    )
+    return prepare_owned_jarvis_run_submission(submitted)
+
+
 def _install_transport(
     monkeypatch: pytest.MonkeyPatch,
     *,
@@ -205,6 +243,44 @@ def _install_transport(
     monkeypatch.setattr("clio_relay.session_api.http.client.HTTPConnection", connection_factory)
     monkeypatch.setattr("clio_relay.session_api._ssh_forward", forward)
     return captured, connections
+
+
+def _submit_jarvis_run_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    admitted: RelayJob,
+    expected_digest: str,
+    arguments: dict[str, object],
+) -> RelayJob:
+    """Submit caller arguments against one simulated authenticated admission receipt."""
+
+    identity = session_identity_document(
+        owner_token="owner-token",
+        cluster="ares",
+        session_id="desktop-session-1",
+        generation_id="generation-1",
+        nonce="1" * 64,
+    )
+    _install_transport(
+        monkeypatch,
+        responses=[
+            _Response(identity),
+            _Response(admitted.model_dump(mode="json")),
+        ],
+    )
+    return submit_owned_session_job(
+        definition=ClusterDefinition(name="ares", ssh_host="ares-login"),
+        settings=_settings(tmp_path),
+        path="/jobs/jarvis-mcp-call",
+        payload={
+            "cluster": "ares",
+            "tool": "jarvis_run",
+            "arguments": arguments,
+            "expected_server_artifact_digest": expected_digest,
+            "idempotency_key": "owned-session-client",
+        },
+    )
 
 
 def test_owned_session_client_proves_identity_before_sending_credentials(
@@ -289,6 +365,82 @@ def test_owned_session_submission_rejects_dropped_artifact_dependencies(
                 "expected_server_artifact_digest": expected_digest,
                 "idempotency_key": "owned-session-client",
                 "used_artifact_refs": [{"artifact_id": "artifact_input", "sha256": "b" * 64}],
+            },
+        )
+
+
+def test_owned_session_submission_accepts_relay_owned_jarvis_execution_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Admission may add only its deterministic execution ID to jarvis_run arguments."""
+
+    expected_digest = "a" * 64
+    admitted = _admitted_jarvis_run_job(expected_digest)
+    received = _submit_jarvis_run_receipt(
+        tmp_path,
+        monkeypatch,
+        admitted=admitted,
+        expected_digest=expected_digest,
+        arguments={"pipeline_id": "science-pipeline"},
+    )
+
+    assert isinstance(received.spec, McpCallSpec)
+    assert isinstance(admitted.spec, McpCallSpec)
+    assert received.spec.arguments == admitted.spec.arguments
+    assert received.spec.arguments["execution_id"].startswith("jarvis_")
+
+
+def test_owned_session_submission_rejects_other_jarvis_run_arguments_after_normalization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Execution-ID normalization must not hide a changed pipeline or other caller input."""
+
+    expected_digest = "a" * 64
+    admitted = _admitted_jarvis_run_job(expected_digest, pipeline_id="other-pipeline")
+    with pytest.raises(RelayError, match="different JARVIS MCP call"):
+        _submit_jarvis_run_receipt(
+            tmp_path,
+            monkeypatch,
+            admitted=admitted,
+            expected_digest=expected_digest,
+            arguments={"pipeline_id": "science-pipeline"},
+        )
+
+
+def test_owned_session_submission_accepts_only_proven_jarvis_execution_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit execution ID is valid only when the receipt's durable identity proves it."""
+
+    expected_digest = "a" * 64
+    admitted = _admitted_jarvis_run_job(expected_digest)
+    assert isinstance(admitted.spec, McpCallSpec)
+    execution_id = admitted.spec.arguments["execution_id"]
+    received = _submit_jarvis_run_receipt(
+        tmp_path,
+        monkeypatch,
+        admitted=admitted,
+        expected_digest=expected_digest,
+        arguments={
+            "pipeline_id": "science-pipeline",
+            "execution_id": execution_id,
+        },
+    )
+    assert isinstance(received.spec, McpCallSpec)
+    assert received.spec.arguments["execution_id"] == execution_id
+
+    with pytest.raises(RelayError, match="different execution identity"):
+        _submit_jarvis_run_receipt(
+            tmp_path,
+            monkeypatch,
+            admitted=admitted,
+            expected_digest=expected_digest,
+            arguments={
+                "pipeline_id": "science-pipeline",
+                "execution_id": "jarvis_forged",
             },
         )
 

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1945,7 +1945,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.3.32"
+    assert policy.release_version == "1.3.33"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 18
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.3.32"
+version = "1.3.33"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- accept the deterministic execution ID injected by owned JARVIS run admission
- retain exact receipt validation for all caller-owned arguments
- reject changed pipelines, unbound runs, and forged explicit execution IDs
- advance the release identity to 1.3.33

## Why

A successful jarvis_run was admitted and submitted on Ares, but desktop receipt validation compared the normalized server payload to the original request byte-for-byte. The server-owned execution ID therefore surfaced a valid submission as an error and encouraged the agent to retry.

## Verification

- focused session API tests: 9 passed
- focused release identity/policy tests: 2 passed
- adjacent focused set: 19 passed
- Ruff clean and formatted
- Pyright: 0 errors
- live failure reproduced through the released standalone Host/Ares path