### PR TITLE
fix(types): type Linux containment evidence explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.0` uses a release-first patch process. A maintainer builds the
+> Version `1.4.1` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.0"
+$Version = "1.4.1"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.0"
+release_version: "1.4.1"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 969a0e753cfbba4fd1f6b1935d490da639c852c061bf13b8f91b780246b572b9
+acceptance_matrix_sha256: 849a6b883f5fb523bbfc949b9c365a16811ac8150329a5b7b235b7bb74333ddf
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.0"
+$Tag = "v1.4.1"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.0" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.1" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.0",
-  "matrix_sha256": "969a0e753cfbba4fd1f6b1935d490da639c852c061bf13b8f91b780246b572b9",
+  "release_version": "1.4.1",
+  "matrix_sha256": "849a6b883f5fb523bbfc949b9c365a16811ac8150329a5b7b235b7bb74333ddf",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/jarvis-packages/clio_relay/clio_relay/process_containment.py
+++ b/jarvis-packages/clio_relay/clio_relay/process_containment.py
@@ -496,11 +496,12 @@ def containment_capability(*, startup_deadline: float | None = None) -> dict[str
         cached = _containment_capability_cache
     if cached is not None:
         return dict(cached)
+    result: dict[str, object]
     if os.name == "nt":
         try:
             handle = _create_windows_job()
         except RuntimeError as exc:
-            result: dict[str, object] = {
+            result = {
                 "mode": "windows_job_object",
                 "enforceable": False,
                 "reason": str(exc),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.0"
+version = "1.4.1"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/src/clio_relay/process_containment.py
+++ b/src/clio_relay/process_containment.py
@@ -496,11 +496,12 @@ def containment_capability(*, startup_deadline: float | None = None) -> dict[str
         cached = _containment_capability_cache
     if cached is not None:
         return dict(cached)
+    result: dict[str, object]
     if os.name == "nt":
         try:
             handle = _create_windows_job()
         except RuntimeError as exc:
-            result: dict[str, object] = {
+            result = {
                 "mode": "windows_job_object",
                 "enforceable": False,
                 "reason": str(exc),

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.0"
+    assert version == "1.4.1"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1860,13 +1860,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.0-py3-none-any.whl",
+            resource_id="clio-relay-1.4.1-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.0.tar.gz",
+            resource_id="clio_relay-1.4.1.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2005,7 +2005,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.0"
+    assert policy.release_version == "1.4.1"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- declares the cross-platform containment capability document before platform branching so Linux and Windows paths share the exact `dict[str, object]` public type
- keeps the cluster-embedded containment implementation byte-identical to the package source
- advances the release identity and acceptance-matrix binding to 1.4.1

## Root cause

The type annotation was introduced only inside the Windows exception branch. Native Windows Pyright accepted the file because it narrowed away the Linux branch, but Linux Pyright inferred the Linux capability result as `dict[str, str | bool]` and correctly rejected assignment into the invariant `dict[str, object]` cache slot.

## Validation

- `pyright --pythonplatform Linux` on both containment implementations: 0 errors, 0 warnings
- exact embedded/source mirror test: passed
- release identity, acceptance matrix, and machine-readable policy tests: passed
- Ruff lint/format and dependency-lock check: passed

This is the focused fix for the v1.4.0 tag CI failure.
