### PR TITLE
fix: probe secure runtimes while live

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.2` uses a release-first patch process. A maintainer builds the
+> Version `1.4.3` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -752,6 +752,18 @@ unchanged as `binding`:
 }
 ```
 
+For live acceptance, the outer relay/JARVIS source job is deliberately not
+waited to terminal. The runner polls the supported `clio-relay job status`
+surface until that running `RelayJob` contains valid structured JARVIS runtime
+metadata, then performs the query and bind while retaining the source job. A
+failed or canceled source job, malformed metadata, or the existing acceptance
+timeout fails closed. If the execution is running before its selected service
+reports ready, the runner repeats the identity-bound execution query within the
+same deadline; a nonempty selector mismatch or multiple matches fails
+immediately. The `wait_for_terminal=true` argument above is scoped to
+the inner `jarvis_get_execution` MCP dispatch; it does not replace the live
+source-job poll or wait for the scheduler allocation to end.
+
 The compact binding contains selectors only. The bind operation accepts no host,
 port, endpoint path, dataset descriptor,
 scheduler identity, or lifecycle command from the caller. It verifies the exact

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.2"
+$Version = "1.4.3"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }
@@ -1519,6 +1519,18 @@ Invoke-RelayReport -Id "ares-secure-runtime" -ReportOption "--report" -Command @
   "--timeout-seconds", "900", "--poll-seconds", "1"
 )
 ```
+
+This scenario polls the released remote `clio-relay job status` contract for
+valid structured runtime metadata while the outer relay/JARVIS/SLURM source job
+is still `running`. It must not call the outer `job wait` or the completed-job
+artifact verifier before exercising the service. A failed or canceled source
+job, invalid metadata, or the same bounded timeout fails the report. The inner
+`jarvis_get_execution(wait_for_terminal=true)` remains required because it waits
+for that MCP dispatch and durable result, not for the source scheduler job to
+finish. A zero-binding result is retried within the same deadline while a
+nonempty selector mismatch or ambiguous match fails immediately. The report
+records the source relay job as retained and never requests scheduler
+cancellation.
 
 Detach and teardown inside this probe always pass
 `cancel_scheduler_job=false`. A naturally completed allocation is acceptable

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.2"
+release_version: "1.4.3"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 2db9a93f8ec88c41fa3fa937cdf62022f9bea211f78f1a7c23e4771907fe2e7a
+acceptance_matrix_sha256: 3ef31b0f5ce75c626de7c00f9c2a432e12adbad88c89cd77c8a630429bbea55b
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true
@@ -1111,6 +1111,7 @@ requirements:
     scenarios:
       - secure-runtime
     required_checks:
+      - secure-runtime.source-live-metadata
       - secure-runtime.jarvis-v3.5-query
       - secure-runtime.private-authority-bind
       - secure-runtime.browser-protocol

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.2"
+$Tag = "v1.4.3"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.2" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.3" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.2",
-  "matrix_sha256": "2db9a93f8ec88c41fa3fa937cdf62022f9bea211f78f1a7c23e4771907fe2e7a",
+  "release_version": "1.4.3",
+  "matrix_sha256": "3ef31b0f5ce75c626de7c00f9c2a432e12adbad88c89cd77c8a630429bbea55b",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/jarvis-packages/clio_relay/clio_relay/process_containment.py
+++ b/jarvis-packages/clio_relay/clio_relay/process_containment.py
@@ -55,14 +55,18 @@ class OwnedProcessSpawnError(RuntimeError):
         process_id: int,
         mode: str,
         cleanup_errors: list[str],
+        cause: BaseException,
     ) -> None:
         self.process_id = process_id
         self.mode = mode
         self.cleanup_verified = not cleanup_errors
         self.cleanup_errors = tuple(cleanup_errors)
+        self.startup_error_type = type(cause).__name__
+        self.startup_error_message = str(cause)
         detail = ",".join(cleanup_errors) if cleanup_errors else "none"
         super().__init__(
             "owned process startup failed: "
+            f"cause={self.startup_error_type}: {self.startup_error_message}; "
             f"pid={process_id} mode={mode} cleanup_verified={self.cleanup_verified} "
             f"cleanup_errors={detail}"
         )
@@ -580,7 +584,7 @@ def spawn_owned_process(
                 target_environment=validated_target_environment,
                 startup_deadline=startup_deadline,
             )
-        except BaseException:
+        except BaseException as exc:
             cleanup_errors = _cleanup_failed_owned_spawn(
                 process,
                 readiness=readiness,
@@ -591,7 +595,8 @@ def spawn_owned_process(
                 process_id=process.pid,
                 mode=mode,
                 cleanup_errors=cleanup_errors,
-            ) from None
+                cause=exc,
+            ) from exc
         return process
     if enforceable and mode == "linux_systemd_scope":
         process, unit, scope, readiness = _spawn_linux_systemd_scope(
@@ -621,7 +626,7 @@ def spawn_owned_process(
                 target_environment=validated_target_environment,
                 startup_deadline=startup_deadline,
             )
-        except BaseException:
+        except BaseException as exc:
             cleanup_errors = _cleanup_failed_owned_spawn(
                 process,
                 readiness=readiness,
@@ -633,7 +638,8 @@ def spawn_owned_process(
                 process_id=process.pid,
                 mode=mode,
                 cleanup_errors=cleanup_errors,
-            ) from None
+                cause=exc,
+            ) from exc
         return process
     process, readiness = _spawn_broker(command, popen_kwargs)
     registered = False
@@ -653,7 +659,7 @@ def spawn_owned_process(
             target_environment=validated_target_environment,
             startup_deadline=startup_deadline,
         )
-    except BaseException:
+    except BaseException as exc:
         cleanup_errors = _cleanup_failed_owned_spawn(
             process,
             readiness=readiness,
@@ -663,7 +669,8 @@ def spawn_owned_process(
             process_id=process.pid,
             mode="cooperative_process_group",
             cleanup_errors=cleanup_errors,
-        ) from None
+            cause=exc,
+        ) from exc
     return process
 
 
@@ -1454,7 +1461,7 @@ def _spawn_linux_systemd_scope(
             startup_deadline=startup_deadline,
         )
         scope = _validated_systemd_cgroup_path(control_group, unit=unit)
-    except BaseException:
+    except BaseException as exc:
         cleanup_errors = _cleanup_failed_linux_systemd_spawn(
             process,
             unit=unit,
@@ -1465,7 +1472,8 @@ def _spawn_linux_systemd_scope(
             process_id=process.pid,
             mode="linux_systemd_scope",
             cleanup_errors=cleanup_errors,
-        ) from None
+            cause=exc,
+        ) from exc
     return process, unit, scope, readiness
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.2"
+version = "1.4.3"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"

--- a/src/clio_relay/live_acceptance.py
+++ b/src/clio_relay/live_acceptance.py
@@ -35,7 +35,7 @@ from clio_relay.cluster_config import ClusterDefinition
 from clio_relay.config import RelaySettings
 from clio_relay.doctor import run_cluster_doctor
 from clio_relay.errors import ConfigurationError, RelayError
-from clio_relay.identifiers import DurableRecordId
+from clio_relay.identifiers import DurableRecordId, validate_durable_record_id
 from clio_relay.installation import (
     verify_remote_clio_kit_native_execution_component,
     verify_remote_native_jarvis_component,
@@ -52,7 +52,13 @@ from clio_relay.mcp_stdio_validation import (
     decode_strict_json,
     run_packaged_mcp_stdio_session,
 )
-from clio_relay.models import GatewaySession, GatewaySessionState
+from clio_relay.models import (
+    TERMINAL_STATES,
+    GatewaySession,
+    GatewaySessionState,
+    JobState,
+    RelayJob,
+)
 from clio_relay.pagination import MAX_RESPONSE_PAGE_RECORDS
 from clio_relay.progress_provenance import (
     validate_package_progress_acceptance_metadata,
@@ -649,37 +655,77 @@ def _run_live_acceptance(
         )
         lines.append(f"acceptance.live_progress_adapter={expected_progress_adapter}")
 
-    _wait_for_success(
-        options.definition,
-        job_id,
-        timeout_seconds=options.timeout_seconds,
-        poll_seconds=options.poll_seconds,
-        runner=command_runner,
-    )
-    lines.append("acceptance.job_state=succeeded")
-    if options.verify_cluster_deployment:
-        lines.append("worker.execute=passed")
-
-    runtime_metadata = _verify_completed_job(
-        options.definition,
-        job_id,
-        line_prefix="acceptance",
-        lines=lines,
-        runner=command_runner,
-        expected_progress_adapter=expected_progress_adapter,
-        expected_progress_package=expected_progress_package,
-        recorder=recorder,
-        require_structured_runtime_metadata=options.require_structured_runtime_metadata,
-    )
     secure_runtime_forbidden_values: set[str] = set()
-    if secure_runtime_probe is not None:
+    if secure_runtime_probe is None:
+        _wait_for_success(
+            options.definition,
+            job_id,
+            timeout_seconds=options.timeout_seconds,
+            poll_seconds=options.poll_seconds,
+            runner=command_runner,
+        )
+        lines.append("acceptance.job_state=succeeded")
+        if options.verify_cluster_deployment:
+            lines.append("worker.execute=passed")
+
+        _verify_completed_job(
+            options.definition,
+            job_id,
+            line_prefix="acceptance",
+            lines=lines,
+            runner=command_runner,
+            expected_progress_adapter=expected_progress_adapter,
+            expected_progress_package=expected_progress_package,
+            recorder=recorder,
+            require_structured_runtime_metadata=options.require_structured_runtime_metadata,
+        )
+    else:
         if recorder is None:
             raise ConfigurationError(
                 "secure runtime acceptance requires a machine-readable report path"
             )
-        if runtime_metadata is None or not runtime_metadata.structured:
-            raise RelayError(
-                "secure runtime acceptance requires structured JARVIS runtime metadata"
+        with _validation_check(
+            recorder,
+            "secure-runtime.source-live-metadata",
+            "observe trusted runtime metadata while retaining the running source job",
+            forbidden_values=set(),
+        ) as evidence:
+            runtime_metadata = _wait_for_live_structured_runtime_metadata(
+                options.definition,
+                job_id,
+                line_prefix="acceptance",
+                lines=lines,
+                timeout_seconds=options.timeout_seconds,
+                poll_seconds=options.poll_seconds,
+                runner=command_runner,
+            )
+            runtime_document = runtime_metadata.document
+            runtime_source = str(runtime_document["source"])
+            evidence.append(
+                EvidenceReference(
+                    kind="relay_job_status",
+                    reference=f"relay-job://{options.cluster}/{job_id}",
+                    metadata={
+                        "state": JobState.RUNNING.value,
+                        "runtime_metadata_source": runtime_source,
+                        "source_job_retained": True,
+                        "cancel_scheduler_job": False,
+                    },
+                )
+            )
+            recorder.add_resource(
+                ValidationResource(
+                    kind="relay_job",
+                    resource_id=job_id,
+                    role="secure_runtime_source",
+                    cluster=options.cluster,
+                    state=JobState.RUNNING.value,
+                    metadata={
+                        "runtime_metadata_source": runtime_source,
+                        "retained": True,
+                        "cancel_scheduler_job": False,
+                    },
+                )
             )
         secure_runtime_forbidden_values = _verify_secure_runtime_acceptance(
             options,
@@ -1320,35 +1366,80 @@ def _verify_secure_runtime_acceptance(
             "query one execution-owned service through the pinned JARVIS v3.5 contract",
             forbidden_values=forbidden_values,
         ) as evidence:
-            query_session = run_packaged_mcp_stdio_session(
-                profile="user",
-                tool="jarvis_get_execution",
-                arguments={
-                    "cluster": options.cluster,
-                    "pipeline_id": pipeline_id,
-                    "execution_id": execution_id,
-                    "include_service_runtimes": True,
-                    "wait_for_terminal": True,
-                    "wait_timeout_seconds": options.timeout_seconds,
-                    "poll_seconds": options.poll_seconds,
-                },
-                timeout_seconds=options.timeout_seconds + 30.0,
-                require_enforceable_containment=True,
-            )
-            query_result = _packaged_mcp_structured_result(
-                query_session,
-                expected_tool="jarvis_get_execution",
-            )
-            query_mcp_evidence = _packaged_mcp_acceptance_evidence(
-                query_session,
-                expected_tool="jarvis_get_execution",
-            )
-            public_documents.append(query_result)
-            handoff = _select_secure_runtime_handoff(
-                query_result,
-                cluster=options.cluster,
-                config=config,
-            )
+            query_deadline = time.monotonic() + options.timeout_seconds
+            query_attempt = 0
+            first_query_identity: PackagedMcpAcceptanceEvidence | None = None
+            handoff: JarvisServiceRuntimeHandoff | None = None
+            while True:
+                remaining = query_deadline - time.monotonic()
+                if remaining <= 0:
+                    raise RelayError(
+                        "timed out waiting for one ready JARVIS service runtime binding: "
+                        f"{execution_id}"
+                    )
+                query_attempt += 1
+                query_session = run_packaged_mcp_stdio_session(
+                    profile="user",
+                    tool="jarvis_get_execution",
+                    arguments={
+                        "cluster": options.cluster,
+                        "pipeline_id": pipeline_id,
+                        "execution_id": execution_id,
+                        "include_service_runtimes": True,
+                        "wait_for_terminal": True,
+                        "wait_timeout_seconds": remaining,
+                        "poll_seconds": options.poll_seconds,
+                    },
+                    timeout_seconds=remaining + 30.0,
+                    require_enforceable_containment=True,
+                )
+                query_result = _packaged_mcp_structured_result(
+                    query_session,
+                    expected_tool="jarvis_get_execution",
+                )
+                query_mcp_evidence = _packaged_mcp_acceptance_evidence(
+                    query_session,
+                    expected_tool="jarvis_get_execution",
+                )
+                if first_query_identity is None:
+                    first_query_identity = query_mcp_evidence
+                elif query_mcp_evidence != first_query_identity:
+                    raise RelayError(
+                        "packaged MCP identity changed while waiting for service readiness"
+                    )
+                public_documents.append(query_result)
+                candidate_handoff = _select_secure_runtime_handoff(
+                    query_result,
+                    cluster=options.cluster,
+                    config=config,
+                )
+                if candidate_handoff is not None:
+                    handoff = candidate_handoff
+                    break
+                evidence.append(
+                    EvidenceReference(
+                        kind="packaged_mcp_stdio",
+                        reference=(
+                            f"packaged-mcp://jarvis_get_execution/readiness-attempt/{query_attempt}"
+                        ),
+                        excerpt="execution query returned no ready service runtime binding",
+                        metadata={
+                            **query_mcp_evidence.model_dump(mode="json"),
+                            "pipeline_id": pipeline_id,
+                            "execution_id": execution_id,
+                            "ready_binding_count": 0,
+                        },
+                    )
+                )
+                remaining = query_deadline - time.monotonic()
+                if remaining <= 0:
+                    raise RelayError(
+                        "timed out waiting for one ready JARVIS service runtime binding: "
+                        f"{execution_id}"
+                    )
+                time.sleep(min(options.poll_seconds, remaining))
+
+            assert handoff is not None
             source_artifact_sha256 = _query_source_artifact_sha256(
                 query_result,
                 handoff=handoff,
@@ -2209,13 +2300,18 @@ def _select_secure_runtime_handoff(
     *,
     cluster: str,
     config: SecureRuntimeProbeConfig,
-) -> JarvisServiceRuntimeHandoff:
+) -> JarvisServiceRuntimeHandoff | None:
     """Select exactly one artifact-bound service handoff using configured identities."""
     if query_result.get("terminal") is not True or query_result.get("state") != "succeeded":
         raise RelayError("JARVIS execution query did not complete successfully")
+    if query_result.get("cluster") != cluster:
+        raise RelayError("JARVIS execution query changed cluster identity")
+    _query_receipt_artifact_identity(query_result)
     raw_bindings = query_result.get("service_runtime_bindings")
     if not isinstance(raw_bindings, list):
         raise RelayError("JARVIS v3.5 execution query omitted service_runtime_bindings")
+    if not raw_bindings:
+        return None
     bindings: list[JarvisServiceRuntimeHandoff] = []
     for raw in cast(list[object], raw_bindings):
         try:
@@ -2248,22 +2344,37 @@ def _query_source_artifact_sha256(
     handoff: JarvisServiceRuntimeHandoff,
 ) -> str:
     """Bind the compact handoff to the same immutable private MCP artifact."""
-    if query_result.get("job_id") != handoff.source_job_id:
+    job_id, artifact_id, digest = _query_receipt_artifact_identity(query_result)
+    if job_id != handoff.source_job_id:
         raise RelayError("service runtime handoff source job differs from its query receipt")
+    if artifact_id != handoff.source_artifact_id:
+        raise RelayError("service runtime handoff source artifact differs from its query receipt")
+    return digest
+
+
+def _query_receipt_artifact_identity(
+    query_result: dict[str, Any],
+) -> tuple[str, str, str]:
+    """Validate one durable query receipt and its private result-artifact identity."""
+    try:
+        job_id = validate_durable_record_id(query_result.get("job_id"))
+    except (TypeError, ValueError) as exc:
+        raise RelayError("JARVIS execution query omitted a durable relay job identity") from exc
     raw_artifact = query_result.get("mcp_result_artifact")
     if not isinstance(raw_artifact, dict):
         raise RelayError("JARVIS execution query omitted mcp_result_artifact")
     artifact = cast(dict[str, object], raw_artifact)
-    if (
-        artifact.get("artifact_id") != handoff.source_artifact_id
-        or artifact.get("job_id") != handoff.source_job_id
-        or artifact.get("kind") != "mcp_result"
-    ):
-        raise RelayError("service runtime handoff does not match its private MCP artifact")
+    try:
+        artifact_id = validate_durable_record_id(artifact.get("artifact_id"))
+        artifact_job_id = validate_durable_record_id(artifact.get("job_id"))
+    except (TypeError, ValueError) as exc:
+        raise RelayError("JARVIS execution query artifact identity was invalid") from exc
+    if artifact_job_id != job_id or artifact.get("kind") != "mcp_result":
+        raise RelayError("JARVIS execution query artifact does not match its receipt")
     digest = artifact.get("sha256")
     if not isinstance(digest, str) or re.fullmatch(r"[0-9a-f]{64}", digest) is None:
         raise RelayError("service runtime source artifact omitted a canonical SHA-256")
-    return digest
+    return job_id, artifact_id, digest
 
 
 def _secure_runtime_cleanup_candidate(
@@ -3228,6 +3339,97 @@ def _generated_agent_prompt(
     )
 
 
+def _wait_for_live_structured_runtime_metadata(
+    definition: ClusterDefinition,
+    job_id: str,
+    *,
+    line_prefix: str,
+    lines: list[str],
+    timeout_seconds: float,
+    poll_seconds: float,
+    runner: CommandRunner,
+) -> RuntimeMetadataAcceptance:
+    """Wait for trusted runtime metadata without waiting for its source job to finish."""
+    deadline = time.monotonic() + timeout_seconds
+    structured_sources = {
+        RuntimeMetadataSource.JARVIS_MCP,
+        RuntimeMetadataSource.JARVIS_SIDECAR,
+    }
+    while True:
+        raw_status = _remote_clio_json(
+            definition,
+            ["job", "status", job_id],
+            runner=runner,
+        )
+        if not isinstance(raw_status, dict):
+            raise RelayError("secure runtime source job status was not a JSON object")
+        status = cast(dict[str, Any], raw_status)
+        raw_job = status.get("job")
+        try:
+            job = RelayJob.model_validate(raw_job)
+        except ValueError as exc:
+            raise RelayError(f"secure runtime source RelayJob was invalid: {exc}") from exc
+        if job.job_id != job_id:
+            raise RelayError(
+                "secure runtime source job status changed identity: "
+                f"expected={job_id} observed={job.job_id}"
+            )
+        reported_terminal = status.get("terminal")
+        actual_terminal = job.state in TERMINAL_STATES
+        if not isinstance(reported_terminal, bool) or reported_terminal is not actual_terminal:
+            raise RelayError("secure runtime source job status had inconsistent terminal state")
+        if actual_terminal:
+            lines.append(f"{line_prefix}.job_state={job.state.value}")
+            if job.state.value in {"failed", "canceled"}:
+                raise RelayError(
+                    "secure runtime source job "
+                    f"{job.state.value} before structured runtime metadata was usable"
+                )
+            raise RelayError(
+                "secure runtime source job succeeded before a live structured runtime was available"
+            )
+
+        raw_runtime = job.metadata.get("runtime_metadata")
+        if raw_runtime is not None:
+            if not isinstance(raw_runtime, dict):
+                raise RelayError("secure runtime source metadata was not a JSON object")
+            try:
+                validated = JarvisRuntimeMetadata.model_validate(raw_runtime)
+            except ValueError as exc:
+                raise RelayError(f"secure runtime source metadata was invalid: {exc}") from exc
+            if validated.source in structured_sources:
+                if not validated.pipeline_id or not validated.execution_id:
+                    raise RelayError(
+                        "secure runtime source metadata omitted pipeline_id or execution_id"
+                    )
+                if job.state is not JobState.RUNNING:
+                    if time.monotonic() >= deadline:
+                        lines.append(f"{line_prefix}.job_state={job.state.value}")
+                        raise RelayError(
+                            f"timed out waiting for the secure runtime source job to run: {job_id}"
+                        )
+                    time.sleep(poll_seconds)
+                    continue
+                document = validated.model_dump(mode="json")
+                lines.append(f"{line_prefix}.job_state={job.state.value}")
+                lines.extend(
+                    _runtime_metadata_document_facts(
+                        document,
+                        line_prefix=line_prefix,
+                    )
+                )
+                lines.append(f"{line_prefix}.source_job_retained=ok")
+                return RuntimeMetadataAcceptance(document=document, structured=True)
+
+        if time.monotonic() >= deadline:
+            lines.append(f"{line_prefix}.job_state={job.state.value}")
+            raise RelayError(
+                "timed out waiting for structured runtime metadata from secure runtime "
+                f"source job: {job_id}"
+            )
+        time.sleep(poll_seconds)
+
+
 def _wait_for_success(
     definition: ClusterDefinition,
     job_id: str,
@@ -3587,11 +3789,20 @@ def _runtime_metadata_facts(
 ) -> list[str]:
     """Validate a runtime metadata payload and return report-ready facts."""
     runtime = _decode_runtime_metadata_payload(payload)
-    source = str(runtime["source"])
-    facts = [
+    return [
         f"{line_prefix}.runtime_metadata_artifact={artifact_id}",
-        f"{line_prefix}.runtime_metadata_source={source}",
+        *_runtime_metadata_document_facts(runtime, line_prefix=line_prefix),
     ]
+
+
+def _runtime_metadata_document_facts(
+    runtime: dict[str, Any],
+    *,
+    line_prefix: str,
+) -> list[str]:
+    """Return report-ready facts for one already validated runtime document."""
+    source = str(runtime["source"])
+    facts = [f"{line_prefix}.runtime_metadata_source={source}"]
     structured_sources = {
         RuntimeMetadataSource.JARVIS_MCP.value,
         RuntimeMetadataSource.JARVIS_SIDECAR.value,

--- a/src/clio_relay/live_acceptance.py
+++ b/src/clio_relay/live_acceptance.py
@@ -1393,6 +1393,11 @@ def _verify_secure_runtime_acceptance(
                     timeout_seconds=remaining + 30.0,
                     require_enforceable_containment=True,
                 )
+                if time.monotonic() >= query_deadline:
+                    raise RelayError(
+                        "timed out waiting for one ready JARVIS service runtime binding: "
+                        f"{execution_id}"
+                    )
                 query_result = _packaged_mcp_structured_result(
                     query_session,
                     expected_tool="jarvis_get_execution",
@@ -3397,6 +3402,11 @@ def _wait_for_live_structured_runtime_metadata(
                 validated = JarvisRuntimeMetadata.model_validate(raw_runtime)
             except ValueError as exc:
                 raise RelayError(f"secure runtime source metadata was invalid: {exc}") from exc
+            if validated.schema_version != RUNTIME_METADATA_SCHEMA:
+                raise RelayError(
+                    "secure runtime source metadata used an unsupported schema version: "
+                    f"{validated.schema_version}"
+                )
             if validated.source in structured_sources:
                 if not validated.pipeline_id or not validated.execution_id:
                     raise RelayError(

--- a/src/clio_relay/process_containment.py
+++ b/src/clio_relay/process_containment.py
@@ -55,14 +55,18 @@ class OwnedProcessSpawnError(RuntimeError):
         process_id: int,
         mode: str,
         cleanup_errors: list[str],
+        cause: BaseException,
     ) -> None:
         self.process_id = process_id
         self.mode = mode
         self.cleanup_verified = not cleanup_errors
         self.cleanup_errors = tuple(cleanup_errors)
+        self.startup_error_type = type(cause).__name__
+        self.startup_error_message = str(cause)
         detail = ",".join(cleanup_errors) if cleanup_errors else "none"
         super().__init__(
             "owned process startup failed: "
+            f"cause={self.startup_error_type}: {self.startup_error_message}; "
             f"pid={process_id} mode={mode} cleanup_verified={self.cleanup_verified} "
             f"cleanup_errors={detail}"
         )
@@ -580,7 +584,7 @@ def spawn_owned_process(
                 target_environment=validated_target_environment,
                 startup_deadline=startup_deadline,
             )
-        except BaseException:
+        except BaseException as exc:
             cleanup_errors = _cleanup_failed_owned_spawn(
                 process,
                 readiness=readiness,
@@ -591,7 +595,8 @@ def spawn_owned_process(
                 process_id=process.pid,
                 mode=mode,
                 cleanup_errors=cleanup_errors,
-            ) from None
+                cause=exc,
+            ) from exc
         return process
     if enforceable and mode == "linux_systemd_scope":
         process, unit, scope, readiness = _spawn_linux_systemd_scope(
@@ -621,7 +626,7 @@ def spawn_owned_process(
                 target_environment=validated_target_environment,
                 startup_deadline=startup_deadline,
             )
-        except BaseException:
+        except BaseException as exc:
             cleanup_errors = _cleanup_failed_owned_spawn(
                 process,
                 readiness=readiness,
@@ -633,7 +638,8 @@ def spawn_owned_process(
                 process_id=process.pid,
                 mode=mode,
                 cleanup_errors=cleanup_errors,
-            ) from None
+                cause=exc,
+            ) from exc
         return process
     process, readiness = _spawn_broker(command, popen_kwargs)
     registered = False
@@ -653,7 +659,7 @@ def spawn_owned_process(
             target_environment=validated_target_environment,
             startup_deadline=startup_deadline,
         )
-    except BaseException:
+    except BaseException as exc:
         cleanup_errors = _cleanup_failed_owned_spawn(
             process,
             readiness=readiness,
@@ -663,7 +669,8 @@ def spawn_owned_process(
             process_id=process.pid,
             mode="cooperative_process_group",
             cleanup_errors=cleanup_errors,
-        ) from None
+            cause=exc,
+        ) from exc
     return process
 
 
@@ -1454,7 +1461,7 @@ def _spawn_linux_systemd_scope(
             startup_deadline=startup_deadline,
         )
         scope = _validated_systemd_cgroup_path(control_group, unit=unit)
-    except BaseException:
+    except BaseException as exc:
         cleanup_errors = _cleanup_failed_linux_systemd_spawn(
             process,
             unit=unit,
@@ -1465,7 +1472,8 @@ def _spawn_linux_systemd_scope(
             process_id=process.pid,
             mode="linux_systemd_scope",
             cleanup_errors=cleanup_errors,
-        ) from None
+            cause=exc,
+        ) from exc
     return process, unit, scope, readiness
 
 

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1699,7 +1699,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "2db9a93f8ec88c41fa3fa937cdf62022f9bea211f78f1a7c23e4771907fe2e7a"
+        "3ef31b0f5ce75c626de7c00f9c2a432e12adbad88c89cd77c8a630429bbea55b"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_live_acceptance.py
+++ b/tests/test_live_acceptance.py
@@ -34,14 +34,23 @@ from clio_relay.live_acceptance import (
     _http_json,  # pyright: ignore[reportPrivateUsage]
     _packaged_mcp_acceptance_evidence,  # pyright: ignore[reportPrivateUsage]
     _secure_runtime_probe_config,  # pyright: ignore[reportPrivateUsage]
+    _select_secure_runtime_handoff,  # pyright: ignore[reportPrivateUsage]
     _verify_cluster_deployment,  # pyright: ignore[reportPrivateUsage]
     _verify_live_package_progress,  # pyright: ignore[reportPrivateUsage]
     _verify_runtime_metadata_artifact,  # pyright: ignore[reportPrivateUsage]
     _verify_secure_runtime_acceptance,  # pyright: ignore[reportPrivateUsage]
+    _wait_for_live_structured_runtime_metadata,  # pyright: ignore[reportPrivateUsage]
     run_live_acceptance,
 )
 from clio_relay.mcp_stdio_validation import PackagedMcpStdioSession
-from clio_relay.models import GatewaySession, GatewaySessionState
+from clio_relay.models import (
+    GatewaySession,
+    GatewaySessionState,
+    JarvisRunSpec,
+    JobKind,
+    JobState,
+    RelayJob,
+)
 from clio_relay.service_runtime import ServiceRuntimeStartResult, ServiceRuntimeStopResult
 from clio_relay.session_lifecycle import CleanupResource
 from clio_relay.validation_report import (
@@ -103,6 +112,54 @@ def _provider_progress_record(
             "prediction_status": prediction_status,
             "eta_seconds": 1.0,
         },
+    }
+
+
+_LIVE_SOURCE_JOB_ID = "job_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+
+def _structured_live_runtime_metadata() -> dict[str, object]:
+    """Build one valid nonterminal JARVIS-owned runtime observation."""
+    return {
+        "schema_version": "clio-relay.jarvis-runtime.v1",
+        "source": "jarvis_mcp",
+        "execution_id": "execution-live-41",
+        "pipeline_id": "pipeline-live-41",
+        "scheduler_provider": "slurm",
+        "scheduler_job_id": "22064",
+        "terminal": {"state": "running", "terminal": False},
+        "field_sources": {
+            "execution_id": "jarvis_mcp",
+            "pipeline_id": "jarvis_mcp",
+            "scheduler_provider": "jarvis_mcp",
+            "scheduler_job_id": "jarvis_mcp",
+        },
+    }
+
+
+def _live_source_status(
+    state: JobState,
+    *,
+    runtime_metadata: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """Render the supported remote ``job status`` envelope for a source run."""
+    metadata: dict[str, object] = {}
+    if runtime_metadata is not None:
+        metadata["runtime_metadata"] = runtime_metadata
+    job = RelayJob(
+        job_id=_LIVE_SOURCE_JOB_ID,
+        cluster="test-cluster",
+        kind=JobKind.JARVIS,
+        state=state,
+        spec=JarvisRunSpec(command=["true"]),
+        idempotency_key="secure-runtime-live-source",
+        metadata=metadata,
+    )
+    return {
+        "job": job.model_dump(mode="json"),
+        "relay_queue": {"state": state.value},
+        "scheduler": [],
+        "terminal": state in {JobState.SUCCEEDED, JobState.FAILED, JobState.CANCELED},
     }
 
 
@@ -314,6 +371,241 @@ def test_live_acceptance_does_not_mark_untrusted_metadata_as_structured() -> Non
     assert "acceptance.structured_runtime_metadata=ok" not in lines
     assert "acceptance.structured_runtime_scheduler_identity=ok" not in lines
     assert "runtime_metadata.compatibility=acceptance:untrusted_compatibility" in lines
+
+
+def test_secure_runtime_acceptance_polls_running_source_metadata() -> None:
+    """A live service probe starts from authoritative metadata while its job runs."""
+    commands: list[str] = []
+
+    def fake_runner(
+        command: list[str],
+        *,
+        input: bytes | None = None,
+    ) -> subprocess.CompletedProcess[bytes]:
+        del input
+        commands.append(command[-1])
+        return _completed(
+            command,
+            json.dumps(
+                _live_source_status(
+                    JobState.RUNNING,
+                    runtime_metadata=_structured_live_runtime_metadata(),
+                )
+            ),
+        )
+
+    lines: list[str] = []
+    result = _wait_for_live_structured_runtime_metadata(
+        ClusterDefinition(name="test-cluster", ssh_host="test-host"),
+        _LIVE_SOURCE_JOB_ID,
+        line_prefix="acceptance",
+        lines=lines,
+        timeout_seconds=5,
+        poll_seconds=0.01,
+        runner=fake_runner,
+    )
+
+    assert result.structured is True
+    assert result.document["execution_id"] == "execution-live-41"
+    assert "acceptance.job_state=running" in lines
+    assert "acceptance.structured_runtime_metadata=ok" in lines
+    assert "acceptance.source_job_retained=ok" in lines
+    assert len(commands) == 1
+    assert f"job status {_LIVE_SOURCE_JOB_ID}" in commands[0]
+
+
+def test_secure_runtime_acceptance_fails_if_source_job_fails_before_metadata() -> None:
+    """A failed source job cannot be mistaken for a not-yet-ready live service."""
+
+    def fake_runner(
+        command: list[str],
+        *,
+        input: bytes | None = None,
+    ) -> subprocess.CompletedProcess[bytes]:
+        del input
+        return _completed(command, json.dumps(_live_source_status(JobState.FAILED)))
+
+    with pytest.raises(RelayError, match="source job failed before structured runtime metadata"):
+        _wait_for_live_structured_runtime_metadata(
+            ClusterDefinition(name="test-cluster", ssh_host="test-host"),
+            _LIVE_SOURCE_JOB_ID,
+            line_prefix="acceptance",
+            lines=[],
+            timeout_seconds=5,
+            poll_seconds=0.01,
+            runner=fake_runner,
+        )
+
+
+def test_secure_runtime_acceptance_metadata_poll_is_bounded() -> None:
+    """Missing live metadata exhausts the caller's existing acceptance timeout."""
+    calls = 0
+
+    def fake_runner(
+        command: list[str],
+        *,
+        input: bytes | None = None,
+    ) -> subprocess.CompletedProcess[bytes]:
+        nonlocal calls
+        del input
+        calls += 1
+        return _completed(command, json.dumps(_live_source_status(JobState.RUNNING)))
+
+    with pytest.raises(RelayError, match="timed out waiting for structured runtime metadata"):
+        _wait_for_live_structured_runtime_metadata(
+            ClusterDefinition(name="test-cluster", ssh_host="test-host"),
+            _LIVE_SOURCE_JOB_ID,
+            line_prefix="acceptance",
+            lines=[],
+            timeout_seconds=0,
+            poll_seconds=0.01,
+            runner=fake_runner,
+        )
+
+    assert calls == 1
+
+
+def test_secure_runtime_orchestration_never_waits_for_outer_job_terminal(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Secure acceptance probes a running service without batch completion checks."""
+    pipeline = tmp_path / "secure-runtime.yaml"
+    pipeline.write_text("name: secure-runtime\npkgs: []\n", encoding="utf-8")
+    commands: list[str] = []
+    verifier_calls: list[dict[str, Any]] = []
+    config = SecureRuntimeProbeConfig(
+        package_name="builtin.paraview",
+        command={"command_id": "view-command-41"},
+        protocol_adapter=SecureRuntimeProtocolAdapter.model_validate(
+            {
+                "command_request_id_pointer": "/command_id",
+                "health": {
+                    "service_instance_id_pointer": "/service_instance_id",
+                    "revision_pointer": "/revision",
+                },
+                "state": {
+                    "service_instance_id_pointer": "/service_instance_id",
+                    "execution_id_pointer": "/execution_id",
+                    "dataset_descriptor_pointer": "/dataset/descriptor",
+                    "revision_pointer": "/revision",
+                },
+                "command": {
+                    "service_instance_id_pointer": "/state/service_instance_id",
+                    "execution_id_pointer": "/state/execution_id",
+                    "dataset_descriptor_pointer": "/state/dataset/descriptor",
+                    "revision_pointer": "/state/revision",
+                    "command_id_pointer": "/command_id",
+                },
+                "events": {
+                    "service_instance_id_pointer": "/service_instance_id",
+                    "execution_id_pointer": "/execution_id",
+                    "dataset_descriptor_pointer": "/dataset/descriptor",
+                    "revision_pointer": "/revision",
+                    "event_name": "state",
+                },
+            }
+        ),
+    )
+
+    def fake_runner(
+        command: list[str],
+        *,
+        input: bytes | None = None,
+    ) -> subprocess.CompletedProcess[bytes]:
+        del input
+        script = command[-1]
+        commands.append(script)
+        if "mkdir -p" in script or "cat >" in script:
+            return _completed(command, "")
+        if "job submit" in script:
+            return _completed(command, f"{_LIVE_SOURCE_JOB_ID}\n")
+        if f"job status {_LIVE_SOURCE_JOB_ID}" in script:
+            return _completed(
+                command,
+                json.dumps(
+                    _live_source_status(
+                        JobState.RUNNING,
+                        runtime_metadata=_structured_live_runtime_metadata(),
+                    )
+                ),
+            )
+        raise AssertionError(f"unexpected command: {command}")
+
+    def forbidden_batch_call(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("secure runtime acceptance used a batch terminal verifier")
+
+    def verify_secure_runtime(
+        _options: LiveAcceptanceOptions,
+        *,
+        config: SecureRuntimeProbeConfig,
+        runtime_metadata: dict[str, Any],
+        recorder: ValidationRecorder,
+    ) -> set[str]:
+        verifier_calls.append(
+            {
+                "config": config,
+                "runtime_metadata": runtime_metadata,
+                "recorder": recorder,
+            }
+        )
+        return set()
+
+    def fake_cluster_doctor(_definition: ClusterDefinition) -> list[str]:
+        return ["cluster: test-cluster"]
+
+    def configured_probe(_pipeline_yaml: str) -> SecureRuntimeProbeConfig:
+        return config
+
+    monkeypatch.setattr(
+        "clio_relay.live_acceptance.run_cluster_doctor",
+        fake_cluster_doctor,
+    )
+    monkeypatch.setattr(
+        "clio_relay.live_acceptance._secure_runtime_probe_config",
+        configured_probe,
+    )
+    monkeypatch.setattr("clio_relay.live_acceptance._wait_for_success", forbidden_batch_call)
+    monkeypatch.setattr("clio_relay.live_acceptance._verify_completed_job", forbidden_batch_call)
+    monkeypatch.setattr(
+        "clio_relay.live_acceptance._verify_secure_runtime_acceptance",
+        verify_secure_runtime,
+    )
+
+    report_path = tmp_path / "secure-runtime-report.json"
+    lines = run_live_acceptance(
+        LiveAcceptanceOptions(
+            cluster="test-cluster",
+            definition=ClusterDefinition(name="test-cluster", ssh_host="test-host"),
+            jarvis_yaml=pipeline,
+            report_path=report_path,
+            timeout_seconds=5,
+            poll_seconds=0.01,
+        ),
+        runner=fake_runner,
+    )
+
+    assert len(verifier_calls) == 1
+    assert verifier_calls[0]["runtime_metadata"]["execution_id"] == "execution-live-41"
+    assert not any("job wait" in command for command in commands)
+    assert not any("job monitor" in command for command in commands)
+    assert "acceptance.job_state=running" in lines
+    assert "secure-runtime.acceptance=ok" in lines
+    assert "live acceptance passed" in lines
+    report = load_validation_report(report_path)
+    source_check = next(
+        check for check in report.checks if check.check_id == "secure-runtime.source-live-metadata"
+    )
+    assert source_check.status.value == "passed"
+    source = next(
+        resource
+        for resource in report.resources
+        if resource.kind == "relay_job" and resource.resource_id == _LIVE_SOURCE_JOB_ID
+    )
+    assert source.role == "secure_runtime_source"
+    assert source.state == "running"
+    assert source.metadata["retained"] is True
+    assert source.metadata["cancel_scheduler_job"] is False
 
 
 def test_live_acceptance_stages_files_and_strips_relay_extension(
@@ -2287,6 +2579,7 @@ def test_secure_runtime_acceptance_records_exact_v35_browser_and_cleanup_path(
         "scheduler_cancel_requested": False,
     }
     mcp_calls: list[tuple[str, dict[str, Any]]] = []
+    query_attempts = 0
 
     def packaged_session(
         *,
@@ -2297,6 +2590,7 @@ def test_secure_runtime_acceptance_records_exact_v35_browser_and_cleanup_path(
         extra_environment: dict[str, str] | None = None,
         require_enforceable_containment: bool = False,
     ) -> PackagedMcpStdioSession:
+        nonlocal query_attempts
         assert profile == "user"
         assert timeout_seconds > 0
         assert require_enforceable_containment is True
@@ -2308,7 +2602,16 @@ def test_secure_runtime_acceptance_records_exact_v35_browser_and_cleanup_path(
         else:
             assert extra_environment is None
         mcp_calls.append((tool, arguments))
-        payload = query_result if tool == "jarvis_get_execution" else bind_result
+        payload: dict[str, Any]
+        if tool == "jarvis_get_execution":
+            query_attempts += 1
+            if query_attempts == 1:
+                payload = dict(query_result)
+                payload["service_runtime_bindings"] = list[dict[str, Any]]()
+            else:
+                payload = query_result
+        else:
+            payload = bind_result
         return _secure_runtime_packaged_session(
             tool,
             payload,
@@ -2530,18 +2833,18 @@ def test_secure_runtime_acceptance_records_exact_v35_browser_and_cleanup_path(
 
     assert [name for name, _arguments in mcp_calls] == [
         "jarvis_get_execution",
+        "jarvis_get_execution",
         "relay_bind_jarvis_runtime",
     ]
-    assert mcp_calls[0][1] == {
-        "cluster": cluster,
-        "pipeline_id": "pipeline-service-41",
-        "execution_id": "execution-service-41",
-        "include_service_runtimes": True,
-        "wait_for_terminal": True,
-        "wait_timeout_seconds": 30,
-        "poll_seconds": 0.01,
-    }
-    assert mcp_calls[1][1]["binding"] == handoff
+    for _name, query_arguments in mcp_calls[:2]:
+        assert query_arguments["cluster"] == cluster
+        assert query_arguments["pipeline_id"] == "pipeline-service-41"
+        assert query_arguments["execution_id"] == "execution-service-41"
+        assert query_arguments["include_service_runtimes"] is True
+        assert query_arguments["wait_for_terminal"] is True
+        assert 0 < query_arguments["wait_timeout_seconds"] <= 30
+        assert query_arguments["poll_seconds"] == 0.01
+    assert mcp_calls[2][1]["binding"] == handoff
     assert _SecureSupervisor.calls == [
         "browser_attach",
         "browser_detach",
@@ -2565,6 +2868,13 @@ def test_secure_runtime_acceptance_records_exact_v35_browser_and_cleanup_path(
         if reference.kind == "secure_runtime_acceptance"
     )
     metadata = evidence.metadata
+    readiness_evidence = next(
+        reference
+        for check in report.checks
+        for reference in check.evidence
+        if reference.reference == "packaged-mcp://jarvis_get_execution/readiness-attempt/1"
+    )
+    assert readiness_evidence.metadata["ready_binding_count"] == 0
     assert metadata["cluster"] == cluster
     assert metadata["lifecycle_states"] == ["ready", "degraded", "ready", "closed"]
     assert metadata["scheduler_cancel_requested"] is False
@@ -2606,6 +2916,165 @@ def test_secure_runtime_acceptance_records_exact_v35_browser_and_cleanup_path(
         forbidden_values=forbidden,
         label="finished secure runtime report",
     )
+
+
+def test_secure_runtime_ready_binding_wait_is_bounded(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A running execution with no ready service fails on the acceptance deadline."""
+    cluster = "operator-readiness-timeout"
+    calls = 0
+    clock = 100.0
+
+    def monotonic() -> float:
+        return clock
+
+    def sleep(seconds: float) -> None:
+        nonlocal clock
+        clock += seconds
+
+    def packaged_session(
+        *,
+        profile: str,
+        tool: str,
+        arguments: dict[str, Any],
+        timeout_seconds: float,
+        extra_environment: dict[str, str] | None = None,
+        require_enforceable_containment: bool = False,
+    ) -> PackagedMcpStdioSession:
+        nonlocal calls
+        del profile, arguments, timeout_seconds, extra_environment
+        assert tool == "jarvis_get_execution"
+        assert require_enforceable_containment is True
+        calls += 1
+        return _secure_runtime_packaged_session(
+            tool,
+            {
+                "terminal": True,
+                "state": "succeeded",
+                "cluster": cluster,
+                "job_id": "job_readiness_timeout",
+                "mcp_result_artifact": {
+                    "artifact_id": "artifact_readiness_timeout",
+                    "job_id": "job_readiness_timeout",
+                    "kind": "mcp_result",
+                    "sha256": "a" * 64,
+                },
+                "service_runtime_bindings": [],
+            },
+            transcript_sha256="9" * 64,
+        )
+
+    monkeypatch.setattr(
+        "clio_relay.live_acceptance.run_packaged_mcp_stdio_session",
+        packaged_session,
+    )
+    monkeypatch.setattr("clio_relay.live_acceptance.time.monotonic", monotonic)
+    monkeypatch.setattr("clio_relay.live_acceptance.time.sleep", sleep)
+    recorder = ValidationRecorder(
+        new_live_validation_report(
+            scenario="secure-runtime-readiness-timeout",
+            cluster=cluster,
+            launcher="uv-tool",
+            install_source="pypi:clio-relay",
+            artifact_sha256="8" * 64,
+        )
+    )
+
+    with pytest.raises(
+        RelayError,
+        match="timed out waiting for one ready JARVIS service runtime binding",
+    ):
+        _verify_secure_runtime_acceptance(
+            LiveAcceptanceOptions(
+                cluster=cluster,
+                definition=ClusterDefinition(name=cluster, ssh_host="timeout.invalid"),
+                timeout_seconds=1,
+                poll_seconds=1,
+                transport_token="transport-token-timeout",
+                transport_secret_key="transport-secret-timeout",
+            ),
+            config=SecureRuntimeProbeConfig(
+                package_name="builtin.paraview",
+                command={"command_id": "timeout-command"},
+                protocol_adapter=_secure_runtime_protocol_adapter(),
+            ),
+            runtime_metadata={
+                "pipeline_id": "pipeline-readiness-timeout",
+                "execution_id": "execution-readiness-timeout",
+            },
+            recorder=recorder,
+        )
+
+    assert calls == 1
+
+
+def test_secure_runtime_ready_binding_ambiguity_fails_immediately() -> None:
+    """Multiple matching ready services are an identity error, not a retry state."""
+    cluster = "operator-ambiguous-runtime"
+    handoff = {
+        "cluster": cluster,
+        "source_job_id": "job_ambiguous_runtime",
+        "source_artifact_id": "artifact_ambiguous_runtime",
+        "package_id": "paraview-ambiguous",
+        "package_name": "builtin.paraview",
+        "service_instance_id": "visualizer-ambiguous-a",
+    }
+    config = SecureRuntimeProbeConfig(
+        package_name="builtin.paraview",
+        package_id="paraview-ambiguous",
+        command={"command_id": "ambiguous-command"},
+        protocol_adapter=_secure_runtime_protocol_adapter(),
+    )
+
+    with pytest.raises(RelayError, match="matched=2"):
+        _select_secure_runtime_handoff(
+            {
+                "terminal": True,
+                "state": "succeeded",
+                "cluster": cluster,
+                "job_id": "job_ambiguous_runtime",
+                "mcp_result_artifact": {
+                    "artifact_id": "artifact_ambiguous_runtime",
+                    "job_id": "job_ambiguous_runtime",
+                    "kind": "mcp_result",
+                    "sha256": "b" * 64,
+                },
+                "service_runtime_bindings": [
+                    handoff,
+                    {**handoff, "service_instance_id": "visualizer-ambiguous-b"},
+                ],
+            },
+            cluster=cluster,
+            config=config,
+        )
+
+
+def test_secure_runtime_empty_binding_rejects_cluster_identity_drift() -> None:
+    """An empty binding list is transient only for the exact requested cluster."""
+    cluster = "operator-exact-runtime"
+    with pytest.raises(RelayError, match="changed cluster identity"):
+        _select_secure_runtime_handoff(
+            {
+                "terminal": True,
+                "state": "succeeded",
+                "cluster": "operator-wrong-runtime",
+                "job_id": "job_exact_runtime",
+                "mcp_result_artifact": {
+                    "artifact_id": "artifact_exact_runtime",
+                    "job_id": "job_exact_runtime",
+                    "kind": "mcp_result",
+                    "sha256": "c" * 64,
+                },
+                "service_runtime_bindings": [],
+            },
+            cluster=cluster,
+            config=SecureRuntimeProbeConfig(
+                package_name="builtin.paraview",
+                command={"command_id": "exact-command"},
+                protocol_adapter=_secure_runtime_protocol_adapter(),
+            ),
+        )
 
 
 def test_secure_runtime_bind_failure_preserves_error_and_attempts_safe_teardown(
@@ -2655,6 +3124,7 @@ def test_secure_runtime_bind_failure_preserves_error_and_attempts_safe_teardown(
     query_result = {
         "terminal": True,
         "state": "succeeded",
+        "cluster": cluster,
         "job_id": handoff["source_job_id"],
         "mcp_result_artifact": {
             "artifact_id": handoff["source_artifact_id"],

--- a/tests/test_live_acceptance.py
+++ b/tests/test_live_acceptance.py
@@ -465,6 +465,39 @@ def test_secure_runtime_acceptance_metadata_poll_is_bounded() -> None:
     assert calls == 1
 
 
+def test_secure_runtime_acceptance_rejects_unsupported_metadata_schema() -> None:
+    """A model-shaped document cannot bypass the exact runtime schema pin."""
+    metadata = _structured_live_runtime_metadata()
+    metadata["schema_version"] = "unsupported.runtime.v99"
+
+    def fake_runner(
+        command: list[str],
+        *,
+        input: bytes | None = None,
+    ) -> subprocess.CompletedProcess[bytes]:
+        del input
+        return _completed(
+            command,
+            json.dumps(
+                _live_source_status(
+                    JobState.RUNNING,
+                    runtime_metadata=metadata,
+                )
+            ),
+        )
+
+    with pytest.raises(RelayError, match="unsupported schema version"):
+        _wait_for_live_structured_runtime_metadata(
+            ClusterDefinition(name="test-cluster", ssh_host="test-host"),
+            _LIVE_SOURCE_JOB_ID,
+            line_prefix="acceptance",
+            lines=[],
+            timeout_seconds=5,
+            poll_seconds=0.01,
+            runner=fake_runner,
+        )
+
+
 def test_secure_runtime_orchestration_never_waits_for_outer_job_terminal(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -3002,6 +3035,102 @@ def test_secure_runtime_ready_binding_wait_is_bounded(
             runtime_metadata={
                 "pipeline_id": "pipeline-readiness-timeout",
                 "execution_id": "execution-readiness-timeout",
+            },
+            recorder=recorder,
+        )
+
+    assert calls == 1
+
+
+def test_secure_runtime_late_ready_binding_fails_deadline(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A ready result returned after the advertised deadline is not accepted."""
+    cluster = "operator-late-ready"
+    clock = 100.0
+    calls = 0
+    handoff = {
+        "cluster": cluster,
+        "source_job_id": "job_late_ready",
+        "source_artifact_id": "artifact_late_ready",
+        "package_id": "paraview-late-ready",
+        "package_name": "builtin.paraview",
+        "service_instance_id": "visualizer-late-ready",
+    }
+
+    def monotonic() -> float:
+        return clock
+
+    def packaged_session(
+        *,
+        profile: str,
+        tool: str,
+        arguments: dict[str, Any],
+        timeout_seconds: float,
+        extra_environment: dict[str, str] | None = None,
+        require_enforceable_containment: bool = False,
+    ) -> PackagedMcpStdioSession:
+        nonlocal calls, clock
+        del profile, arguments, timeout_seconds, extra_environment
+        assert tool == "jarvis_get_execution"
+        assert require_enforceable_containment is True
+        calls += 1
+        clock = 101.0
+        return _secure_runtime_packaged_session(
+            tool,
+            {
+                "terminal": True,
+                "state": "succeeded",
+                "cluster": cluster,
+                "job_id": handoff["source_job_id"],
+                "mcp_result_artifact": {
+                    "artifact_id": handoff["source_artifact_id"],
+                    "job_id": handoff["source_job_id"],
+                    "kind": "mcp_result",
+                    "sha256": "d" * 64,
+                },
+                "service_runtime_bindings": [handoff],
+            },
+            transcript_sha256="e" * 64,
+        )
+
+    monkeypatch.setattr(
+        "clio_relay.live_acceptance.run_packaged_mcp_stdio_session",
+        packaged_session,
+    )
+    monkeypatch.setattr("clio_relay.live_acceptance.time.monotonic", monotonic)
+    recorder = ValidationRecorder(
+        new_live_validation_report(
+            scenario="secure-runtime-late-ready",
+            cluster=cluster,
+            launcher="uv-tool",
+            install_source="pypi:clio-relay",
+            artifact_sha256="f" * 64,
+        )
+    )
+
+    with pytest.raises(
+        RelayError,
+        match="timed out waiting for one ready JARVIS service runtime binding",
+    ):
+        _verify_secure_runtime_acceptance(
+            LiveAcceptanceOptions(
+                cluster=cluster,
+                definition=ClusterDefinition(name=cluster, ssh_host="late-ready.invalid"),
+                timeout_seconds=1,
+                poll_seconds=0.1,
+                transport_token="transport-token-late-ready",
+                transport_secret_key="transport-secret-late-ready",
+            ),
+            config=SecureRuntimeProbeConfig(
+                package_name="builtin.paraview",
+                package_id="paraview-late-ready",
+                command={"command_id": "late-ready-command"},
+                protocol_adapter=_secure_runtime_protocol_adapter(),
+            ),
+            runtime_metadata={
+                "pipeline_id": "pipeline-late-ready",
+                "execution_id": "execution-late-ready",
             },
             recorder=recorder,
         )

--- a/tests/test_mcp_stdio_validation.py
+++ b/tests/test_mcp_stdio_validation.py
@@ -902,10 +902,12 @@ def test_packaged_stdio_surfaces_safe_failed_startup_cleanup_evidence(
             process_id=8123,
             mode="windows_job_object",
             cleanup_errors=["owned spawn termination failed: RuntimeError"],
+            cause=RuntimeError("private startup detail"),
         )
 
     monkeypatch.setattr(mcp_stdio_validation_module, "spawn_owned_process", fail_spawn)
     with pytest.raises(RelayError, match="cleanup_verified=False") as failure:
         run_packaged_mcp_stdio_session(profile="user", tool="jarvis_run", arguments={})
     assert "pid=8123" in str(failure.value)
+    assert "private startup detail" not in str(failure.value)
     assert failure.value.__cause__ is None

--- a/tests/test_process_containment.py
+++ b/tests/test_process_containment.py
@@ -374,9 +374,16 @@ def test_registration_failure_cleans_new_process_without_touching_stale_owner(
     monkeypatch.setattr(process_containment, "_remove_broker_readiness", remove_readiness)
     monkeypatch.setattr(process_containment, "terminate_owned_process", fail_stale_termination)
     try:
-        with pytest.raises(OwnedProcessSpawnError) as failure:
+        with pytest.raises(
+            OwnedProcessSpawnError,
+            match="process containment was already registered",
+        ) as failure:
             process_containment.spawn_owned_process(["test-command"])
         assert failure.value.cleanup_verified is True
+        assert isinstance(failure.value.__cause__, RuntimeError)
+        assert str(failure.value.__cause__) == (
+            f"process containment was already registered: {process_id}"
+        )
         assert private._OWNED_PROCESSES[process_id] is stale_state
         assert "readiness" in actions
         if mode == "linux_systemd_scope":

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.2"
+    assert version == "1.4.3"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -413,6 +413,9 @@ def test_jarvis_release_requirement_enforces_unified_gray_scott_contract() -> No
     )
     assert lammps.get("evidence_group_resource_kind") is None
 
+    secure_runtime = requirements["ares-secure-jarvis-runtime"]
+    assert "secure-runtime.source-live-metadata" in secure_runtime["required_checks"]
+
     catalog = requirements["ares-non-jarvis-virtual-mcp"]
     assert "remote-mcp.scientific-catalog-user-contract" in catalog["required_checks"]
     assert "remote-mcp.scientific-catalog-result" in catalog["required_checks"]

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1860,13 +1860,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.2-py3-none-any.whl",
+            resource_id="clio-relay-1.4.3-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.2.tar.gz",
+            resource_id="clio_relay-1.4.3.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2005,7 +2005,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.2"
+    assert policy.release_version == "1.4.3"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.2"
+version = "1.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- probe structured JARVIS runtime metadata while the outer service job is still running
- retry zero ready-service bindings within one strict deadline and fail closed on identity drift or ambiguity
- preserve actionable owned-process startup causes alongside verified cleanup evidence
- bump the release identity and acceptance policy to 1.4.3

## Focused verification
- 15 secure-runtime and process-containment regression tests passed
- 7 release identity, policy, matrix, and embedded-mirror tests passed
- Ruff passed on all touched Python files
- Pyright: 0 errors, 0 warnings
- git diff --check passed

Scheduler cancellation remains opt-in and was not requested.