### PR TITLE
fix: reserve endpoint capacity for control queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.3` uses a release-first patch process. A maintainer builds the
+> Version `1.4.4` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/ai/interface-context.md
+++ b/docs/ai/interface-context.md
@@ -11,6 +11,7 @@ Core setup:
 - `clio-relay cluster add`
 - `clio-relay cluster bootstrap`
 - `clio-relay cluster install-endpoint-service`
+- `clio-relay cluster restart-endpoint-service`
 - `clio-relay doctor`
 - `clio-relay live-test`
 - `clio-relay release validate-local`

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -33,6 +33,21 @@ explicit `session teardown --stop-worker` does. The persistent unit restarts
 after both clean and failed worker-process exits; an explicit systemd stop is
 still respected and remains stopped until an operator starts it again.
 
+Worker capacity is part of the cluster definition, not a property reconstructed
+from whichever restart command happened to run last. New and legacy cluster
+definitions default to three total slots with one slot reserved for control
+queries. A normal reinstall uses that persisted policy. To restart the exact
+installed unit without replacing its `ExecStart` or capacity policy, use:
+
+```powershell
+clio-relay cluster restart-endpoint-service --cluster my-cluster
+```
+
+The restart-only command verifies the installed unit's total, reserved-control,
+and per-kind capacity arguments against the persisted cluster policy before it
+restarts anything. A legacy or drifted unit is left untouched and must be
+reinstalled with `cluster install-endpoint-service`.
+
 ### Upgrade durable queue indexes
 
 The worker service runs this preflight before it accepts work:
@@ -457,19 +472,31 @@ For targeted operator cleanup, pass `--job-id` to `queue stale` or
 `queue cleanup-stale`. The exact-job form still computes bounded queue context,
 but it cannot recover or cancel a neighboring stale record.
 
-Worker capacity is configured when the user-level worker service is installed:
+Worker capacity is persisted per cluster and applied whenever the user-level
+worker service is installed:
 
 ```powershell
-clio-relay cluster install-endpoint-service --cluster my-cluster --concurrency 4 --kind-concurrency jarvis=2 --kind-concurrency remote_agent=2 --kind-concurrency mcp_call=1 --start --enable
+clio-relay cluster install-endpoint-service --cluster my-cluster --concurrency 4 --control-query-concurrency 1 --kind-concurrency jarvis=2 --kind-concurrency remote_agent=2 --start --enable
 ```
 
 This keeps one sudo-less user service per cluster and runs multiple in-process
 worker slots inside that service. `--concurrency` is the total process capacity.
-Repeat `--kind-concurrency KIND=LIMIT` to reserve an independent admission cap
-for `jarvis`, `remote_agent`, or `mcp_call`; omitted kinds remain governed only
-by total capacity. The queue checks these limits atomically with durable lease
-creation across slots and processes. A saturated kind is skipped so it cannot
-block an eligible job of another kind. `clio-relay worker status`, HTTP
+`--control-query-concurrency` carves a strict control-query lane out of that
+total; managed policies retain at least one control slot and one workload slot.
+This allows status, progress, artifact, and runtime-binding queries to execute
+while a long-lived workload is still running. Repeat `--kind-concurrency
+KIND=LIMIT` to add a ceiling for `jarvis`, `remote_agent`, or `mcp_call`;
+omitted kinds remain governed only by their lane and total capacity. Kind limits
+are caps, not reserved slots. An `mcp_call` kind limit applies to workload-class
+MCP calls; reserved control queries use the separately configured control-query
+cap, so a long-running workload MCP call cannot consume its query lane. The
+queue checks these limits atomically with
+durable lease creation across slots and processes. A saturated kind is skipped
+so it cannot block an eligible job of another kind. Explicit install overrides
+are saved back to the cluster registry, so a later install with no capacity
+flags cannot silently reset the worker to one slot. Use
+`--clear-kind-concurrency` to remove every persisted per-kind override.
+`clio-relay worker status`, HTTP
 `/workers`, and the equivalent MCP operation report the configured policy,
 whether fresh worker registrations agree, and active leases by kind.
 

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.3"
+$Version = "1.4.4"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.3"
+release_version: "1.4.4"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 3ef31b0f5ce75c626de7c00f9c2a432e12adbad88c89cd77c8a630429bbea55b
+acceptance_matrix_sha256: fcec6b68da80ee672143dba9f3ec224d77b2622a65e6322d1648b68a8385da10
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.3"
+$Tag = "v1.4.4"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.3" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.4" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.3",
-  "matrix_sha256": "3ef31b0f5ce75c626de7c00f9c2a432e12adbad88c89cd77c8a630429bbea55b",
+  "release_version": "1.4.4",
+  "matrix_sha256": "fcec6b68da80ee672143dba9f3ec224d77b2622a65e6322d1648b68a8385da10",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.3"
+version = "1.4.4"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.3"
+__version__ = "1.4.4"

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -44,6 +44,7 @@ from clio_relay.cluster_config import (
     RemoteMcpContract,
     RemoteMcpProfile,
     RemoteMcpServerConfig,
+    WorkerCapacityPolicy,
     default_registry_path,
 )
 from clio_relay.config import RelaySettings
@@ -51,6 +52,7 @@ from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.deployment import (
     install_endpoint_user_service_over_ssh,
     render_endpoint_user_service,
+    restart_endpoint_user_service_over_ssh,
     write_endpoint_user_service,
 )
 from clio_relay.doctor import run_cluster_doctor, run_doctor
@@ -69,6 +71,7 @@ from clio_relay.jarvis_mcp import (
     CLIO_KIT_JARVIS_MCP_VERSION,
     CLIO_KIT_JARVIS_USER_CONTRACT_SHA256,
     JARVIS_MCP_CACHE_SERVER_NAME,
+    is_virtual_jarvis_control_query,
     jarvis_cd_lock_binding_expectation,
     jarvis_mcp_artifact_binding_from_entry,
     jarvis_mcp_env_from,
@@ -90,6 +93,7 @@ from clio_relay.mcp_server import (
 )
 from clio_relay.mcp_stdio_validation import PackagedMcpStdioSession, run_packaged_mcp_stdio_session
 from clio_relay.models import (
+    MCP_ADMISSION_AUTHORITY_METADATA_KEY,
     ArtifactUse,
     Cursor,
     EndpointRole,
@@ -98,7 +102,9 @@ from clio_relay.models import (
     JarvisRunSpec,
     JobKind,
     JobState,
+    McpAdmissionClass,
     McpCallSpec,
+    McpControlQueryEvidence,
     McpOperation,
     MonitorRule,
     MonitorRuleAction,
@@ -176,6 +182,7 @@ from clio_relay.remote_cli import (
     write_remote_file,
 )
 from clio_relay.remote_mcp import (
+    MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS,
     MAX_REMOTE_MCP_SPACK_CONFIGURATION_COMPONENT_BYTES,
     MAX_REMOTE_MCP_SPACK_CONFIGURATION_COMPONENTS,
     MAX_REMOTE_MCP_SPACK_CONFIGURATION_MANIFEST_BYTES,
@@ -190,6 +197,8 @@ from clio_relay.remote_mcp import (
     cache_entry_from_discovery_artifact,
     default_remote_mcp_cache_path,
     remote_mcp_execution_fingerprint,
+    resolve_pinned_mcp_admission,
+    resolve_registered_remote_mcp_admission,
 )
 from clio_relay.retention import TerminalRetentionCoordinator
 from clio_relay.scheduler_providers import (
@@ -1021,6 +1030,10 @@ def endpoint_start(
         int,
         typer.Option(help="Number of in-process worker slots for worker endpoints."),
     ] = 1,
+    control_query_concurrency: Annotated[
+        int,
+        typer.Option(help="Slots carved out of total capacity for control-class MCP queries."),
+    ] = 0,
     kind_concurrency: Annotated[
         list[str] | None,
         typer.Option(
@@ -1036,6 +1049,10 @@ def endpoint_start(
     """Start a desktop or worker endpoint."""
     if concurrency < 1:
         raise typer.BadParameter("--concurrency must be at least 1")
+    if control_query_concurrency < 0:
+        raise typer.BadParameter("--control-query-concurrency must not be negative")
+    if control_query_concurrency >= concurrency:
+        raise typer.BadParameter("--control-query-concurrency must be less than --concurrency")
     kind_limits = _kind_concurrency_options(kind_concurrency)
     settings = RelaySettings.from_env()
     definition: ClusterDefinition | None = None
@@ -1052,6 +1069,7 @@ def endpoint_start(
         settings=settings,
         cluster=cluster or "local",
         concurrency=concurrency,
+        control_query_concurrency=control_query_concurrency,
         kind_concurrency=kind_limits,
         scheduler_provider=(
             provider_for_scheduler(selected_scheduler) if role == EndpointRole.WORKER else None
@@ -1120,9 +1138,13 @@ def endpoint_render_user_service(
         typer.Option(help="Optional path to write the systemd user service."),
     ] = None,
     concurrency: Annotated[
-        int,
+        int | None,
         typer.Option(help="Number of in-process worker slots for the user service."),
-    ] = 1,
+    ] = None,
+    control_query_concurrency: Annotated[
+        int | None,
+        typer.Option(help="Slots reserved within total capacity for live control queries."),
+    ] = None,
     kind_concurrency: Annotated[
         list[str] | None,
         typer.Option(
@@ -1130,14 +1152,26 @@ def endpoint_render_user_service(
             help="Per-kind worker limit as KIND=LIMIT; repeat for multiple kinds.",
         ),
     ] = None,
+    clear_kind_concurrency: Annotated[
+        bool,
+        typer.Option(help="Clear every persisted per-kind override in the rendered unit."),
+    ] = False,
 ) -> None:
     """Render a sudo-less systemd user service for a worker endpoint."""
     definition = _require_cluster(cluster)
+    capacity = _resolved_worker_capacity_policy(
+        definition,
+        concurrency=concurrency,
+        control_query_concurrency=control_query_concurrency,
+        kind_concurrency=kind_concurrency,
+        clear_kind_concurrency=clear_kind_concurrency,
+    )
     service_text = render_endpoint_user_service(
         cluster=cluster,
         definition=definition,
-        concurrency=concurrency,
-        kind_concurrency=_kind_concurrency_options(kind_concurrency),
+        concurrency=capacity.concurrency,
+        control_query_concurrency=capacity.control_query_concurrency,
+        kind_concurrency=capacity.kind_concurrency,
     )
     if output is None:
         typer.echo(service_text)
@@ -1212,7 +1246,12 @@ def cluster_list() -> None:
     """List configured clusters."""
     registry = ClusterRegistry.load(default_registry_path())
     for name, definition in sorted(registry.clusters.items()):
-        typer.echo(f"{name} ssh={definition.ssh_host} profile={definition.bootstrap_profile}")
+        capacity = definition.worker_capacity
+        typer.echo(
+            f"{name} ssh={definition.ssh_host} profile={definition.bootstrap_profile} "
+            f"worker_concurrency={capacity.concurrency} "
+            f"control_query_concurrency={capacity.control_query_concurrency}"
+        )
 
 
 @cluster_app.command("add")
@@ -1257,6 +1296,21 @@ def cluster_add(
             help="Registered scheduler provider for relay-owned status/cancel operations."
         ),
     ] = "external",
+    worker_concurrency: Annotated[
+        int,
+        typer.Option(help="Total slot capacity for the managed cluster worker service."),
+    ] = 3,
+    worker_control_query_concurrency: Annotated[
+        int,
+        typer.Option(help="Slots reserved within total worker capacity for live control queries."),
+    ] = 1,
+    worker_kind_concurrency: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--worker-kind-concurrency",
+            help="Per-kind managed-worker limit as KIND=LIMIT; repeat for multiple kinds.",
+        ),
+    ] = None,
     agent_npm_package: Annotated[
         str | None,
         typer.Option(help="Optional npm package used to install the agent."),
@@ -1341,6 +1395,14 @@ def cluster_add(
             agent_bin=_none_if_blank(agent_bin),
             agent_adapter=agent_adapter,
             scheduler_provider=scheduler_provider,
+            worker_capacity=WorkerCapacityPolicy(
+                concurrency=worker_concurrency,
+                control_query_concurrency=worker_control_query_concurrency,
+                kind_concurrency=_kind_concurrency_options(
+                    worker_kind_concurrency,
+                    param_hint="--worker-kind-concurrency",
+                ),
+            ),
             target_identity=(
                 ClusterTargetIdentity(
                     hostnames=target_hostname,
@@ -1745,6 +1807,28 @@ def remote_mcp_refresh(
             )
         else:
             queue = _managed_queue_from_env()
+            admission_class, admission_authority = resolve_registered_remote_mcp_admission(
+                queue=queue,
+                definition=definition,
+                cluster=cluster,
+                server=registration.command,
+                server_args=registration.args,
+                env_from=registration.env_from,
+                operation=McpOperation.TOOLS_LIST,
+                tool=None,
+                expected_server_artifact_digest=None,
+                evidence=None,
+                timeout_seconds=timeout_seconds,
+            )
+            metadata = (
+                {}
+                if admission_authority is None
+                else {
+                    MCP_ADMISSION_AUTHORITY_METADATA_KEY: admission_authority.model_dump(
+                        mode="json"
+                    )
+                }
+            )
             job = queue.submit_job(
                 RelayJob(
                     cluster=cluster,
@@ -1753,10 +1837,12 @@ def remote_mcp_refresh(
                         server=registration.command,
                         server_args=registration.args,
                         env_from=registration.env_from,
+                        admission_class=admission_class,
                         operation=McpOperation.TOOLS_LIST,
                         timeout_seconds=timeout_seconds,
                     ),
                     idempotency_key=key,
+                    metadata=metadata,
                 )
             )
             terminal = wait_for_terminal(
@@ -3005,15 +3091,87 @@ def cluster_install_endpoint_service(
     start: Annotated[bool, typer.Option(help="Restart the service after installing.")] = True,
     enable: Annotated[bool, typer.Option(help="Enable the user service.")] = True,
     concurrency: Annotated[
-        int,
-        typer.Option(help="Number of in-process worker slots for the user service."),
-    ] = 1,
+        int | None,
+        typer.Option(
+            help="Override and persist total worker slots; defaults to the cluster policy."
+        ),
+    ] = None,
+    control_query_concurrency: Annotated[
+        int | None,
+        typer.Option(
+            help=(
+                "Override and persist slots reserved within total capacity for live "
+                "control queries."
+            )
+        ),
+    ] = None,
     kind_concurrency: Annotated[
         list[str] | None,
         typer.Option(
             "--kind-concurrency",
             help="Per-kind worker limit as KIND=LIMIT; repeat for multiple kinds.",
         ),
+    ] = None,
+    clear_kind_concurrency: Annotated[
+        bool,
+        typer.Option(help="Clear and persist every per-kind worker capacity override."),
+    ] = False,
+    require_persistent: Annotated[
+        bool,
+        typer.Option(
+            "--require-persistent/--allow-login-scoped",
+            help=(
+                "Require systemd user lingering so the enabled worker survives all logouts. "
+                "The login-scoped opt-out is diagnostic and not release-gate eligible."
+            ),
+        ),
+    ] = True,
+) -> None:
+    """Install a worker service from its persisted cluster capacity policy."""
+    definition = _require_cluster(cluster)
+    capacity = _resolved_worker_capacity_policy(
+        definition,
+        concurrency=concurrency,
+        control_query_concurrency=control_query_concurrency,
+        kind_concurrency=kind_concurrency,
+        clear_kind_concurrency=clear_kind_concurrency,
+    )
+    if capacity != definition.worker_capacity:
+        ClusterRegistry.mutate(
+            default_registry_path(),
+            lambda registry: registry.clusters.__setitem__(
+                cluster,
+                registry.require(cluster).model_copy(update={"worker_capacity": capacity}),
+            ),
+        )
+        definition = definition.model_copy(update={"worker_capacity": capacity})
+    service_text = render_endpoint_user_service(
+        cluster=cluster,
+        definition=definition,
+        concurrency=capacity.concurrency,
+        control_query_concurrency=capacity.control_query_concurrency,
+        kind_concurrency=capacity.kind_concurrency,
+    )
+    _run_or_exit(
+        lambda: _echo_lines(
+            install_endpoint_user_service_over_ssh(
+                cluster=cluster,
+                ssh_host=ssh_host or definition.ssh_host,
+                service_text=service_text,
+                start=start,
+                enable=enable,
+                require_persistent=require_persistent,
+            )
+        )
+    )
+
+
+@cluster_app.command("restart-endpoint-service")
+def cluster_restart_endpoint_service(
+    cluster: Annotated[str, typer.Option(help="Configured cluster name.")],
+    ssh_host: Annotated[
+        str | None,
+        typer.Option(help="Override SSH host alias for this run."),
     ] = None,
     require_persistent: Annotated[
         bool,
@@ -3026,22 +3184,14 @@ def cluster_install_endpoint_service(
         ),
     ] = True,
 ) -> None:
-    """Install and optionally start a sudo-less worker endpoint service over SSH."""
+    """Verify persisted capacity, then restart without rewriting the installed unit."""
     definition = _require_cluster(cluster)
-    service_text = render_endpoint_user_service(
-        cluster=cluster,
-        definition=definition,
-        concurrency=concurrency,
-        kind_concurrency=_kind_concurrency_options(kind_concurrency),
-    )
     _run_or_exit(
         lambda: _echo_lines(
-            install_endpoint_user_service_over_ssh(
+            restart_endpoint_user_service_over_ssh(
                 cluster=cluster,
                 ssh_host=ssh_host or definition.ssh_host,
-                service_text=service_text,
-                start=start,
-                enable=enable,
+                expected_capacity=definition.worker_capacity,
                 require_persistent=require_persistent,
             )
         )
@@ -7478,6 +7628,13 @@ def mcp_call(
         str | None,
         typer.Option(help="Expected discovery-time MCP server artifact SHA-256 binding."),
     ] = None,
+    control_query_evidence_json: Annotated[
+        str | None,
+        typer.Option(
+            help="Internal discovery evidence offered for server-side admission validation.",
+            hidden=True,
+        ),
+    ] = None,
 ) -> None:
     """Submit a durable remote MCP call or schema-discovery operation."""
     definition = _require_cluster(cluster)
@@ -7494,6 +7651,14 @@ def mcp_call(
     )
     if operation == McpOperation.TOOLS_LIST and arguments:
         raise typer.BadParameter("tools/list does not accept arguments")
+    try:
+        control_query_evidence = (
+            McpControlQueryEvidence.model_validate_json(control_query_evidence_json)
+            if control_query_evidence_json is not None
+            else None
+        )
+    except ValidationError as exc:
+        raise typer.BadParameter("--control-query-evidence-json is invalid") from exc
     digest = hashlib.sha256(
         json.dumps(
             {"operation": operation.value, "tool": tool, "arguments": arguments},
@@ -7504,22 +7669,6 @@ def mcp_call(
     server_args = server_arg or []
     environment_references = _environment_references(env_from)
     artifact_uses = _artifact_use_refs(used_artifact)
-    server_digest = hashlib.sha256(
-        json.dumps(
-            {
-                "server": server,
-                "args": server_args,
-                "env_from": environment_references,
-                "expected_server_artifact_digest": expected_server_artifact_digest,
-            },
-            sort_keys=True,
-            separators=(",", ":"),
-        ).encode("utf-8")
-    ).hexdigest()
-    key = idempotency_key or (
-        f"mcp:{cluster}:{server_digest}:{operation.value}:{tool}:{digest}"
-        + _artifact_use_idempotency_suffix(artifact_uses)
-    )
     if should_execute_on_cluster(definition):
         remote_arguments_path: str | None = None
         remote_command = [
@@ -7530,9 +7679,20 @@ def mcp_call(
             server,
             "--operation",
             operation.value,
-            "--idempotency-key",
-            key,
         ]
+        if idempotency_key is not None:
+            remote_command.extend(["--idempotency-key", idempotency_key])
+        if control_query_evidence is not None:
+            remote_command.extend(
+                [
+                    "--control-query-evidence-json",
+                    json.dumps(
+                        control_query_evidence.model_dump(mode="json"),
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                ]
+            )
         if tool is not None:
             remote_arguments_path = (
                 ".local/share/clio-relay/desktop-submissions/"
@@ -7572,23 +7732,86 @@ def mcp_call(
                     remove_empty_parent=True,
                 )
         return
-    job = RelayJob(
-        cluster=cluster,
-        kind=JobKind.MCP_CALL,
-        spec=McpCallSpec(
-            server=server,
-            server_args=server_args,
-            env_from=environment_references,
-            expected_server_artifact_digest=expected_server_artifact_digest,
-            operation=operation,
-            tool=tool,
-            arguments=arguments,
-            timeout_seconds=timeout_seconds,
-        ),
-        idempotency_key=key,
-        used_artifact_refs=artifact_uses,
-    )
-    saved = _submit_managed_job(job)
+    queue = _managed_queue_from_env()
+    try:
+        try:
+            resolved_admission_class, admission_authority = resolve_registered_remote_mcp_admission(
+                queue=queue,
+                definition=definition,
+                cluster=cluster,
+                server=server,
+                server_args=server_args,
+                env_from=environment_references,
+                operation=operation,
+                tool=tool,
+                expected_server_artifact_digest=expected_server_artifact_digest,
+                evidence=control_query_evidence,
+                timeout_seconds=timeout_seconds,
+            )
+        except ValueError as exc:
+            raise typer.BadParameter(str(exc)) from exc
+        admission_identity: dict[str, object] = {
+            "server": server,
+            "args": server_args,
+            "env_from": environment_references,
+            "expected_server_artifact_digest": expected_server_artifact_digest,
+        }
+        if (
+            resolved_admission_class is McpAdmissionClass.CONTROL_QUERY
+            or admission_authority is not None
+        ):
+            admission_identity.update(
+                {
+                    "timeout_seconds": timeout_seconds,
+                    "admission_class": resolved_admission_class.value,
+                    "admission_authority": (
+                        None
+                        if admission_authority is None
+                        else admission_authority.model_dump(mode="json")
+                    ),
+                }
+            )
+        server_digest = hashlib.sha256(
+            json.dumps(
+                admission_identity,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+        key = idempotency_key or (
+            f"mcp:{cluster}:{server_digest}:{operation.value}:{tool}:{digest}"
+            + _artifact_use_idempotency_suffix(artifact_uses)
+        )
+        metadata = (
+            {}
+            if admission_authority is None
+            else {MCP_ADMISSION_AUTHORITY_METADATA_KEY: admission_authority.model_dump(mode="json")}
+        )
+        job = RelayJob(
+            cluster=cluster,
+            kind=JobKind.MCP_CALL,
+            spec=McpCallSpec(
+                server=server,
+                server_args=server_args,
+                env_from=environment_references,
+                expected_server_artifact_digest=expected_server_artifact_digest,
+                admission_class=resolved_admission_class,
+                operation=operation,
+                tool=tool,
+                arguments=arguments,
+                timeout_seconds=timeout_seconds,
+            ),
+            idempotency_key=key,
+            used_artifact_refs=artifact_uses,
+            metadata=metadata,
+        )
+        try:
+            saved = queue.submit_job(job)
+        except StorageAdmissionError as exc:
+            _echo_storage_admission_error(exc)
+            raise typer.Exit(code=1) from exc
+    finally:
+        queue.close()
     typer.echo(saved.job_id)
 
 
@@ -7650,6 +7873,18 @@ def jarvis_mcp_call(
     )
     if operation == McpOperation.TOOLS_LIST and arguments:
         raise typer.BadParameter("tools/list does not accept arguments")
+    try:
+        resolved_admission_class, admission_authority = resolve_pinned_mcp_admission(
+            operation=operation,
+            tool=tool,
+            expected_server_artifact_digest=expected_server_artifact_digest,
+            pinned_control_query=(tool is not None and is_virtual_jarvis_control_query(tool)),
+            timeout_seconds=timeout_seconds,
+        )
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    if resolved_admission_class is McpAdmissionClass.CONTROL_QUERY and timeout_seconds is None:
+        timeout_seconds = MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS
     digest = hashlib.sha256(
         json.dumps(
             {"operation": operation.value, "tool": tool, "arguments": arguments},
@@ -7658,10 +7893,19 @@ def jarvis_mcp_call(
         ).encode("utf-8")
     ).hexdigest()
     artifact_uses = _artifact_use_refs(used_artifact)
-    key = idempotency_key or (
+    legacy_key = (
         f"mcp:{cluster}:jarvis:{operation.value}:{tool}:{digest}:"
         f"{expected_server_artifact_digest or 'unbound'}"
         + _artifact_use_idempotency_suffix(artifact_uses)
+    )
+    key = idempotency_key or (
+        legacy_key
+        if resolved_admission_class is McpAdmissionClass.WORKLOAD
+        else (
+            f"{legacy_key}:{resolved_admission_class.value}:"
+            f"{admission_authority.source if admission_authority is not None else 'none'}:"
+            f"timeout={timeout_seconds}"
+        )
     )
     if definition is not None and should_execute_on_cluster(definition):
         remote_args: str | None = None
@@ -7708,6 +7952,11 @@ def jarvis_mcp_call(
         return
     server = jarvis_mcp_server()
     server_args = jarvis_mcp_server_args()
+    metadata = (
+        {}
+        if admission_authority is None
+        else {MCP_ADMISSION_AUTHORITY_METADATA_KEY: admission_authority.model_dump(mode="json")}
+    )
     job = RelayJob(
         cluster=cluster,
         kind=JobKind.MCP_CALL,
@@ -7717,6 +7966,7 @@ def jarvis_mcp_call(
             env_from=jarvis_mcp_env_from(),
             expected_server_artifact_digest=expected_server_artifact_digest,
             expected_jarvis_cd_lock_binding=jarvis_cd_lock_binding_expectation(),
+            admission_class=resolved_admission_class,
             operation=operation,
             tool=tool,
             arguments=arguments,
@@ -7724,6 +7974,7 @@ def jarvis_mcp_call(
         ),
         idempotency_key=key,
         used_artifact_refs=artifact_uses,
+        metadata=metadata,
     )
     saved = _submit_managed_job(job)
     typer.echo(saved.job_id)
@@ -10599,6 +10850,14 @@ def _run_jarvis_remote_contract_discovery(
     else:
         server = jarvis_mcp_server()
         server_args = jarvis_mcp_server_args()
+        admission_class, admission_authority = resolve_pinned_mcp_admission(
+            operation=McpOperation.TOOLS_LIST,
+            tool=None,
+            expected_server_artifact_digest=None,
+            pinned_control_query=False,
+            timeout_seconds=MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS,
+        )
+        assert admission_authority is not None
         submitted = queue.submit_job(
             RelayJob(
                 cluster=cluster,
@@ -10608,10 +10867,16 @@ def _run_jarvis_remote_contract_discovery(
                     server_args=server_args,
                     env_from=jarvis_mcp_env_from(),
                     expected_jarvis_cd_lock_binding=jarvis_cd_lock_binding_expectation(),
+                    admission_class=admission_class,
                     operation=McpOperation.TOOLS_LIST,
-                    timeout_seconds=max(1, int(wait_timeout_seconds)),
+                    timeout_seconds=MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS,
                 ),
                 idempotency_key=idempotency_key,
+                metadata={
+                    MCP_ADMISSION_AUTHORITY_METADATA_KEY: admission_authority.model_dump(
+                        mode="json"
+                    )
+                },
             )
         )
         job_id = submitted.job_id
@@ -12443,13 +12708,57 @@ def _require_durable_session_identity(value: str, *, field: str) -> str:
         raise RelayError(f"invalid {field}: {error}") from error
 
 
-def _kind_concurrency_options(items: list[str] | None) -> dict[JobKind, int]:
+def _kind_concurrency_options(
+    items: list[str] | None,
+    *,
+    param_hint: str = "--kind-concurrency",
+) -> dict[JobKind, int]:
     try:
         return parse_kind_concurrency_options(items)
     except ConfigurationError as exc:
         raise typer.BadParameter(
             str(exc),
-            param_hint="--kind-concurrency",
+            param_hint=param_hint,
+        ) from exc
+
+
+def _resolved_worker_capacity_policy(
+    definition: ClusterDefinition,
+    *,
+    concurrency: int | None,
+    control_query_concurrency: int | None,
+    kind_concurrency: list[str] | None,
+    clear_kind_concurrency: bool,
+) -> WorkerCapacityPolicy:
+    """Resolve optional CLI overrides against one persisted worker policy."""
+    if clear_kind_concurrency and kind_concurrency is not None:
+        raise typer.BadParameter(
+            "--clear-kind-concurrency cannot be combined with --kind-concurrency"
+        )
+    current = definition.worker_capacity
+    selected_kind_concurrency = (
+        {}
+        if clear_kind_concurrency
+        else (
+            current.kind_concurrency
+            if kind_concurrency is None
+            else _kind_concurrency_options(kind_concurrency)
+        )
+    )
+    try:
+        return WorkerCapacityPolicy(
+            concurrency=current.concurrency if concurrency is None else concurrency,
+            control_query_concurrency=(
+                current.control_query_concurrency
+                if control_query_concurrency is None
+                else control_query_concurrency
+            ),
+            kind_concurrency=selected_kind_concurrency,
+        )
+    except ValidationError as exc:
+        raise typer.BadParameter(
+            str(exc),
+            param_hint="--concurrency/--control-query-concurrency",
         ) from exc
 
 

--- a/src/clio_relay/cluster_config.py
+++ b/src/clio_relay/cluster_config.py
@@ -18,7 +18,7 @@ from filelock import FileLock
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
 
 from clio_relay.errors import ConfigurationError
-from clio_relay.models import validate_mcp_env_from
+from clio_relay.models import JobKind, validate_mcp_env_from
 from clio_relay.remote_values import validate_remote_path
 
 CLUSTER_REGISTRY_ENV = "CLIO_RELAY_CLUSTER_REGISTRY"
@@ -368,6 +368,53 @@ class RemoteMcpServerConfig(BaseModel):
         return self
 
 
+class WorkerCapacityPolicy(BaseModel):
+    """Persisted capacity policy for one managed cluster worker service.
+
+    ``concurrency`` is the total number of worker slots. The control-query
+    capacity is carved out of that total so a long-lived workload cannot make
+    its own live status and binding queries impossible.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    concurrency: int = Field(default=3, ge=2, strict=True)
+    control_query_concurrency: int = Field(default=1, ge=1, strict=True)
+    kind_concurrency: dict[JobKind, int] = Field(
+        default_factory=dict[JobKind, int],
+        max_length=len(JobKind),
+    )
+
+    @field_validator("kind_concurrency", mode="before")
+    @classmethod
+    def _validate_kind_concurrency(cls, value: object) -> object:
+        if not isinstance(value, dict):
+            raise ValueError("worker kind concurrency must be an object")
+        normalized: dict[JobKind, int] = {}
+        for raw_kind, raw_limit in cast(dict[object, object], value).items():
+            if not isinstance(raw_kind, str):
+                raise ValueError("worker job kind keys must be strings")
+            try:
+                kind = JobKind(raw_kind)
+            except ValueError as exc:
+                expected = ", ".join(kind.value for kind in JobKind)
+                raise ValueError(
+                    f"unknown worker job kind {raw_kind!r}; expected one of {expected}"
+                ) from exc
+            if type(raw_limit) is not int or raw_limit < 1:
+                raise ValueError(
+                    f"worker concurrency limit for {kind.value} must be an integer at least 1"
+                )
+            normalized[kind] = raw_limit
+        return normalized
+
+    @model_validator(mode="after")
+    def _reserve_a_workload_slot(self) -> WorkerCapacityPolicy:
+        if self.control_query_concurrency >= self.concurrency:
+            raise ValueError("worker control_query_concurrency must be less than total concurrency")
+        return self
+
+
 class ClusterDefinition(BaseModel):
     """A locally configured cluster target."""
 
@@ -387,6 +434,7 @@ class ClusterDefinition(BaseModel):
     agent_npm_bin: str | None = None
     agent_args: list[str] = Field(default_factory=list)
     scheduler_provider: str = "external"
+    worker_capacity: WorkerCapacityPolicy = Field(default_factory=WorkerCapacityPolicy)
     remote_mcp_servers: dict[str, RemoteMcpServerConfig] = Field(
         default_factory=dict,
         max_length=MAX_REMOTE_MCP_SERVERS_PER_CLUSTER,
@@ -487,8 +535,15 @@ class ClusterDefinition(BaseModel):
 
 
 def cluster_route_revision(definition: ClusterDefinition) -> str:
-    """Return a stable digest for every operator-controlled cluster route field."""
-    payload = definition.model_dump(mode="json", exclude={"remote_mcp_servers"})
+    """Return a stable digest for fields that determine durable queue routing.
+
+    Remote MCP registrations and worker scheduling capacity can change without
+    changing the SSH destination or queue location of an existing job handle.
+    """
+    payload = definition.model_dump(
+        mode="json",
+        exclude={"remote_mcp_servers", "worker_capacity"},
+    )
     return hashlib.sha256(
         json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     ).hexdigest()

--- a/src/clio_relay/core_queue.py
+++ b/src/clio_relay/core_queue.py
@@ -51,6 +51,8 @@ from clio_relay.models import (
     JobState,
     JobTombstone,
     Lease,
+    McpAdmissionClass,
+    McpCallSpec,
     MonitorRule,
     OwnerSessionClosure,
     OwnerSessionJobMembership,
@@ -5411,10 +5413,33 @@ class ClioCoreQueue:
         ttl_seconds: int = 300,
         max_attempts: int = 3,
         kind_concurrency: KindConcurrencyInput | None = None,
+        mcp_admission_class: McpAdmissionClass | None = None,
+        mcp_admission_limit: int | None = None,
     ) -> Lease | None:
-        """Lease the next queued job for a cluster worker."""
+        """Lease the next queued job accepted by one atomic worker lane.
+
+        ``mcp_admission_class`` is a strict lane filter.  Workload lanes accept
+        every non-MCP job plus workload-class MCP jobs; control lanes accept
+        only explicitly classified MCP control queries.  The optional limit is
+        checked against active durable leases while the same queue lock selects
+        and leases the next job.
+        """
         endpoint_id = self._require_durable_record_id(endpoint_id, field="endpoint_id")
         normalized_kind_concurrency = normalize_kind_concurrency(kind_concurrency)
+        if mcp_admission_class is not None and not isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
+            mcp_admission_class,
+            McpAdmissionClass,
+        ):
+            raise ConfigurationError("worker MCP admission class is invalid")
+        if mcp_admission_limit is not None:
+            if mcp_admission_class is None:
+                raise ConfigurationError("worker MCP admission limit requires an admission class")
+            if (
+                isinstance(mcp_admission_limit, bool)
+                or not isinstance(mcp_admission_limit, int)  # pyright: ignore[reportUnnecessaryIsInstance]
+                or mcp_admission_limit < 1
+            ):
+                raise ConfigurationError("worker MCP admission limit must be at least 1")
         self.initialize()
         with self._lock:
             self._recover_pending_transitions_unlocked()
@@ -5428,6 +5453,15 @@ class ClioCoreQueue:
                 expiry_refs=reusable_expiry_refs,
             )
             if active is not None:
+                active_job = self.get_job(active.job_id)
+                if mcp_admission_class is not None and not _job_matches_mcp_admission_class(
+                    active_job,
+                    mcp_admission_class,
+                ):
+                    raise QueueConflictError(
+                        "endpoint active lease does not match its MCP admission lane: "
+                        f"{endpoint_id}"
+                    )
                 return active
             active_counts, global_lease_total = self._lease_capacity_snapshot(
                 cluster=cluster,
@@ -5435,6 +5469,17 @@ class ClioCoreQueue:
             )
             if global_lease_total >= MAX_LIVE_LEASE_RECORDS:
                 return None
+            mcp_admission_at_limit = False
+            active_mcp_workload_count: int | None = None
+            if mcp_admission_class is not None and mcp_admission_limit is not None:
+                mcp_admission_at_limit = (
+                    self._active_mcp_admission_count_unlocked(
+                        cluster=cluster,
+                        admission_class=mcp_admission_class,
+                        expiry_refs=reusable_expiry_refs,
+                    )
+                    >= mcp_admission_limit
+                )
             queued_jobs, _ = self._scan_many(
                 self._storage_root / "jobs_queued",
                 RelayJob,
@@ -5443,10 +5488,31 @@ class ClioCoreQueue:
             for job in sorted(queued_jobs, key=self._job_submission_order_key_unlocked):
                 if job.cluster != cluster or job.state != JobState.QUEUED:
                     continue
+                if mcp_admission_class is not None and not _job_matches_mcp_admission_class(
+                    job,
+                    mcp_admission_class,
+                ):
+                    continue
+                if mcp_admission_at_limit and job.kind is JobKind.MCP_CALL:
+                    continue
                 if self._job_has_pending_execution_cleanup_unlocked(job.cluster, job.job_id):
                     continue
                 kind_limit = normalized_kind_concurrency.get(job.kind)
-                if kind_limit is not None and active_counts.get(job.kind, 0) >= kind_limit:
+                active_kind_count = active_counts.get(job.kind, 0)
+                if job.kind is JobKind.MCP_CALL and mcp_admission_class is not None:
+                    if mcp_admission_class is McpAdmissionClass.CONTROL_QUERY:
+                        # Control queries have their own explicit, atomic admission cap.
+                        # A workload MCP ceiling must never consume the reserved lane.
+                        kind_limit = None
+                    else:
+                        if active_mcp_workload_count is None:
+                            active_mcp_workload_count = self._active_mcp_admission_count_unlocked(
+                                cluster=cluster,
+                                admission_class=McpAdmissionClass.WORKLOAD,
+                                expiry_refs=reusable_expiry_refs,
+                            )
+                        active_kind_count = active_mcp_workload_count
+                if kind_limit is not None and active_kind_count >= kind_limit:
                     continue
                 return self._lease_job_unlocked(
                     job,
@@ -5455,6 +5521,67 @@ class ClioCoreQueue:
                     validated_global_total=global_lease_total,
                 )
         return None
+
+    def _active_mcp_admission_count_unlocked(
+        self,
+        *,
+        cluster: str,
+        admission_class: McpAdmissionClass,
+        expiry_refs: list[_LeaseExpiryReference] | None,
+    ) -> int:
+        """Count one MCP admission class from bounded, validated live leases."""
+        if expiry_refs is None:
+            expiry_refs, truncated = self._scan_expiry_refs(limit=MAX_LIVE_LEASE_RECORDS)
+            if truncated:
+                raise QueueConflictError("lease expiry index exceeded its safety bound")
+        cluster_token = _lease_cluster_token(cluster)
+        count = 0
+        for (
+            expires_key,
+            indexed_cluster,
+            job_kind,
+            endpoint_token,
+            job_token,
+            lease_token,
+            identity_token,
+        ) in expiry_refs:
+            if indexed_cluster != cluster_token or job_kind is not JobKind.MCP_CALL:
+                continue
+            identity = self._read_lease_index_identity_by_token(
+                lease_token,
+                identity_token,
+            )
+            if (
+                identity.cluster != cluster
+                or identity.job_kind is not JobKind.MCP_CALL
+                or _lease_endpoint_token(identity.endpoint_id) != endpoint_token
+                or _lease_job_token(identity.job_id) != job_token
+                or _lease_expiry_key(identity.expires_at) != expires_key
+            ):
+                raise QueueConflictError(
+                    f"lease expiry admission identity mismatch: {identity.lease_id}"
+                )
+            lease = self._read_optional(
+                self._storage_root / "leases" / f"{identity.lease_id}.json",
+                Lease,
+            )
+            if lease is None:
+                raise QueueConflictError(
+                    f"lease expiry admission index is orphaned: {identity.lease_id}"
+                )
+            self._validate_lease_index_identity(lease, identity)
+            job = self.get_job(identity.job_id)
+            if (
+                job.cluster != cluster
+                or job.kind is not JobKind.MCP_CALL
+                or job.leased_by != identity.endpoint_id
+            ):
+                raise QueueConflictError(
+                    f"active MCP admission lease changed job identity: {identity.lease_id}"
+                )
+            if _job_matches_mcp_admission_class(job, admission_class):
+                count += 1
+        return count
 
     def acquire_job(
         self,
@@ -12553,6 +12680,21 @@ def _endpoint_fresh_bucket(value: datetime) -> int:
     return int(observed.timestamp()) // ENDPOINT_FRESH_BUCKET_SECONDS
 
 
+def _job_matches_mcp_admission_class(
+    job: RelayJob,
+    admission_class: McpAdmissionClass,
+) -> bool:
+    """Match one durable job to a strict MCP worker lane.
+
+    Non-MCP and kind/spec-mismatched jobs remain workload so the ordinary lane
+    can fail them explicitly.  They can never enter the privileged control
+    lane.
+    """
+    if job.kind is not JobKind.MCP_CALL or not isinstance(job.spec, McpCallSpec):
+        return admission_class is McpAdmissionClass.WORKLOAD
+    return job.spec.admission_class is admission_class
+
+
 def _scheduler_cancellation_request(job: RelayJob) -> dict[str, object] | None:
     raw = job.metadata.get("cancellation_request")
     if not isinstance(raw, dict):
@@ -13728,6 +13870,14 @@ def _job_idempotency_digest(job: RelayJob) -> str:
         spec_payload = cast(dict[str, object], raw_spec)
         if spec_payload.get("expected_jarvis_cd_lock_binding") is None:
             spec_payload.pop("expected_jarvis_cd_lock_binding", None)
+        # Preserve the pre-admission-lane digest for ordinary MCP work. Only an
+        # explicit control-query promotion is new caller-visible identity.
+        if (
+            job.kind is JobKind.MCP_CALL
+            and isinstance(job.spec, McpCallSpec)
+            and job.spec.admission_class is McpAdmissionClass.WORKLOAD
+        ):
+            spec_payload.pop("admission_class", None)
         if is_owned_jarvis_run_spec(job.kind, job.spec):
             raw_arguments = spec_payload.get("arguments")
             if isinstance(raw_arguments, dict):

--- a/src/clio_relay/deployment.py
+++ b/src/clio_relay/deployment.py
@@ -8,8 +8,9 @@ import shlex
 import subprocess
 from math import isfinite
 from pathlib import Path
+from typing import Literal
 
-from clio_relay.cluster_config import ClusterDefinition
+from clio_relay.cluster_config import ClusterDefinition, WorkerCapacityPolicy
 from clio_relay.errors import RelayError
 from clio_relay.identifiers import filesystem_key
 from clio_relay.installation import INSTALL_RECEIPT_PATH_ENV
@@ -30,12 +31,29 @@ def render_endpoint_user_service(
     cluster: str,
     definition: ClusterDefinition,
     relay_bin: str = "%h/.local/bin/clio-relay",
-    concurrency: int = 1,
+    concurrency: int | None = None,
+    control_query_concurrency: int | None = None,
     kind_concurrency: KindConcurrencyInput | None = None,
 ) -> str:
     """Render a user-level systemd service for a configured worker endpoint."""
-    if concurrency < 1:
-        raise RelayError("worker concurrency must be at least 1")
+    capacity = definition.worker_capacity
+    selected_concurrency = capacity.concurrency if concurrency is None else concurrency
+    selected_control_concurrency = (
+        capacity.control_query_concurrency
+        if control_query_concurrency is None
+        else control_query_concurrency
+    )
+    selected_kind_concurrency = (
+        capacity.kind_concurrency if kind_concurrency is None else kind_concurrency
+    )
+    if selected_concurrency < 2:
+        raise RelayError("managed worker concurrency must be at least 2")
+    if selected_control_concurrency < 1:
+        raise RelayError("managed worker control-query concurrency must be at least 1")
+    if selected_control_concurrency >= selected_concurrency:
+        raise RelayError(
+            "managed worker control-query concurrency must be less than total concurrency"
+        )
     core_source = definition.core_dir
     spool_source = definition.spool_dir
     jarvis_source = definition.jarvis_bin or "$HOME/.local/bin/jarvis"
@@ -54,7 +72,7 @@ def render_endpoint_user_service(
     )
     agent_bin = render_systemd_remote_value(agent_source, field="agent_bin")
     agent_args = " ".join(definition.agent_args)
-    kind_limits = kind_concurrency_metadata(kind_concurrency)
+    kind_limits = kind_concurrency_metadata(selected_kind_concurrency)
     jarvis_mcp_line = _optional_environment_line(
         JARVIS_MCP_COMMAND_ENV,
         os.environ.get(JARVIS_MCP_COMMAND_ENV),
@@ -84,7 +102,9 @@ def render_endpoint_user_service(
         "--cluster",
         cluster,
         "--concurrency",
-        str(concurrency),
+        str(selected_concurrency),
+        "--control-query-concurrency",
+        str(selected_control_concurrency),
     ]
     for kind, limit in kind_limits.items():
         exec_start_arguments.extend(["--kind-concurrency", f"{kind}={limit}"])
@@ -183,6 +203,48 @@ def install_endpoint_user_service_over_ssh(
         enable=enable,
         require_persistent=require_persistent,
     )
+    return _run_endpoint_service_script_over_ssh(
+        ssh_host=ssh_host,
+        remote_script=remote_script,
+        timeout_seconds=timeout_seconds,
+        operation="installation",
+    )
+
+
+def restart_endpoint_user_service_over_ssh(
+    *,
+    cluster: str,
+    ssh_host: str,
+    expected_capacity: WorkerCapacityPolicy,
+    require_persistent: bool = True,
+    timeout_seconds: float = 120.0,
+) -> list[str]:
+    """Restart an installed endpoint unit after verifying its persisted policy."""
+    _validate_ssh_destination(ssh_host)
+    if not isfinite(timeout_seconds) or timeout_seconds <= 0:
+        raise RelayError("endpoint service SSH timeout must be finite and positive")
+    service_name = endpoint_user_service_name(cluster)
+    remote_script = _remote_restart_script(
+        service_name=service_name,
+        expected_capacity=expected_capacity,
+        require_persistent=require_persistent,
+    )
+    return _run_endpoint_service_script_over_ssh(
+        ssh_host=ssh_host,
+        remote_script=remote_script,
+        timeout_seconds=timeout_seconds,
+        operation="restart",
+    )
+
+
+def _run_endpoint_service_script_over_ssh(
+    *,
+    ssh_host: str,
+    remote_script: str,
+    timeout_seconds: float,
+    operation: Literal["installation", "restart"],
+) -> list[str]:
+    """Run one bounded endpoint-service operation through SSH."""
     try:
         result = subprocess.run(
             ["ssh", ssh_host, "bash", "-s"],
@@ -193,13 +255,14 @@ def install_endpoint_user_service_over_ssh(
         )
     except subprocess.TimeoutExpired as exc:
         raise RelayError(
-            f"endpoint service installation exceeded {timeout_seconds:g} seconds"
+            f"endpoint service {operation} exceeded {timeout_seconds:g} seconds"
         ) from exc
     if result.returncode != 0:
         stderr = result.stderr.decode("utf-8", errors="replace")
         stdout = result.stdout.decode("utf-8", errors="replace")
         detail = stderr.strip() or stdout.strip()
-        raise RelayError(f"failed to install endpoint user service: {detail}")
+        verb = "install" if operation == "installation" else "restart"
+        raise RelayError(f"failed to {verb} endpoint user service: {detail}")
     return result.stdout.decode("utf-8", errors="replace").splitlines()
 
 
@@ -271,6 +334,150 @@ fi
 mkdir -p "$HOME/.config/systemd/user"
 printf '%s' {service_literal} > "$HOME/.config/systemd/user/{service_name}"
 {command}"""
+    return script.replace("\r\n", "\n")
+
+
+def _remote_restart_script(
+    *,
+    service_name: str,
+    expected_capacity: WorkerCapacityPolicy,
+    require_persistent: bool,
+) -> str:
+    """Render a restart-only script that verifies but cannot replace the unit."""
+    if _SYSTEMD_SERVICE_NAME.fullmatch(service_name) is None:
+        raise RelayError(f"unsafe endpoint systemd service name: {service_name!r}")
+    service_literal = shlex.quote(service_name)
+    persistent_literal = "1" if require_persistent else "0"
+    expected_kind_concurrency = ",".join(
+        f"{kind}={limit}"
+        for kind, limit in kind_concurrency_metadata(expected_capacity.kind_concurrency).items()
+    )
+    script = f"""set -euo pipefail
+require_persistent={persistent_literal}
+expected_concurrency={shlex.quote(str(expected_capacity.concurrency))}
+expected_control_query_concurrency={shlex.quote(str(expected_capacity.control_query_concurrency))}
+expected_kind_concurrency={shlex.quote(expected_kind_concurrency)}
+relay_user="${{USER:-$(id -un)}}"
+linger="$(loginctl show-user "$relay_user" -p Linger --value 2>/dev/null || true)"
+if [ "$linger" = "yes" ]; then
+  persistence_mode=systemd-user-linger
+elif [ "$require_persistent" = "1" ]; then
+  echo "persistent endpoint service requires systemd user lingering (Linger=yes)" >&2
+  echo "run 'loginctl enable-linger $relay_user' once, or ask the site administrator" >&2
+  echo "to enable lingering for this account" >&2
+  echo "use --allow-login-scoped only when logout-time shutdown is explicitly acceptable" >&2
+  exit 78
+else
+  persistence_mode=login-scoped
+  echo "warning: endpoint service is login-scoped and may stop after the final login exits" >&2
+fi
+export SYSTEMD_COLORS=0 LANG=C LC_ALL=C
+service_enabled="$(systemctl --user is-enabled {service_literal} 2>/dev/null || true)"
+if [ "$service_enabled" != "enabled" ]; then
+  echo "endpoint service is not installed and enabled: {service_name} $service_enabled" >&2
+  exit 1
+fi
+installed_exec_start="$(
+  systemctl --user show {service_literal} \
+    --property=ExecStart --value --no-pager 2>/dev/null || true
+)"
+set -f
+argv_count=0
+in_argv=0
+expected_value=""
+policy_parse_error=""
+observed_concurrency=""
+observed_control_query_concurrency=""
+observed_kind_concurrency=""
+for token in $installed_exec_start; do
+  if [ "$in_argv" = "0" ]; then
+    case "$token" in
+      "argv[]="*)
+        argv_count=$((argv_count + 1))
+        in_argv=1
+        ;;
+    esac
+    continue
+  fi
+  if [ "$token" = ";" ]; then
+    if [ -n "$expected_value" ]; then
+      policy_parse_error="missing value for $expected_value"
+      expected_value=""
+    fi
+    in_argv=0
+    continue
+  fi
+  if [ -n "$expected_value" ]; then
+    case "$expected_value" in
+      concurrency) observed_concurrency="$token" ;;
+      control_query_concurrency) observed_control_query_concurrency="$token" ;;
+      kind_concurrency)
+        if [ -n "$observed_kind_concurrency" ]; then
+          observed_kind_concurrency="$observed_kind_concurrency,$token"
+        else
+          observed_kind_concurrency="$token"
+        fi
+        ;;
+    esac
+    expected_value=""
+    continue
+  fi
+  case "$token" in
+    --concurrency)
+      if [ -n "$observed_concurrency" ]; then
+        policy_parse_error="duplicate --concurrency"
+      fi
+      expected_value="concurrency"
+      ;;
+    --control-query-concurrency)
+      if [ -n "$observed_control_query_concurrency" ]; then
+        policy_parse_error="duplicate --control-query-concurrency"
+      fi
+      expected_value="control_query_concurrency"
+      ;;
+    --kind-concurrency)
+      expected_value="kind_concurrency"
+      ;;
+  esac
+done
+if [ -n "$expected_value" ]; then
+  policy_parse_error="missing value for $expected_value"
+fi
+if [ "$argv_count" -ne 1 ] || [ -n "$policy_parse_error" ] || \
+   [ "$observed_concurrency" != "$expected_concurrency" ] || \
+   [ "$observed_control_query_concurrency" != "$expected_control_query_concurrency" ] || \
+   [ "$observed_kind_concurrency" != "$expected_kind_concurrency" ]; then
+  echo "endpoint service capacity policy does not match the persisted cluster policy" >&2
+  printf 'expected concurrency=%s control_query_concurrency=%s kind_concurrency=%s\\n' \
+    "$expected_concurrency" "$expected_control_query_concurrency" \
+    "${{expected_kind_concurrency:-none}}" >&2
+  printf 'observed concurrency=%s control_query_concurrency=%s kind_concurrency=%s\\n' \
+    "${{observed_concurrency:-missing}}" \
+    "${{observed_control_query_concurrency:-missing}}" \
+    "${{observed_kind_concurrency:-none}}" >&2
+  if [ -n "$policy_parse_error" ]; then
+    printf 'policy parse error: %s\\n' "$policy_parse_error" >&2
+  fi
+  echo "run 'clio-relay cluster install-endpoint-service --cluster <configured-cluster>'" >&2
+  echo "to reinstall the managed unit" >&2
+  exit 79
+fi
+systemctl --user restart {service_literal}
+service_active="$(systemctl --user is-active {service_literal} 2>/dev/null || true)"
+if [ "$service_active" != "active" ]; then
+  echo "endpoint service is not active after restart: {service_name} $service_active" >&2
+  exit 1
+fi
+echo user_systemd=$(systemctl --user is-system-running || true)
+echo linger="$linger"
+echo endpoint_service.persistence="$persistence_mode"
+echo endpoint_service.enabled="$service_enabled"
+echo endpoint_service.active="$service_active"
+echo endpoint_service.unit_rewritten=false
+echo endpoint_service.policy_source=installed-unit
+echo endpoint_service.policy_validated=true
+systemctl --user --no-pager --plain --full status {service_literal} || true
+"""
     return script.replace("\r\n", "\n")
 
 

--- a/src/clio_relay/endpoint.py
+++ b/src/clio_relay/endpoint.py
@@ -56,6 +56,7 @@ from clio_relay.models import (
     JobKind,
     JobState,
     Lease,
+    McpAdmissionClass,
     McpCallSpec,
     ProgressRecord,
     RelayEvent,
@@ -256,6 +257,7 @@ class EndpointWorker:
         settings: RelaySettings,
         cluster: str = "local",
         concurrency: int = 1,
+        control_query_concurrency: int = 0,
         kind_concurrency: KindConcurrencyInput | None = None,
         queue: ClioCoreQueue | None = None,
         provider: JarvisCdProvider | None = None,
@@ -263,11 +265,30 @@ class EndpointWorker:
         storage_runtime: StorageRuntime | None = None,
         reconcile_execution_cleanup: bool = True,
     ) -> None:
-        if concurrency < 1:
+        if (
+            isinstance(concurrency, bool)
+            or not isinstance(concurrency, int)  # pyright: ignore[reportUnnecessaryIsInstance]
+            or concurrency < 1
+        ):
             raise ConfigurationError("worker concurrency must be at least 1")
+        if (
+            isinstance(control_query_concurrency, bool)
+            or not isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
+                control_query_concurrency,
+                int,
+            )
+            or control_query_concurrency < 0
+        ):
+            raise ConfigurationError("worker control-query concurrency cannot be negative")
+        if control_query_concurrency >= concurrency:
+            raise ConfigurationError(
+                "worker control-query concurrency must leave at least one workload slot"
+            )
         self.role = role
         self.cluster = cluster
         self.concurrency = concurrency
+        self.control_query_concurrency = control_query_concurrency
+        self.workload_concurrency = concurrency - control_query_concurrency
         self.kind_concurrency = normalize_kind_concurrency(kind_concurrency)
         self.reconcile_execution_cleanup = reconcile_execution_cleanup
         self._foreground_jobs_since_cleanup = 0
@@ -382,6 +403,8 @@ class EndpointWorker:
         if self.role == EndpointRole.WORKER and self.concurrency > 1:
             metadata["worker_supervisor"] = True
         if self.role == EndpointRole.WORKER:
+            metadata["workload_concurrency"] = self.workload_concurrency
+            metadata["control_query_concurrency"] = self.control_query_concurrency
             metadata["installation_info"] = _worker_installation_snapshot()
             process_identity = _worker_process_identity()
             if process_identity is not None:
@@ -399,17 +422,25 @@ class EndpointWorker:
         self.endpoint = self.queue.register_endpoint(endpoint)
         return self.endpoint
 
-    def run_once(self) -> RelayJob | None:
-        """Run one leased cluster job if available."""
+    def run_once(
+        self,
+        *,
+        mcp_admission_class: McpAdmissionClass = McpAdmissionClass.WORKLOAD,
+        mcp_admission_limit: int | None = None,
+    ) -> RelayJob | None:
+        """Run one job from a strict workload or reserved MCP control lane."""
         self._require_open_queue_identity()
         if self.role != EndpointRole.WORKER:
             return None
         endpoint = self.endpoint or self.register()
         self.endpoint = self.queue.register_endpoint(endpoint)
         self.queue.recover_stale_jobs(cluster=self.cluster)
-        self._reconcile_canceled_scheduler_jobs()
+        workload_lane = mcp_admission_class is McpAdmissionClass.WORKLOAD
+        if workload_lane:
+            self._reconcile_canceled_scheduler_jobs()
         if (
-            self.reconcile_execution_cleanup
+            workload_lane
+            and self.reconcile_execution_cleanup
             and self._foreground_jobs_since_cleanup >= EXECUTION_CLEANUP_MAX_FOREGROUND_JOBS
         ):
             self._reconcile_pending_execution_cleanup()
@@ -419,9 +450,11 @@ class EndpointWorker:
             cluster=self.cluster,
             ttl_seconds=self.lease_ttl_seconds,
             kind_concurrency=self.kind_concurrency,
+            mcp_admission_class=mcp_admission_class,
+            mcp_admission_limit=mcp_admission_limit,
         )
         if lease is None:
-            if self.reconcile_execution_cleanup:
+            if workload_lane and self.reconcile_execution_cleanup:
                 self._reconcile_pending_execution_cleanup()
                 self._foreground_jobs_since_cleanup = 0
             return None
@@ -433,7 +466,7 @@ class EndpointWorker:
                 self._record_unhandled_job_failure(job, exc)
         finally:
             self.queue.release_lease(lease.lease_id)
-        if self.reconcile_execution_cleanup:
+        if workload_lane and self.reconcile_execution_cleanup:
             self._foreground_jobs_since_cleanup += 1
         return self.queue.get_job(job.job_id)
 
@@ -513,25 +546,41 @@ class EndpointWorker:
                 time.sleep(poll_seconds)
 
     def _serve_worker_slots(self, *, poll_seconds: float) -> None:
+        slot_admission_classes = [
+            *([McpAdmissionClass.WORKLOAD] * self.workload_concurrency),
+            *([McpAdmissionClass.CONTROL_QUERY] * self.control_query_concurrency),
+        ]
         with concurrent.futures.ThreadPoolExecutor(max_workers=self.concurrency) as executor:
             futures = [
-                executor.submit(self._serve_worker_slot, index, poll_seconds)
-                for index in range(self.concurrency)
+                executor.submit(
+                    self._serve_worker_slot,
+                    index,
+                    poll_seconds,
+                    admission_class,
+                )
+                for index, admission_class in enumerate(slot_admission_classes)
             ]
             for future in concurrent.futures.as_completed(futures):
                 future.result()
 
-    def _serve_worker_slot(self, index: int, poll_seconds: float) -> None:
+    def _serve_worker_slot(
+        self,
+        index: int,
+        poll_seconds: float,
+        admission_class: McpAdmissionClass,
+    ) -> None:
+        workload_lane = admission_class is McpAdmissionClass.WORKLOAD
         worker = EndpointWorker(
             role=self.role,
             settings=self.settings,
             cluster=self.cluster,
             concurrency=1,
+            control_query_concurrency=0,
             kind_concurrency=self.kind_concurrency,
             queue=self.queue,
             scheduler_provider=self.scheduler_provider,
             storage_runtime=self.storage_runtime,
-            reconcile_execution_cleanup=index == 0,
+            reconcile_execution_cleanup=workload_lane and index == 0,
         )
         endpoint = EndpointRegistration(
             role=self.role,
@@ -542,6 +591,9 @@ class EndpointWorker:
                 "worker_slot": index,
                 "parent_endpoint_id": None if self.endpoint is None else self.endpoint.endpoint_id,
                 "concurrency": 1,
+                "workload_concurrency": 1 if workload_lane else 0,
+                "control_query_concurrency": 0 if workload_lane else 1,
+                "mcp_admission_class": admission_class.value,
                 "kind_concurrency": kind_concurrency_metadata(self.kind_concurrency),
                 "process_containment": process_containment.containment_capability(),
                 "installation_info": _worker_installation_snapshot(),
@@ -554,7 +606,14 @@ class EndpointWorker:
         )
         worker.endpoint = self.queue.register_endpoint(endpoint)
         while True:
-            worker.run_once()
+            worker.run_once(
+                mcp_admission_class=admission_class,
+                mcp_admission_limit=(
+                    self.control_query_concurrency
+                    if admission_class is McpAdmissionClass.CONTROL_QUERY
+                    else None
+                ),
+            )
             time.sleep(poll_seconds)
 
     def _run_job(self, job: RelayJob, lease: Lease) -> None:

--- a/src/clio_relay/http_api.py
+++ b/src/clio_relay/http_api.py
@@ -26,11 +26,13 @@ from fastapi import (
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from clio_relay.cluster_config import ClusterRegistry, default_registry_path
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.errors import ConfigurationError, NotFoundError, QueueConflictError
 from clio_relay.identifiers import DurableRecordId
 from clio_relay.jarvis_mcp import (
+    is_virtual_jarvis_control_query,
     jarvis_cd_lock_binding_expectation,
     jarvis_mcp_artifact_binding,
     jarvis_mcp_env_from,
@@ -38,6 +40,7 @@ from clio_relay.jarvis_mcp import (
     jarvis_mcp_server_args,
 )
 from clio_relay.models import (
+    MCP_ADMISSION_AUTHORITY_METADATA_KEY,
     ArtifactRef,
     ArtifactUse,
     Cursor,
@@ -46,7 +49,11 @@ from clio_relay.models import (
     JarvisRunSpec,
     JobKind,
     JobState,
+    McpAdmissionAuthority,
+    McpAdmissionClass,
     McpCallSpec,
+    McpControlQueryEvidence,
+    McpOperation,
     MonitorRule,
     ProgressRecord,
     RelayEvent,
@@ -86,6 +93,11 @@ from clio_relay.relay_ops import (
 )
 from clio_relay.relay_ops import (
     job_status as get_job_status_operation,
+)
+from clio_relay.remote_mcp import (
+    MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS,
+    resolve_pinned_mcp_admission,
+    resolve_registered_remote_mcp_admission,
 )
 from clio_relay.retention import TerminalRetentionCoordinator
 from clio_relay.session_api import (
@@ -374,8 +386,10 @@ class McpCallSubmitRequest(BaseModel):
         default=None,
         pattern=r"^[0-9a-f]{64}$",
     )
-    tool: str
+    operation: McpOperation = McpOperation.TOOLS_CALL
+    tool: str | None = None
     arguments: dict[str, object] = Field(default_factory=dict)
+    control_query_evidence: McpControlQueryEvidence | None = None
     timeout_seconds: int | None = Field(default=None, gt=0)
     idempotency_key: str
     used_artifact_refs: list[ArtifactUse] = Field(
@@ -389,6 +403,23 @@ class McpCallSubmitRequest(BaseModel):
         """Reject invalid names and relay-owned credential references."""
         return validate_mcp_env_from(value)
 
+    @model_validator(mode="after")
+    def validate_operation_contract(self) -> McpCallSubmitRequest:
+        """Keep call and discovery payloads unambiguous before admission."""
+        if self.operation is McpOperation.TOOLS_CALL:
+            if not self.tool:
+                raise ValueError("tool is required for tools/call")
+            return self
+        if self.tool is not None:
+            raise ValueError("tool must be omitted for tools/list")
+        if self.arguments:
+            raise ValueError("arguments must be empty for tools/list")
+        if self.expected_server_artifact_digest is not None:
+            raise ValueError("tools/list must not carry an expected server artifact digest")
+        if self.control_query_evidence is not None:
+            raise ValueError("tools/list must not carry control-query route evidence")
+        return self
+
 
 class JarvisMcpCallSubmitRequest(BaseModel):
     """HTTP request to submit a remote JARVIS MCP tool call."""
@@ -396,7 +427,8 @@ class JarvisMcpCallSubmitRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     cluster: str
-    tool: str
+    operation: McpOperation = McpOperation.TOOLS_CALL
+    tool: str | None = None
     arguments: dict[str, object] = Field(default_factory=dict)
     expected_server_artifact_digest: str | None = Field(
         default=None,
@@ -412,8 +444,37 @@ class JarvisMcpCallSubmitRequest(BaseModel):
     @model_validator(mode="after")
     def reject_internal_jarvis_run_wait(self) -> JarvisMcpCallSubmitRequest:
         """Keep workload waiting out of the trusted handle-first HTTP ingress."""
+        if self.operation is McpOperation.TOOLS_CALL and not self.tool:
+            raise ValueError("tool is required for tools/call")
+        if self.operation is McpOperation.TOOLS_LIST:
+            if self.tool is not None:
+                raise ValueError("tool must be omitted for tools/list")
+            if self.arguments:
+                raise ValueError("arguments must be empty for tools/list")
+            if self.expected_server_artifact_digest is not None:
+                raise ValueError("tools/list must not carry an expected server artifact digest")
+            if (
+                self.timeout_seconds is not None
+                and self.timeout_seconds > MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS
+            ):
+                raise ValueError(
+                    "pinned MCP control-query timeout exceeds "
+                    f"{MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS} seconds"
+                )
+            return self
         if self.tool == "jarvis_run" and "wait" in self.arguments:
             raise ValueError("jarvis_run does not accept internal wait; use jarvis_get_execution")
+        if (
+            self.expected_server_artifact_digest is not None
+            and self.tool is not None
+            and is_virtual_jarvis_control_query(self.tool)
+            and self.timeout_seconds is not None
+            and self.timeout_seconds > MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS
+        ):
+            raise ValueError(
+                "pinned MCP control-query timeout exceeds "
+                f"{MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS} seconds"
+            )
         return self
 
 
@@ -663,7 +724,11 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
         require_owned_job(artifact.job_id)
         return artifact
 
-    def submit_owned(job: RelayJob) -> RelayJob:
+    def submit_owned(
+        job: RelayJob,
+        *,
+        mcp_admission_authority: McpAdmissionAuthority | None = None,
+    ) -> RelayJob:
         ensure_intake_open()
         if owner_session_cluster is not None and job.cluster != owner_session_cluster:
             raise HTTPException(
@@ -677,6 +742,7 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
                 "owner_session_id",
                 "owner_session_generation_id",
                 "owner_session_admission_id",
+                MCP_ADMISSION_AUTHORITY_METADATA_KEY,
             }.intersection(metadata)
         )
         if protected:
@@ -686,6 +752,28 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
                     "job ownership metadata is server-managed and cannot be supplied: "
                     + ", ".join(protected)
                 ),
+            )
+        if job.kind is JobKind.MCP_CALL:
+            if not isinstance(job.spec, McpCallSpec):
+                raise HTTPException(status_code=422, detail="MCP job has an invalid specification")
+            if job.spec.admission_class is McpAdmissionClass.CONTROL_QUERY:
+                if mcp_admission_authority is None:
+                    raise HTTPException(
+                        status_code=422,
+                        detail="control-query MCP admission requires server authority",
+                    )
+                metadata[MCP_ADMISSION_AUTHORITY_METADATA_KEY] = mcp_admission_authority.model_dump(
+                    mode="json"
+                )
+            elif mcp_admission_authority is not None:
+                raise HTTPException(
+                    status_code=422,
+                    detail="workload MCP admission must not carry control-query authority",
+                )
+        elif mcp_admission_authority is not None:
+            raise HTTPException(
+                status_code=422,
+                detail="MCP admission authority cannot be attached to another job kind",
             )
         if resolved.owner_session_id is not None:
             for use in job.used_artifact_refs:
@@ -760,6 +848,11 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
         dependencies=[auth_dependency, session_submission_dependency],
     )
     def submit_job(job: RelayJob) -> RelayJob:
+        if job.kind is JobKind.MCP_CALL:
+            raise HTTPException(
+                status_code=422,
+                detail="MCP jobs must use /jobs/mcp-call or /jobs/jarvis-mcp-call",
+            )
         return submit_owned(job)
 
     @app.post(
@@ -822,6 +915,28 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
         dependencies=[auth_dependency, session_submission_dependency],
     )
     def submit_mcp_call(request: McpCallSubmitRequest) -> RelayJob:
+        registry_path = default_registry_path()
+        try:
+            definition = (
+                ClusterRegistry.load(registry_path).clusters.get(request.cluster)
+                if registry_path.exists()
+                else None
+            )
+            admission_class, admission_authority = resolve_registered_remote_mcp_admission(
+                queue=queue,
+                definition=definition,
+                cluster=request.cluster,
+                server=request.server,
+                server_args=request.server_args,
+                env_from=request.env_from,
+                operation=request.operation,
+                tool=request.tool,
+                expected_server_artifact_digest=request.expected_server_artifact_digest,
+                evidence=request.control_query_evidence,
+                timeout_seconds=request.timeout_seconds,
+            )
+        except (ConfigurationError, ValueError) as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
         return submit_owned(
             RelayJob(
                 cluster=request.cluster,
@@ -831,13 +946,16 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
                     server_args=request.server_args,
                     env_from=request.env_from,
                     expected_server_artifact_digest=(request.expected_server_artifact_digest),
+                    admission_class=admission_class,
+                    operation=request.operation,
                     tool=request.tool,
                     arguments=request.arguments,
                     timeout_seconds=request.timeout_seconds,
                 ),
                 idempotency_key=request.idempotency_key,
                 used_artifact_refs=request.used_artifact_refs,
-            )
+            ),
+            mcp_admission_authority=admission_authority,
         )
 
     @app.post(
@@ -847,7 +965,26 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
     )
     def submit_jarvis_mcp_call(request: JarvisMcpCallSubmitRequest) -> RelayJob:
         expected_digest = request.expected_server_artifact_digest
-        if resolved.owner_session_id is not None and expected_digest is None:
+        try:
+            admission_class, admission_authority = resolve_pinned_mcp_admission(
+                operation=request.operation,
+                tool=request.tool,
+                expected_server_artifact_digest=expected_digest,
+                pinned_control_query=(
+                    request.tool is not None and is_virtual_jarvis_control_query(request.tool)
+                ),
+                timeout_seconds=request.timeout_seconds,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        timeout_seconds = request.timeout_seconds
+        if admission_class is McpAdmissionClass.CONTROL_QUERY and timeout_seconds is None:
+            timeout_seconds = MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS
+        if (
+            resolved.owner_session_id is not None
+            and request.operation is McpOperation.TOOLS_CALL
+            and expected_digest is None
+        ):
             raise HTTPException(
                 status_code=422,
                 detail=("owned JARVIS MCP submission requires expected_server_artifact_digest"),
@@ -858,7 +995,11 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
         # not substitute a second, unrelated cache as authority here: preserve
         # the supplied digest in the durable spec and let the MCP runner compare
         # it with the server artifact observed immediately before launch.
-        if expected_digest is not None and resolved.owner_session_id is None:
+        if (
+            request.operation is McpOperation.TOOLS_CALL
+            and expected_digest is not None
+            and resolved.owner_session_id is None
+        ):
             try:
                 observed_digest = jarvis_mcp_artifact_binding(request.cluster)
             except ValueError as exc:
@@ -880,13 +1021,16 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
                     env_from=jarvis_mcp_env_from(),
                     expected_server_artifact_digest=expected_digest,
                     expected_jarvis_cd_lock_binding=jarvis_cd_lock_binding_expectation(),
+                    admission_class=admission_class,
+                    operation=request.operation,
                     tool=request.tool,
                     arguments=request.arguments,
-                    timeout_seconds=request.timeout_seconds,
+                    timeout_seconds=timeout_seconds,
                 ),
                 idempotency_key=request.idempotency_key,
                 used_artifact_refs=request.used_artifact_refs,
-            )
+            ),
+            mcp_admission_authority=admission_authority,
         )
 
     @app.get("/jobs/{job_id}", response_model=RelayJob, dependencies=[auth_dependency])

--- a/src/clio_relay/jarvis_mcp.py
+++ b/src/clio_relay/jarvis_mcp.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 
 from clio_relay.identifiers import durable_record_id_json_schema
 from clio_relay.remote_mcp import (
+    MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS,
     VIRTUAL_REMOTE_MCP_JOB_OUTPUT_SCHEMA,
     RemoteMcpSchemaCache,
     RemoteMcpSchemaCacheEntry,
@@ -532,6 +533,21 @@ def jarvis_mcp_server_args() -> list[str]:
     return jarvis_mcp_command()[1:]
 
 
+def is_virtual_jarvis_control_query(remote_tool: str) -> bool:
+    """Return whether the pinned virtual JARVIS contract marks a tool read-only."""
+    definition = _VIRTUAL_JARVIS_TOOLS.get(remote_tool)
+    if definition is None:
+        return False
+    annotations = definition.get("annotations")
+    if not isinstance(annotations, dict):
+        return False
+    typed_annotations = cast(JSON, annotations)
+    return bool(
+        typed_annotations.get("readOnlyHint") is True
+        and typed_annotations.get("destructiveHint") is False
+    )
+
+
 def virtual_jarvis_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
     """Return agent-facing virtual tools for the cluster-local JARVIS MCP server."""
     tools: list[JSON] = []
@@ -545,7 +561,15 @@ def virtual_jarvis_tool_definitions(*, clusters: list[str] | None = None) -> lis
                 **({"enum": sorted(clusters)} if clusters is not None else {}),
             },
             **properties,
-            "timeout_seconds": {"type": "integer", "minimum": 1},
+            "timeout_seconds": {
+                "type": "integer",
+                "minimum": 1,
+                **(
+                    {"maximum": MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS}
+                    if is_virtual_jarvis_control_query(remote_tool)
+                    else {}
+                ),
+            },
             "idempotency_key": {"type": "string"},
             "wait_for_terminal": {
                 "type": "boolean",

--- a/src/clio_relay/live_acceptance.py
+++ b/src/clio_relay/live_acceptance.py
@@ -575,6 +575,24 @@ def _run_live_acceptance(
                 ),
             )
         )
+    if secure_runtime_probe is not None:
+        if recorder is None:
+            raise ConfigurationError(
+                "secure runtime acceptance requires a machine-readable report path"
+            )
+        with _validation_check(
+            recorder,
+            "secure-runtime.control-query-capacity",
+            "verify one free reserved control-query slot before source submission",
+            forbidden_values=set(),
+        ) as evidence:
+            _require_secure_runtime_control_capacity(
+                options.definition,
+                cluster=options.cluster,
+                runner=command_runner,
+                evidence=evidence,
+            )
+        lines.append("secure-runtime.control_query_capacity=ready")
     if verify_transport:
         assert transport_token is not None
         assert transport_secret_key is not None
@@ -680,10 +698,7 @@ def _run_live_acceptance(
             require_structured_runtime_metadata=options.require_structured_runtime_metadata,
         )
     else:
-        if recorder is None:
-            raise ConfigurationError(
-                "secure runtime acceptance requires a machine-readable report path"
-            )
+        assert recorder is not None
         with _validation_check(
             recorder,
             "secure-runtime.source-live-metadata",
@@ -3342,6 +3357,76 @@ def _generated_agent_prompt(
         f"{pipeline_yaml.rstrip()}\n"
         "```\n"
     )
+
+
+def _require_secure_runtime_control_capacity(
+    definition: ClusterDefinition,
+    *,
+    cluster: str,
+    runner: CommandRunner,
+    evidence: list[EvidenceReference] | None = None,
+) -> dict[str, object]:
+    """Return verified free control-query capacity before scheduling a service."""
+    raw_status = _remote_clio_json(
+        definition,
+        ["worker", "status", "--cluster", cluster],
+        runner=runner,
+    )
+    if not isinstance(raw_status, dict):
+        raise RelayError("secure runtime worker status was not a JSON object")
+    status = cast(dict[str, object], raw_status)
+    configured_control = status.get("configured_control_query_concurrency")
+    configured_workload = status.get("configured_workload_concurrency")
+    consistent = status.get("control_query_concurrency_consistent")
+    scan_truncated = status.get("scan_truncated")
+    active_raw = status.get("active_leases_by_mcp_admission_class")
+    active = cast(dict[str, object], active_raw) if isinstance(active_raw, dict) else None
+    active_control = None if active is None else active.get("control_query")
+    observed: dict[str, object] = {
+        "configured_workload_concurrency": configured_workload,
+        "configured_control_query_concurrency": configured_control,
+        "active_control_query_leases": active_control,
+        "control_query_concurrency_consistent": consistent,
+        "scan_truncated": scan_truncated,
+        "worker_generation_id": status.get("worker_generation_id"),
+        "worker_generation_complete": status.get("worker_generation_complete"),
+        "source_submitted": False,
+        "scheduler_job_created": False,
+    }
+    if (
+        type(configured_control) is int
+        and type(active_control) is int
+        and configured_control >= active_control
+    ):
+        observed["free_control_query_slots"] = configured_control - active_control
+    if evidence is not None:
+        evidence.append(
+            EvidenceReference(
+                kind="worker_capacity",
+                reference=f"relay-worker://{cluster}/control-query",
+                metadata=observed,
+            )
+        )
+    if scan_truncated is not False:
+        raise RelayError("secure runtime worker-capacity scan was incomplete")
+    if consistent is not True:
+        raise RelayError("secure runtime worker control-query policy is inconsistent")
+    if type(configured_workload) is not int or configured_workload < 1:
+        raise RelayError("secure runtime requires at least one workload worker slot")
+    if type(configured_control) is not int or configured_control < 1:
+        raise RelayError("secure runtime requires at least one reserved control-query slot")
+    if type(active_control) is not int or active_control < 0:
+        raise RelayError("secure runtime worker status omitted active control-query usage")
+    if active_control >= configured_control:
+        raise RelayError("secure runtime has no free reserved control-query slot")
+    observed.update(
+        {
+            "free_control_query_slots": configured_control - active_control,
+            "control_query_concurrency_consistent": True,
+            "scan_truncated": False,
+        }
+    )
+    return observed
 
 
 def _wait_for_live_structured_runtime_metadata(

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -35,6 +35,7 @@ from clio_relay.identifiers import (
 )
 from clio_relay.jarvis_mcp import (
     JARVIS_MCP_CACHE_SERVER_NAME,
+    is_virtual_jarvis_control_query,
     is_virtual_jarvis_tool,
     jarvis_cd_lock_binding_expectation,
     jarvis_mcp_artifact_binding,
@@ -52,6 +53,7 @@ from clio_relay.jarvis_service_runtime import (
     resolve_jarvis_service_runtime,
 )
 from clio_relay.models import (
+    MCP_ADMISSION_AUTHORITY_METADATA_KEY,
     ArtifactRef,
     ArtifactUse,
     Cursor,
@@ -60,7 +62,10 @@ from clio_relay.models import (
     JarvisRunSpec,
     JobKind,
     JobState,
+    McpAdmissionClass,
     McpCallSpec,
+    McpControlQueryEvidence,
+    McpOperation,
     MonitorRule,
     MonitorRuleAction,
     ProgressRecord,
@@ -102,12 +107,16 @@ from clio_relay.remote_cli import (
     write_remote_file,
 )
 from clio_relay.remote_mcp import (
+    MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS,
     RemoteMcpSchemaCache,
     VirtualRemoteMcpCatalog,
     cluster_route_revision_json_schema,
     default_remote_mcp_cache_path,
+    is_remote_mcp_control_query,
     load_virtual_remote_mcp_catalog,
     remote_mcp_registration_revision,
+    resolve_pinned_mcp_admission,
+    resolve_registered_remote_mcp_admission,
     unavailable_virtual_remote_mcp_catalog,
 )
 from clio_relay.retention import TerminalRetentionCoordinator
@@ -1540,6 +1549,7 @@ def _call_tool(
         result["catalog_revision"] = catalog.revision
     elif catalog is not None and name in catalog.tools:
         cluster = _required_str(arguments, "cluster")
+        virtual_tool = catalog.tools[name]
         route = catalog.resolve(name, cluster)
         forwarded_arguments = catalog.forwarded_arguments(name, arguments)
         relay_arguments = catalog.relay_arguments(name, arguments)
@@ -1555,13 +1565,23 @@ def _call_tool(
                 "expected_cluster_route_revision": route.cluster_route_revision,
                 "registered_server_name": route.server_name,
                 "expected_remote_mcp_registration_revision": (route.registration_revision),
+                "control_query_evidence": (
+                    route.control_query_evidence.model_dump(mode="json")
+                    if route.expected_server_artifact_digest is not None
+                    and is_remote_mcp_control_query(virtual_tool.remote_tool)
+                    and route.control_query_evidence is not None
+                    else None
+                ),
                 "tool": route.remote_tool_name,
                 "arguments": forwarded_arguments,
                 "timeout_seconds": route.timeout_seconds,
                 **relay_arguments,
                 "idempotency_key": (
-                    f"mcp:virtual:{cluster}:{route.server_name}:"
-                    f"{route.remote_tool_name}:{uuid4().hex}"
+                    relay_arguments.get("idempotency_key")
+                    or (
+                        f"mcp:virtual:{cluster}:{route.server_name}:"
+                        f"{route.remote_tool_name}:{uuid4().hex}"
+                    )
                 ),
             },
             queue=queue,
@@ -3743,6 +3763,7 @@ def _submit_mcp_call(
     *,
     queue: ClioCoreQueue,
     settings: RelaySettings,
+    pinned_jarvis: bool = False,
 ) -> JSON:
     cluster = _required_str(arguments, "cluster")
     used_artifact_refs = _artifact_use_refs(arguments)
@@ -3762,6 +3783,15 @@ def _submit_mcp_call(
         if raw_expected_jarvis_cd_lock_binding is not None
         else None
     )
+    raw_control_query_evidence = arguments.get("control_query_evidence")
+    try:
+        control_query_evidence = (
+            McpControlQueryEvidence.model_validate(raw_control_query_evidence)
+            if raw_control_query_evidence is not None
+            else None
+        )
+    except ValidationError as exc:
+        raise ValueError("invalid MCP control-query discovery evidence") from exc
     tool = _required_str(arguments, "tool")
     tool_arguments = _object(arguments.get("arguments", {}))
     timeout_seconds = _optional_int(arguments, "timeout_seconds")
@@ -3778,6 +3808,8 @@ def _submit_mcp_call(
         "arguments_digest": digest,
         "timeout_seconds": timeout_seconds,
     }
+    if control_query_evidence is not None:
+        identity["control_query_evidence"] = control_query_evidence.model_dump(mode="json")
     if expected_jarvis_cd_lock_binding is not None:
         identity["expected_jarvis_cd_lock_binding"] = expected_jarvis_cd_lock_binding
     if used_artifact_refs:
@@ -3834,6 +3866,18 @@ def _submit_mcp_call(
                 f"remote MCP registration changed for {cluster}/{registered_server_name}; "
                 "call tools/list again before submission"
             )
+    if control_query_evidence is not None:
+        if not registered_remote_mcp_route:
+            raise ValueError("MCP control-query evidence requires a registered remote route")
+        if (
+            control_query_evidence.cluster != cluster
+            or control_query_evidence.registered_server_name != registered_server_name
+            or control_query_evidence.cluster_route_revision != expected_cluster_route_revision
+            or control_query_evidence.registration_revision != expected_registration_revision
+            or control_query_evidence.expected_server_artifact_digest
+            != expected_server_artifact_digest
+        ):
+            raise ValueError("MCP control-query evidence does not match its selected route")
     if definition is not None and should_execute_on_cluster(definition):
         if settings.owner_session_id is not None:
             payload: dict[str, object] = {
@@ -3841,11 +3885,14 @@ def _submit_mcp_call(
                 "server": server,
                 "server_args": server_args,
                 "env_from": env_from,
+                "operation": McpOperation.TOOLS_CALL.value,
                 "tool": tool,
                 "arguments": tool_arguments,
                 "idempotency_key": idempotency_key,
                 "used_artifact_refs": [item.model_dump(mode="json") for item in used_artifact_refs],
             }
+            if control_query_evidence is not None:
+                payload["control_query_evidence"] = control_query_evidence.model_dump(mode="json")
             if timeout_seconds is not None:
                 payload["timeout_seconds"] = timeout_seconds
             if expected_server_artifact_digest is not None:
@@ -3886,6 +3933,17 @@ def _submit_mcp_call(
             "--idempotency-key",
             idempotency_key,
         ]
+        if control_query_evidence is not None:
+            remote_args.extend(
+                [
+                    "--control-query-evidence-json",
+                    json.dumps(
+                        control_query_evidence.model_dump(mode="json"),
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                ]
+            )
         if timeout_seconds is not None:
             remote_args.extend(["--timeout-seconds", str(timeout_seconds)])
         for item in server_args:
@@ -3912,6 +3970,39 @@ def _submit_mcp_call(
             definition=definition,
             arguments=arguments,
         )
+    operation = McpOperation.TOOLS_CALL
+    if pinned_jarvis:
+        admission_class, admission_authority = resolve_pinned_mcp_admission(
+            operation=operation,
+            tool=tool,
+            expected_server_artifact_digest=expected_server_artifact_digest,
+            pinned_control_query=is_virtual_jarvis_control_query(tool),
+            timeout_seconds=timeout_seconds,
+        )
+    elif control_query_evidence is not None:
+        if definition is None:
+            raise ValueError("registered MCP control-query admission requires a cluster route")
+        admission_class, admission_authority = resolve_registered_remote_mcp_admission(
+            queue=queue,
+            definition=definition,
+            cluster=cluster,
+            server=server,
+            server_args=server_args,
+            env_from=env_from,
+            operation=operation,
+            tool=tool,
+            expected_server_artifact_digest=expected_server_artifact_digest,
+            evidence=control_query_evidence,
+            timeout_seconds=timeout_seconds,
+        )
+    else:
+        admission_class = McpAdmissionClass.WORKLOAD
+        admission_authority = None
+    metadata = (
+        {}
+        if admission_authority is None
+        else {MCP_ADMISSION_AUTHORITY_METADATA_KEY: admission_authority.model_dump(mode="json")}
+    )
     job = _submit_local_job(
         queue,
         RelayJob(
@@ -3923,12 +4014,15 @@ def _submit_mcp_call(
                 env_from=env_from,
                 expected_server_artifact_digest=expected_server_artifact_digest,
                 expected_jarvis_cd_lock_binding=expected_jarvis_cd_lock_binding,
+                admission_class=admission_class,
+                operation=operation,
                 tool=tool,
                 arguments=tool_arguments,
                 timeout_seconds=timeout_seconds,
             ),
             idempotency_key=idempotency_key,
             used_artifact_refs=used_artifact_refs,
+            metadata=metadata,
         ),
         settings=settings,
     )
@@ -4165,19 +4259,6 @@ def _submit_jarvis_mcp_call(
     digest = hashlib.sha256(
         json.dumps(tool_arguments, sort_keys=True, separators=(",", ":")).encode("utf-8")
     ).hexdigest()
-    dependency_suffix = (
-        ":"
-        + _stable_digest(
-            {"used_artifact_refs": [item.model_dump(mode="json") for item in used_artifact_refs]}
-        )
-        if used_artifact_refs
-        else ""
-    )
-    idempotency_key = str(
-        forwarded.get("idempotency_key")
-        or f"mcp:{cluster}:jarvis:{tool}:{digest}{dependency_suffix}"
-    )
-    forwarded["idempotency_key"] = idempotency_key
     forwarded["expected_jarvis_cd_lock_binding"] = jarvis_cd_lock_binding_expectation()
     registered_route = arguments.get("registered_route") is True
     definition = (
@@ -4219,6 +4300,39 @@ def _submit_jarvis_mcp_call(
         )
     if expected_server_artifact_digest is not None:
         forwarded["expected_server_artifact_digest"] = expected_server_artifact_digest
+    timeout_seconds = _optional_int(arguments, "timeout_seconds")
+    admission_class, admission_authority = resolve_pinned_mcp_admission(
+        operation=McpOperation.TOOLS_CALL,
+        tool=tool,
+        expected_server_artifact_digest=expected_server_artifact_digest,
+        pinned_control_query=is_virtual_jarvis_control_query(tool),
+        timeout_seconds=timeout_seconds,
+    )
+    if admission_class is McpAdmissionClass.CONTROL_QUERY and timeout_seconds is None:
+        timeout_seconds = MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS
+    if timeout_seconds is not None:
+        forwarded["timeout_seconds"] = timeout_seconds
+    dependency_suffix = (
+        ":"
+        + _stable_digest(
+            {"used_artifact_refs": [item.model_dump(mode="json") for item in used_artifact_refs]}
+        )
+        if used_artifact_refs
+        else ""
+    )
+    legacy_idempotency_key = f"mcp:{cluster}:jarvis:{tool}:{digest}{dependency_suffix}"
+    derived_idempotency_key = (
+        legacy_idempotency_key
+        if admission_class is McpAdmissionClass.WORKLOAD
+        else (
+            f"mcp:{cluster}:jarvis:{tool}:{digest}:"
+            f"{expected_server_artifact_digest or 'unbound'}:{admission_class.value}:"
+            f"{admission_authority.source if admission_authority is not None else 'none'}:"
+            f"timeout={timeout_seconds}{dependency_suffix}"
+        )
+    )
+    idempotency_key = str(forwarded.get("idempotency_key") or derived_idempotency_key)
+    forwarded["idempotency_key"] = idempotency_key
     if definition is not None and should_execute_on_cluster(definition):
         if settings.owner_session_id is not None:
             if expected_server_artifact_digest is None:
@@ -4227,13 +4341,13 @@ def _submit_jarvis_mcp_call(
                 )
             payload: dict[str, object] = {
                 "cluster": cluster,
+                "operation": McpOperation.TOOLS_CALL.value,
                 "tool": tool,
                 "arguments": tool_arguments,
                 "expected_server_artifact_digest": expected_server_artifact_digest,
                 "idempotency_key": idempotency_key,
                 "used_artifact_refs": [item.model_dump(mode="json") for item in used_artifact_refs],
             }
-            timeout_seconds = _optional_int(arguments, "timeout_seconds")
             if timeout_seconds is not None:
                 payload["timeout_seconds"] = timeout_seconds
             job = submit_owned_session_job(
@@ -4269,7 +4383,6 @@ def _submit_jarvis_mcp_call(
             "--idempotency-key",
             idempotency_key,
         ]
-        timeout_seconds = _optional_int(arguments, "timeout_seconds")
         if timeout_seconds is not None:
             remote_args.extend(["--timeout-seconds", str(timeout_seconds)])
         if expected_server_artifact_digest is not None:
@@ -4296,7 +4409,12 @@ def _submit_jarvis_mcp_call(
     server_args = jarvis_mcp_server_args()
     forwarded["server"] = server
     forwarded["server_args"] = server_args
-    return _submit_mcp_call(forwarded, queue=queue, settings=settings)
+    return _submit_mcp_call(
+        forwarded,
+        queue=queue,
+        settings=settings,
+        pinned_jarvis=True,
+    )
 
 
 def _submission_result(

--- a/src/clio_relay/models.py
+++ b/src/clio_relay/models.py
@@ -24,6 +24,7 @@ RELAY_CREDENTIAL_ENV_NAMES = frozenset(
         "CLIO_RELAY_STCP_SECRET",
     }
 )
+MCP_ADMISSION_AUTHORITY_METADATA_KEY = "mcp_admission_authority"
 
 
 def validate_mcp_env_from(value: dict[str, str]) -> dict[str, str]:
@@ -84,6 +85,83 @@ class McpOperation(StrEnum):
 
     TOOLS_CALL = "tools/call"
     TOOLS_LIST = "tools/list"
+
+
+class McpAdmissionClass(StrEnum):
+    """Durable worker-lane admission assigned to one remote MCP operation.
+
+    ``control_query`` is a privileged scheduling assertion.  Generic callers
+    must remain on ``workload``; trusted ingress may promote an artifact-bound,
+    non-destructive read operation after validating its registered contract.
+    """
+
+    WORKLOAD = "workload"
+    CONTROL_QUERY = "control_query"
+
+
+class McpControlQueryEvidence(BaseModel):
+    """Cluster-owned discovery evidence offered for reserved query admission."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["clio-relay.mcp-control-query-evidence.v1"] = (
+        "clio-relay.mcp-control-query-evidence.v1"
+    )
+    cluster: str = Field(min_length=1, max_length=256)
+    registered_server_name: str = Field(min_length=1, max_length=256)
+    cluster_route_revision: str = Field(pattern=r"^[0-9a-f]{64}$")
+    registration_revision: str = Field(pattern=r"^[0-9a-f]{64}$")
+    discovery_job_id: DurableRecordId
+    discovery_artifact_id: DurableRecordId
+    discovery_artifact_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    discovery_schema_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    expected_server_artifact_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+class McpAdmissionAuthority(BaseModel):
+    """Server-stamped provenance explaining one reserved MCP admission."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["clio-relay.mcp-admission-authority.v1"] = (
+        "clio-relay.mcp-admission-authority.v1"
+    )
+    admission_class: Literal["control_query"] = "control_query"
+    source: Literal[
+        "intrinsic_tools_list",
+        "pinned_jarvis_contract",
+        "registered_discovery_artifact",
+    ]
+    operation: McpOperation
+    tool: str | None = Field(default=None, max_length=512)
+    expected_server_artifact_digest: str | None = Field(
+        default=None,
+        pattern=r"^[0-9a-f]{64}$",
+    )
+    evidence: McpControlQueryEvidence | None = None
+
+    @model_validator(mode="after")
+    def validate_authority_source(self) -> McpAdmissionAuthority:
+        """Require source-specific evidence and operation bindings."""
+        if self.source == "intrinsic_tools_list":
+            if self.operation is not McpOperation.TOOLS_LIST:
+                raise ValueError("intrinsic MCP admission authority requires tools/list")
+            if self.tool is not None or self.evidence is not None:
+                raise ValueError("intrinsic tools/list authority must not name a tool or evidence")
+            return self
+        if self.operation is not McpOperation.TOOLS_CALL or not self.tool:
+            raise ValueError("MCP control-query authority requires one tools/call tool")
+        if self.expected_server_artifact_digest is None:
+            raise ValueError("MCP control-query authority requires an artifact digest")
+        if self.source == "pinned_jarvis_contract":
+            if self.evidence is not None:
+                raise ValueError("pinned JARVIS authority must not carry generic route evidence")
+            return self
+        if self.evidence is None:
+            raise ValueError("registered MCP authority requires discovery evidence")
+        if self.evidence.expected_server_artifact_digest != self.expected_server_artifact_digest:
+            raise ValueError("registered MCP authority artifact binding changed")
+        return self
 
 
 class JobState(StrEnum):
@@ -431,6 +509,7 @@ class McpCallSpec(BaseModel):
     env_from: dict[str, str] = Field(default_factory=dict)
     expected_server_artifact_digest: str | None = None
     expected_jarvis_cd_lock_binding: dict[str, str] | None = None
+    admission_class: McpAdmissionClass = McpAdmissionClass.WORKLOAD
     operation: McpOperation = McpOperation.TOOLS_CALL
     tool: str | None = None
     arguments: dict[str, Any] = Field(default_factory=dict)
@@ -480,6 +559,13 @@ class McpCallSpec(BaseModel):
         if self.operation == McpOperation.TOOLS_CALL:
             if self.tool is None or not self.tool:
                 raise ValueError("tool is required for tools/call")
+            if (
+                self.admission_class is McpAdmissionClass.CONTROL_QUERY
+                and self.expected_server_artifact_digest is None
+            ):
+                raise ValueError(
+                    "control_query MCP calls require an expected server artifact digest"
+                )
             return self
         if self.tool is not None:
             raise ValueError("tool must be omitted for tools/list")

--- a/src/clio_relay/queue_management.py
+++ b/src/clio_relay/queue_management.py
@@ -15,6 +15,8 @@ from clio_relay.models import (
     JobKind,
     JobState,
     Lease,
+    McpAdmissionClass,
+    McpCallSpec,
     RelayJob,
     utc_now,
 )
@@ -763,7 +765,9 @@ def _admission_snapshot(
     supervisor_endpoints = [
         endpoint for endpoint in workers if endpoint.metadata.get("worker_supervisor") is True
     ]
-    kind_policy_endpoints = supervisor_endpoints or capacity_endpoints
+    kind_policy_endpoints = (
+        [*supervisor_endpoints, *capacity_endpoints] if supervisor_endpoints else capacity_endpoints
+    )
     kind_configurations, kind_configurations_valid = _kind_concurrency_configurations(
         kind_policy_endpoints
     )
@@ -1282,8 +1286,15 @@ def worker_status(
         and now - endpoint.last_seen_at <= timedelta(seconds=fresh_seconds)
     ]
     endpoints_truncated = fresh_endpoints_truncated or history_endpoints_truncated
-    slot_endpoints = [endpoint for endpoint in endpoints if "worker_slot" in endpoint.metadata]
-    if slot_endpoints:
+    (
+        slot_endpoints,
+        supervisor_endpoints,
+        worker_generation_id,
+        worker_generation_complete,
+        fresh_worker_generation_count,
+    ) = _select_active_worker_generation(queue, endpoints)
+    supervised_generation_selected = worker_generation_id is not None
+    if supervised_generation_selected:
         capacity_endpoints = slot_endpoints
         configured_concurrency = len(slot_endpoints)
     else:
@@ -1295,19 +1306,64 @@ def worker_status(
         configured_concurrency = sum(
             _endpoint_concurrency(endpoint.metadata) for endpoint in capacity_endpoints
         )
-    supervisor_endpoints = [
-        endpoint for endpoint in endpoints if endpoint.metadata.get("worker_supervisor") is True
-    ]
     kind_policy_endpoints = supervisor_endpoints or capacity_endpoints
     kind_configurations, kind_configurations_valid = _kind_concurrency_configurations(
         kind_policy_endpoints
     )
-    kind_concurrency_consistent = kind_configurations_valid and len(kind_configurations) <= 1
+    kind_concurrency_consistent = (
+        kind_configurations_valid
+        and len(kind_configurations) <= 1
+        and worker_generation_complete is not False
+    )
     configured_kind_concurrency: dict[str, int] | None
     if kind_concurrency_consistent:
         configured_kind_concurrency = kind_configurations[0] if kind_configurations else {}
     else:
         configured_kind_concurrency = None
+    lane_policy_endpoints = supervisor_endpoints or capacity_endpoints
+    lane_configurations = [
+        _endpoint_lane_configuration(endpoint.metadata) for endpoint in lane_policy_endpoints
+    ]
+    distinct_lane_configurations = sorted(
+        {item for item in lane_configurations if item is not None}
+    )
+    configured_workload_concurrency: int | None = None
+    configured_control_query_concurrency: int | None = None
+    if slot_endpoints:
+        slot_lane_configurations = [
+            _endpoint_lane_configuration(endpoint.metadata) for endpoint in slot_endpoints
+        ]
+        workload_slots = sum(item == (1, 0) for item in slot_lane_configurations)
+        control_slots = sum(item == (0, 1) for item in slot_lane_configurations)
+        lane_concurrency_consistent = (
+            all(item is not None for item in slot_lane_configurations)
+            and workload_slots + control_slots == len(slot_endpoints)
+            and worker_generation_complete is not False
+        )
+        if supervisor_endpoints:
+            supervisor_lane_configurations = [
+                _endpoint_lane_configuration(endpoint.metadata) for endpoint in supervisor_endpoints
+            ]
+            lane_concurrency_consistent = (
+                lane_concurrency_consistent
+                and all(item is not None for item in supervisor_lane_configurations)
+                and set(cast(tuple[int, int], item) for item in supervisor_lane_configurations)
+                == {(workload_slots, control_slots)}
+            )
+        if lane_concurrency_consistent:
+            configured_workload_concurrency = workload_slots
+            configured_control_query_concurrency = control_slots
+        distinct_lane_configurations = [(workload_slots, control_slots)]
+    else:
+        lane_concurrency_consistent = (
+            all(item is not None for item in lane_configurations)
+            and len(distinct_lane_configurations) <= 1
+            and worker_generation_complete is not False
+        )
+        if lane_concurrency_consistent and distinct_lane_configurations:
+            configured_workload_concurrency, configured_control_query_concurrency = (
+                distinct_lane_configurations[0]
+            )
     scanned_leases, leases_truncated = queue.scan_leases(limit=scan_limit)
     leases: list[Lease] = []
     jobs_by_id: dict[str, RelayJob] = {}
@@ -1321,6 +1377,9 @@ def worker_status(
         leases.append(lease)
         jobs_by_id[job.job_id] = job
     active_leases_by_kind = {kind.value: 0 for kind in JobKind}
+    active_leases_by_mcp_admission_class = {
+        admission_class.value: 0 for admission_class in McpAdmissionClass
+    }
     counted_jobs: set[str] = set()
     for lease in leases:
         if lease.is_expired() or lease.job_id in counted_jobs:
@@ -1330,6 +1389,13 @@ def worker_status(
             continue
         counted_jobs.add(job.job_id)
         active_leases_by_kind[job.kind.value] += 1
+        active_leases_by_mcp_admission_class[
+            (
+                job.spec.admission_class.value
+                if job.kind is JobKind.MCP_CALL and isinstance(job.spec, McpCallSpec)
+                else McpAdmissionClass.WORKLOAD.value
+            )
+        ] += 1
     return {
         "cluster": cluster,
         "workers": [endpoint.model_dump(mode="json") for endpoint in endpoints],
@@ -1338,7 +1404,21 @@ def worker_status(
         "configured_kind_concurrency": configured_kind_concurrency,
         "kind_concurrency_consistent": kind_concurrency_consistent,
         "kind_concurrency_configurations": kind_configurations,
+        "configured_workload_concurrency": configured_workload_concurrency,
+        "configured_control_query_concurrency": configured_control_query_concurrency,
+        "control_query_concurrency_consistent": lane_concurrency_consistent,
+        "worker_generation_id": worker_generation_id,
+        "worker_generation_complete": worker_generation_complete,
+        "fresh_worker_generation_count": fresh_worker_generation_count,
+        "control_query_concurrency_configurations": [
+            {
+                "workload": workload,
+                "control_query": control,
+            }
+            for workload, control in distinct_lane_configurations
+        ],
         "active_leases_by_kind": active_leases_by_kind,
+        "active_leases_by_mcp_admission_class": active_leases_by_mcp_admission_class,
         "active_job_capacity": queue.active_job_capacity(),
         "fresh_seconds": fresh_seconds,
         "registered_worker_count": len(all_endpoints),
@@ -1409,6 +1489,136 @@ def _endpoint_concurrency(metadata: dict[str, object]) -> int:
     if isinstance(value, int) and value > 0:
         return value
     return 1
+
+
+def _select_active_worker_generation(
+    queue: ClioCoreQueue,
+    endpoints: list[EndpointRegistration],
+) -> tuple[
+    list[EndpointRegistration],
+    list[EndpointRegistration],
+    str | None,
+    bool | None,
+    int,
+]:
+    """Select the newest supervised process generation and its fresh slots.
+
+    Endpoint records intentionally survive process exit. During a systemd
+    restart, the previous and replacement generations can therefore both be
+    inside the freshness window. Capacity must come from exactly one complete
+    parent generation rather than summing those records together.
+    """
+    fresh_supervisors = {
+        endpoint.endpoint_id: endpoint
+        for endpoint in endpoints
+        if endpoint.metadata.get("worker_supervisor") is True
+    }
+    slots_by_parent: dict[str, list[EndpointRegistration]] = {}
+    unbound_slots: list[EndpointRegistration] = []
+    for endpoint in endpoints:
+        if "worker_slot" not in endpoint.metadata:
+            continue
+        parent_endpoint_id = endpoint.metadata.get("parent_endpoint_id")
+        if not isinstance(parent_endpoint_id, str) or not parent_endpoint_id:
+            unbound_slots.append(endpoint)
+            continue
+        slots_by_parent.setdefault(parent_endpoint_id, []).append(endpoint)
+    candidate_ids = set(fresh_supervisors) | set(slots_by_parent)
+    if not candidate_ids:
+        if unbound_slots:
+            return unbound_slots, [], None, False, 0
+        return [], [], None, None, 0
+
+    candidates: list[
+        tuple[datetime, str, EndpointRegistration | None, list[EndpointRegistration]]
+    ] = []
+    for parent_endpoint_id in candidate_ids:
+        try:
+            parent = fresh_supervisors.get(parent_endpoint_id) or queue.get_endpoint(
+                parent_endpoint_id
+            )
+        except NotFoundError:
+            parent = None
+        slots = slots_by_parent.get(parent_endpoint_id, [])
+        observed_at = (
+            parent.registered_at
+            if parent is not None
+            else max(slot.registered_at for slot in slots)
+        )
+        candidates.append((observed_at, parent_endpoint_id, parent, slots))
+    _observed_at, selected_id, selected_parent, selected_slots = max(
+        candidates,
+        key=lambda item: (item[0], item[1]),
+    )
+    selected_slots = sorted(
+        [*selected_slots, *unbound_slots],
+        key=lambda endpoint: (
+            _worker_slot_index(endpoint.metadata),
+            endpoint.endpoint_id,
+        ),
+    )
+    complete = _worker_generation_is_complete(selected_parent, selected_slots)
+    return (
+        selected_slots,
+        [] if selected_parent is None else [selected_parent],
+        selected_id,
+        complete,
+        len(candidate_ids),
+    )
+
+
+def _worker_generation_is_complete(
+    parent: EndpointRegistration | None,
+    slots: list[EndpointRegistration],
+) -> bool:
+    """Require every declared slot from one exact supervisor generation."""
+    if parent is None or parent.metadata.get("worker_supervisor") is not True:
+        return False
+    expected_concurrency = _endpoint_concurrency(parent.metadata)
+    if expected_concurrency < 2 or len(slots) != expected_concurrency:
+        return False
+    indices = [_worker_slot_index(endpoint.metadata) for endpoint in slots]
+    if indices != list(range(expected_concurrency)):
+        return False
+    return all(
+        endpoint.metadata.get("parent_endpoint_id") == parent.endpoint_id
+        and _endpoint_concurrency(endpoint.metadata) == 1
+        and endpoint.hostname == parent.hostname
+        and endpoint.pid == parent.pid
+        and endpoint.registered_at >= parent.registered_at
+        for endpoint in slots
+    )
+
+
+def _worker_slot_index(metadata: dict[str, object]) -> int:
+    """Return a sortable slot index while keeping malformed metadata invalid."""
+    value = metadata.get("worker_slot")
+    return value if type(value) is int and value >= 0 else 2**63 - 1
+
+
+def _endpoint_lane_configuration(metadata: dict[str, object]) -> tuple[int, int] | None:
+    """Return one explicit workload/control slot declaration, or fail closed."""
+    workload = metadata.get("workload_concurrency")
+    control = metadata.get("control_query_concurrency")
+    if (
+        type(workload) is not int
+        or type(control) is not int
+        or workload < 0
+        or control < 0
+        or workload + control != _endpoint_concurrency(metadata)
+    ):
+        return None
+    admission_class = metadata.get("mcp_admission_class")
+    if admission_class is not None:
+        if admission_class not in {
+            McpAdmissionClass.WORKLOAD.value,
+            McpAdmissionClass.CONTROL_QUERY.value,
+        }:
+            return None
+        expected = (1, 0) if admission_class == McpAdmissionClass.WORKLOAD.value else (0, 1)
+        if (workload, control) != expected:
+            return None
+    return workload, control
 
 
 def _kind_concurrency_configurations(

--- a/src/clio_relay/remote_mcp.py
+++ b/src/clio_relay/remote_mcp.py
@@ -8,6 +8,8 @@ deterministic, and free of cluster-side execution side effects.
 
 from __future__ import annotations
 
+import base64
+import binascii
 import hashlib
 import hmac
 import json
@@ -37,6 +39,7 @@ from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from clio_relay.cluster_config import (
+    ClusterDefinition,
     ClusterRegistry,
     RemoteMcpProfile,
     RemoteMcpServerConfig,
@@ -46,11 +49,23 @@ from clio_relay.cluster_config import (
     open_private_atomic_file,
     read_bounded_configuration_bytes,
 )
+from clio_relay.errors import NotFoundError, RelayError
+from clio_relay.models import (
+    JobKind,
+    JobState,
+    McpAdmissionAuthority,
+    McpAdmissionClass,
+    McpCallSpec,
+    McpControlQueryEvidence,
+    McpOperation,
+)
 
 if TYPE_CHECKING:
+    from clio_relay.core_queue import ClioCoreQueue
     from clio_relay.validation_report import LiveValidationReport, ValidationResource
 
 JSON = dict[str, Any]
+MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS = 60
 REMOTE_MCP_CACHE_ENV = "CLIO_RELAY_REMOTE_MCP_CACHE"
 REMOTE_MCP_CACHE_VERSION = 1
 REMOTE_MCP_CACHE_SOURCE = "durable_relay_mcp_tools_list"
@@ -210,6 +225,15 @@ _JSON_SCHEMA_VALIDATORS.update(
 )
 
 VIRTUAL_REMOTE_MCP_RELAY_CONTROL_SCHEMAS: dict[str, JSON] = {
+    "idempotency_key": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 512,
+        "description": (
+            "Stable retry identity consumed by clio-relay and never forwarded to the "
+            "remote MCP server. Reuse it only for the exact same call payload."
+        ),
+    },
     "wait_for_terminal": {
         "type": "boolean",
         "default": False,
@@ -358,6 +382,22 @@ class RemoteMcpToolSchema(BaseModel):
                 f"remote MCP tool schema exceeds {MAX_REMOTE_MCP_TOOL_SCHEMA_BYTES} bytes"
             )
         return self
+
+
+def is_remote_mcp_control_query(tool: RemoteMcpToolSchema) -> bool:
+    """Return whether discovery explicitly classifies a tool as a safe query.
+
+    MCP annotations are advisory server claims, so this predicate is only one
+    input to admission. Callers must additionally bind the invocation to the
+    registered route and exact discovered server artifact before assigning the
+    reserved control-query class.
+    """
+    annotations = tool.annotations
+    return bool(
+        annotations is not None
+        and annotations.get("readOnlyHint") is True
+        and annotations.get("destructiveHint") is False
+    )
 
 
 class RemoteMcpDiscoveryProvenance(BaseModel):
@@ -1220,12 +1260,22 @@ class RemoteMcpRoute:
     contract: str | None
     cluster_route_revision: str
     registration_revision: str
+    control_query_evidence: McpControlQueryEvidence | None = None
 
 
 def _virtual_remote_mcp_relay_arguments(arguments: JSON) -> JSON:
     """Validate and copy relay-only controls from an agent-facing invocation."""
 
     controls: JSON = {}
+    if "idempotency_key" in arguments:
+        idempotency_key = arguments["idempotency_key"]
+        if (
+            not isinstance(idempotency_key, str)
+            or not idempotency_key
+            or len(idempotency_key) > 512
+        ):
+            raise ValueError("idempotency_key must be a non-empty string of at most 512 characters")
+        controls["idempotency_key"] = idempotency_key
     for field_name in ("wait_for_terminal", "include_logs"):
         if field_name not in arguments:
             continue
@@ -1371,6 +1421,8 @@ class _Candidate:
     base_alias: str
     identity: str
     expected_server_artifact_digest: str | None
+    discovery_provenance: RemoteMcpDiscoveryProvenance
+    discovery_schema_digest: str
 
 
 def unavailable_virtual_remote_mcp_catalog(reason: str) -> VirtualRemoteMcpCatalog:
@@ -1526,6 +1578,243 @@ def cache_entry_from_discovery_artifact(
             server_artifact=cast(JSON, server_artifact),
         ),
     )
+
+
+def resolve_registered_remote_mcp_admission(
+    *,
+    queue: ClioCoreQueue,
+    definition: ClusterDefinition | None,
+    cluster: str,
+    server: str,
+    server_args: list[str],
+    env_from: dict[str, str],
+    operation: McpOperation,
+    tool: str | None,
+    expected_server_artifact_digest: str | None,
+    evidence: McpControlQueryEvidence | None,
+    timeout_seconds: int | None = None,
+    now: datetime | None = None,
+) -> tuple[McpAdmissionClass, McpAdmissionAuthority | None]:
+    """Derive admission from intrinsic discovery or cluster-owned route evidence.
+
+    A caller can offer evidence but can never select the resulting worker lane.
+    The receiving queue independently reloads the operator registration and the
+    exact durable ``tools/list`` artifact before granting reserved capacity.
+    """
+    if operation is McpOperation.TOOLS_LIST:
+        if evidence is not None:
+            raise ValueError("tools/list must not carry control-query route evidence")
+        if definition is None or definition.name != cluster:
+            return McpAdmissionClass.WORKLOAD, None
+        matches = [
+            registration
+            for registration in definition.remote_mcp_servers.values()
+            if registration.enabled
+            and registration.command == server
+            and registration.args == server_args
+            and registration.env_from == env_from
+        ]
+        if not matches:
+            return McpAdmissionClass.WORKLOAD, None
+        if len(matches) != 1:
+            raise ValueError("tools/list route matches multiple operator registrations")
+        if timeout_seconds is None:
+            raise ValueError("registered tools/list control admission requires an explicit timeout")
+        if timeout_seconds <= 0:
+            raise ValueError("registered tools/list timeout must be positive")
+        if timeout_seconds > matches[0].call_timeout_seconds:
+            raise ValueError("tools/list timeout exceeds the operator registration limit")
+        return (
+            McpAdmissionClass.CONTROL_QUERY,
+            McpAdmissionAuthority(
+                source="intrinsic_tools_list",
+                operation=McpOperation.TOOLS_LIST,
+            ),
+        )
+    if evidence is None:
+        return McpAdmissionClass.WORKLOAD, None
+    if not tool:
+        raise ValueError("control-query evidence requires one tools/call tool")
+    if expected_server_artifact_digest is None:
+        raise ValueError("control-query evidence requires an expected server artifact digest")
+    if definition is None:
+        raise ValueError("control-query evidence requires a configured cluster route")
+    if evidence.cluster != cluster or definition.name != cluster:
+        raise ValueError("control-query evidence does not match the selected cluster")
+    if not hmac.compare_digest(
+        evidence.cluster_route_revision,
+        cluster_route_revision(definition),
+    ):
+        raise ValueError("cluster route changed after MCP discovery; refresh the registered server")
+    registration = definition.remote_mcp_servers.get(evidence.registered_server_name)
+    if registration is None or not registration.enabled:
+        raise ValueError("registered MCP server is unavailable; refresh its discovery")
+    if not hmac.compare_digest(
+        evidence.registration_revision,
+        remote_mcp_registration_revision(registration),
+    ):
+        raise ValueError("registered MCP server changed after discovery; refresh its discovery")
+    if (
+        registration.command != server
+        or registration.args != server_args
+        or registration.env_from != env_from
+    ):
+        raise ValueError("MCP call route does not match its operator registration")
+    if not registration.allows_tool(tool):
+        raise ValueError("MCP tool is not allowlisted by its operator registration")
+    if registration.allow_mutable_artifact:
+        raise ValueError("mutable MCP server artifacts cannot use reserved query capacity")
+    if timeout_seconds is None:
+        raise ValueError("registered MCP control admission requires an explicit timeout")
+    if timeout_seconds <= 0:
+        raise ValueError("registered MCP query timeout must be positive")
+    if timeout_seconds > registration.call_timeout_seconds:
+        raise ValueError("MCP query timeout exceeds the operator registration limit")
+    if not hmac.compare_digest(
+        evidence.expected_server_artifact_digest,
+        expected_server_artifact_digest,
+    ):
+        raise ValueError("MCP call artifact binding does not match its discovery evidence")
+
+    try:
+        discovery_job = queue.get_job(evidence.discovery_job_id)
+        discovery_artifact = queue.get_artifact(evidence.discovery_artifact_id)
+    except NotFoundError as exc:
+        raise ValueError(
+            "MCP control-query discovery evidence is unavailable; refresh discovery"
+        ) from exc
+    if (
+        discovery_job.cluster != cluster
+        or discovery_job.kind is not JobKind.MCP_CALL
+        or discovery_job.state is not JobState.SUCCEEDED
+        or not isinstance(discovery_job.spec, McpCallSpec)
+        or discovery_job.spec.operation is not McpOperation.TOOLS_LIST
+        or discovery_job.spec.server != registration.command
+        or discovery_job.spec.server_args != registration.args
+        or discovery_job.spec.env_from != registration.env_from
+    ):
+        raise ValueError("MCP discovery job does not match the registered tools/list route")
+    if (
+        discovery_artifact.job_id != discovery_job.job_id
+        or discovery_artifact.kind != "mcp_result"
+        or discovery_artifact.sha256 is None
+        or not hmac.compare_digest(
+            discovery_artifact.sha256,
+            evidence.discovery_artifact_sha256,
+        )
+    ):
+        raise ValueError("MCP discovery artifact identity does not match its evidence")
+    try:
+        artifact_payload = _control_query_discovery_artifact_bytes(
+            queue,
+            evidence.discovery_artifact_id,
+        )
+    except RelayError as exc:
+        raise ValueError(
+            "MCP control-query discovery artifact is unavailable; refresh discovery"
+        ) from exc
+    observed_artifact_sha256 = hashlib.sha256(artifact_payload).hexdigest()
+    if not hmac.compare_digest(
+        observed_artifact_sha256,
+        evidence.discovery_artifact_sha256,
+    ):
+        raise ValueError("MCP discovery artifact bytes changed after evidence was issued")
+    entry = cache_entry_from_discovery_artifact(
+        cluster=cluster,
+        server_name=evidence.registered_server_name,
+        registration=registration,
+        discovery_job_id=evidence.discovery_job_id,
+        artifact_id=evidence.discovery_artifact_id,
+        artifact_sha256=evidence.discovery_artifact_sha256,
+        artifact_payload=artifact_payload,
+        discovered_at=discovery_job.updated_at,
+    )
+    if not hmac.compare_digest(entry.schema_digest, evidence.discovery_schema_digest):
+        raise ValueError("MCP discovery schema does not match its route evidence")
+    if not entry.is_fresh(now=now):
+        raise ValueError("MCP control-query discovery evidence expired; refresh discovery")
+    matching_tools = [candidate for candidate in entry.tools if candidate.name == tool]
+    if len(matching_tools) != 1 or not is_remote_mcp_control_query(matching_tools[0]):
+        raise ValueError("MCP tool is not explicitly classified as a non-destructive read query")
+    if not _server_artifact_verified(entry.provenance.server_artifact):
+        raise ValueError("MCP discovery did not verify an immutable server artifact")
+    observed_server_digest = remote_mcp_server_artifact_digest(entry.provenance.server_artifact)
+    if not hmac.compare_digest(observed_server_digest, expected_server_artifact_digest):
+        raise ValueError("MCP server artifact does not match the discovered route binding")
+    return (
+        McpAdmissionClass.CONTROL_QUERY,
+        McpAdmissionAuthority(
+            source="registered_discovery_artifact",
+            operation=McpOperation.TOOLS_CALL,
+            tool=tool,
+            expected_server_artifact_digest=expected_server_artifact_digest,
+            evidence=evidence,
+        ),
+    )
+
+
+def resolve_pinned_mcp_admission(
+    *,
+    operation: McpOperation,
+    tool: str | None,
+    expected_server_artifact_digest: str | None,
+    pinned_control_query: bool,
+    timeout_seconds: int | None = None,
+) -> tuple[McpAdmissionClass, McpAdmissionAuthority | None]:
+    """Derive tools/list or built-in JARVIS query admission without caller input."""
+    if operation is McpOperation.TOOLS_LIST:
+        _validate_pinned_control_query_timeout(timeout_seconds)
+        return (
+            McpAdmissionClass.CONTROL_QUERY,
+            McpAdmissionAuthority(
+                source="intrinsic_tools_list",
+                operation=McpOperation.TOOLS_LIST,
+            ),
+        )
+    if pinned_control_query and tool is not None and expected_server_artifact_digest is not None:
+        _validate_pinned_control_query_timeout(timeout_seconds)
+        return (
+            McpAdmissionClass.CONTROL_QUERY,
+            McpAdmissionAuthority(
+                source="pinned_jarvis_contract",
+                operation=McpOperation.TOOLS_CALL,
+                tool=tool,
+                expected_server_artifact_digest=expected_server_artifact_digest,
+            ),
+        )
+    return McpAdmissionClass.WORKLOAD, None
+
+
+def _validate_pinned_control_query_timeout(timeout_seconds: int | None) -> None:
+    """Reject an explicitly invalid timeout on a reserved pinned query."""
+    if timeout_seconds is None:
+        return
+    if timeout_seconds <= 0:
+        raise ValueError("pinned MCP control-query timeout must be positive")
+    if timeout_seconds > MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS:
+        raise ValueError(
+            "pinned MCP control-query timeout exceeds "
+            f"{MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS} seconds"
+        )
+
+
+def _control_query_discovery_artifact_bytes(
+    queue: ClioCoreQueue,
+    artifact_id: str,
+) -> bytes:
+    """Read one queue-owned artifact envelope without trusting a caller path."""
+    from clio_relay.relay_ops import read_artifact_bytes
+
+    envelope = read_artifact_bytes(queue, artifact_id)
+    if envelope.get("encoding") != "base64":
+        raise ValueError("MCP discovery artifact encoding is unsupported")
+    encoded = envelope.get("data")
+    if not isinstance(encoded, str):
+        raise ValueError("MCP discovery artifact payload is unavailable")
+    try:
+        return base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("MCP discovery artifact payload is not valid base64") from exc
 
 
 def build_virtual_remote_mcp_catalog(
@@ -1696,6 +1985,8 @@ def build_virtual_remote_mcp_catalog(
                             if not registration.allow_mutable_artifact
                             else None
                         ),
+                        discovery_provenance=entry.provenance,
+                        discovery_schema_digest=entry.schema_digest,
                     )
                 )
 
@@ -1736,22 +2027,39 @@ def build_virtual_remote_mcp_catalog(
     for identity, group in sorted(grouped.items()):
         alias = aliases[identity]
         first = group[0]
-        routes = {
-            candidate.cluster: RemoteMcpRoute(
+        routes: dict[str, RemoteMcpRoute] = {}
+        for candidate in group:
+            registration_revision = remote_mcp_registration_revision(candidate.registration)
+            expected_digest = candidate.expected_server_artifact_digest
+            evidence = (
+                McpControlQueryEvidence(
+                    cluster=candidate.cluster,
+                    registered_server_name=candidate.server_name,
+                    cluster_route_revision=route_revisions[candidate.cluster],
+                    registration_revision=registration_revision,
+                    discovery_job_id=candidate.discovery_provenance.discovery_job_id,
+                    discovery_artifact_id=candidate.discovery_provenance.artifact_id,
+                    discovery_artifact_sha256=(candidate.discovery_provenance.artifact_sha256),
+                    discovery_schema_digest=candidate.discovery_schema_digest,
+                    expected_server_artifact_digest=expected_digest,
+                )
+                if expected_digest is not None
+                else None
+            )
+            routes[candidate.cluster] = RemoteMcpRoute(
                 cluster=candidate.cluster,
                 server_name=candidate.server_name,
                 command=candidate.registration.command,
                 args=tuple(candidate.registration.args),
                 env_from=tuple(sorted(candidate.registration.env_from.items())),
-                expected_server_artifact_digest=candidate.expected_server_artifact_digest,
+                expected_server_artifact_digest=expected_digest,
                 remote_tool_name=candidate.tool.name,
                 timeout_seconds=candidate.registration.call_timeout_seconds,
                 contract=candidate.registration.contract,
                 cluster_route_revision=route_revisions[candidate.cluster],
-                registration_revision=remote_mcp_registration_revision(candidate.registration),
+                registration_revision=registration_revision,
+                control_query_evidence=evidence,
             )
-            for candidate in group
-        }
         virtual_tools[alias] = VirtualRemoteMcpTool(
             alias=alias,
             namespace=first.namespace,
@@ -1774,6 +2082,11 @@ def build_virtual_remote_mcp_catalog(
                             "registration_revision": route.registration_revision,
                             "expected_server_artifact_digest": (
                                 route.expected_server_artifact_digest
+                            ),
+                            "control_query_evidence": (
+                                None
+                                if route.control_query_evidence is None
+                                else route.control_query_evidence.model_dump(mode="json")
                             ),
                         }
                         for cluster, route in sorted(tool.routes.items())

--- a/src/clio_relay/session_api.py
+++ b/src/clio_relay/session_api.py
@@ -22,16 +22,23 @@ from pydantic import ValidationError
 from clio_relay.cluster_config import ClusterDefinition
 from clio_relay.config import RelaySettings
 from clio_relay.errors import ConfigurationError, RelayError
+from clio_relay.jarvis_mcp import is_virtual_jarvis_control_query
 from clio_relay.models import (
+    MCP_ADMISSION_AUTHORITY_METADATA_KEY,
     ArtifactUse,
     JarvisRunSpec,
     JobKind,
+    McpAdmissionAuthority,
+    McpAdmissionClass,
     McpCallSpec,
+    McpControlQueryEvidence,
+    McpOperation,
     RelayJob,
     RemoteAgentTaskSpec,
     deterministic_jarvis_execution_id,
     is_owned_jarvis_run_spec,
 )
+from clio_relay.remote_mcp import resolve_pinned_mcp_admission
 from clio_relay.session_lifecycle import (
     challenge_remote_session_identity,
     status_remote_session,
@@ -302,11 +309,50 @@ def _validate_submission_receipt(
     if path == "/jobs/mcp-call":
         if job.kind is not JobKind.MCP_CALL or not isinstance(job.spec, McpCallSpec):
             raise RelayError("owned session API returned the wrong job kind")
+        try:
+            operation = McpOperation(payload.get("operation", McpOperation.TOOLS_CALL.value))
+            raw_evidence = payload.get("control_query_evidence")
+            evidence = (
+                McpControlQueryEvidence.model_validate(raw_evidence)
+                if raw_evidence is not None
+                else None
+            )
+        except (TypeError, ValueError, ValidationError) as exc:
+            raise RelayError("owned session submission has invalid MCP admission evidence") from exc
+        expected_authority: McpAdmissionAuthority | None
+        if operation is McpOperation.TOOLS_LIST:
+            if job.spec.admission_class is McpAdmissionClass.CONTROL_QUERY:
+                _expected_class = McpAdmissionClass.CONTROL_QUERY
+                expected_authority = McpAdmissionAuthority(
+                    source="intrinsic_tools_list",
+                    operation=McpOperation.TOOLS_LIST,
+                )
+            else:
+                _expected_class = McpAdmissionClass.WORKLOAD
+                expected_authority = None
+        elif evidence is not None:
+            tool = payload.get("tool")
+            expected_digest = payload.get("expected_server_artifact_digest")
+            if not isinstance(tool, str) or not isinstance(expected_digest, str):
+                raise RelayError("owned session MCP evidence is missing its call binding")
+            _expected_class = McpAdmissionClass.CONTROL_QUERY
+            expected_authority = McpAdmissionAuthority(
+                source="registered_discovery_artifact",
+                operation=operation,
+                tool=tool,
+                expected_server_artifact_digest=expected_digest,
+                evidence=evidence,
+            )
+        else:
+            _expected_class = McpAdmissionClass.WORKLOAD
+            expected_authority = None
         expected = {
             "server": payload.get("server"),
             "server_args": payload.get("server_args", []),
             "env_from": payload.get("env_from", {}),
             "expected_server_artifact_digest": payload.get("expected_server_artifact_digest"),
+            "admission_class": _expected_class.value,
+            "operation": operation.value,
             "tool": payload.get("tool"),
             "arguments": payload.get("arguments", {}),
             "timeout_seconds": payload.get("timeout_seconds"),
@@ -316,25 +362,56 @@ def _validate_submission_receipt(
             "server_args": job.spec.server_args,
             "env_from": job.spec.env_from,
             "expected_server_artifact_digest": (job.spec.expected_server_artifact_digest),
+            "admission_class": job.spec.admission_class.value,
+            "operation": job.spec.operation.value,
             "tool": job.spec.tool,
             "arguments": job.spec.arguments,
             "timeout_seconds": job.spec.timeout_seconds,
         }
         if observed != expected:
             raise RelayError("owned session API returned a different MCP call")
+        _validate_admission_authority(job, expected=expected_authority)
         return
     if path == "/jobs/jarvis-mcp-call":
         if job.kind is not JobKind.MCP_CALL or not isinstance(job.spec, McpCallSpec):
             raise RelayError("owned session API returned the wrong job kind")
+        try:
+            operation = McpOperation(payload.get("operation", McpOperation.TOOLS_CALL.value))
+        except ValueError as exc:
+            raise RelayError(
+                "owned session submission has an invalid JARVIS MCP operation"
+            ) from exc
+        raw_tool = payload.get("tool")
+        tool = raw_tool if isinstance(raw_tool, str) else None
+        raw_expected_digest = payload.get("expected_server_artifact_digest")
+        expected_digest = raw_expected_digest if isinstance(raw_expected_digest, str) else None
+        raw_timeout = payload.get("timeout_seconds")
+        if raw_timeout is not None and (
+            isinstance(raw_timeout, bool) or not isinstance(raw_timeout, int)
+        ):
+            raise RelayError("owned session submission has an invalid JARVIS MCP timeout")
+        try:
+            expected_class, expected_authority = resolve_pinned_mcp_admission(
+                operation=operation,
+                tool=tool,
+                expected_server_artifact_digest=expected_digest,
+                pinned_control_query=(tool is not None and is_virtual_jarvis_control_query(tool)),
+                timeout_seconds=raw_timeout,
+            )
+        except ValueError as exc:
+            raise RelayError("owned session submission has an invalid JARVIS MCP timeout") from exc
         expected_arguments = _expected_jarvis_mcp_arguments(job, payload=payload)
         if (
-            job.spec.tool != payload.get("tool")
+            job.spec.operation is not operation
+            or job.spec.tool != payload.get("tool")
             or job.spec.arguments != expected_arguments
             or job.spec.expected_server_artifact_digest
             != payload.get("expected_server_artifact_digest")
+            or job.spec.admission_class is not expected_class
             or job.spec.timeout_seconds != payload.get("timeout_seconds")
         ):
             raise RelayError("owned session API returned a different JARVIS MCP call")
+        _validate_admission_authority(job, expected=expected_authority)
         return
     if path == "/jobs/jarvis":
         if job.kind is not JobKind.JARVIS or not isinstance(job.spec, JarvisRunSpec):
@@ -370,6 +447,24 @@ def _validate_submission_receipt(
         }
         if observed_agent != expected_agent:
             raise RelayError("owned session API returned a different remote-agent task")
+
+
+def _validate_admission_authority(
+    job: RelayJob,
+    *,
+    expected: McpAdmissionAuthority | None,
+) -> None:
+    """Require the exact deterministic authority stamped by trusted HTTP ingress."""
+    raw_authority = job.metadata.get(MCP_ADMISSION_AUTHORITY_METADATA_KEY)
+    if raw_authority is None:
+        observed = None
+    else:
+        try:
+            observed = McpAdmissionAuthority.model_validate(raw_authority)
+        except ValidationError as exc:
+            raise RelayError("owned session API returned invalid MCP admission authority") from exc
+    if observed != expected:
+        raise RelayError("owned session API returned different MCP admission authority")
 
 
 def _expected_jarvis_mcp_arguments(

--- a/src/clio_relay/storage_runtime.py
+++ b/src/clio_relay/storage_runtime.py
@@ -23,6 +23,7 @@ from clio_relay.core_queue import (
     MAX_ACTIVE_JOB_RECORDS,
     MAX_LIVE_LEASE_RECORDS,
     ClioCoreQueue,
+    _job_matches_mcp_admission_class,  # pyright: ignore[reportPrivateUsage]
 )
 from clio_relay.errors import ConfigurationError, NotFoundError, QueueConflictError, RelayError
 from clio_relay.filesystem_paths import internal_filesystem_path, logical_filesystem_path
@@ -31,6 +32,7 @@ from clio_relay.models import (
     JobKind,
     JobState,
     Lease,
+    McpAdmissionClass,
     RelayJob,
     StorageReservationEstimate,
 )
@@ -560,9 +562,25 @@ class StorageManagedQueue(ClioCoreQueue):
         ttl_seconds: int = 300,
         max_attempts: int = 3,
         kind_concurrency: KindConcurrencyInput | None = None,
+        mcp_admission_class: McpAdmissionClass | None = None,
+        mcp_admission_limit: int | None = None,
     ) -> Lease | None:
-        """Run terminal stale recovery outside the acquire lock before leasing."""
+        """Recover stale work, then lease atomically from one strict worker lane."""
         normalized = normalize_kind_concurrency(kind_concurrency)
+        if mcp_admission_class is not None and not isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
+            mcp_admission_class,
+            McpAdmissionClass,
+        ):
+            raise ConfigurationError("worker MCP admission class is invalid")
+        if mcp_admission_limit is not None:
+            if mcp_admission_class is None:
+                raise ConfigurationError("worker MCP admission limit requires an admission class")
+            if (
+                isinstance(mcp_admission_limit, bool)
+                or not isinstance(mcp_admission_limit, int)  # pyright: ignore[reportUnnecessaryIsInstance]
+                or mcp_admission_limit < 1
+            ):
+                raise ConfigurationError("worker MCP admission limit must be at least 1")
         self.recover_stale_jobs(cluster=cluster, max_attempts=max_attempts)
         self.initialize()
         with self._acquire_lock_with_replay():
@@ -572,9 +590,29 @@ class StorageManagedQueue(ClioCoreQueue):
                 cluster=cluster,
             )
             if active is not None:
+                active_job = self.get_job(active.job_id)
+                if mcp_admission_class is not None and not _job_matches_mcp_admission_class(
+                    active_job,
+                    mcp_admission_class,
+                ):
+                    raise QueueConflictError(
+                        "endpoint active lease does not match its MCP admission lane: "
+                        f"{endpoint_id}"
+                    )
                 return active
             if global_lease_total >= MAX_LIVE_LEASE_RECORDS:
                 return None
+            mcp_admission_at_limit = False
+            active_mcp_workload_count: int | None = None
+            if mcp_admission_class is not None and mcp_admission_limit is not None:
+                mcp_admission_at_limit = (
+                    self._active_mcp_admission_count_unlocked(
+                        cluster=cluster,
+                        admission_class=mcp_admission_class,
+                        expiry_refs=None,
+                    )
+                    >= mcp_admission_limit
+                )
             queued_jobs, truncated = self._scan_many(  # pyright: ignore[reportPrivateUsage]
                 self._storage_root / "jobs_queued",  # pyright: ignore[reportPrivateUsage]
                 RelayJob,
@@ -588,13 +626,32 @@ class StorageManagedQueue(ClioCoreQueue):
             ):
                 if queued.cluster != cluster or queued.state is not JobState.QUEUED:
                     continue
+                if mcp_admission_class is not None and not _job_matches_mcp_admission_class(
+                    queued,
+                    mcp_admission_class,
+                ):
+                    continue
+                if mcp_admission_at_limit and queued.kind is JobKind.MCP_CALL:
+                    continue
                 if self._job_has_pending_execution_cleanup_unlocked(  # pyright: ignore[reportPrivateUsage]
                     queued.cluster,
                     queued.job_id,
                 ):
                     continue
                 kind_limit = normalized.get(queued.kind)
-                if kind_limit is not None and active_counts.get(queued.kind, 0) >= kind_limit:
+                active_kind_count = active_counts.get(queued.kind, 0)
+                if queued.kind is JobKind.MCP_CALL and mcp_admission_class is not None:
+                    if mcp_admission_class is McpAdmissionClass.CONTROL_QUERY:
+                        kind_limit = None
+                    else:
+                        if active_mcp_workload_count is None:
+                            active_mcp_workload_count = self._active_mcp_admission_count_unlocked(
+                                cluster=cluster,
+                                admission_class=McpAdmissionClass.WORKLOAD,
+                                expiry_refs=None,
+                            )
+                        active_kind_count = active_mcp_workload_count
+                if kind_limit is not None and active_kind_count >= kind_limit:
                     continue
                 return self._lease_job_unlocked(  # pyright: ignore[reportPrivateUsage]
                     queued,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,7 @@ from clio_relay.cluster_config import (
     ClusterRegistry,
     ClusterTargetIdentity,
     FrpTransportConfig,
+    RemoteMcpServerConfig,
 )
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.errors import ConfigurationError, QueueConflictError, RelayError
@@ -43,7 +44,9 @@ from clio_relay.models import (
     JarvisRunSpec,
     JobKind,
     JobState,
+    McpAdmissionClass,
     McpCallSpec,
+    McpOperation,
     RelayJob,
     RelayTask,
     SchedulerPhase,
@@ -5992,6 +5995,179 @@ def test_cli_mcp_call_preserves_arguments(tmp_path: Path, monkeypatch: MonkeyPat
     assert job.spec.timeout_seconds == 90
 
 
+@pytest.mark.parametrize("command", ["mcp-call", "jarvis-mcp-call"])
+def test_cli_mcp_call_rejects_public_admission_class_option(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    command: str,
+) -> None:
+    """The CLI exposes no caller-selectable reserved worker lane."""
+    monkeypatch.chdir(tmp_path)
+    _write_test_cluster(tmp_path)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            command,
+            "--cluster",
+            "ares",
+            "--tool",
+            "jarvis_describe" if command == "jarvis-mcp-call" else "inspect",
+            *(["--server", "arbitrary-mcp"] if command == "mcp-call" else []),
+            "--admission-class",
+            "control_query",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "No such option: --admission-class" in result.output
+
+
+def test_cli_arbitrary_tools_list_remains_workload(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """An arbitrary MCP discovery command cannot occupy reserved capacity."""
+    core_dir = tmp_path / "core"
+    monkeypatch.chdir(tmp_path)
+    _write_test_cluster(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(core_dir))
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "mcp-call",
+            "--cluster",
+            "ares",
+            "--server",
+            "arbitrary-mcp",
+            "--server-arg=--hang",
+            "--operation",
+            "tools/list",
+            "--timeout-seconds",
+            "1",
+            "--idempotency-key",
+            "arbitrary-tools-list",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    job = ClioCoreQueue(core_dir).get_job(result.output.strip())
+    assert isinstance(job.spec, McpCallSpec)
+    assert job.spec.operation is McpOperation.TOOLS_LIST
+    assert job.spec.admission_class is McpAdmissionClass.WORKLOAD
+
+
+def test_cli_generic_default_key_tracks_timeout_and_derived_authority(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Default retries cannot alias workload, registered control, or timeout changes."""
+    core_dir = tmp_path / "core"
+    monkeypatch.chdir(tmp_path)
+    _write_test_cluster(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(core_dir))
+
+    def invoke(timeout: int) -> Any:
+        return CliRunner().invoke(
+            app,
+            [
+                "mcp-call",
+                "--cluster",
+                "ares",
+                "--server",
+                "science-mcp",
+                "--server-arg=--stdio",
+                "--operation",
+                "tools/list",
+                "--timeout-seconds",
+                str(timeout),
+            ],
+        )
+
+    workload_result = invoke(30)
+    assert workload_result.exit_code == 0, workload_result.output
+    registration = RemoteMcpServerConfig(
+        command="science-mcp",
+        args=["--stdio"],
+        allow_tools=["inspect"],
+        call_timeout_seconds=60,
+    )
+    ClusterRegistry(
+        clusters={
+            "ares": ClusterDefinition(
+                name="ares",
+                ssh_host="ares",
+                remote_mcp_servers={"science": registration},
+            )
+        }
+    ).save(tmp_path / ".clio-relay" / "clusters.json")
+    control_30_result = invoke(30)
+    control_60_result = invoke(60)
+    assert control_30_result.exit_code == 0, control_30_result.output
+    assert control_60_result.exit_code == 0, control_60_result.output
+
+    queue = ClioCoreQueue(core_dir)
+    jobs = [
+        queue.get_job(result.output.strip())
+        for result in (workload_result, control_30_result, control_60_result)
+    ]
+    assert all(isinstance(job.spec, McpCallSpec) for job in jobs)
+    specs = [cast(McpCallSpec, job.spec) for job in jobs]
+    assert specs[0].admission_class is McpAdmissionClass.WORKLOAD
+    assert specs[1].admission_class is McpAdmissionClass.CONTROL_QUERY
+    assert specs[2].admission_class is McpAdmissionClass.CONTROL_QUERY
+    assert len({job.idempotency_key for job in jobs}) == 3
+    legacy_server_digest = hashlib.sha256(
+        json.dumps(
+            {
+                "server": "science-mcp",
+                "args": ["--stdio"],
+                "env_from": {},
+                "expected_server_artifact_digest": None,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    legacy_arguments_digest = hashlib.sha256(
+        json.dumps(
+            {"operation": "tools/list", "tool": None, "arguments": {}},
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    assert jobs[0].idempotency_key == (
+        f"mcp:ares:{legacy_server_digest}:tools/list:None:{legacy_arguments_digest}"
+    )
+
+
+def test_cli_pinned_jarvis_control_query_rejects_oversized_timeout(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Pinned control-query processes cannot outlive the reserved-lane bound."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_CLI_MODE", "local")
+    monkeypatch.setenv("CLIO_RELAY_REMOTE_CLUSTER", "ares")
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "jarvis-mcp-call",
+            "--cluster",
+            "ares",
+            "--operation",
+            "tools/list",
+            "--timeout-seconds",
+            "61",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "timeout exceeds 60 seconds" in result.output
+
+
 def test_cli_jarvis_mcp_call_uses_builtin_cluster_command(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -6393,6 +6569,8 @@ def test_target_side_jarvis_discovery_uses_receipt_without_cluster_registry(
     assert isinstance(job.spec, McpCallSpec)
     assert job.spec.operation.value == "tools/list"
     assert job.spec.tool is None
+    assert job.spec.admission_class is McpAdmissionClass.CONTROL_QUERY
+    assert job.spec.timeout_seconds == 60
     assert job.spec.expected_jarvis_cd_lock_binding == jarvis_cd_lock_binding_expectation()
 
 

--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import ctypes
+import hashlib
+import json
 import os
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -19,6 +21,8 @@ from clio_relay.cluster_config import (
     ClusterRegistry,
     ClusterTargetIdentity,
     RemoteMcpServerConfig,
+    WorkerCapacityPolicy,
+    cluster_route_revision,
     default_registry_path,
     ensure_private_configuration_directory,
     ensure_private_configuration_path,
@@ -645,6 +649,35 @@ def test_cluster_target_identity_round_trips_operator_pins(tmp_path: Path) -> No
     registry.save(path)
 
     assert ClusterRegistry.load(path) == registry
+
+
+def test_cluster_route_revision_excludes_worker_capacity_across_upgrade_and_edits() -> None:
+    """Scheduling capacity changes must not invalidate durable queue-route handles."""
+    legacy_definition = ClusterDefinition.model_validate(
+        {
+            "name": "ares",
+            "ssh_host": "ares-login",
+            "scheduler_provider": "slurm",
+        }
+    )
+    legacy_payload = legacy_definition.model_dump(
+        mode="json",
+        exclude={"remote_mcp_servers", "worker_capacity"},
+    )
+    pre_upgrade_revision = hashlib.sha256(
+        json.dumps(legacy_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    tuned_definition = legacy_definition.model_copy(
+        update={
+            "worker_capacity": WorkerCapacityPolicy(
+                concurrency=8,
+                control_query_concurrency=2,
+            )
+        }
+    )
+
+    assert cluster_route_revision(legacy_definition) == pre_upgrade_revision
+    assert cluster_route_revision(tuned_definition) == pre_upgrade_revision
 
 
 @pytest.mark.parametrize(

--- a/tests/test_control_query_admission.py
+++ b/tests/test_control_query_admission.py
@@ -1,0 +1,525 @@
+"""Tests for the generic reserved remote-MCP control-query lane."""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Barrier, Event
+
+import pytest
+from pydantic import ValidationError
+
+from clio_relay.config import RelaySettings
+from clio_relay.core_queue import ClioCoreQueue
+from clio_relay.endpoint import EndpointWorker
+from clio_relay.errors import ConfigurationError, QueueConflictError
+from clio_relay.jarvis_provider import JarvisCdProvider
+from clio_relay.models import (
+    EndpointRole,
+    JarvisRunSpec,
+    JobKind,
+    JobState,
+    Lease,
+    McpAdmissionClass,
+    McpCallSpec,
+    McpOperation,
+    RelayJob,
+)
+from clio_relay.storage_runtime import storage_managed_queue
+
+
+def test_control_query_model_is_fail_closed_but_allows_discovery() -> None:
+    """Only artifact-bound calls or contract discovery can enter control capacity."""
+    assert McpCallSpec(server="science", tool="inspect").admission_class is (
+        McpAdmissionClass.WORKLOAD
+    )
+
+    with pytest.raises(ValidationError, match="expected server artifact digest"):
+        McpCallSpec(
+            server="science",
+            tool="inspect",
+            admission_class=McpAdmissionClass.CONTROL_QUERY,
+        )
+
+    control_call = McpCallSpec(
+        server="science",
+        expected_server_artifact_digest="a" * 64,
+        tool="inspect",
+        admission_class=McpAdmissionClass.CONTROL_QUERY,
+    )
+    discovery = McpCallSpec(
+        server="science",
+        operation=McpOperation.TOOLS_LIST,
+        admission_class=McpAdmissionClass.CONTROL_QUERY,
+    )
+
+    assert control_call.admission_class is McpAdmissionClass.CONTROL_QUERY
+    assert discovery.admission_class is McpAdmissionClass.CONTROL_QUERY
+    with pytest.raises(ValidationError):
+        McpCallSpec.model_validate(
+            {
+                "server": "science",
+                "tool": "inspect",
+                "admission_class": "reserved_by_caller",
+            }
+        )
+
+
+def test_queue_lanes_are_strict_and_reject_endpoint_lane_changes(tmp_path: Path) -> None:
+    """Control slots never consume workload or kind/spec-mismatched records."""
+    queue = ClioCoreQueue(tmp_path / "core")
+    mismatched = queue.submit_job(
+        RelayJob(
+            cluster="alpha",
+            kind=JobKind.JARVIS,
+            spec=_control_spec("mismatched"),
+            idempotency_key="mismatched-control-spec",
+        )
+    )
+    workload = queue.submit_job(_mcp_job("workload", McpAdmissionClass.WORKLOAD))
+    control = queue.submit_job(_mcp_job("control", McpAdmissionClass.CONTROL_QUERY))
+    discovery = queue.submit_job(
+        RelayJob(
+            cluster="alpha",
+            kind=JobKind.MCP_CALL,
+            spec=McpCallSpec(
+                server="science",
+                operation=McpOperation.TOOLS_LIST,
+                admission_class=McpAdmissionClass.CONTROL_QUERY,
+            ),
+            idempotency_key="control-discovery",
+        )
+    )
+
+    control_lease = queue.acquire_next_job(
+        "control-worker",
+        cluster="alpha",
+        mcp_admission_class=McpAdmissionClass.CONTROL_QUERY,
+        mcp_admission_limit=1,
+    )
+    workload_lease = queue.acquire_next_job(
+        "workload-worker",
+        cluster="alpha",
+        mcp_admission_class=McpAdmissionClass.WORKLOAD,
+    )
+
+    assert control_lease is not None and control_lease.job_id == control.job_id
+    assert workload_lease is not None and workload_lease.job_id == mismatched.job_id
+    assert queue.get_job(workload.job_id).state is JobState.QUEUED
+    with pytest.raises(QueueConflictError, match="does not match"):
+        queue.acquire_next_job(
+            "workload-worker",
+            cluster="alpha",
+            mcp_admission_class=McpAdmissionClass.CONTROL_QUERY,
+        )
+    queue.release_lease(workload_lease.lease_id)
+    next_workload_lease = queue.acquire_next_job(
+        "next-workload-worker",
+        cluster="alpha",
+        mcp_admission_class=McpAdmissionClass.WORKLOAD,
+    )
+    assert next_workload_lease is not None
+    assert next_workload_lease.job_id == workload.job_id
+    queue.release_lease(next_workload_lease.lease_id)
+    assert (
+        queue.acquire_next_job(
+            "empty-workload-worker",
+            cluster="alpha",
+            mcp_admission_class=McpAdmissionClass.WORKLOAD,
+        )
+        is None
+    )
+    queue.release_lease(control_lease.lease_id)
+    discovery_lease = queue.acquire_next_job(
+        "discovery-control-worker",
+        cluster="alpha",
+        mcp_admission_class=McpAdmissionClass.CONTROL_QUERY,
+        mcp_admission_limit=1,
+    )
+    assert discovery_lease is not None
+    assert discovery_lease.job_id == discovery.job_id
+
+
+def test_control_query_limit_is_atomic_across_queue_instances(tmp_path: Path) -> None:
+    """Independent worker slots cannot race past the durable control cap."""
+    root = tmp_path / "core"
+    queue = ClioCoreQueue(root)
+    queue.submit_job(_mcp_job("control-one", McpAdmissionClass.CONTROL_QUERY))
+    queue.submit_job(_mcp_job("control-two", McpAdmissionClass.CONTROL_QUERY))
+    barrier = Barrier(2)
+
+    def acquire(index: int) -> str | None:
+        instance = ClioCoreQueue(root)
+        barrier.wait()
+        lease = instance.acquire_next_job(
+            f"control-worker-{index}",
+            cluster="alpha",
+            mcp_admission_class=McpAdmissionClass.CONTROL_QUERY,
+            mcp_admission_limit=1,
+        )
+        return None if lease is None else lease.job_id
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(acquire, (1, 2)))
+
+    assert sum(result is not None for result in results) == 1
+    assert len(queue.list_leases(cluster="alpha")) == 1
+
+
+def test_workload_mcp_kind_cap_cannot_consume_reserved_control_capacity(
+    tmp_path: Path,
+) -> None:
+    """A workload MCP ceiling remains independent from the reserved query lane."""
+    queue = ClioCoreQueue(tmp_path / "core")
+    workload = queue.submit_job(_mcp_job("workload", McpAdmissionClass.WORKLOAD))
+    control = queue.submit_job(_mcp_job("control", McpAdmissionClass.CONTROL_QUERY))
+    kind_limit = {JobKind.MCP_CALL: 1}
+
+    workload_lease = queue.acquire_next_job(
+        "workload-worker",
+        cluster="alpha",
+        kind_concurrency=kind_limit,
+        mcp_admission_class=McpAdmissionClass.WORKLOAD,
+    )
+    control_lease = queue.acquire_next_job(
+        "control-worker",
+        cluster="alpha",
+        kind_concurrency=kind_limit,
+        mcp_admission_class=McpAdmissionClass.CONTROL_QUERY,
+        mcp_admission_limit=1,
+    )
+
+    assert workload_lease is not None and workload_lease.job_id == workload.job_id
+    assert control_lease is not None and control_lease.job_id == control.job_id
+    assert len(queue.list_leases(cluster="alpha")) == 2
+
+
+def test_storage_managed_queue_preserves_strict_lane_filter(tmp_path: Path) -> None:
+    """The production storage wrapper leases from the same reserved lane contract."""
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        spool_max_log_bytes_per_stream=50,
+        spool_max_log_bytes_per_job=100,
+        storage_minimum_free_bytes=0,
+        storage_max_job_reservation_bytes=1_000,
+        storage_job_core_allowance_bytes=20,
+        storage_job_result_allowance_bytes=30,
+    )
+    queue = storage_managed_queue(settings)
+    try:
+        workload = queue.submit_job(_mcp_job("managed-workload", McpAdmissionClass.WORKLOAD))
+        control = queue.submit_job(_mcp_job("managed-control", McpAdmissionClass.CONTROL_QUERY))
+
+        lease = queue.acquire_next_job(
+            "managed-control-worker",
+            cluster="alpha",
+            mcp_admission_class=McpAdmissionClass.CONTROL_QUERY,
+            mcp_admission_limit=1,
+        )
+
+        assert lease is not None and lease.job_id == control.job_id
+        assert queue.get_job(workload.job_id).state is JobState.QUEUED
+    finally:
+        queue.close()
+
+
+def test_storage_managed_workload_cap_preserves_reserved_control_capacity(
+    tmp_path: Path,
+) -> None:
+    """Production storage admission keeps workload and control MCP caps disjoint."""
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        spool_max_log_bytes_per_stream=50,
+        spool_max_log_bytes_per_job=100,
+        storage_minimum_free_bytes=0,
+        storage_max_job_reservation_bytes=1_000,
+        storage_job_core_allowance_bytes=20,
+        storage_job_result_allowance_bytes=30,
+    )
+    queue = storage_managed_queue(settings)
+    try:
+        workload = queue.submit_job(_mcp_job("managed-workload", McpAdmissionClass.WORKLOAD))
+        control = queue.submit_job(_mcp_job("managed-control", McpAdmissionClass.CONTROL_QUERY))
+        kind_limit = {JobKind.MCP_CALL: 1}
+
+        workload_lease = queue.acquire_next_job(
+            "managed-workload-worker",
+            cluster="alpha",
+            kind_concurrency=kind_limit,
+            mcp_admission_class=McpAdmissionClass.WORKLOAD,
+        )
+        control_lease = queue.acquire_next_job(
+            "managed-control-worker",
+            cluster="alpha",
+            kind_concurrency=kind_limit,
+            mcp_admission_class=McpAdmissionClass.CONTROL_QUERY,
+            mcp_admission_limit=1,
+        )
+
+        assert workload_lease is not None and workload_lease.job_id == workload.job_id
+        assert control_lease is not None and control_lease.job_id == control.job_id
+        assert len(queue.list_leases(cluster="alpha")) == 2
+    finally:
+        queue.close()
+
+
+def test_reserved_query_finishes_while_workload_keeps_lease_and_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A query overlaps a live workload without canceling or stealing ownership."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    source = queue.submit_job(
+        RelayJob(
+            cluster="alpha",
+            kind=JobKind.JARVIS,
+            spec=JarvisRunSpec(command=["long-science-run"]),
+            idempotency_key="long-science-run",
+        )
+    )
+    query = queue.submit_job(_mcp_job("live-status", McpAdmissionClass.CONTROL_QUERY))
+    provider = _BlockingLaneProvider()
+    workload_worker = EndpointWorker(
+        role=EndpointRole.WORKER,
+        settings=settings,
+        cluster="alpha",
+        queue=queue,
+        provider=provider,
+    )
+    control_worker = EndpointWorker(
+        role=EndpointRole.WORKER,
+        settings=settings,
+        cluster="alpha",
+        queue=queue,
+        provider=provider,
+    )
+    workload_worker.lease_renew_seconds = 0
+    control_worker.lease_renew_seconds = 0
+
+    def forbidden_reconciliation() -> None:
+        raise AssertionError("a control-query slot must not reconcile workload cancellation")
+
+    monkeypatch.setattr(
+        control_worker,
+        "_reconcile_canceled_scheduler_jobs",
+        forbidden_reconciliation,
+    )
+    monkeypatch.setattr(
+        control_worker,
+        "_reconcile_pending_execution_cleanup",
+        forbidden_reconciliation,
+    )
+    workload_worker.register()
+    control_worker.register()
+
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            source_future = executor.submit(workload_worker.run_once)
+            assert provider.source_started.wait(timeout=10)
+            source_lease = _lease_for_job(queue, source.job_id)
+            assert source_lease is not None
+            assert queue.get_job(source.job_id).state is JobState.RUNNING
+
+            query_result = control_worker.run_once(
+                mcp_admission_class=McpAdmissionClass.CONTROL_QUERY,
+                mcp_admission_limit=1,
+            )
+
+            assert query_result is not None
+            assert query_result.job_id == query.job_id
+            assert query_result.state is JobState.SUCCEEDED
+            assert provider.query_started.is_set()
+            live_source = queue.get_job(source.job_id)
+            renewed_source_lease = _lease_for_job(queue, source.job_id)
+            assert live_source.state is JobState.RUNNING
+            assert live_source.leased_by == source_lease.endpoint_id
+            assert "cancellation_request" not in live_source.metadata
+            assert renewed_source_lease is not None
+            assert renewed_source_lease.lease_id == source_lease.lease_id
+            assert renewed_source_lease.expires_at >= source_lease.expires_at
+            assert _lease_for_job(queue, query.job_id) is None
+
+            source_events, _ = queue.read_event_page(source.job_id, limit=100)
+            assert all("cancel" not in event.event_type for event in source_events)
+            provider.release_source.set()
+            source_result = source_future.result(timeout=10)
+
+        assert source_result is not None
+        assert source_result.state is JobState.SUCCEEDED
+    finally:
+        provider.release_source.set()
+        workload_worker.close()
+        control_worker.close()
+
+
+def test_supervised_slots_publish_total_and_disjoint_lane_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parent and child records expose total capacity and each slot's exact lane."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    parent = EndpointWorker(
+        role=EndpointRole.WORKER,
+        settings=settings,
+        cluster="alpha",
+        concurrency=3,
+        control_query_concurrency=1,
+        queue=queue,
+    )
+    parent_endpoint = parent.register()
+    observed: list[tuple[dict[str, object], dict[str, object]]] = []
+
+    class StopSlot(Exception):
+        """Stop one synthetic supervised slot after its first dispatch attempt."""
+
+    def stop_slot(self: EndpointWorker, **kwargs: object) -> None:
+        assert self.endpoint is not None
+        observed.append((dict(self.endpoint.metadata), kwargs))
+        self.close()
+        raise StopSlot
+
+    monkeypatch.setattr(EndpointWorker, "run_once", stop_slot)
+    try:
+        with pytest.raises(StopSlot):
+            parent._serve_worker_slot(  # pyright: ignore[reportPrivateUsage]
+                0,
+                0,
+                McpAdmissionClass.WORKLOAD,
+            )
+        with pytest.raises(StopSlot):
+            parent._serve_worker_slot(  # pyright: ignore[reportPrivateUsage]
+                2,
+                0,
+                McpAdmissionClass.CONTROL_QUERY,
+            )
+    finally:
+        parent.close()
+
+    assert parent_endpoint.metadata["concurrency"] == 3
+    assert parent_endpoint.metadata["workload_concurrency"] == 2
+    assert parent_endpoint.metadata["control_query_concurrency"] == 1
+    assert parent_endpoint.metadata["worker_supervisor"] is True
+    workload_metadata, workload_call = observed[0]
+    control_metadata, control_call = observed[1]
+    assert workload_metadata["parent_endpoint_id"] == parent_endpoint.endpoint_id
+    assert workload_metadata["mcp_admission_class"] == "workload"
+    assert workload_metadata["workload_concurrency"] == 1
+    assert workload_metadata["control_query_concurrency"] == 0
+    assert workload_call == {
+        "mcp_admission_class": McpAdmissionClass.WORKLOAD,
+        "mcp_admission_limit": None,
+    }
+    assert control_metadata["parent_endpoint_id"] == parent_endpoint.endpoint_id
+    assert control_metadata["mcp_admission_class"] == "control_query"
+    assert control_metadata["workload_concurrency"] == 0
+    assert control_metadata["control_query_concurrency"] == 1
+    assert control_call == {
+        "mcp_admission_class": McpAdmissionClass.CONTROL_QUERY,
+        "mcp_admission_limit": 1,
+    }
+
+
+@pytest.mark.parametrize(
+    ("concurrency", "control_query_concurrency"),
+    [(True, 0), (1, 1), (3, -1), (3, True)],
+)
+def test_endpoint_rejects_invalid_lane_capacity(
+    tmp_path: Path,
+    concurrency: int,
+    control_query_concurrency: int,
+) -> None:
+    """Runtime construction retains at least one valid workload slot."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+
+    with pytest.raises(ConfigurationError):
+        EndpointWorker(
+            role=EndpointRole.WORKER,
+            settings=settings,
+            cluster="alpha",
+            concurrency=concurrency,
+            control_query_concurrency=control_query_concurrency,
+        )
+
+
+def _mcp_job(key: str, admission_class: McpAdmissionClass) -> RelayJob:
+    """Build one generic remote-MCP job for a strict worker lane."""
+    return RelayJob(
+        cluster="alpha",
+        kind=JobKind.MCP_CALL,
+        spec=(
+            McpCallSpec(server="science", tool=key)
+            if admission_class is McpAdmissionClass.WORKLOAD
+            else _control_spec(key)
+        ),
+        idempotency_key=key,
+    )
+
+
+def _control_spec(tool: str) -> McpCallSpec:
+    """Build one artifact-bound, non-destructive control call specification."""
+    return McpCallSpec(
+        server="science",
+        expected_server_artifact_digest="a" * 64,
+        tool=tool,
+        admission_class=McpAdmissionClass.CONTROL_QUERY,
+    )
+
+
+def _lease_for_job(queue: ClioCoreQueue, job_id: str) -> Lease | None:
+    """Return the one active lease for a job, if present."""
+    return next(
+        (lease for lease in queue.list_leases(cluster="alpha") if lease.job_id == job_id),
+        None,
+    )
+
+
+class _BlockingLaneProvider(JarvisCdProvider):
+    """Keep a workload live while allowing one remote-MCP query to finish."""
+
+    def __init__(self) -> None:
+        super().__init__(jarvis_bin="jarvis")
+        self.source_started = Event()
+        self.query_started = Event()
+        self.release_source = Event()
+
+    def run_pipeline_streaming(
+        self,
+        pipeline_path: Path,
+        *,
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        on_stdout: Callable[[str], None] | None = None,
+        on_stderr: Callable[[str], None] | None = None,
+        on_start: Callable[[int], None] | None = None,
+        should_cancel: Callable[[], bool] | None = None,
+        on_poll: Callable[[], None] | None = None,
+        timeout_seconds: int | None = None,
+        on_timeout: Callable[[], None] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        del cwd, env, on_stdout, on_stderr, timeout_seconds, on_timeout
+        document = pipeline_path.read_text(encoding="utf-8")
+        if on_start is not None:
+            on_start(1001)
+        if "clio_relay.mcp_call" in document:
+            self.query_started.set()
+            if on_poll is not None:
+                on_poll()
+            return subprocess.CompletedProcess(["jarvis"], 0, "", "")
+
+        self.source_started.set()
+        deadline = time.monotonic() + 10
+        while not self.release_source.wait(0.01):
+            if should_cancel is not None and should_cancel():
+                return subprocess.CompletedProcess(["jarvis"], -15, "", "")
+            if time.monotonic() >= deadline:
+                return subprocess.CompletedProcess(["jarvis"], 124, "", "timed out")
+            if on_poll is not None:
+                on_poll()
+        return subprocess.CompletedProcess(["jarvis"], 0, "", "")

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -8,12 +8,18 @@ import pytest
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
+from clio_relay.cluster_config import (
+    ClusterDefinition,
+    ClusterRegistry,
+    RemoteMcpServerConfig,
+)
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.errors import ConfigurationError
 from clio_relay.http_api import create_app
 from clio_relay.jarvis_mcp import jarvis_cd_lock_binding_expectation
 from clio_relay.models import (
+    MCP_ADMISSION_AUTHORITY_METADATA_KEY,
     ArtifactRef,
     Cursor,
     EndpointRegistration,
@@ -23,7 +29,10 @@ from clio_relay.models import (
     JarvisRunSpec,
     JobKind,
     JobState,
+    McpAdmissionAuthority,
+    McpAdmissionClass,
     McpCallSpec,
+    McpOperation,
     MonitorRule,
     RelayJob,
     RelayTask,
@@ -344,6 +353,144 @@ def test_http_typed_submit_endpoints_create_real_jobs(tmp_path: Path) -> None:
     assert jarvis_mcp.spec.server_args == ["mcp-server", "jarvis"]
     assert jarvis_mcp.spec.tool == "jarvis_describe"
     assert jarvis_mcp.spec.arguments == {"target": "packages"}
+
+
+def test_http_mcp_admission_is_server_owned_and_raw_bypass_is_closed(
+    tmp_path: Path,
+) -> None:
+    """Reject caller lane claims and keep arbitrary tools/list on workload capacity."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    client = cast(Any, TestClient(create_app(settings)))
+    raw_mcp = RelayJob(
+        cluster="test-cluster",
+        kind=JobKind.MCP_CALL,
+        spec=McpCallSpec(server="arbitrary-mcp", tool="inspect"),
+        idempotency_key="raw-mcp-bypass",
+    )
+    forged_metadata = RelayJob(
+        cluster="test-cluster",
+        kind=JobKind.JARVIS,
+        spec=JarvisRunSpec(command=["true"]),
+        idempotency_key="raw-authority-bypass",
+        metadata={MCP_ADMISSION_AUTHORITY_METADATA_KEY: {"source": "forged"}},
+    )
+
+    raw_response = client.post("/jobs", json=raw_mcp.model_dump(mode="json"))
+    metadata_response = client.post(
+        "/jobs",
+        json=forged_metadata.model_dump(mode="json"),
+    )
+    generic_enum = client.post(
+        "/jobs/mcp-call",
+        json={
+            "cluster": "test-cluster",
+            "server": "arbitrary-mcp",
+            "tool": "inspect",
+            "admission_class": "control_query",
+            "idempotency_key": "forged-generic-enum",
+        },
+    )
+    jarvis_enum = client.post(
+        "/jobs/jarvis-mcp-call",
+        json={
+            "cluster": "test-cluster",
+            "tool": "jarvis_describe",
+            "admission_class": "control_query",
+            "idempotency_key": "forged-jarvis-enum",
+        },
+    )
+    arbitrary_discovery = client.post(
+        "/jobs/mcp-call",
+        json={
+            "cluster": "test-cluster",
+            "server": "arbitrary-mcp",
+            "server_args": ["--hang"],
+            "operation": "tools/list",
+            "timeout_seconds": 1,
+            "idempotency_key": "arbitrary-tools-list",
+        },
+    )
+
+    assert raw_response.status_code == 422
+    assert "must use /jobs/mcp-call" in raw_response.json()["detail"]
+    assert metadata_response.status_code == 422
+    assert "server-managed" in metadata_response.json()["detail"]
+    assert generic_enum.status_code == 422
+    assert jarvis_enum.status_code == 422
+    assert arbitrary_discovery.status_code == 200
+    queued = ClioCoreQueue(settings.core_dir).get_job(arbitrary_discovery.json()["job_id"])
+    assert isinstance(queued.spec, McpCallSpec)
+    assert queued.spec.operation is McpOperation.TOOLS_LIST
+    assert queued.spec.admission_class is McpAdmissionClass.WORKLOAD
+    assert MCP_ADMISSION_AUTHORITY_METADATA_KEY not in queued.metadata
+
+
+def test_http_registered_tools_list_gets_bounded_intrinsic_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Promote only an exact enabled registration and persist server provenance."""
+    registration = RemoteMcpServerConfig(
+        command="science-mcp",
+        args=["--stdio"],
+        env_from={"SCIENCE_TOKEN": "SITE_SCIENCE_TOKEN"},
+        allow_tools=["inspect"],
+        call_timeout_seconds=30,
+    )
+    registry_path = tmp_path / "clusters.json"
+    ClusterRegistry(
+        clusters={
+            "alpha": ClusterDefinition(
+                name="alpha",
+                ssh_host="alpha-login",
+                remote_mcp_servers={"science": registration},
+            )
+        }
+    ).save(registry_path)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    client = cast(Any, TestClient(create_app(settings)))
+    payload = {
+        "cluster": "alpha",
+        "server": registration.command,
+        "server_args": registration.args,
+        "env_from": registration.env_from,
+        "operation": "tools/list",
+        "timeout_seconds": registration.call_timeout_seconds,
+        "idempotency_key": "registered-tools-list",
+    }
+
+    accepted = client.post("/jobs/mcp-call", json=payload)
+    omitted_payload = {
+        **payload,
+        "idempotency_key": "registered-tools-list-omitted",
+    }
+    omitted_payload.pop("timeout_seconds")
+    omitted = client.post(
+        "/jobs/mcp-call",
+        json=omitted_payload,
+    )
+    overlong = client.post(
+        "/jobs/mcp-call",
+        json={
+            **payload,
+            "timeout_seconds": registration.call_timeout_seconds + 1,
+            "idempotency_key": "registered-tools-list-overlong",
+        },
+    )
+
+    assert accepted.status_code == 200
+    assert omitted.status_code == 409
+    assert "explicit timeout" in omitted.json()["detail"]
+    assert overlong.status_code == 409
+    queued = ClioCoreQueue(settings.core_dir).get_job(accepted.json()["job_id"])
+    assert isinstance(queued.spec, McpCallSpec)
+    assert queued.spec.admission_class is McpAdmissionClass.CONTROL_QUERY
+    authority = McpAdmissionAuthority.model_validate(
+        queued.metadata[MCP_ADMISSION_AUTHORITY_METADATA_KEY]
+    )
+    assert authority.source == "intrinsic_tools_list"
+    assert authority.operation is McpOperation.TOOLS_LIST
 
 
 def test_owned_jarvis_mcp_submission_inherits_operator_spack_reference(
@@ -972,14 +1119,33 @@ def test_owned_jarvis_mcp_submission_forwards_desktop_binding_without_remote_cac
         "/jobs/jarvis-mcp-call",
         json={**payload, "expected_server_artifact_digest": expected_digest},
     )
+    oversized = client.post(
+        "/jobs/jarvis-mcp-call",
+        json={
+            **payload,
+            "expected_server_artifact_digest": expected_digest,
+            "timeout_seconds": 61,
+            "idempotency_key": "owned-artifact-source-oversized",
+        },
+    )
 
     assert omitted.status_code == 422
     assert accepted.status_code == 200
+    assert oversized.status_code == 422
+    assert "timeout exceeds 60 seconds" in str(oversized.json())
     job = queue.get_job(accepted.json()["job_id"])
     assert isinstance(job.spec, McpCallSpec)
     assert job.spec.expected_server_artifact_digest == expected_digest
     assert job.spec.expected_jarvis_cd_lock_binding == jarvis_cd_lock_binding_expectation()
-    assert job.metadata == {
+    assert job.spec.timeout_seconds == 60
+    metadata = dict(job.metadata)
+    authority = McpAdmissionAuthority.model_validate(
+        metadata.pop(MCP_ADMISSION_AUTHORITY_METADATA_KEY)
+    )
+    assert authority.source == "pinned_jarvis_contract"
+    assert authority.tool == "jarvis_get_execution"
+    assert authority.expected_server_artifact_digest == expected_digest
+    assert metadata == {
         "owner": "clio-relay",
         "owner_session_id": "desktop-session-1",
         "owner_session_generation_id": "generation-1",

--- a/tests/test_jarvis_mcp_validation.py
+++ b/tests/test_jarvis_mcp_validation.py
@@ -18,6 +18,7 @@ from clio_relay.jarvis_mcp import (
     jarvis_mcp_server_args,
     jarvis_user_contract,
     jarvis_user_contract_digest,
+    is_virtual_jarvis_control_query,
     render_virtual_jarvis_agent_context,
     virtual_jarvis_tool_definitions,
 )
@@ -53,6 +54,15 @@ def test_virtual_jarvis_context_teaches_bounded_interactive_waiting() -> None:
     assert "current call" in context
     assert "intentionally queuing transport" in context
     assert "not workload completion" in context
+
+
+def test_virtual_jarvis_control_queries_follow_the_pinned_annotations() -> None:
+    """Only read-only, non-destructive JARVIS operations use reserved capacity."""
+    assert is_virtual_jarvis_control_query("jarvis_get_execution") is True
+    assert is_virtual_jarvis_control_query("jarvis_describe") is True
+    assert is_virtual_jarvis_control_query("jarvis_run") is False
+    assert is_virtual_jarvis_control_query("jarvis_add_step") is False
+    assert is_virtual_jarvis_control_query("not-a-contract-tool") is False
 
 
 def test_jarvis_mcp_validation_accepts_structured_durable_run() -> None:

--- a/tests/test_live_acceptance.py
+++ b/tests/test_live_acceptance.py
@@ -33,6 +33,7 @@ from clio_relay.live_acceptance import (
     _find_agent_child_job,  # pyright: ignore[reportPrivateUsage]
     _http_json,  # pyright: ignore[reportPrivateUsage]
     _packaged_mcp_acceptance_evidence,  # pyright: ignore[reportPrivateUsage]
+    _require_secure_runtime_control_capacity,  # pyright: ignore[reportPrivateUsage]
     _secure_runtime_probe_config,  # pyright: ignore[reportPrivateUsage]
     _select_secure_runtime_handoff,  # pyright: ignore[reportPrivateUsage]
     _verify_cluster_deployment,  # pyright: ignore[reportPrivateUsage]
@@ -551,6 +552,22 @@ def test_secure_runtime_orchestration_never_waits_for_outer_job_terminal(
         commands.append(script)
         if "mkdir -p" in script or "cat >" in script:
             return _completed(command, "")
+        if "worker status --cluster test-cluster" in script:
+            return _completed(
+                command,
+                json.dumps(
+                    {
+                        "configured_workload_concurrency": 2,
+                        "configured_control_query_concurrency": 1,
+                        "control_query_concurrency_consistent": True,
+                        "active_leases_by_mcp_admission_class": {
+                            "workload": 0,
+                            "control_query": 0,
+                        },
+                        "scan_truncated": False,
+                    }
+                ),
+            )
         if "job submit" in script:
             return _completed(command, f"{_LIVE_SOURCE_JOB_ID}\n")
         if f"job status {_LIVE_SOURCE_JOB_ID}" in script:
@@ -639,6 +656,50 @@ def test_secure_runtime_orchestration_never_waits_for_outer_job_terminal(
     assert source.state == "running"
     assert source.metadata["retained"] is True
     assert source.metadata["cancel_scheduler_job"] is False
+
+
+def test_secure_runtime_capacity_failure_records_pre_submission_evidence() -> None:
+    """A missing reserved lane is diagnosable and cannot create scheduler work."""
+    evidence: list[Any] = []
+
+    def fake_runner(
+        command: list[str],
+        *,
+        input: bytes | None = None,
+    ) -> subprocess.CompletedProcess[bytes]:
+        del input
+        return _completed(
+            command,
+            json.dumps(
+                {
+                    "configured_workload_concurrency": 1,
+                    "configured_control_query_concurrency": 0,
+                    "control_query_concurrency_consistent": False,
+                    "active_leases_by_mcp_admission_class": {
+                        "workload": 0,
+                        "control_query": 0,
+                    },
+                    "worker_generation_id": "endpoint_replacement",
+                    "worker_generation_complete": False,
+                    "scan_truncated": False,
+                }
+            ),
+        )
+
+    with pytest.raises(RelayError, match="control-query policy is inconsistent"):
+        _require_secure_runtime_control_capacity(
+            ClusterDefinition(name="test-cluster", ssh_host="test-host"),
+            cluster="test-cluster",
+            runner=fake_runner,
+            evidence=evidence,
+        )
+
+    assert len(evidence) == 1
+    metadata = evidence[0].metadata
+    assert metadata["worker_generation_id"] == "endpoint_replacement"
+    assert metadata["worker_generation_complete"] is False
+    assert metadata["source_submitted"] is False
+    assert metadata["scheduler_job_created"] is False
 
 
 def test_live_acceptance_stages_files_and_strips_relay_extension(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -32,6 +32,7 @@ from clio_relay.mcp_server import (
     serve_stdio,
 )
 from clio_relay.models import (
+    MCP_ADMISSION_AUTHORITY_METADATA_KEY,
     ArtifactRef,
     Cursor,
     EndpointRegistration,
@@ -40,7 +41,11 @@ from clio_relay.models import (
     JarvisRunSpec,
     JobKind,
     JobState,
+    McpAdmissionAuthority,
+    McpAdmissionClass,
     McpCallSpec,
+    McpControlQueryEvidence,
+    McpOperation,
     RelayJob,
     RelayTask,
     RemoteAgentTaskSpec,
@@ -358,6 +363,8 @@ def test_mcp_lists_relay_tools(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
         tool for tool in response["result"]["tools"] if tool["name"] == "jarvis_get_execution"
     )
     query_properties = query_tool["inputSchema"]["properties"]
+    assert query_properties["timeout_seconds"]["maximum"] == 60
+    assert "maximum" not in run_tool["inputSchema"]["properties"]["timeout_seconds"]
     assert query_tool["inputSchema"]["required"] == [
         "cluster",
         "pipeline_id",
@@ -2516,6 +2523,17 @@ def test_owned_registered_remote_mcp_call_uses_authenticated_session_api(
         contract=None,
         cluster_route_revision=cluster_route_revision(definition),
         registration_revision=remote_mcp_registration_revision(registration),
+        control_query_evidence=McpControlQueryEvidence(
+            cluster="ares",
+            registered_server_name="science",
+            cluster_route_revision=cluster_route_revision(definition),
+            registration_revision=remote_mcp_registration_revision(registration),
+            discovery_job_id="job_discovery",
+            discovery_artifact_id="artifact_result",
+            discovery_artifact_sha256="d" * 64,
+            discovery_schema_digest="e" * 64,
+            expected_server_artifact_digest="c" * 64,
+        ),
     )
     virtual_tool = VirtualRemoteMcpTool(
         alias="science_inspect",
@@ -2528,6 +2546,7 @@ def test_owned_registered_remote_mcp_call_uses_authenticated_session_api(
                 "required": ["dataset"],
                 "additionalProperties": False,
             },
+            annotations={"readOnlyHint": True, "destructiveHint": False},
         ),
         routes={"ares": route},
         arguments_wrapped=False,
@@ -2551,6 +2570,17 @@ def test_owned_registered_remote_mcp_call_uses_authenticated_session_api(
         captured.update(kwargs)
         payload = cast(dict[str, object], kwargs["payload"])
         selected_settings = cast(RelaySettings, kwargs["settings"])
+        evidence = McpControlQueryEvidence.model_validate(payload["control_query_evidence"])
+        authority = McpAdmissionAuthority(
+            source="registered_discovery_artifact",
+            operation=McpOperation.TOOLS_CALL,
+            tool=cast(str, payload["tool"]),
+            expected_server_artifact_digest=cast(
+                str,
+                payload["expected_server_artifact_digest"],
+            ),
+            evidence=evidence,
+        )
         job = RelayJob(
             cluster="ares",
             kind=JobKind.MCP_CALL,
@@ -2561,6 +2591,7 @@ def test_owned_registered_remote_mcp_call_uses_authenticated_session_api(
                     str,
                     payload["expected_server_artifact_digest"],
                 ),
+                admission_class=McpAdmissionClass.CONTROL_QUERY,
                 tool=cast(str, payload["tool"]),
                 arguments=cast(dict[str, object], payload["arguments"]),
             ),
@@ -2569,6 +2600,7 @@ def test_owned_registered_remote_mcp_call_uses_authenticated_session_api(
                 "owner": "clio-relay",
                 "owner_session_id": selected_settings.owner_session_id,
                 "owner_session_generation_id": (selected_settings.owner_session_generation_id),
+                MCP_ADMISSION_AUTHORITY_METADATA_KEY: authority.model_dump(mode="json"),
             },
         )
         submitted_jobs.append(job)
@@ -2613,10 +2645,16 @@ def test_owned_registered_remote_mcp_call_uses_authenticated_session_api(
     payload = cast(dict[str, object], captured["payload"])
     assert payload["server"] == "science-mcp"
     assert payload["expected_server_artifact_digest"] == "c" * 64
+    assert "admission_class" not in payload
+    assert McpControlQueryEvidence.model_validate(payload["control_query_evidence"]) == (
+        route.control_query_evidence
+    )
     assert payload["arguments"] == {"dataset": "asteroid2018"}
     assert queue.list_jobs() == []
 
     submitted = submitted_jobs[0]
+    assert isinstance(submitted.spec, McpCallSpec)
+    assert submitted.spec.admission_class is McpAdmissionClass.CONTROL_QUERY
     terminal = submitted.model_copy(update={"state": JobState.SUCCEEDED})
     requests: list[tuple[str, str]] = []
 
@@ -2731,6 +2769,195 @@ def test_owned_registered_remote_mcp_call_uses_authenticated_session_api(
     assert stale is not None
     assert "cluster route changed" in stale["error"]["message"]
     assert len(requests) == 6
+
+
+def test_registered_remote_mcp_ssh_forwarding_carries_evidence_not_lane(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SSH fallback lets the cluster receiver derive admission from exact evidence."""
+    registration = RemoteMcpServerConfig(
+        command="science-mcp",
+        args=["--stdio"],
+        allow_tools=["inspect"],
+    )
+    definition = ClusterDefinition(
+        name="ares",
+        ssh_host="ares-login",
+        remote_mcp_servers={"science": registration},
+    )
+    registry_path = tmp_path / "clusters.json"
+    ClusterRegistry(clusters={"ares": definition}).save(registry_path)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+    monkeypatch.setenv("CLIO_RELAY_CLI_MODE", "ssh")
+    evidence = McpControlQueryEvidence(
+        cluster="ares",
+        registered_server_name="science",
+        cluster_route_revision=cluster_route_revision(definition),
+        registration_revision=remote_mcp_registration_revision(registration),
+        discovery_job_id="job_discovery",
+        discovery_artifact_id="artifact_result",
+        discovery_artifact_sha256="d" * 64,
+        discovery_schema_digest="e" * 64,
+        expected_server_artifact_digest="c" * 64,
+    )
+    commands: list[list[str]] = []
+
+    def ignore_write(_definition: ClusterDefinition, _path: str, _data: bytes) -> None:
+        return None
+
+    def ignore_remove(
+        _definition: ClusterDefinition,
+        _path: str,
+        *,
+        remove_empty_parent: bool,
+    ) -> None:
+        del remove_empty_parent
+
+    monkeypatch.setattr(mcp_server_module, "write_remote_file", ignore_write)
+    monkeypatch.setattr(mcp_server_module, "remove_remote_file", ignore_remove)
+
+    def run_remote(_definition: ClusterDefinition, command: list[str]) -> str:
+        commands.append(command)
+        return "job_remote_registered\n"
+
+    monkeypatch.setattr(mcp_server_module, "run_remote_clio", run_remote)
+    result = mcp_server_module._submit_mcp_call(  # pyright: ignore[reportPrivateUsage]
+        {
+            "cluster": "ares",
+            "server": registration.command,
+            "server_args": registration.args,
+            "tool": "inspect",
+            "arguments": {"dataset": "asteroid2018"},
+            "timeout_seconds": registration.call_timeout_seconds,
+            "expected_server_artifact_digest": "c" * 64,
+            "registered_route": True,
+            "registered_remote_mcp_route": True,
+            "expected_cluster_route_revision": cluster_route_revision(definition),
+            "registered_server_name": "science",
+            "expected_remote_mcp_registration_revision": (
+                remote_mcp_registration_revision(registration)
+            ),
+            "control_query_evidence": evidence.model_dump(mode="json"),
+        },
+        queue=ClioCoreQueue(tmp_path / "core"),
+        settings=RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool"),
+    )
+
+    assert result["job_id"] == "job_remote_registered"
+    command = commands[0]
+    assert "--admission-class" not in command
+    evidence_json = command[command.index("--control-query-evidence-json") + 1]
+    assert McpControlQueryEvidence.model_validate_json(evidence_json) == evidence
+
+
+def test_virtual_remote_mcp_idempotency_replays_exactly_and_conflicts_on_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Expose a relay-only retry key without leaking it into remote tool arguments."""
+    registration = RemoteMcpServerConfig(
+        command="science-mcp",
+        args=["--stdio"],
+        allow_tools=["mutate"],
+        profiles=["user"],
+    )
+    definition = ClusterDefinition(
+        name="alpha",
+        ssh_host="localhost",
+        remote_mcp_servers={"science": registration},
+    )
+    registry_path = tmp_path / "clusters.json"
+    ClusterRegistry(clusters={"alpha": definition}).save(registry_path)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+    monkeypatch.setenv("CLIO_RELAY_CLI_MODE", "local")
+    route = RemoteMcpRoute(
+        cluster="alpha",
+        server_name="science",
+        command=registration.command,
+        args=tuple(registration.args),
+        env_from=(),
+        expected_server_artifact_digest=None,
+        remote_tool_name="mutate",
+        timeout_seconds=registration.call_timeout_seconds,
+        contract=None,
+        cluster_route_revision=cluster_route_revision(definition),
+        registration_revision=remote_mcp_registration_revision(registration),
+    )
+    catalog = VirtualRemoteMcpCatalog(
+        revision="f" * 64,
+        tools={
+            "science_mutate": VirtualRemoteMcpTool(
+                alias="science_mutate",
+                namespace="science",
+                remote_tool=RemoteMcpToolSchema(
+                    name="mutate",
+                    input_schema={
+                        "type": "object",
+                        "properties": {"value": {"type": "integer"}},
+                        "required": ["value"],
+                        "additionalProperties": False,
+                    },
+                    annotations={"readOnlyHint": False, "destructiveHint": True},
+                ),
+                routes={"alpha": route},
+                arguments_wrapped=False,
+            )
+        },
+        issues=(),
+        cluster_route_revisions={"alpha": cluster_route_revision(definition)},
+    )
+
+    def selected_catalog(*, profile: str, reserved_names: set[str]) -> VirtualRemoteMcpCatalog:
+        del profile, reserved_names
+        return catalog
+
+    monkeypatch.setattr(mcp_server_module, "_remote_mcp_catalog", selected_catalog)
+    queue = ClioCoreQueue(tmp_path / "core")
+    session = McpSessionState()
+    assert (
+        handle_request(
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+            queue=queue,
+            profile="user",
+            session=session,
+        )
+        is not None
+    )
+
+    def invoke(request_id: int, value: int) -> dict[str, Any] | None:
+        return handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": "tools/call",
+                "params": {
+                    "name": "science_mutate",
+                    "arguments": {
+                        "cluster": "alpha",
+                        "value": value,
+                        "idempotency_key": "agent-retry-1",
+                    },
+                },
+            },
+            queue=queue,
+            profile="user",
+            session=session,
+        )
+
+    first = invoke(2, 1)
+    replay = invoke(3, 1)
+    conflict = invoke(4, 2)
+
+    assert first is not None and replay is not None and conflict is not None
+    first_job_id = first["result"]["structuredContent"]["job_id"]
+    assert replay["result"]["structuredContent"]["job_id"] == first_job_id
+    assert "idempotency" in conflict["error"]["message"].lower()
+    assert len(queue.list_jobs()) == 1
+    job = queue.get_job(first_job_id)
+    assert isinstance(job.spec, McpCallSpec)
+    assert job.spec.arguments == {"value": 1}
+    assert job.idempotency_key == "agent-retry-1"
 
 
 def test_virtual_remote_mcp_wait_envelope_returns_same_call_result_without_leaking(
@@ -3284,6 +3511,8 @@ def test_mcp_virtual_jarvis_execution_query_routes_selectors_through_remote_job(
     job = queue.get_job(response["result"]["structuredContent"]["job_id"])
     assert isinstance(job.spec, McpCallSpec)
     assert job.spec.tool == "jarvis_get_execution"
+    assert job.spec.admission_class is McpAdmissionClass.CONTROL_QUERY
+    assert job.spec.timeout_seconds == 60
     assert job.spec.arguments == {
         "pipeline_id": "example",
         "execution_id": "jarvis_execution_1",
@@ -3297,6 +3526,55 @@ def test_mcp_virtual_jarvis_execution_query_routes_selectors_through_remote_job(
             "cursor": "opaque_cursor_1",
         },
     }
+
+
+def test_jarvis_default_key_changes_after_artifact_bound_control_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An earlier unbound workload call cannot alias a later pinned control query."""
+    _configure_local_cluster(tmp_path, monkeypatch, "test-cluster")
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    arguments = {
+        "cluster": "test-cluster",
+        "tool": "jarvis_get_execution",
+        "arguments": {"pipeline_id": "example", "execution_id": "execution-1"},
+    }
+
+    unbound = mcp_server_module._submit_jarvis_mcp_call(  # pyright: ignore[reportPrivateUsage]
+        arguments,
+        queue=queue,
+        settings=settings,
+    )
+    bound = mcp_server_module._submit_jarvis_mcp_call(  # pyright: ignore[reportPrivateUsage]
+        {**arguments, "registered_route": True},
+        queue=queue,
+        settings=settings,
+    )
+    unbound_job = queue.get_job(cast(str, unbound["job_id"]))
+    bound_job = queue.get_job(cast(str, bound["job_id"]))
+
+    assert unbound_job.job_id != bound_job.job_id
+    assert unbound_job.idempotency_key != bound_job.idempotency_key
+    legacy_digest = hashlib.sha256(
+        json.dumps(
+            arguments["arguments"],
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    assert unbound_job.idempotency_key == (
+        f"mcp:test-cluster:jarvis:jarvis_get_execution:{legacy_digest}"
+    )
+    assert isinstance(unbound_job.spec, McpCallSpec)
+    assert isinstance(bound_job.spec, McpCallSpec)
+    assert unbound_job.spec.expected_server_artifact_digest is None
+    assert unbound_job.spec.admission_class is McpAdmissionClass.WORKLOAD
+    assert unbound_job.spec.timeout_seconds is None
+    assert bound_job.spec.expected_server_artifact_digest == "a" * 64
+    assert bound_job.spec.admission_class is McpAdmissionClass.CONTROL_QUERY
+    assert bound_job.spec.timeout_seconds == 60
 
 
 def test_mcp_virtual_jarvis_run_is_fresh_unless_idempotency_is_explicit(

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -25,6 +25,7 @@ from clio_relay.models import (
     JarvisRunSpec,
     JobKind,
     JobState,
+    McpAdmissionClass,
     McpCallSpec,
     MonitorRule,
     MonitorRuleAction,
@@ -1165,6 +1166,7 @@ def test_null_jarvis_binding_preserves_pre_upgrade_mcp_submission_digest() -> No
         legacy_payload.pop(generated_field, None)
     legacy_spec = cast(dict[str, object], legacy_payload["spec"])
     legacy_spec.pop("expected_jarvis_cd_lock_binding")
+    legacy_spec.pop("admission_class")
     expected = hashlib.sha256(
         json.dumps(legacy_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     ).hexdigest()
@@ -1174,6 +1176,86 @@ def test_null_jarvis_binding_preserves_pre_upgrade_mcp_submission_digest() -> No
     )
 
     assert observed == expected
+
+
+def test_control_query_admission_changes_mcp_submission_digest() -> None:
+    """A promoted control query cannot alias the legacy workload identity."""
+    workload = RelayJob(
+        cluster="configured-target",
+        kind=JobKind.MCP_CALL,
+        spec=McpCallSpec(
+            server="operator-mcp",
+            expected_server_artifact_digest="a" * 64,
+            tool="operator_query",
+        ),
+        idempotency_key="mcp-admission-class",
+    )
+    control = workload.model_copy(
+        update={
+            "spec": workload.spec.model_copy(
+                update={"admission_class": McpAdmissionClass.CONTROL_QUERY}
+            )
+        }
+    )
+
+    assert core_queue_module._job_idempotency_digest(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        workload
+    ) != core_queue_module._job_idempotency_digest(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        control
+    )
+
+
+def test_legacy_workload_mcp_idempotency_record_replays_after_lane_upgrade(
+    tmp_path: Path,
+) -> None:
+    """A durable pre-lane MCP reservation remains replayable after model loading."""
+    queue = ClioCoreQueue(tmp_path)
+    queue.initialize()
+    job = RelayJob(
+        cluster="configured-target",
+        kind=JobKind.MCP_CALL,
+        spec=McpCallSpec(
+            server="operator-mcp",
+            tool="operator_query",
+            arguments={"query": "status"},
+        ),
+        idempotency_key="legacy-workload-mcp",
+    )
+    legacy_payload = job.model_dump(mode="json")
+    for generated_field in {
+        "job_id",
+        "state",
+        "created_at",
+        "updated_at",
+        "leased_by",
+        "attempts",
+        "last_error",
+        "submission_digest",
+        "used_artifact_refs",
+    }:
+        legacy_payload.pop(generated_field, None)
+    legacy_spec = cast(dict[str, object], legacy_payload["spec"])
+    legacy_spec.pop("expected_jarvis_cd_lock_binding")
+    legacy_spec.pop("admission_class")
+    legacy_digest = hashlib.sha256(
+        json.dumps(legacy_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    _idempotency_path(tmp_path, job.idempotency_key).write_text(
+        json.dumps(
+            {
+                "state": "reserved",
+                "job_id": "job_legacy_workload_mcp",
+                "idempotency_key": job.idempotency_key,
+                "job_digest": legacy_digest,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    saved = queue.submit_job(job)
+
+    assert saved.job_id == "job_legacy_workload_mcp"
+    assert saved.spec == job.spec
 
 
 def test_submit_repairs_existing_job_missing_initial_event(tmp_path: Path) -> None:

--- a/tests/test_queue_management.py
+++ b/tests/test_queue_management.py
@@ -18,6 +18,8 @@ from clio_relay.models import (
     JobKind,
     JobState,
     Lease,
+    McpAdmissionClass,
+    McpCallSpec,
     ProgressRecord,
     RelayJob,
     RelayTask,
@@ -850,6 +852,161 @@ def test_worker_status_counts_active_slots_not_supervisor(tmp_path: Path) -> Non
     assert status["stale_worker_count"] == 0
 
 
+def test_worker_status_reports_reserved_control_capacity_and_usage(tmp_path: Path) -> None:
+    """Operators can distinguish reserved query capacity from workload slots."""
+    queue = ClioCoreQueue(tmp_path / "core")
+    parent = queue.register_endpoint(
+        EndpointRegistration(
+            role=EndpointRole.WORKER,
+            cluster="ares",
+            hostname="node",
+            pid=123,
+            metadata={
+                "concurrency": 3,
+                "workload_concurrency": 2,
+                "control_query_concurrency": 1,
+                "worker_supervisor": True,
+            },
+        )
+    )
+    slots: list[EndpointRegistration] = []
+    for index, admission_class in enumerate(
+        (
+            McpAdmissionClass.WORKLOAD,
+            McpAdmissionClass.WORKLOAD,
+            McpAdmissionClass.CONTROL_QUERY,
+        )
+    ):
+        workload = admission_class is McpAdmissionClass.WORKLOAD
+        slots.append(
+            queue.register_endpoint(
+                EndpointRegistration(
+                    role=EndpointRole.WORKER,
+                    cluster="ares",
+                    hostname="node",
+                    pid=123,
+                    metadata={
+                        "worker_slot": index,
+                        "parent_endpoint_id": parent.endpoint_id,
+                        "concurrency": 1,
+                        "workload_concurrency": 1 if workload else 0,
+                        "control_query_concurrency": 0 if workload else 1,
+                        "mcp_admission_class": admission_class.value,
+                    },
+                )
+            )
+        )
+    source = queue.submit_job(
+        RelayJob(
+            cluster="ares",
+            kind=JobKind.JARVIS,
+            spec=JarvisRunSpec(command=["sleep", "30"]),
+            idempotency_key="status-source",
+        )
+    )
+    query = queue.submit_job(
+        RelayJob(
+            cluster="ares",
+            kind=JobKind.MCP_CALL,
+            spec=McpCallSpec(
+                server="science-mcp",
+                expected_server_artifact_digest="a" * 64,
+                admission_class=McpAdmissionClass.CONTROL_QUERY,
+                tool="inspect",
+            ),
+            idempotency_key="status-query",
+        )
+    )
+    assert queue.acquire_job(source.job_id, slots[0].endpoint_id, cluster="ares") is not None
+    assert queue.acquire_job(query.job_id, slots[2].endpoint_id, cluster="ares") is not None
+
+    status = worker_status(queue, cluster="ares")
+
+    assert status["configured_concurrency"] == 3
+    assert status["configured_workload_concurrency"] == 2
+    assert status["configured_control_query_concurrency"] == 1
+    assert status["control_query_concurrency_consistent"] is True
+    assert status["active_leases_by_mcp_admission_class"] == {
+        "workload": 1,
+        "control_query": 1,
+    }
+
+
+def test_worker_status_selects_newest_complete_generation_during_restart(
+    tmp_path: Path,
+) -> None:
+    """Fresh records from the replaced process cannot double-count capacity."""
+    queue = ClioCoreQueue(tmp_path / "core")
+    old_parent = _register_supervised_worker_generation(queue, pid=101)
+    new_parent = _register_supervised_worker_generation(queue, pid=202)
+
+    status = worker_status(queue, cluster="ares")
+
+    assert status["worker_generation_id"] == new_parent.endpoint_id
+    assert status["worker_generation_complete"] is True
+    assert status["fresh_worker_generation_count"] == 2
+    assert status["worker_count"] == 3
+    assert status["configured_concurrency"] == 3
+    assert status["configured_workload_concurrency"] == 2
+    assert status["configured_control_query_concurrency"] == 1
+    assert status["control_query_concurrency_consistent"] is True
+    assert old_parent.endpoint_id != new_parent.endpoint_id
+
+
+def test_worker_status_rejects_incomplete_newest_generation_during_restart(
+    tmp_path: Path,
+) -> None:
+    """A complete stale generation cannot mask a replacement still starting."""
+    queue = ClioCoreQueue(tmp_path / "core")
+    _register_supervised_worker_generation(queue, pid=101)
+    new_parent = _register_supervised_worker_generation(
+        queue,
+        pid=202,
+        slot_indices=(0, 2),
+    )
+
+    status = worker_status(queue, cluster="ares")
+
+    assert status["worker_generation_id"] == new_parent.endpoint_id
+    assert status["worker_generation_complete"] is False
+    assert status["fresh_worker_generation_count"] == 2
+    assert status["worker_count"] == 2
+    assert status["configured_concurrency"] == 2
+    assert status["configured_workload_concurrency"] is None
+    assert status["configured_control_query_concurrency"] is None
+    assert status["control_query_concurrency_consistent"] is False
+
+
+def test_worker_status_fails_closed_for_fresh_slot_with_missing_parent(tmp_path: Path) -> None:
+    """An orphan slot remains visible but cannot establish usable capacity."""
+    queue = ClioCoreQueue(tmp_path / "core")
+    queue.register_endpoint(
+        EndpointRegistration(
+            role=EndpointRole.WORKER,
+            cluster="ares",
+            hostname="node",
+            pid=202,
+            metadata={
+                "worker_slot": 0,
+                "parent_endpoint_id": "missing-parent",
+                "concurrency": 1,
+                "workload_concurrency": 1,
+                "control_query_concurrency": 0,
+                "mcp_admission_class": McpAdmissionClass.WORKLOAD.value,
+            },
+        )
+    )
+
+    status = worker_status(queue, cluster="ares")
+
+    assert status["worker_generation_id"] == "missing-parent"
+    assert status["worker_generation_complete"] is False
+    assert status["worker_count"] == 1
+    assert status["configured_workload_concurrency"] is None
+    assert status["configured_control_query_concurrency"] is None
+    assert status["control_query_concurrency_consistent"] is False
+
+
 def test_stale_discovery_fails_closed_when_active_window_truncates(
     tmp_path: Path,
 ) -> None:
@@ -1002,6 +1159,54 @@ def test_stale_discovery_fails_closed_when_exact_lease_index_truncates(
     assert result["lease_scan_truncated"] is True
     assert result["lease_scan_truncated_job_ids"] == [job.job_id]
     assert result["jobs"] == []
+
+
+def _register_supervised_worker_generation(
+    queue: ClioCoreQueue,
+    *,
+    pid: int,
+    slot_indices: tuple[int, ...] = (0, 1, 2),
+) -> EndpointRegistration:
+    """Register one synthetic two-workload/one-control worker generation."""
+    parent = queue.register_endpoint(
+        EndpointRegistration(
+            role=EndpointRole.WORKER,
+            cluster="ares",
+            hostname="node",
+            pid=pid,
+            metadata={
+                "concurrency": 3,
+                "workload_concurrency": 2,
+                "control_query_concurrency": 1,
+                "worker_supervisor": True,
+                "kind_concurrency": {"jarvis": 2},
+            },
+        )
+    )
+    for index in slot_indices:
+        workload = index < 2
+        queue.register_endpoint(
+            EndpointRegistration(
+                role=EndpointRole.WORKER,
+                cluster="ares",
+                hostname="node",
+                pid=pid,
+                metadata={
+                    "worker_slot": index,
+                    "parent_endpoint_id": parent.endpoint_id,
+                    "concurrency": 1,
+                    "workload_concurrency": 1 if workload else 0,
+                    "control_query_concurrency": 0 if workload else 1,
+                    "mcp_admission_class": (
+                        McpAdmissionClass.WORKLOAD.value
+                        if workload
+                        else McpAdmissionClass.CONTROL_QUERY.value
+                    ),
+                    "kind_concurrency": {"jarvis": 2},
+                },
+            )
+        )
+    return parent
 
 
 def job_id_cursor(job_id: str) -> Cursor:

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.3"
+    assert version == "1.4.4"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_remote_mcp.py
+++ b/tests/test_remote_mcp.py
@@ -40,7 +40,15 @@ from clio_relay.jarvis_mcp import (
 )
 from clio_relay.mcp_server import McpSessionState, handle_request, serve_stdio
 from clio_relay.mcp_stdio_validation import PackagedMcpStdioSession
-from clio_relay.models import JobKind, JobState, McpCallSpec, McpOperation, RelayJob
+from clio_relay.models import (
+    JobKind,
+    JobState,
+    McpAdmissionClass,
+    McpCallSpec,
+    McpControlQueryEvidence,
+    McpOperation,
+    RelayJob,
+)
 from clio_relay.remote_mcp import (
     MAX_REMOTE_MCP_CACHE_BYTES,
     MAX_REMOTE_MCP_SPACK_CONFIGURATION_COMPONENT_BYTES,
@@ -64,6 +72,7 @@ from clio_relay.remote_mcp import (
     build_virtual_remote_mcp_catalog,
     cache_entry_from_discovery_artifact,
     inject_cluster_argument,
+    is_remote_mcp_control_query,
     remote_mcp_server_artifact_digest,
 )
 from clio_relay.spool import JobSpool
@@ -75,6 +84,213 @@ NOW = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
 class _SchemaValidator(Protocol):
     def validate(self, instance: object) -> None:
         """Validate one JSON-compatible instance."""
+
+
+@pytest.mark.parametrize(
+    ("annotations", "expected"),
+    [
+        ({"readOnlyHint": True, "destructiveHint": False}, True),
+        ({"readOnlyHint": True}, False),
+        ({"destructiveHint": False}, False),
+        ({"readOnlyHint": False, "destructiveHint": False}, False),
+        ({"readOnlyHint": True, "destructiveHint": True}, False),
+        (None, False),
+    ],
+)
+def test_control_query_classification_requires_explicit_safe_annotations(
+    annotations: dict[str, object] | None,
+    expected: bool,
+) -> None:
+    """Advisory discovery annotations must fail closed when incomplete."""
+    tool = RemoteMcpToolSchema(
+        name="inspect",
+        input_schema={"type": "object"},
+        annotations=annotations,
+    )
+
+    assert is_remote_mcp_control_query(tool) is expected
+
+
+def test_registered_control_query_requires_exact_durable_discovery_evidence(
+    tmp_path: Path,
+) -> None:
+    """Re-read the cluster-owned artifact and reject a caller-tampered proof."""
+    registration = _registration()
+    definition = _cluster("alpha", {"science": registration})
+    queue = ClioCoreQueue(tmp_path / "core")
+    discovery = queue.submit_job(
+        RelayJob(
+            cluster="alpha",
+            kind=JobKind.MCP_CALL,
+            spec=McpCallSpec(
+                server=registration.command,
+                server_args=registration.args,
+                env_from=registration.env_from,
+                operation=McpOperation.TOOLS_LIST,
+                admission_class=McpAdmissionClass.CONTROL_QUERY,
+            ),
+            idempotency_key="registered-control-discovery",
+        )
+    )
+    payload = _discovery_artifact(
+        registration,
+        tools=[
+            {
+                **_tool("inspect", required=["path"]),
+                "annotations": {"readOnlyHint": True, "destructiveHint": False},
+            }
+        ],
+    )
+    spool = JobSpool(tmp_path / "spool", discovery)
+    spool.initialize()
+    result_path = spool.path / "mcp-result.json"
+    result_path.write_bytes(payload)
+    artifact = queue.append_artifact(spool.artifact_for(result_path, kind="mcp_result"))
+    discovery = queue.update_job_state(
+        discovery.job_id,
+        JobState.SUCCEEDED,
+        message="discovery complete",
+    )
+    entry = cache_entry_from_discovery_artifact(
+        cluster="alpha",
+        server_name="science",
+        registration=registration,
+        discovery_job_id=discovery.job_id,
+        artifact_id=artifact.artifact_id,
+        artifact_sha256=cast(str, artifact.sha256),
+        artifact_payload=payload,
+        discovered_at=discovery.updated_at,
+    )
+    server_digest = remote_mcp_server_artifact_digest(entry.provenance.server_artifact)
+    evidence = McpControlQueryEvidence(
+        cluster="alpha",
+        registered_server_name="science",
+        cluster_route_revision=cluster_route_revision(definition),
+        registration_revision=remote_mcp.remote_mcp_registration_revision(registration),
+        discovery_job_id=discovery.job_id,
+        discovery_artifact_id=artifact.artifact_id,
+        discovery_artifact_sha256=cast(str, artifact.sha256),
+        discovery_schema_digest=entry.schema_digest,
+        expected_server_artifact_digest=server_digest,
+    )
+
+    admission_class, authority = remote_mcp.resolve_registered_remote_mcp_admission(
+        queue=queue,
+        definition=definition,
+        cluster="alpha",
+        server=registration.command,
+        server_args=registration.args,
+        env_from=registration.env_from,
+        operation=McpOperation.TOOLS_CALL,
+        tool="inspect",
+        expected_server_artifact_digest=server_digest,
+        evidence=evidence,
+        timeout_seconds=registration.call_timeout_seconds,
+    )
+
+    assert admission_class is McpAdmissionClass.CONTROL_QUERY
+    assert authority is not None
+    assert authority.source == "registered_discovery_artifact"
+    assert authority.evidence == evidence
+    with pytest.raises(ValueError, match="schema does not match"):
+        remote_mcp.resolve_registered_remote_mcp_admission(
+            queue=queue,
+            definition=definition,
+            cluster="alpha",
+            server=registration.command,
+            server_args=registration.args,
+            env_from=registration.env_from,
+            operation=McpOperation.TOOLS_CALL,
+            tool="inspect",
+            expected_server_artifact_digest=server_digest,
+            evidence=evidence.model_copy(update={"discovery_schema_digest": "f" * 64}),
+            timeout_seconds=registration.call_timeout_seconds,
+        )
+    with pytest.raises(ValueError, match="evidence expired"):
+        remote_mcp.resolve_registered_remote_mcp_admission(
+            queue=queue,
+            definition=definition,
+            cluster="alpha",
+            server=registration.command,
+            server_args=registration.args,
+            env_from=registration.env_from,
+            operation=McpOperation.TOOLS_CALL,
+            tool="inspect",
+            expected_server_artifact_digest=server_digest,
+            evidence=evidence,
+            timeout_seconds=registration.call_timeout_seconds,
+            now=discovery.updated_at + timedelta(seconds=registration.schema_cache_ttl_seconds),
+        )
+
+
+def test_generic_tools_list_only_uses_control_lane_for_exact_registration(
+    tmp_path: Path,
+) -> None:
+    """Arbitrary discovery commands remain workload and registered timeouts stay bounded."""
+    registration = _registration()
+    definition = _cluster("alpha", {"science": registration})
+    queue = ClioCoreQueue(tmp_path / "core")
+
+    arbitrary_class, arbitrary_authority = remote_mcp.resolve_registered_remote_mcp_admission(
+        queue=queue,
+        definition=definition,
+        cluster="alpha",
+        server="arbitrary-mcp",
+        server_args=["--hang"],
+        env_from={},
+        operation=McpOperation.TOOLS_LIST,
+        tool=None,
+        expected_server_artifact_digest=None,
+        evidence=None,
+        timeout_seconds=1,
+    )
+    registered_class, registered_authority = remote_mcp.resolve_registered_remote_mcp_admission(
+        queue=queue,
+        definition=definition,
+        cluster="alpha",
+        server=registration.command,
+        server_args=registration.args,
+        env_from=registration.env_from,
+        operation=McpOperation.TOOLS_LIST,
+        tool=None,
+        expected_server_artifact_digest=None,
+        evidence=None,
+        timeout_seconds=registration.call_timeout_seconds,
+    )
+
+    assert arbitrary_class is McpAdmissionClass.WORKLOAD
+    assert arbitrary_authority is None
+    assert registered_class is McpAdmissionClass.CONTROL_QUERY
+    assert registered_authority is not None
+    assert registered_authority.source == "intrinsic_tools_list"
+    with pytest.raises(ValueError, match="requires an explicit timeout"):
+        remote_mcp.resolve_registered_remote_mcp_admission(
+            queue=queue,
+            definition=definition,
+            cluster="alpha",
+            server=registration.command,
+            server_args=registration.args,
+            env_from=registration.env_from,
+            operation=McpOperation.TOOLS_LIST,
+            tool=None,
+            expected_server_artifact_digest=None,
+            evidence=None,
+            timeout_seconds=None,
+        )
+    with pytest.raises(ValueError, match="timeout exceeds"):
+        remote_mcp.resolve_registered_remote_mcp_admission(
+            queue=queue,
+            definition=definition,
+            cluster="alpha",
+            server=registration.command,
+            server_args=registration.args,
+            env_from=registration.env_from,
+            operation=McpOperation.TOOLS_LIST,
+            tool=None,
+            expected_server_artifact_digest=None,
+            evidence=None,
+            timeout_seconds=registration.call_timeout_seconds + 1,
+        )
 
 
 def test_remote_mcp_registration_is_deny_by_default_and_validated() -> None:

--- a/tests/test_session_api.py
+++ b/tests/test_session_api.py
@@ -13,8 +13,12 @@ from clio_relay.cluster_config import ClusterDefinition
 from clio_relay.config import RelaySettings
 from clio_relay.errors import RelayError
 from clio_relay.models import (
+    MCP_ADMISSION_AUTHORITY_METADATA_KEY,
     JobKind,
+    McpAdmissionAuthority,
+    McpAdmissionClass,
     McpCallSpec,
+    McpOperation,
     RelayJob,
     prepare_owned_jarvis_run_submission,
 )
@@ -133,14 +137,22 @@ def _job(expected_digest: str) -> RelayJob:
             server="clio-kit",
             server_args=["mcp-server", "jarvis"],
             expected_server_artifact_digest=expected_digest,
+            admission_class=McpAdmissionClass.CONTROL_QUERY,
             tool="jarvis_get_execution",
             arguments={"execution_id": "execution-1"},
+            timeout_seconds=60,
         ),
         idempotency_key="owned-session-client",
         metadata={
             "owner": "clio-relay",
             "owner_session_id": "desktop-session-1",
             "owner_session_generation_id": "generation-1",
+            MCP_ADMISSION_AUTHORITY_METADATA_KEY: McpAdmissionAuthority(
+                source="pinned_jarvis_contract",
+                operation=McpOperation.TOOLS_CALL,
+                tool="jarvis_get_execution",
+                expected_server_artifact_digest=expected_digest,
+            ).model_dump(mode="json"),
         },
     )
 
@@ -307,6 +319,7 @@ def test_owned_session_client_proves_identity_before_sending_credentials(
         "tool": "jarvis_get_execution",
         "arguments": {"execution_id": "execution-1"},
         "expected_server_artifact_digest": expected_digest,
+        "timeout_seconds": 60,
         "idempotency_key": "owned-session-client",
     }
 

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1860,13 +1860,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.3-py3-none-any.whl",
+            resource_id="clio-relay-1.4.4-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.3.tar.gz",
+            resource_id="clio_relay-1.4.4.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2005,7 +2005,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.3"
+    assert policy.release_version == "1.4.4"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/tests/test_worker_concurrency.py
+++ b/tests/test_worker_concurrency.py
@@ -285,7 +285,8 @@ def test_user_service_renders_deterministic_kind_limits() -> None:
     )
 
     assert (
-        "--concurrency 4 --kind-concurrency remote_agent=2 "
+        "--concurrency 4 --control-query-concurrency 1 "
+        "--kind-concurrency remote_agent=2 "
         "--kind-concurrency mcp_call=1 --scheduler-provider slurm"
     ) in rendered
 

--- a/tests/test_worker_service_policy.py
+++ b/tests/test_worker_service_policy.py
@@ -1,0 +1,450 @@
+"""Tests for persisted managed-worker capacity and safe service restart."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import cast
+
+import pytest
+from pydantic import ValidationError
+from typer.testing import CliRunner
+
+from clio_relay import cli, deployment
+from clio_relay.cli import app
+from clio_relay.cluster_config import (
+    ClusterDefinition,
+    ClusterRegistry,
+    WorkerCapacityPolicy,
+)
+from clio_relay.core_queue import ClioCoreQueue
+from clio_relay.deployment import render_endpoint_user_service
+from clio_relay.models import JobKind
+
+
+def test_managed_worker_capacity_defaults_are_safe_and_durable(tmp_path: Path) -> None:
+    """Legacy definitions acquire one reserved control slot on load and save."""
+    definition = ClusterDefinition.model_validate({"name": "alpha", "ssh_host": "alpha-login"})
+
+    assert definition.worker_capacity == WorkerCapacityPolicy(
+        concurrency=3,
+        control_query_concurrency=1,
+    )
+
+    registry_path = tmp_path / "clusters.json"
+    ClusterRegistry(clusters={"alpha": definition}).save(registry_path)
+    loaded = ClusterRegistry.load(registry_path).require("alpha")
+
+    assert loaded.worker_capacity == definition.worker_capacity
+    payload = registry_path.read_text(encoding="utf-8")
+    assert '"concurrency": 3' in payload
+    assert '"control_query_concurrency": 1' in payload
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [
+        {"concurrency": 1, "control_query_concurrency": 1},
+        {"concurrency": 3, "control_query_concurrency": 0},
+        {"concurrency": 3, "control_query_concurrency": 3},
+        {"concurrency": True, "control_query_concurrency": 1},
+        {
+            "concurrency": 3,
+            "control_query_concurrency": 1,
+            "kind_concurrency": {"unknown": 1},
+        },
+    ],
+)
+def test_managed_worker_capacity_rejects_unsafe_policy(policy: dict[str, object]) -> None:
+    """Managed policies always retain both a workload and a control-query slot."""
+    with pytest.raises(ValidationError):
+        WorkerCapacityPolicy.model_validate(policy)
+
+
+def test_user_service_uses_the_persisted_cluster_capacity_policy() -> None:
+    """Rendering without overrides cannot fall back to the old one-slot default."""
+    definition = ClusterDefinition(
+        name="alpha",
+        ssh_host="alpha-login",
+        scheduler_provider="slurm",
+        worker_capacity=WorkerCapacityPolicy(
+            concurrency=5,
+            control_query_concurrency=2,
+            kind_concurrency={JobKind.JARVIS: 3},
+        ),
+    )
+
+    rendered = render_endpoint_user_service(cluster="alpha", definition=definition)
+
+    assert (
+        "--concurrency 5 --control-query-concurrency 2 "
+        "--kind-concurrency jarvis=3 --scheduler-provider slurm"
+    ) in rendered
+
+
+def test_cluster_add_persists_generic_worker_capacity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Capacity is operator-configured per cluster rather than keyed to a site name."""
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "cluster",
+            "add",
+            "--name",
+            "arbitrary-site",
+            "--ssh-host",
+            "arbitrary-login",
+            "--worker-concurrency",
+            "8",
+            "--worker-control-query-concurrency",
+            "2",
+            "--worker-kind-concurrency",
+            "jarvis=4",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    capacity = (
+        ClusterRegistry.load(tmp_path / ".clio-relay" / "clusters.json")
+        .require("arbitrary-site")
+        .worker_capacity
+    )
+    assert capacity == WorkerCapacityPolicy(
+        concurrency=8,
+        control_query_concurrency=2,
+        kind_concurrency={JobKind.JARVIS: 4},
+    )
+
+
+def test_endpoint_cli_passes_reserved_control_capacity_to_worker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The service-level flag reaches durable endpoint capacity metadata."""
+    core = tmp_path / "core"
+    monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(core))
+    monkeypatch.setenv("CLIO_RELAY_SPOOL_DIR", str(tmp_path / "spool"))
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "endpoint",
+            "start",
+            "--role",
+            "worker",
+            "--cluster",
+            "alpha",
+            "--scheduler-provider",
+            "external",
+            "--once",
+            "--concurrency",
+            "3",
+            "--control-query-concurrency",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    endpoints = ClioCoreQueue(core).list_endpoints(cluster="alpha")
+    assert len(endpoints) == 1
+    assert endpoints[0].metadata["concurrency"] == 3
+    assert endpoints[0].metadata["workload_concurrency"] == 2
+    assert endpoints[0].metadata["control_query_concurrency"] == 1
+
+
+def test_install_service_persists_explicit_capacity_overrides(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A later reinstall reuses the exact operator-selected capacity policy."""
+    monkeypatch.chdir(tmp_path)
+    registry_path = tmp_path / ".clio-relay" / "clusters.json"
+    ClusterRegistry(
+        clusters={
+            "alpha": ClusterDefinition(
+                name="alpha",
+                ssh_host="alpha-login",
+                worker_capacity=WorkerCapacityPolicy(
+                    concurrency=4,
+                    control_query_concurrency=1,
+                    kind_concurrency={JobKind.JARVIS: 2},
+                ),
+            )
+        }
+    ).save(registry_path)
+    rendered_units: list[str] = []
+
+    def install(
+        *,
+        cluster: str,
+        ssh_host: str,
+        service_text: str,
+        start: bool,
+        enable: bool,
+        require_persistent: bool,
+        timeout_seconds: float = 120.0,
+    ) -> list[str]:
+        del start, enable, require_persistent, timeout_seconds
+        assert cluster == "alpha"
+        assert ssh_host == "alpha-login"
+        rendered_units.append(service_text)
+        return ["endpoint_service.active=active"]
+
+    monkeypatch.setattr(cli, "install_endpoint_user_service_over_ssh", install)
+    runner = CliRunner()
+
+    changed = runner.invoke(
+        app,
+        [
+            "cluster",
+            "install-endpoint-service",
+            "--cluster",
+            "alpha",
+            "--concurrency",
+            "6",
+            "--control-query-concurrency",
+            "2",
+            "--kind-concurrency",
+            "remote_agent=3",
+        ],
+    )
+    repeated = runner.invoke(
+        app,
+        ["cluster", "install-endpoint-service", "--cluster", "alpha"],
+    )
+
+    assert changed.exit_code == 0, changed.output
+    assert repeated.exit_code == 0, repeated.output
+    persisted = ClusterRegistry.load(registry_path).require("alpha").worker_capacity
+    assert persisted == WorkerCapacityPolicy(
+        concurrency=6,
+        control_query_concurrency=2,
+        kind_concurrency={JobKind.REMOTE_AGENT: 3},
+    )
+    expected = "--concurrency 6 --control-query-concurrency 2 --kind-concurrency remote_agent=3"
+    assert len(rendered_units) == 2
+    assert all(expected in unit for unit in rendered_units)
+
+
+def test_restart_service_cli_preserves_registry_and_never_installs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The restart-only command cannot rewrite a unit through the install helper."""
+    monkeypatch.chdir(tmp_path)
+    registry_path = tmp_path / ".clio-relay" / "clusters.json"
+    ClusterRegistry(
+        clusters={
+            "alpha": ClusterDefinition(
+                name="alpha",
+                ssh_host="alpha-login",
+                worker_capacity=WorkerCapacityPolicy(
+                    concurrency=7,
+                    control_query_concurrency=2,
+                ),
+            )
+        }
+    ).save(registry_path)
+    before = registry_path.read_bytes()
+    calls: list[tuple[str, str, WorkerCapacityPolicy, bool]] = []
+
+    def restart(
+        *,
+        cluster: str,
+        ssh_host: str,
+        expected_capacity: WorkerCapacityPolicy,
+        require_persistent: bool,
+        timeout_seconds: float = 120.0,
+    ) -> list[str]:
+        del timeout_seconds
+        calls.append((cluster, ssh_host, expected_capacity, require_persistent))
+        return [
+            "endpoint_service.unit_rewritten=false",
+            "endpoint_service.policy_source=installed-unit",
+            "endpoint_service.policy_validated=true",
+        ]
+
+    def fail_install(**_kwargs: object) -> list[str]:
+        raise AssertionError("restart-only must not call the installer")
+
+    monkeypatch.setattr(cli, "restart_endpoint_user_service_over_ssh", restart)
+    monkeypatch.setattr(cli, "install_endpoint_user_service_over_ssh", fail_install)
+
+    result = CliRunner().invoke(
+        app,
+        ["cluster", "restart-endpoint-service", "--cluster", "alpha"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        (
+            "alpha",
+            "alpha-login",
+            WorkerCapacityPolicy(concurrency=7, control_query_concurrency=2),
+            True,
+        )
+    ]
+    assert registry_path.read_bytes() == before
+    assert "endpoint_service.unit_rewritten=false" in result.output
+    assert "endpoint_service.policy_validated=true" in result.output
+
+
+def test_remote_restart_script_controls_existing_unit_without_rewriting_it() -> None:
+    """Restart-only shell behavior reads service state and never emits unit content."""
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.fail("bash is required to validate the remote endpoint restart")
+    expected_capacity = WorkerCapacityPolicy(
+        concurrency=7,
+        control_query_concurrency=2,
+        kind_concurrency={JobKind.JARVIS: 3, JobKind.REMOTE_AGENT: 2},
+    )
+    script = deployment._remote_restart_script(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        service_name="clio-relay-worker-test.service",
+        expected_capacity=expected_capacity,
+        require_persistent=True,
+    )
+    assert '> "$HOME/.config/systemd/user' not in script
+    assert "daemon-reload" not in script
+    assert "systemctl --user enable" not in script
+    harness = f"""set -u
+export USER=test-user
+loginctl() {{ echo yes; }}
+systemctl() {{
+  echo "systemctl=$*" >&2
+  case "${{2:-}}" in
+    is-enabled) echo enabled ;;
+    show)
+      echo "argv[]=/home/test/.local/bin/clio-relay endpoint start --role worker" \
+        "--cluster test --concurrency 7 --control-query-concurrency 2" \
+        "--kind-concurrency jarvis=3 --kind-concurrency remote_agent=2" \
+        "--scheduler-provider external ;"
+      ;;
+    is-active) echo active ;;
+    is-system-running) echo running ;;
+  esac
+}}
+{script}
+"""
+
+    result = subprocess.run(
+        [bash, "-s"],
+        input=harness.encode("utf-8"),
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 0, stderr
+    assert "endpoint_service.unit_rewritten=false" in stdout
+    assert "endpoint_service.policy_source=installed-unit" in stdout
+    assert "endpoint_service.policy_validated=true" in stdout
+    assert "systemctl=--user restart clio-relay-worker-test.service" in stderr
+    assert "daemon-reload" not in stderr
+    assert "systemctl=--user enable " not in stderr
+
+
+def test_remote_restart_script_refuses_policy_mismatch_before_restart() -> None:
+    """A legacy or drifted unit cannot be restarted as though it were policy-safe."""
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.fail("bash is required to validate the remote endpoint restart")
+    script = deployment._remote_restart_script(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        service_name="clio-relay-worker-test.service",
+        expected_capacity=WorkerCapacityPolicy(
+            concurrency=3,
+            control_query_concurrency=1,
+            kind_concurrency={JobKind.JARVIS: 2},
+        ),
+        require_persistent=True,
+    )
+    harness = f"""set -u
+export USER=test-user
+loginctl() {{ echo yes; }}
+systemctl() {{
+  echo "systemctl=$*" >&2
+  case "${{2:-}}" in
+    is-enabled) echo enabled ;;
+    show)
+      echo "argv[]=/home/test/.local/bin/clio-relay endpoint start --role worker" \
+        "--cluster test --concurrency 1 --scheduler-provider external ;"
+      ;;
+    is-active) echo active ;;
+    is-system-running) echo running ;;
+  esac
+}}
+{script}
+"""
+
+    result = subprocess.run(
+        [bash, "-s"],
+        input=harness.encode("utf-8"),
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 79
+    assert "capacity policy does not match the persisted cluster policy" in stderr
+    assert "expected concurrency=3 control_query_concurrency=1 kind_concurrency=jarvis=2" in stderr
+    assert "observed concurrency=1 control_query_concurrency=missing" in stderr
+    assert "cluster install-endpoint-service" in stderr
+    assert "systemctl=--user restart" not in stderr
+    assert "endpoint_service.unit_rewritten" not in stdout
+
+
+def test_restart_helper_uses_bounded_ssh_without_service_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public restart helper sends only the generated control script."""
+    observed: dict[str, object] = {}
+
+    def run(
+        command: list[str],
+        *,
+        input: bytes,
+        capture_output: bool,
+        check: bool,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[bytes]:
+        assert capture_output is True
+        assert check is False
+        observed.update(command=command, input=input, timeout=timeout)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            b"endpoint_service.unit_rewritten=false\n",
+            b"",
+        )
+
+    monkeypatch.setattr(deployment.subprocess, "run", run)
+
+    lines = deployment.restart_endpoint_user_service_over_ssh(
+        cluster="alpha",
+        ssh_host="alpha-login",
+        expected_capacity=WorkerCapacityPolicy(
+            concurrency=5,
+            control_query_concurrency=2,
+            kind_concurrency={JobKind.REMOTE_AGENT: 3},
+        ),
+        timeout_seconds=17,
+    )
+
+    assert lines == ["endpoint_service.unit_rewritten=false"]
+    assert observed["command"] == ["ssh", "alpha-login", "bash", "-s"]
+    assert observed["timeout"] == 17
+    sent = cast(bytes, observed["input"]).decode("utf-8")
+    assert '> "$HOME/.config/systemd/user' not in sent
+    assert "ExecStart=" not in sent
+    assert "expected_concurrency=5" in sent
+    assert "expected_control_query_concurrency=2" in sent
+    assert "expected_kind_concurrency=remote_agent=3" in sent

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.3"
+version = "1.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- Persist per-cluster endpoint capacity and reserve a strict control-query lane so long-lived MCP workloads cannot starve status, progress, artifact, or runtime-binding queries.
- Derive reserved admission only from pinned JARVIS semantics or fresh, immutable, cluster-owned remote-MCP discovery evidence; reject caller lane claims, stale/tampered proofs, unbounded queries, and raw HTTP bypasses.
- Make worker status generation-safe, validate restart policy without rewriting systemd, and fail secure-runtime acceptance before scheduler submission when reserved capacity is unavailable.
- Preserve legacy workload idempotency while adding safe retry keys for generalized virtual MCP tools.

## Focused validation

- 33 ingress/admission/forwarding/idempotency tests passed.
- 20 independent adversarial security tests passed.
- Final worker-policy, queue, secure-runtime, and release-policy suite passed after correcting the 1.4.4 matrix digest.
- Ruff passed.
- Pyright: 0 errors, 0 warnings.
- `git diff --check` passed.

Live released-wheel validation on Ares follows immediately after publication; no scheduler jobs are cancelled by this patch or its acceptance path.