### PR TITLE
fix: restore release lint gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.4` uses a release-first patch process. A maintainer builds the
+> Version `1.4.5` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.4"
+$Version = "1.4.5"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.4"
+release_version: "1.4.5"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: fcec6b68da80ee672143dba9f3ec224d77b2622a65e6322d1648b68a8385da10
+acceptance_matrix_sha256: 696ef04cea5755ad899b70f57147d397f7d8c19e6a0ac3b968aaedc125df312e
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.4"
+$Tag = "v1.4.5"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.4" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.5" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.4",
-  "matrix_sha256": "fcec6b68da80ee672143dba9f3ec224d77b2622a65e6322d1648b68a8385da10",
+  "release_version": "1.4.5",
+  "matrix_sha256": "696ef04cea5755ad899b70f57147d397f7d8c19e6a0ac3b968aaedc125df312e",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.4"
+version = "1.4.5"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.4"
+__version__ = "1.4.5"

--- a/tests/test_jarvis_mcp_validation.py
+++ b/tests/test_jarvis_mcp_validation.py
@@ -13,12 +13,12 @@ from clio_relay.jarvis_mcp import (
     CLIO_KIT_JARVIS_MCP_VERSION,
     CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
     CLIO_KIT_JARVIS_USER_CONTRACT_SHA256,
+    is_virtual_jarvis_control_query,
     jarvis_cd_lock_binding_expectation,
     jarvis_mcp_server,
     jarvis_mcp_server_args,
     jarvis_user_contract,
     jarvis_user_contract_digest,
-    is_virtual_jarvis_control_query,
     render_virtual_jarvis_agent_context,
     virtual_jarvis_tool_definitions,
 )

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.4"
+    assert version == "1.4.5"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1860,13 +1860,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.4-py3-none-any.whl",
+            resource_id="clio-relay-1.4.5-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.4.tar.gz",
+            resource_id="clio_relay-1.4.5.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2005,7 +2005,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.4"
+    assert policy.release_version == "1.4.5"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.4"
+version = "1.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- Fix the sole v1.4.4 tag-CI failure by restoring Ruff-sorted imports in the JARVIS MCP validation test.
- Bump the patch release to 1.4.5 and update the bound acceptance-matrix digest.

## Focused validation

- Exact CI reproduction: `ruff check tests/test_jarvis_mcp_validation.py` passed.
- Four release identity/policy assertions passed.
- `uv lock --check` passed.
- `git diff --check` passed.

The v1.4.4 workflow syntax and pinned clio-kit checksum had already passed; no behavioral test failed before the lint gate stopped the remaining jobs.