### PR TITLE
fix: bind remote MCP authority to owned sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.5` uses a release-first patch process. A maintainer builds the
+> Version `1.4.6` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.5"
+$Version = "1.4.6"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.5"
+release_version: "1.4.6"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 696ef04cea5755ad899b70f57147d397f7d8c19e6a0ac3b968aaedc125df312e
+acceptance_matrix_sha256: 6537d915d549074c8516ae3361531545a2a0501c4d62009d5182c010e5b8b261
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.5"
+$Tag = "v1.4.6"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.5" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.6" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.5",
-  "matrix_sha256": "696ef04cea5755ad899b70f57147d397f7d8c19e6a0ac3b968aaedc125df312e",
+  "release_version": "1.4.6",
+  "matrix_sha256": "6537d915d549074c8516ae3361531545a2a0501c4d62009d5182c010e5b8b261",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.5"
+version = "1.4.6"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.5"
+__version__ = "1.4.6"

--- a/src/clio_relay/http_api.py
+++ b/src/clio_relay/http_api.py
@@ -5,11 +5,14 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
+import os
 import secrets
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from datetime import datetime
+from pathlib import Path
 from typing import Annotated, TypeVar, cast
 
 from fastapi import (
@@ -24,9 +27,17 @@ from fastapi import (
     status,
 )
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
-from clio_relay.cluster_config import ClusterRegistry, default_registry_path
+from clio_relay.cluster_config import (
+    CLUSTER_REGISTRY_ENV,
+    MAX_CLUSTER_REGISTRY_BYTES,
+    ClusterDefinition,
+    ClusterRegistry,
+    cluster_route_revision,
+    default_registry_path,
+    read_bounded_configuration_bytes,
+)
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.errors import ConfigurationError, NotFoundError, QueueConflictError
@@ -645,6 +656,83 @@ class GatewaySessionUpdateRequest(BaseModel):
     _metadata_is_not_runtime_owned = field_validator("metadata")(_validate_generic_gateway_metadata)
 
 
+_SESSION_REGISTRY_SHA256_ENV = "CLIO_RELAY_SESSION_REGISTRY_SHA256"
+_SESSION_ROUTE_REVISION_ENV = "CLIO_RELAY_SESSION_ROUTE_REVISION"
+
+
+def _bound_owner_session_cluster_definition(
+    *, owner_session_id: str | None, owner_session_cluster: str | None
+) -> ClusterDefinition | None:
+    """Load one immutable process-bound cluster authority for an owned API."""
+    raw_bindings = {
+        CLUSTER_REGISTRY_ENV: os.getenv(CLUSTER_REGISTRY_ENV),
+        _SESSION_REGISTRY_SHA256_ENV: os.getenv(_SESSION_REGISTRY_SHA256_ENV),
+        _SESSION_ROUTE_REVISION_ENV: os.getenv(_SESSION_ROUTE_REVISION_ENV),
+    }
+    session_bindings = {
+        _SESSION_REGISTRY_SHA256_ENV,
+        _SESSION_ROUTE_REVISION_ENV,
+    }
+    configured_session_bindings = {
+        name for name in session_bindings if raw_bindings[name] is not None
+    }
+    if not configured_session_bindings:
+        if owner_session_id is not None:
+            raise ConfigurationError(
+                "owned relay session API requires process-bound cluster authority"
+            )
+        return None
+    configured = {name for name, value in raw_bindings.items() if value is not None}
+    if configured_session_bindings != session_bindings or configured != set(raw_bindings):
+        raise ConfigurationError(
+            "owned session cluster authority path, digest, and route revision must be configured "
+            "together"
+        )
+    if owner_session_id is None or owner_session_cluster is None:
+        raise ConfigurationError("session cluster authority requires an owned relay session")
+    registry_path_raw = raw_bindings[CLUSTER_REGISTRY_ENV]
+    if not registry_path_raw:
+        raise ConfigurationError("owned session cluster registry path must not be blank")
+    registry_sha256 = raw_bindings[_SESSION_REGISTRY_SHA256_ENV]
+    route_revision = raw_bindings[_SESSION_ROUTE_REVISION_ENV]
+    if (
+        not registry_sha256
+        or len(registry_sha256) != 64
+        or any(character not in "0123456789abcdef" for character in registry_sha256)
+    ):
+        raise ConfigurationError("owned session cluster registry SHA-256 is invalid")
+    if (
+        not route_revision
+        or len(route_revision) != 64
+        or any(character not in "0123456789abcdef" for character in route_revision)
+    ):
+        raise ConfigurationError("owned session cluster route revision is invalid")
+    registry_path = Path(registry_path_raw).expanduser()
+    if not registry_path.is_absolute():
+        raise ConfigurationError("owned session cluster registry path must be absolute")
+    try:
+        payload = read_bounded_configuration_bytes(
+            registry_path,
+            max_bytes=MAX_CLUSTER_REGISTRY_BYTES,
+        )
+    except (ConfigurationError, OSError) as exc:
+        raise ConfigurationError("owned session cluster registry is unavailable") from exc
+    if not secrets.compare_digest(hashlib.sha256(payload).hexdigest(), registry_sha256):
+        raise ConfigurationError("owned session cluster registry digest does not match")
+    try:
+        registry = ClusterRegistry.model_validate_json(payload)
+    except ValidationError as exc:
+        raise ConfigurationError("owned session cluster registry is invalid") from exc
+    if set(registry.clusters) != {owner_session_cluster}:
+        raise ConfigurationError(
+            "owned session cluster registry must contain exactly the owner session cluster"
+        )
+    definition = registry.require(owner_session_cluster)
+    if not secrets.compare_digest(cluster_route_revision(definition), route_revision):
+        raise ConfigurationError("owned session cluster route revision does not match")
+    return definition
+
+
 def create_app(settings: RelaySettings | None = None) -> FastAPI:
     """Create the FastAPI relay surface."""
     resolved = settings or RelaySettings.from_env()
@@ -664,6 +752,10 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
             )
         if not resolved.api_token:
             raise ConfigurationError("owned relay session API requires CLIO_RELAY_API_TOKEN")
+    owner_session_cluster_definition = _bound_owner_session_cluster_definition(
+        owner_session_id=resolved.owner_session_id,
+        owner_session_cluster=owner_session_cluster,
+    )
     queue = storage_managed_queue(resolved)
     queue.initialize()
 
@@ -918,9 +1010,13 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
         registry_path = default_registry_path()
         try:
             definition = (
-                ClusterRegistry.load(registry_path).clusters.get(request.cluster)
-                if registry_path.exists()
-                else None
+                owner_session_cluster_definition
+                if owner_session_cluster_definition is not None
+                else (
+                    ClusterRegistry.load(registry_path).clusters.get(request.cluster)
+                    if registry_path.exists()
+                    else None
+                )
             )
             admission_class, admission_authority = resolve_registered_remote_mcp_admission(
                 queue=queue,

--- a/src/clio_relay/session_lifecycle.py
+++ b/src/clio_relay/session_lifecycle.py
@@ -13,7 +13,12 @@ from typing import TYPE_CHECKING, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from clio_relay.cluster_config import ClusterDefinition
+from clio_relay.cluster_config import (
+    MAX_CLUSTER_REGISTRY_BYTES,
+    ClusterDefinition,
+    ClusterRegistry,
+    cluster_route_revision,
+)
 from clio_relay.errors import RelayError
 from clio_relay.identifiers import DurableRecordId, validate_durable_record_id
 from clio_relay.remote_cli import remote_env
@@ -853,6 +858,9 @@ def _start_script(
     expected_release_sha256 = (
         expected_api_release_identity.sha256() if expected_api_release_identity is not None else ""
     )
+    cluster_registry_json, cluster_registry_sha256, route_revision = (
+        _session_cluster_registry_authority(cluster=cluster, definition=definition)
+    )
     return f"""set -euo pipefail
 umask 077
 {remote_env(definition)}
@@ -867,6 +875,8 @@ log_file="$session_dir/api.log"
 metadata_file="$session_dir/metadata.json"
 expected_api_release_identity_json={_shell_single_quote(expected_release_json)}
 expected_api_release_identity_sha256={shlex.quote(expected_release_sha256)}
+cluster_registry_sha256={shlex.quote(cluster_registry_sha256)}
+cluster_route_revision={shlex.quote(route_revision)}
 api_release_identity_json="$(python3 - \
   "$expected_api_release_identity_json" "$expected_api_release_identity_sha256" \
   <<'__CLIO_RELAY_CURRENT_API_RELEASE__'
@@ -1027,13 +1037,21 @@ if [ -n "$existing_owned_pid" ] && [ "{replace_flag}" != "1" ]; then
   python3 - \
     "$metadata_file" "$existing_owned_pid" \
     "$expected_api_release_identity_json" "$expected_api_release_identity_sha256" \
+    "$cluster_registry_sha256" "$cluster_route_revision" \
     <<'__CLIO_RELAY_EXISTING_API_RELEASE__'
 import hashlib
 import json
 import sys
 from pathlib import Path
 
-metadata_path, pid, expected_json, expected_sha256 = sys.argv[1:]
+(
+    metadata_path,
+    pid,
+    expected_json,
+    expected_sha256,
+    expected_registry_sha256,
+    expected_route_revision,
+) = sys.argv[1:]
 metadata = json.loads(Path(metadata_path).read_text(encoding="utf-8"))
 expected_identity = json.loads(expected_json)
 observed_identity = metadata.get("api_release_identity")
@@ -1055,6 +1073,35 @@ marker = f"CLIO_RELAY_API_RELEASE_IDENTITY_SHA256={{observed_sha256}}".encode()
 if marker not in environment:
     raise SystemExit(
         "existing owned session API release identity is not process-bound; use --replace"
+    )
+registry_path = metadata.get("cluster_registry_path")
+observed_registry_sha256 = metadata.get("cluster_registry_sha256")
+observed_route_revision = metadata.get("cluster_route_revision")
+cluster_authority_verified = metadata.get("cluster_authority_verified")
+if (
+    not isinstance(registry_path, str)
+    or not registry_path
+    or observed_registry_sha256 != expected_registry_sha256
+    or observed_route_revision != expected_route_revision
+    or cluster_authority_verified is not True
+):
+    raise SystemExit("existing owned session API cluster authority differs; use --replace")
+try:
+    registry_bytes = Path(registry_path).read_bytes()
+except OSError as exc:
+    raise SystemExit(f"cannot verify existing session API cluster authority: {{exc}}") from exc
+if (
+    hashlib.sha256(registry_bytes).hexdigest() != expected_registry_sha256
+):
+    raise SystemExit("existing owned session API cluster authority differs; use --replace")
+authority_markers = (
+    f"CLIO_RELAY_CLUSTER_REGISTRY={{registry_path}}".encode(),
+    f"CLIO_RELAY_SESSION_REGISTRY_SHA256={{expected_registry_sha256}}".encode(),
+    f"CLIO_RELAY_SESSION_ROUTE_REVISION={{expected_route_revision}}".encode(),
+)
+if any(authority_marker not in environment for authority_marker in authority_markers):
+    raise SystemExit(
+        "existing owned session API cluster authority is not process-bound; use --replace"
     )
 __CLIO_RELAY_EXISTING_API_RELEASE__
 fi
@@ -1149,36 +1196,65 @@ else
   echo "remote API port is already occupied: {remote_api_port}" >&2
   exit 1
 fi
+cluster_registry_file="$session_dir/cluster-registry-$session_generation_id.json"
+cluster_registry_candidate="$cluster_registry_file.$$.tmp"
+trap 'rm -f "$cluster_registry_candidate" "$cluster_registry_file"' EXIT
+printf '%s' {_shell_single_quote(cluster_registry_json)} > "$cluster_registry_candidate"
+python3 - \
+  "$cluster_registry_candidate" "$cluster_registry_file" "$cluster_registry_sha256" \
+  <<'__CLIO_RELAY_CLUSTER_REGISTRY__'
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+candidate = Path(sys.argv[1])
+path = Path(sys.argv[2])
+expected_sha256 = sys.argv[3]
+payload = candidate.read_bytes()
+if hashlib.sha256(payload).hexdigest() != expected_sha256:
+    raise SystemExit("session cluster registry digest does not match its payload")
+try:
+    with candidate.open("rb") as handle:
+        os.fsync(handle.fileno())
+    os.chmod(candidate, 0o600)
+    os.replace(candidate, path)
+finally:
+    candidate.unlink(missing_ok=True)
+__CLIO_RELAY_CLUSTER_REGISTRY__
 api_command=(clio-relay api start --host 127.0.0.1 --port {remote_api_port}{require_token})
 owner_token="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
 api_pid=""
 start_complete=0
 cleanup_incomplete_start() {{
-  if [ "$start_complete" = "1" ] || [ -z "$api_pid" ]; then return; fi
-  kill -- "-$api_pid" 2>/dev/null || kill "$api_pid" 2>/dev/null || true
-  for _ in 1 2 3 4 5; do
-    if ! kill -0 -- "-$api_pid" 2>/dev/null; then break; fi
-    sleep 0.2
-  done
-  if kill -0 -- "-$api_pid" 2>/dev/null; then
-    kill -9 -- "-$api_pid" 2>/dev/null || kill -9 "$api_pid" 2>/dev/null || true
-  fi
-  for _ in 1 2 3 4 5; do
-    if ! kill -0 -- "-$api_pid" 2>/dev/null; then break; fi
-    sleep 0.1
-  done
-  if kill -0 -- "-$api_pid" 2>/dev/null; then
-    echo "incomplete session API process group cleanup: $api_pid" >&2
-    return 1
+  if [ "$start_complete" = "1" ]; then return; fi
+  if [ -n "$api_pid" ]; then
+    kill -- "-$api_pid" 2>/dev/null || kill "$api_pid" 2>/dev/null || true
+    for _ in 1 2 3 4 5; do
+      if ! kill -0 -- "-$api_pid" 2>/dev/null; then break; fi
+      sleep 0.2
+    done
+    if kill -0 -- "-$api_pid" 2>/dev/null; then
+      kill -9 -- "-$api_pid" 2>/dev/null || kill -9 "$api_pid" 2>/dev/null || true
+    fi
+    for _ in 1 2 3 4 5; do
+      if ! kill -0 -- "-$api_pid" 2>/dev/null; then break; fi
+      sleep 0.1
+    done
+    if kill -0 -- "-$api_pid" 2>/dev/null; then
+      echo "incomplete session API process group cleanup: $api_pid" >&2
+      return 1
+    fi
   fi
   python3 - \
     "$metadata_file" "$pid_file" "$api_pid" "$session_generation_id" \
+    "$cluster_registry_file" \
     <<'__CLIO_RELAY_ROLLBACK_METADATA__'
 import json
 import sys
 from pathlib import Path
 
-metadata_path, pid_path, pid_raw, generation_id = sys.argv[1:]
+metadata_path, pid_path, pid_raw, generation_id, registry_path = sys.argv[1:]
 metadata_file = Path(metadata_path)
 pid_file = Path(pid_path)
 try:
@@ -1197,6 +1273,7 @@ except OSError:
     recorded_pid = None
 if recorded_pid == pid_raw:
     pid_file.unlink(missing_ok=True)
+Path(registry_path).unlink(missing_ok=True)
 __CLIO_RELAY_ROLLBACK_METADATA__
 }}
 trap cleanup_incomplete_start EXIT
@@ -1204,6 +1281,9 @@ nohup setsid env \\
   "CLIO_RELAY_SESSION_OWNER_TOKEN=$owner_token" \\
   "CLIO_RELAY_SESSION_GENERATION_ID=$session_generation_id" \\
   "CLIO_RELAY_API_RELEASE_IDENTITY_SHA256=$expected_api_release_identity_sha256" \\
+  "CLIO_RELAY_CLUSTER_REGISTRY=$cluster_registry_file" \\
+  "CLIO_RELAY_SESSION_REGISTRY_SHA256=$cluster_registry_sha256" \\
+  "CLIO_RELAY_SESSION_ROUTE_REVISION=$cluster_route_revision" \\
   "CLIO_RELAY_OWNER_SESSION_ID=$session_id" \\
   "CLIO_RELAY_OWNER_SESSION_CLUSTER={shlex.quote(cluster)}" \\
   "${{api_command[@]}}" \\
@@ -1213,6 +1293,7 @@ echo "$api_pid" > "$pid_file"
 python3 - \
   "$metadata_file" "$api_pid" "$owner_token" "$session_generation_id" \
   "$api_release_identity_json" "$expected_api_release_identity_sha256" \
+  "$cluster_registry_file" "$cluster_registry_sha256" "$cluster_route_revision" \
   <<'__CLIO_RELAY_METADATA__'
 import json
 import os
@@ -1225,6 +1306,9 @@ owner_token = sys.argv[3]
 session_generation_id = sys.argv[4]
 api_release_identity = json.loads(sys.argv[5])
 api_release_identity_sha256 = sys.argv[6]
+cluster_registry_path = sys.argv[7]
+cluster_registry_sha256 = sys.argv[8]
+cluster_route_revision = sys.argv[9]
 for _ in range(40):
     try:
         api_pgid = os.getpgid(api_pid)
@@ -1239,6 +1323,11 @@ for _ in range(40):
         and f"CLIO_RELAY_SESSION_GENERATION_ID={{session_generation_id}}".encode()
         in environment
         and f"CLIO_RELAY_API_RELEASE_IDENTITY_SHA256={{api_release_identity_sha256}}".encode()
+        in environment
+        and f"CLIO_RELAY_CLUSTER_REGISTRY={{cluster_registry_path}}".encode() in environment
+        and f"CLIO_RELAY_SESSION_REGISTRY_SHA256={{cluster_registry_sha256}}".encode()
+        in environment
+        and f"CLIO_RELAY_SESSION_ROUTE_REVISION={{cluster_route_revision}}".encode()
         in environment
     ):
         break
@@ -1257,6 +1346,10 @@ metadata = {{
     "session_generation_id": session_generation_id,
     "api_release_identity": api_release_identity,
     "api_release_identity_sha256": api_release_identity_sha256,
+    "cluster_registry_path": cluster_registry_path,
+    "cluster_registry_sha256": cluster_registry_sha256,
+    "cluster_route_revision": cluster_route_revision,
+    "cluster_authority_verified": True,
     "process_start_ticks": process_start_ticks,
     "started_at": datetime.now(timezone.utc).isoformat(),
     "owner": "clio-relay",
@@ -1320,6 +1413,31 @@ echo "session_generation_id=$session_generation_id"
 echo "remote_api_port={remote_api_port}"
 echo "metadata=$metadata_file"
 """
+
+
+def _session_cluster_registry_authority(
+    *, cluster: str, definition: ClusterDefinition
+) -> tuple[str, str, str]:
+    """Return the exact registry payload and identities owned by one session API."""
+    if definition.name != cluster:
+        raise RelayError("session cluster does not match its cluster definition")
+    registry = ClusterRegistry(clusters={cluster: definition})
+    payload = json.dumps(
+        registry.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    encoded_payload = payload.encode("utf-8")
+    if len(encoded_payload) > MAX_CLUSTER_REGISTRY_BYTES:
+        raise RelayError(
+            "session cluster registry exceeds the "
+            f"{MAX_CLUSTER_REGISTRY_BYTES}-byte configuration limit"
+        )
+    return (
+        payload,
+        hashlib.sha256(encoded_payload).hexdigest(),
+        cluster_route_revision(definition),
+    )
 
 
 def _status_script(*, session_id: str) -> str:  # pyright: ignore[reportUnusedFunction]

--- a/tests/queue_validation_fixtures.py
+++ b/tests/queue_validation_fixtures.py
@@ -21,6 +21,7 @@ from clio_relay.models import (
     EndpointRegistration,
     EndpointRole,
     JobKind,
+    McpAdmissionClass,
     SchedulerPhase,
     SchedulerStatus,
 )
@@ -150,6 +151,24 @@ class LiveWorkerFleet:
 
     def start(self) -> LiveWorkerFleet:
         """Register three slots and start their real worker loops."""
+        self.queue.register_endpoint(
+            EndpointRegistration(
+                endpoint_id="test-supervisor",
+                role=EndpointRole.WORKER,
+                cluster=self.cluster,
+                hostname="test-host",
+                pid=10_000,
+                metadata={
+                    "worker_supervisor": True,
+                    "concurrency": 3,
+                    "workload_concurrency": 3,
+                    "control_query_concurrency": 0,
+                    "kind_concurrency": {"jarvis": 2},
+                    "scheduler_provider": "slurm",
+                    "process_containment": containment_capability(),
+                },
+            )
+        )
         for index in range(3):
             worker = EndpointWorker(
                 role=EndpointRole.WORKER,
@@ -166,11 +185,14 @@ class LiveWorkerFleet:
                 role=EndpointRole.WORKER,
                 cluster=self.cluster,
                 hostname="test-host",
-                pid=10_000 + index,
+                pid=10_000,
                 metadata={
                     "worker_slot": index,
                     "parent_endpoint_id": "test-supervisor",
                     "concurrency": 1,
+                    "workload_concurrency": 1,
+                    "control_query_concurrency": 0,
+                    "mcp_admission_class": McpAdmissionClass.WORKLOAD.value,
                     "kind_concurrency": {"jarvis": 2},
                     "scheduler_provider": "slurm",
                     "process_containment": containment_capability(),

--- a/tests/test_artifact_lineage.py
+++ b/tests/test_artifact_lineage.py
@@ -12,6 +12,12 @@ from typer.testing import CliRunner
 
 import clio_relay.core_queue as core_queue_module
 from clio_relay.cli import app
+from clio_relay.cluster_config import (
+    CLUSTER_REGISTRY_ENV,
+    ClusterDefinition,
+    ClusterRegistry,
+    cluster_route_revision,
+)
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.errors import QueueConflictError
@@ -46,6 +52,26 @@ def _job(
     if job_id is not None:
         values["job_id"] = job_id
     return RelayJob.model_validate(values)
+
+
+def _bind_owned_session_cluster_authority(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Bind the exact test cluster definition to an owned API process."""
+    definition = ClusterDefinition(name="test-cluster", ssh_host="test-cluster")
+    registry_path = tmp_path / "session-authority" / "clusters.json"
+    ClusterRegistry(clusters={definition.name: definition}).save(registry_path)
+    payload = registry_path.read_bytes()
+    monkeypatch.setenv(CLUSTER_REGISTRY_ENV, str(registry_path))
+    monkeypatch.setenv(
+        "CLIO_RELAY_SESSION_REGISTRY_SHA256",
+        hashlib.sha256(payload).hexdigest(),
+    )
+    monkeypatch.setenv(
+        "CLIO_RELAY_SESSION_ROUTE_REVISION",
+        cluster_route_revision(definition),
+    )
 
 
 def _producer_artifact(queue: ClioCoreQueue) -> tuple[RelayJob, ArtifactRef]:
@@ -170,7 +196,9 @@ def test_core_rejects_cross_session_artifact_use_before_idempotency_reservation(
 
 def test_owned_http_submission_rejects_other_session_artifact(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _bind_owned_session_cluster_authority(monkeypatch, tmp_path)
     core_dir = tmp_path / "core"
     queue = ClioCoreQueue(core_dir)
     for session_id, generation_id in (

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1699,7 +1699,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "3ef31b0f5ce75c626de7c00f9c2a432e12adbad88c89cd77c8a630429bbea55b"
+        "696ef04cea5755ad899b70f57147d397f7d8c19e6a0ac3b968aaedc125df312e"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1699,7 +1699,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "696ef04cea5755ad899b70f57147d397f7d8c19e6a0ac3b968aaedc125df312e"
+        "6537d915d549074c8516ae3361531545a2a0501c4d62009d5182c010e5b8b261"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import hashlib
+import json
+import os
 from datetime import timedelta
 from pathlib import Path
 from typing import Any, cast
@@ -9,9 +12,11 @@ from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
 from clio_relay.cluster_config import (
+    CLUSTER_REGISTRY_ENV,
     ClusterDefinition,
     ClusterRegistry,
     RemoteMcpServerConfig,
+    cluster_route_revision,
 )
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
@@ -32,6 +37,7 @@ from clio_relay.models import (
     McpAdmissionAuthority,
     McpAdmissionClass,
     McpCallSpec,
+    McpControlQueryEvidence,
     McpOperation,
     MonitorRule,
     RelayJob,
@@ -40,12 +46,44 @@ from clio_relay.models import (
     TaskTimelineEvent,
     utc_now,
 )
+from clio_relay.remote_mcp import (
+    cache_entry_from_discovery_artifact,
+    remote_mcp_registration_revision,
+    remote_mcp_server_artifact_digest,
+)
 from clio_relay.session_api import (
     OWNER_SESSION_ID_HEADER,
     SESSION_GENERATION_ID_HEADER,
     session_identity_document,
 )
+from clio_relay.spool import JobSpool
 from clio_relay.storage_runtime import StorageManagedQueue
+
+
+def _bind_owned_session_cluster_authority(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    definition: ClusterDefinition | None = None,
+) -> ClusterDefinition:
+    """Bind one exact test cluster definition as owned-session process authority."""
+    bound_definition = definition or ClusterDefinition(
+        name="test-cluster",
+        ssh_host="test-cluster",
+    )
+    registry_path = tmp_path / "session-authority" / "clusters.json"
+    ClusterRegistry(clusters={bound_definition.name: bound_definition}).save(registry_path)
+    payload = registry_path.read_bytes()
+    monkeypatch.setenv(CLUSTER_REGISTRY_ENV, str(registry_path))
+    monkeypatch.setenv(
+        "CLIO_RELAY_SESSION_REGISTRY_SHA256",
+        hashlib.sha256(payload).hexdigest(),
+    )
+    monkeypatch.setenv(
+        "CLIO_RELAY_SESSION_ROUTE_REVISION",
+        cluster_route_revision(bound_definition),
+    )
+    return bound_definition
 
 
 def test_http_monitor_logs_and_artifact_content(tmp_path: Path) -> None:
@@ -854,7 +892,337 @@ def test_owned_session_api_fails_closed_without_cluster_or_owner_token(tmp_path:
         )
 
 
-def test_owned_session_identity_challenge_is_public_and_exact(tmp_path: Path) -> None:
+def test_owned_session_api_fails_closed_without_exact_process_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        api_token="session-api-token",
+        owner_session_id="desktop-session-1",
+        owner_session_generation_id="generation-1",
+        owner_session_cluster="test-cluster",
+        session_owner_token="o" * 32,
+    )
+
+    with pytest.raises(ConfigurationError, match="process-bound cluster authority"):
+        create_app(settings)
+
+    _bind_owned_session_cluster_authority(monkeypatch, tmp_path)
+    monkeypatch.delenv("CLIO_RELAY_SESSION_ROUTE_REVISION")
+    with pytest.raises(ConfigurationError, match="must be configured together"):
+        create_app(settings)
+
+    _bind_owned_session_cluster_authority(monkeypatch, tmp_path)
+    monkeypatch.setenv(CLUSTER_REGISTRY_ENV, "")
+    with pytest.raises(ConfigurationError, match="path must not be blank"):
+        create_app(settings)
+
+
+def test_owned_session_api_rejects_invalid_or_ambiguous_process_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    definition = ClusterDefinition(name="test-cluster", ssh_host="test-cluster")
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        api_token="session-api-token",
+        owner_session_id="desktop-session-1",
+        owner_session_generation_id="generation-1",
+        owner_session_cluster="test-cluster",
+        session_owner_token="o" * 32,
+    )
+
+    _bind_owned_session_cluster_authority(monkeypatch, tmp_path, definition=definition)
+    monkeypatch.setenv("CLIO_RELAY_SESSION_REGISTRY_SHA256", "invalid")
+    with pytest.raises(ConfigurationError, match="registry SHA-256 is invalid"):
+        create_app(settings)
+
+    _bind_owned_session_cluster_authority(monkeypatch, tmp_path, definition=definition)
+    monkeypatch.setenv("CLIO_RELAY_SESSION_ROUTE_REVISION", "invalid")
+    with pytest.raises(ConfigurationError, match="route revision is invalid"):
+        create_app(settings)
+
+    _bind_owned_session_cluster_authority(monkeypatch, tmp_path, definition=definition)
+    monkeypatch.setenv("CLIO_RELAY_SESSION_REGISTRY_SHA256", "f" * 64)
+    with pytest.raises(ConfigurationError, match="registry digest does not match"):
+        create_app(settings)
+
+    _bind_owned_session_cluster_authority(monkeypatch, tmp_path, definition=definition)
+    monkeypatch.setenv("CLIO_RELAY_SESSION_ROUTE_REVISION", "f" * 64)
+    with pytest.raises(ConfigurationError, match="route revision does not match"):
+        create_app(settings)
+
+    _bind_owned_session_cluster_authority(monkeypatch, tmp_path, definition=definition)
+    registry_path = Path(os.environ[CLUSTER_REGISTRY_ENV])
+    ClusterRegistry(
+        clusters={
+            "test-cluster": definition,
+            "other-cluster": ClusterDefinition(
+                name="other-cluster",
+                ssh_host="other-cluster",
+            ),
+        }
+    ).save(registry_path)
+    monkeypatch.setenv(
+        "CLIO_RELAY_SESSION_REGISTRY_SHA256",
+        hashlib.sha256(registry_path.read_bytes()).hexdigest(),
+    )
+    with pytest.raises(ConfigurationError, match="exactly the owner session cluster"):
+        create_app(settings)
+
+
+def test_normal_desktop_api_accepts_operator_registry_without_session_markers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registration = RemoteMcpServerConfig(
+        command="science-mcp",
+        args=["--stdio"],
+        allow_tools=["inspect"],
+        profiles=["user"],
+        call_timeout_seconds=30,
+    )
+    definition = ClusterDefinition(
+        name="alpha",
+        ssh_host="alpha-login",
+        remote_mcp_servers={"science": registration},
+    )
+    registry_path = tmp_path / "desktop-registry" / "clusters.json"
+    ClusterRegistry(clusters={"alpha": definition}).save(registry_path)
+    monkeypatch.setenv(CLUSTER_REGISTRY_ENV, str(registry_path))
+    monkeypatch.delenv("CLIO_RELAY_SESSION_REGISTRY_SHA256", raising=False)
+    monkeypatch.delenv("CLIO_RELAY_SESSION_ROUTE_REVISION", raising=False)
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    client = cast(Any, TestClient(create_app(settings)))
+
+    response = client.post(
+        "/jobs/mcp-call",
+        json={
+            "cluster": "alpha",
+            "server": registration.command,
+            "server_args": registration.args,
+            "operation": "tools/list",
+            "timeout_seconds": 30,
+            "idempotency_key": "desktop-science-discovery",
+        },
+    )
+
+    assert response.status_code == 200
+    job = queue.get_job(response.json()["job_id"])
+    assert isinstance(job.spec, McpCallSpec)
+    assert job.spec.admission_class is McpAdmissionClass.CONTROL_QUERY
+
+
+def test_owned_registered_mcp_call_uses_immutable_session_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registration = RemoteMcpServerConfig(
+        command="science-mcp",
+        args=["--stdio"],
+        env_from={"SCIENCE_TOKEN": "SITE_SCIENCE_TOKEN"},
+        allow_tools=["inspect"],
+        profiles=["user"],
+        call_timeout_seconds=30,
+        schema_cache_ttl_seconds=3600,
+    )
+    definition = ClusterDefinition(
+        name="alpha",
+        ssh_host="alpha-login",
+        remote_mcp_servers={"science": registration},
+    )
+    _bind_owned_session_cluster_authority(
+        monkeypatch,
+        tmp_path,
+        definition=definition,
+    )
+    registry_path = Path(os.environ[CLUSTER_REGISTRY_ENV])
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        api_token="session-api-token",
+        owner_session_id="desktop-session-1",
+        owner_session_generation_id="generation-1",
+        owner_session_cluster="alpha",
+        session_owner_token="o" * 32,
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+    queue.prepare_owner_session_start(
+        "desktop-session-1",
+        recorded_generation_id=None,
+        candidate_generation_id="generation-1",
+    )
+    discovery = queue.submit_job(
+        RelayJob(
+            cluster="alpha",
+            kind=JobKind.MCP_CALL,
+            spec=McpCallSpec(
+                server=registration.command,
+                server_args=registration.args,
+                env_from=registration.env_from,
+                operation=McpOperation.TOOLS_LIST,
+                admission_class=McpAdmissionClass.CONTROL_QUERY,
+            ),
+            idempotency_key="owned-http-science-discovery",
+        )
+    )
+    server_artifact = {
+        "verified": True,
+        "server_process_artifact_verified": True,
+        "executable": {
+            "path": "/opt/science/bin/science-mcp",
+            "sha256": "a" * 64,
+        },
+    }
+    discovery_payload = json.dumps(
+        {
+            "server": registration.command,
+            "server_args": registration.args,
+            "env_from": registration.env_from,
+            "operation": "tools/list",
+            "tool": None,
+            "arguments": {},
+            "protocol_result": {
+                "tools": [
+                    {
+                        "name": "inspect",
+                        "description": "Inspect one scientific dataset.",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {"path": {"type": "string"}},
+                            "required": ["path"],
+                            "additionalProperties": False,
+                        },
+                        "annotations": {
+                            "readOnlyHint": True,
+                            "destructiveHint": False,
+                        },
+                    }
+                ]
+            },
+            "structured_result": None,
+            "protocol_version": "2024-11-05",
+            "server_info": {"name": "science", "version": "1.2.3"},
+            "server_artifact": server_artifact,
+            "returncode": 0,
+            "stdout": "",
+            "stderr": "",
+            "timed_out": False,
+            "protocol_error": None,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    spool = JobSpool(settings.spool_dir, discovery)
+    spool.initialize()
+    result_path = spool.path / "mcp-result.json"
+    result_path.write_bytes(discovery_payload)
+    artifact = queue.append_artifact(spool.artifact_for(result_path, kind="mcp_result"))
+    assert artifact.sha256 is not None
+    artifact_sha256 = artifact.sha256
+    discovery = queue.update_job_state(discovery.job_id, JobState.SUCCEEDED)
+    entry = cache_entry_from_discovery_artifact(
+        cluster="alpha",
+        server_name="science",
+        registration=registration,
+        discovery_job_id=discovery.job_id,
+        artifact_id=artifact.artifact_id,
+        artifact_sha256=artifact_sha256,
+        artifact_payload=discovery_payload,
+        discovered_at=discovery.updated_at,
+    )
+    server_digest = remote_mcp_server_artifact_digest(entry.provenance.server_artifact)
+    evidence = McpControlQueryEvidence(
+        cluster="alpha",
+        registered_server_name="science",
+        cluster_route_revision=cluster_route_revision(definition),
+        registration_revision=remote_mcp_registration_revision(registration),
+        discovery_job_id=discovery.job_id,
+        discovery_artifact_id=artifact.artifact_id,
+        discovery_artifact_sha256=artifact_sha256,
+        discovery_schema_digest=entry.schema_digest,
+        expected_server_artifact_digest=server_digest,
+    )
+    app = create_app(settings)
+    changed_definition = definition.model_copy(update={"ssh_host": "changed-login"})
+    ClusterRegistry(clusters={"alpha": changed_definition}).save(registry_path)
+    client = cast(
+        Any,
+        TestClient(
+            app,
+            headers={
+                "Authorization": "Bearer session-api-token",
+                OWNER_SESSION_ID_HEADER: "desktop-session-1",
+                SESSION_GENERATION_ID_HEADER: "generation-1",
+            },
+        ),
+    )
+    request = {
+        "cluster": "alpha",
+        "server": registration.command,
+        "server_args": registration.args,
+        "env_from": registration.env_from,
+        "expected_server_artifact_digest": server_digest,
+        "operation": "tools/call",
+        "tool": "inspect",
+        "arguments": {"path": "/datasets/example.bp"},
+        "control_query_evidence": evidence.model_dump(mode="json"),
+        "timeout_seconds": 30,
+        "idempotency_key": "owned-http-science-inspect",
+    }
+
+    accepted = client.post("/jobs/mcp-call", json=request)
+    assert accepted.status_code == 200
+    accepted_job = queue.get_job(accepted.json()["job_id"])
+    assert isinstance(accepted_job.spec, McpCallSpec)
+    assert accepted_job.spec.admission_class is McpAdmissionClass.CONTROL_QUERY
+    authority = McpAdmissionAuthority.model_validate(
+        accepted_job.metadata[MCP_ADMISSION_AUTHORITY_METADATA_KEY]
+    )
+    assert authority.source == "registered_discovery_artifact"
+    assert authority.evidence == evidence
+
+    route_drift = client.post(
+        "/jobs/mcp-call",
+        json={
+            **request,
+            "idempotency_key": "owned-http-science-route-drift",
+            "control_query_evidence": {
+                **evidence.model_dump(mode="json"),
+                "cluster_route_revision": cluster_route_revision(changed_definition),
+            },
+        },
+    )
+    assert route_drift.status_code == 409
+    assert "cluster route changed" in route_drift.json()["detail"]
+
+    registration_drift = client.post(
+        "/jobs/mcp-call",
+        json={
+            **request,
+            "idempotency_key": "owned-http-science-registration-drift",
+            "control_query_evidence": {
+                **evidence.model_dump(mode="json"),
+                "registration_revision": "f" * 64,
+            },
+        },
+    )
+    assert registration_drift.status_code == 409
+    assert "registered MCP server changed" in registration_drift.json()["detail"]
+
+    with pytest.raises(ConfigurationError, match="registry digest does not match"):
+        create_app(settings)
+
+
+def test_owned_session_identity_challenge_is_public_and_exact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _bind_owned_session_cluster_authority(monkeypatch, tmp_path)
     settings = RelaySettings(
         core_dir=tmp_path / "core",
         spool_dir=tmp_path / "spool",
@@ -882,7 +1250,9 @@ def test_owned_session_identity_challenge_is_public_and_exact(tmp_path: Path) ->
 
 def test_owned_session_api_stamps_jobs_and_gateways_with_server_ownership(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _bind_owned_session_cluster_authority(monkeypatch, tmp_path)
     settings = RelaySettings(
         core_dir=tmp_path / "core",
         spool_dir=tmp_path / "spool",
@@ -961,7 +1331,9 @@ def test_owned_session_api_stamps_jobs_and_gateways_with_server_ownership(
 
 def test_session_job_submission_rejects_missing_stale_and_unbound_identity(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _bind_owned_session_cluster_authority(monkeypatch, tmp_path)
     settings = RelaySettings(
         core_dir=tmp_path / "core",
         spool_dir=tmp_path / "spool",
@@ -1038,6 +1410,9 @@ def test_session_job_submission_rejects_missing_stale_and_unbound_identity(
     assert queue.list_jobs() == []
     assert queue.list_gateway_sessions() == []
 
+    monkeypatch.delenv(CLUSTER_REGISTRY_ENV)
+    monkeypatch.delenv("CLIO_RELAY_SESSION_REGISTRY_SHA256")
+    monkeypatch.delenv("CLIO_RELAY_SESSION_ROUTE_REVISION")
     unbound_settings = RelaySettings(
         core_dir=tmp_path / "unbound-core",
         spool_dir=tmp_path / "unbound-spool",
@@ -1060,6 +1435,7 @@ def test_owned_jarvis_mcp_submission_forwards_desktop_binding_without_remote_cac
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _bind_owned_session_cluster_authority(monkeypatch, tmp_path)
     expected_digest = "a" * 64
     settings = RelaySettings(
         core_dir=tmp_path / "core",
@@ -1222,6 +1598,7 @@ def test_owned_session_submission_race_with_quiesce_returns_conflict(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _bind_owned_session_cluster_authority(monkeypatch, tmp_path)
     settings = RelaySettings(
         core_dir=tmp_path / "core",
         spool_dir=tmp_path / "spool",
@@ -1272,7 +1649,11 @@ def test_owned_session_submission_race_with_quiesce_returns_conflict(
     assert queue.list_jobs() == []
 
 
-def test_owned_session_api_cannot_take_over_or_close_other_gateways(tmp_path: Path) -> None:
+def test_owned_session_api_cannot_take_over_or_close_other_gateways(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _bind_owned_session_cluster_authority(monkeypatch, tmp_path)
     settings = RelaySettings(
         core_dir=tmp_path / "core",
         spool_dir=tmp_path / "spool",
@@ -1367,7 +1748,9 @@ def test_owned_session_api_cannot_take_over_or_close_other_gateways(tmp_path: Pa
 
 def test_owned_session_api_filters_jobs_redacts_capabilities_and_quiesces_intake(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _bind_owned_session_cluster_authority(monkeypatch, tmp_path)
     settings = RelaySettings(
         core_dir=tmp_path / "core",
         spool_dir=tmp_path / "spool",

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.5"
+    assert version == "1.4.6"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_remote_mcp.py
+++ b/tests/test_remote_mcp.py
@@ -5112,17 +5112,12 @@ def test_cli_validate_catalog_waits_and_projects_automatic_assertion(
             Path(remote_mcp.__file__).with_name("_contracts") / "scientific-catalog-user-v1.1.json"
         ).read_text(encoding="utf-8")
     )
-    refreshed_at = datetime.now(UTC)
-    discovery_entry = _entry(
+    discovery_entry = _persist_discovery_entry(
+        tmp_path,
         registration,
         cluster="alpha",
         server_name="scientific-catalog",
         tools=cast(list[dict[str, object]], contract_artifact["tools"]),
-    ).model_copy(
-        update={
-            "discovered_at": refreshed_at,
-            "expires_at": refreshed_at + timedelta(hours=1),
-        }
     )
     RemoteMcpSchemaCache.update_entry(
         tmp_path / ".clio-relay" / "remote-mcp-cache.json",
@@ -6050,6 +6045,55 @@ def _entry(
         artifact_sha256=hashlib.sha256(artifact_payload).hexdigest(),
         artifact_payload=artifact_payload,
         discovered_at=NOW,
+    )
+
+
+def _persist_discovery_entry(
+    root: Path,
+    registration: RemoteMcpServerConfig,
+    *,
+    cluster: str,
+    server_name: str,
+    tools: list[dict[str, object]],
+) -> RemoteMcpSchemaCacheEntry:
+    """Persist one production-shaped discovery job, artifact, and cache entry."""
+    queue = ClioCoreQueue(root / "core")
+    discovery = queue.submit_job(
+        RelayJob(
+            cluster=cluster,
+            kind=JobKind.MCP_CALL,
+            spec=McpCallSpec(
+                server=registration.command,
+                server_args=registration.args,
+                env_from=registration.env_from,
+                operation=McpOperation.TOOLS_LIST,
+                admission_class=McpAdmissionClass.CONTROL_QUERY,
+                timeout_seconds=registration.call_timeout_seconds,
+            ),
+            idempotency_key=f"discovery:{cluster}:{server_name}",
+        )
+    )
+    payload = _discovery_artifact(registration, tools=tools)
+    spool = JobSpool(root / "spool", discovery)
+    spool.initialize()
+    result_path = spool.path / "mcp-result.json"
+    result_path.write_bytes(payload)
+    artifact = queue.append_artifact(spool.artifact_for(result_path, kind="mcp_result"))
+    assert artifact.sha256 is not None
+    discovery = queue.update_job_state(
+        discovery.job_id,
+        JobState.SUCCEEDED,
+        message="discovery complete",
+    )
+    return cache_entry_from_discovery_artifact(
+        cluster=cluster,
+        server_name=server_name,
+        registration=registration,
+        discovery_job_id=discovery.job_id,
+        artifact_id=artifact.artifact_id,
+        artifact_sha256=artifact.sha256,
+        artifact_payload=payload,
+        discovered_at=discovery.updated_at,
     )
 
 

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -10,7 +10,11 @@ from pytest import MonkeyPatch
 
 import clio_relay.session_lifecycle as session_lifecycle
 from clio_relay import __version__
-from clio_relay.cluster_config import ClusterDefinition
+from clio_relay.cluster_config import (
+    MAX_CLUSTER_REGISTRY_BYTES,
+    ClusterDefinition,
+    RemoteMcpServerConfig,
+)
 from clio_relay.errors import RelayError
 from clio_relay.session_lifecycle import (
     SESSION_CONNECTORS_CHECK_ID,
@@ -275,6 +279,23 @@ def test_start_remote_session_writes_owned_pid_and_metadata(monkeypatch: MonkeyP
     assert "flock -w 10 -x 9" in script
     assert "CLIO_RELAY_SESSION_GENERATION_ID" in script
     assert "CLIO_RELAY_API_RELEASE_IDENTITY_SHA256" in script
+    assert (
+        'cluster_registry_file="$session_dir/cluster-registry-$session_generation_id.json"'
+        in script
+    )
+    assert "printf '%s'" in script
+    assert (
+        '"$cluster_registry_candidate" "$cluster_registry_file" "$cluster_registry_sha256"'
+        in script
+    )
+    assert "CLIO_RELAY_SESSION_REGISTRY_SHA256" in script
+    assert "CLIO_RELAY_SESSION_ROUTE_REVISION" in script
+    assert "cluster_registry_path" in script
+    assert "cluster_registry_sha256" in script
+    assert "cluster_route_revision" in script
+    assert '"cluster_authority_verified": True' in script
+    assert "Path(registry_path).unlink(missing_ok=True)" in script
+    assert "$cluster_registry_json" not in script
     assert "clio-relay.session-api-release.v1" in script
     assert "session API installation changed after worker compatibility verification" in script
     assert "existing owned session API has no release identity; use --replace" in script
@@ -342,6 +363,97 @@ def test_start_remote_session_checks_existing_api_release_before_reuse(
     )
     assert '(Path("/proc") / pid / "environ")' in script
     assert "CLIO_RELAY_API_RELEASE_IDENTITY_SHA256={observed_sha256}" in script
+    assert "existing owned session API cluster authority differs; use --replace" in script
+    assert (
+        "existing owned session API cluster authority is not process-bound; use --replace" in script
+    )
+    assert "cluster_authority_verified" in script
+    assert script.index("__CLIO_RELAY_EXISTING_API_RELEASE__") < script.index(
+        'echo "session_already_running=$session_id"'
+    )
+
+
+def test_start_remote_session_stages_large_registry_without_python_argv(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scripts: list[str] = []
+
+    def fake_run(
+        command: list[str],
+        *,
+        input: bytes,
+        capture_output: bool,
+        check: bool,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[bytes]:
+        del capture_output, check, timeout
+        scripts.append(input.decode("utf-8"))
+        return subprocess.CompletedProcess(command, 0, b"session_started=session-1\n", b"")
+
+    monkeypatch.setattr("clio_relay.session_lifecycle.subprocess.run", fake_run)
+    registration = RemoteMcpServerConfig(
+        command="science-mcp",
+        args=[f"{index:03d}-" + ("x" * 4_000) for index in range(40)],
+        allow_tools=["inspect"],
+    )
+
+    start_remote_session(
+        cluster="alpha",
+        definition=ClusterDefinition(
+            name="alpha",
+            ssh_host="alpha",
+            remote_mcp_servers={"science": registration},
+        ),
+        session_id="session-1",
+        remote_api_port=9001,
+        api_token="token",
+        expected_api_release_identity=_api_release_identity(),
+    )
+
+    script = scripts[0]
+    assert len(script.encode("utf-8")) > 128 * 1024
+    assert "printf '%s'" in script
+    registry_path_arguments = (
+        '"$cluster_registry_candidate" "$cluster_registry_file" "$cluster_registry_sha256"'
+    )
+    assert registry_path_arguments in script
+    assert script.index("python3 -", script.index("printf '%s'")) < script.index(
+        registry_path_arguments
+    )
+    assert 'python3 - "{\\"clusters\\"' not in script
+
+
+def test_start_remote_session_rejects_registry_over_configuration_limit(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    def unexpected_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        del args, kwargs
+        pytest.fail("oversized session authority must fail before SSH")
+
+    monkeypatch.setattr("clio_relay.session_lifecycle.subprocess.run", unexpected_run)
+    registration = RemoteMcpServerConfig(
+        command="science-mcp",
+        args=["x" * 4_000 for _ in range(256)],
+        allow_tools=["inspect"],
+    )
+    definition = ClusterDefinition(
+        name="alpha",
+        ssh_host="alpha",
+        remote_mcp_servers={f"science-{index}": registration for index in range(5)},
+    )
+
+    with pytest.raises(
+        RelayError,
+        match=rf"{MAX_CLUSTER_REGISTRY_BYTES}-byte configuration limit",
+    ):
+        start_remote_session(
+            cluster="alpha",
+            definition=definition,
+            session_id="session-1",
+            remote_api_port=9001,
+            api_token="token",
+            expected_api_release_identity=_api_release_identity(),
+        )
 
 
 def test_status_remote_session_returns_json(monkeypatch: MonkeyPatch) -> None:

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1860,13 +1860,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.5-py3-none-any.whl",
+            resource_id="clio-relay-1.4.6-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.5.tar.gz",
+            resource_id="clio_relay-1.4.6.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2005,7 +2005,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.5"
+    assert policy.release_version == "1.4.6"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.5"
+version = "1.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- Stage the operator-selected cluster definition as an exact, generation-scoped registry for every owned relay API.
- Bind its path, SHA-256, and route revision into the API process and retain the validated definition immutably after startup.
- Fail closed on missing, partial, oversized, mutated, multi-cluster, route-drifted, or registration-drifted authority.
- Preserve ordinary non-session registry behavior and clean staged authority after incomplete startup.
- Update delayed-CI fixtures to use supervised worker generations and real durable MCP discovery artifacts.
- Prepare the `1.4.6` release identity and acceptance matrix.

## Root cause

The desktop discovered registered MCP contracts from its operator registry, but the owned Ares API loaded an incidental cluster-side registry. Those two route authorities differed, so production catalog calls correctly failed closed with HTTP 409 even though pinned JARVIS calls worked.

## Focused validation

- 7 new authority/lifecycle/artifact tests passed.
- 5 exact delayed-CI nodes passed.
- 2 integrated release-identity checks passed.
- Additional focused branch checks covered 20 authority tests, 8 CI/invariant tests, and 27 release-policy tests.
- Ruff, Pyright, `uv lock --check`, and `git diff --check` passed.

The repository-wide regression is intentionally left to the asynchronous tag workflow.