### PR TITLE
fix: preserve owned runtime authority and Windows cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.6` uses a release-first patch process. A maintainer builds the
+> Version `1.4.7` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.6"
+$Version = "1.4.7"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.6"
+release_version: "1.4.7"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 6537d915d549074c8516ae3361531545a2a0501c4d62009d5182c010e5b8b261
+acceptance_matrix_sha256: 06df1af0350d54e090ae43c6005b6d081f1620547fd7dd6ed45710e790b07723
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.6"
+$Tag = "v1.4.7"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.6" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.7" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.6",
-  "matrix_sha256": "6537d915d549074c8516ae3361531545a2a0501c4d62009d5182c010e5b8b261",
+  "release_version": "1.4.7",
+  "matrix_sha256": "06df1af0350d54e090ae43c6005b6d081f1620547fd7dd6ed45710e790b07723",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.6"
+version = "1.4.7"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.6"
+__version__ = "1.4.7"

--- a/src/clio_relay/http_api.py
+++ b/src/clio_relay/http_api.py
@@ -40,8 +40,8 @@ from clio_relay.cluster_config import (
 )
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
-from clio_relay.errors import ConfigurationError, NotFoundError, QueueConflictError
-from clio_relay.identifiers import DurableRecordId
+from clio_relay.errors import ConfigurationError, NotFoundError, QueueConflictError, RelayError
+from clio_relay.identifiers import DurableRecordId, validate_durable_record_id
 from clio_relay.jarvis_mcp import (
     is_virtual_jarvis_control_query,
     jarvis_cd_lock_binding_expectation,
@@ -49,6 +49,13 @@ from clio_relay.jarvis_mcp import (
     jarvis_mcp_env_from,
     jarvis_mcp_server,
     jarvis_mcp_server_args,
+)
+from clio_relay.jarvis_service_runtime import (
+    OWNED_SESSION_JARVIS_RUNTIME_AUTHORITY_PATH,
+    JarvisServiceRuntimeBinding,
+    private_jarvis_service_runtime_authority_document,
+    resolve_local_verified_jarvis_service_runtime_authority,
+    reverify_jarvis_service_runtime,
 )
 from clio_relay.models import (
     MCP_ADMISSION_AUTHORITY_METADATA_KEY,
@@ -656,6 +663,14 @@ class GatewaySessionUpdateRequest(BaseModel):
     _metadata_is_not_runtime_owned = field_validator("metadata")(_validate_generic_gateway_metadata)
 
 
+class JarvisRuntimeAuthorityRequest(BaseModel):
+    """Private exact-binding request accepted only by an owned session API."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    binding: JarvisServiceRuntimeBinding
+
+
 _SESSION_REGISTRY_SHA256_ENV = "CLIO_RELAY_SESSION_REGISTRY_SHA256"
 _SESSION_ROUTE_REVISION_ENV = "CLIO_RELAY_SESSION_ROUTE_REVISION"
 
@@ -933,6 +948,49 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
     def storage_status() -> dict[str, object]:
         """Return the machine-readable queue admission and storage decision."""
         return _public_payload(queue.storage_runtime.status())
+
+    @app.post(
+        OWNED_SESSION_JARVIS_RUNTIME_AUTHORITY_PATH,
+        dependencies=[auth_dependency],
+        include_in_schema=False,
+    )
+    def resolve_owned_jarvis_runtime_authority(
+        request: JarvisRuntimeAuthorityRequest,
+    ) -> dict[str, object]:
+        """Resolve one private capability on its exact receipt-owning cluster host."""
+        if (
+            resolved.owner_session_id is None
+            or owner_session_cluster_definition is None
+            or not resolved.api_token
+        ):
+            raise HTTPException(
+                status_code=404,
+                detail="owned JARVIS runtime authority resolver is unavailable",
+            )
+        binding = request.binding
+        try:
+            require_owned_job(validate_durable_record_id(binding.source_relay_job_id))
+            require_owned_artifact(validate_durable_record_id(binding.source_relay_artifact_id))
+            verified = reverify_jarvis_service_runtime(
+                queue=queue,
+                definition=owner_session_cluster_definition,
+                settings=None,
+                binding_document=binding.model_dump(mode="json"),
+            )
+            authority = resolve_local_verified_jarvis_service_runtime_authority(
+                jarvis_bin=resolved.jarvis_bin,
+                verified=verified,
+            )
+            if authority is None:
+                raise ConfigurationError("legacy JARVIS service runtimes have no private authority")
+            # This one response is intentionally not passed through the public
+            # payload redactor. It travels only on the authenticated,
+            # identity-bound owned-session connection and is never persisted.
+            return private_jarvis_service_runtime_authority_document(authority)
+        except NotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except (ConfigurationError, RelayError, ValueError) as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
 
     @app.post(
         "/jobs",

--- a/src/clio_relay/jarvis_service_runtime.py
+++ b/src/clio_relay/jarvis_service_runtime.py
@@ -49,6 +49,7 @@ RELAY_JARVIS_RUNTIME_BINDING_SCHEMA_V1 = "clio-relay.jarvis-service-runtime-bind
 RELAY_JARVIS_RUNTIME_BINDING_SCHEMA_V2 = "clio-relay.jarvis-service-runtime-binding.v2"
 RELAY_JARVIS_RUNTIME_BINDING_SCHEMA = RELAY_JARVIS_RUNTIME_BINDING_SCHEMA_V2
 JARVIS_SERVICE_RUNTIME_AUTHORITY_SCHEMA = "jarvis.execution.service-runtime-authority.v1"
+OWNED_SESSION_JARVIS_RUNTIME_AUTHORITY_PATH = "/internal/jarvis-runtime-authority"
 _HEX_DIGITS = frozenset("0123456789abcdef")
 _MAX_AUTHORITY_OUTPUT_BYTES = 32 * 1024
 _AUTHORITY_QUERY_TIMEOUT_SECONDS = 30
@@ -670,7 +671,22 @@ def resolve_jarvis_service_runtime_authorization(
         revision=binding.service_revision,
         token_sha256=expected_digest,
     )
-    if should_execute_on_cluster(definition):
+    if settings is not None and settings.owner_session_id is not None:
+        # Browser attachment is deliberately desktop-local, but the private
+        # capability belongs to JARVIS on the cluster that owns the immutable
+        # execution receipt. Resolve it through the already identity-proven,
+        # exact-generation session API instead of consulting desktop PATH.
+        with OwnedSessionApiClient(definition=definition, settings=settings) as client:
+            document = _json_object(
+                client.request_json(
+                    method="POST",
+                    path=OWNED_SESSION_JARVIS_RUNTIME_AUTHORITY_PATH,
+                    body={"binding": binding.model_dump(mode="json")},
+                ),
+                "owned JARVIS service runtime authority resolver",
+            )
+        authority = JarvisServiceRuntimeAuthority.model_validate(document)
+    elif should_execute_on_cluster(definition):
         payload = run_remote_jarvis_runtime_authority(
             definition,
             arguments,
@@ -684,17 +700,40 @@ def resolve_jarvis_service_runtime_authorization(
         authority = JarvisServiceRuntimeAuthority.model_validate(document)
     else:
         resolved_settings = settings or RelaySettings.from_env()
-        authority = resolve_local_jarvis_service_runtime_authority(
+        authority = resolve_local_verified_jarvis_service_runtime_authority(
             jarvis_bin=resolved_settings.jarvis_bin,
-            execution_id=binding.jarvis_execution_id,
-            pipeline_id=pipeline_id,
-            package_id=binding.package_id,
-            service_instance_id=binding.service_instance_id,
-            revision=binding.service_revision,
-            token_sha256=expected_digest,
+            verified=verified,
         )
+        if authority is None:
+            raise RelayError("authenticated JARVIS runtime authority unexpectedly resolved empty")
     _validate_resolved_authority(verified=verified, authority=authority)
     return f"Bearer {authority.authorization.token.get_secret_value()}"
+
+
+def resolve_local_verified_jarvis_service_runtime_authority(
+    *,
+    jarvis_bin: str,
+    verified: VerifiedJarvisServiceRuntime,
+) -> JarvisServiceRuntimeAuthority | None:
+    """Resolve and revalidate one exact verified runtime on its cluster host."""
+    runtime = verified.runtime
+    binding = verified.binding
+    if runtime.schema_version == JARVIS_SERVICE_RUNTIME_SCHEMA_V1:
+        return None
+    expected_digest = binding.authorization_sha256
+    if expected_digest is None:
+        raise RelayError("authenticated JARVIS runtime omitted its authority digest")
+    authority = resolve_local_jarvis_service_runtime_authority(
+        jarvis_bin=jarvis_bin,
+        execution_id=binding.jarvis_execution_id,
+        pipeline_id=verified.native_execution.execution_handle.pipeline_id,
+        package_id=binding.package_id,
+        service_instance_id=binding.service_instance_id,
+        revision=binding.service_revision,
+        token_sha256=expected_digest,
+    )
+    _validate_resolved_authority(verified=verified, authority=authority)
+    return authority
 
 
 def resolve_local_jarvis_service_runtime_authority(

--- a/src/clio_relay/service_runtime.py
+++ b/src/clio_relay/service_runtime.py
@@ -7599,10 +7599,20 @@ def _local_process_ids(*, command_markers: tuple[str, ...] = ()) -> list[int]:
         if not isinstance(item, dict):
             raise RelayError("local Windows process enumeration returned an invalid record")
         record = cast(dict[str, object], item)
-        process_id = _optional_int(record.get("ProcessId"))
+        raw_process_id = record.get("ProcessId")
         command_line = record.get("CommandLine")
-        if process_id is None or process_id <= 0:
+        if (
+            isinstance(raw_process_id, bool)
+            or not isinstance(raw_process_id, int)
+            or raw_process_id < 0
+        ):
             raise RelayError("local Windows process enumeration returned an invalid process id")
+        # Win32_Process includes the System Idle Process as PID 0. It cannot own
+        # or be signaled as a connector, while every relay process identity is
+        # strictly positive, so omit only this Windows sentinel from discovery.
+        if raw_process_id == 0:
+            continue
+        process_id = raw_process_id
         if folded_markers:
             if not isinstance(command_line, str):
                 continue

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1699,7 +1699,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "6537d915d549074c8516ae3361531545a2a0501c4d62009d5182c010e5b8b261"
+        "06df1af0350d54e090ae43c6005b6d081f1620547fd7dd6ed45710e790b07723"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6020,7 +6020,9 @@ def test_cli_mcp_call_rejects_public_admission_class_option(
     )
 
     assert result.exit_code == 2
-    assert "No such option: --admission-class" in result.output
+    output = unstyle(result.output)
+    assert "No such option" in output
+    assert "--admission-class" in output
 
 
 def test_cli_arbitrary_tools_list_remains_workload(

--- a/tests/test_jarvis_handle_first_admission.py
+++ b/tests/test_jarvis_handle_first_admission.py
@@ -217,7 +217,7 @@ def test_idempotent_retry_replays_pre_handle_jarvis_record(
 def test_raw_http_submission_cannot_select_jarvis_handle_identity(
     tmp_path: Path,
 ) -> None:
-    """The authenticated raw route still receives server-owned job entropy."""
+    """The raw route rejects MCP jobs before caller identity reaches intake."""
     settings = RelaySettings(
         core_dir=tmp_path / "core",
         spool_dir=tmp_path / "spool",
@@ -233,23 +233,11 @@ def test_raw_http_submission_cannot_select_jarvis_handle_identity(
 
     response = client.post("/jobs", json=submission.model_dump(mode="json"))
 
-    assert response.status_code == 200
-    accepted = queue.get_job(response.json()["job_id"])
-    assert accepted.job_id != caller_job_id
-    assert _mcp_spec(accepted).arguments["execution_id"] == (
-        deterministic_jarvis_execution_id(
-            cluster=accepted.cluster,
-            idempotency_key=accepted.idempotency_key,
-            job_id=accepted.job_id,
-        )
+    assert response.status_code == 422
+    assert response.json()["detail"] == (
+        "MCP jobs must use /jobs/mcp-call or /jobs/jarvis-mcp-call"
     )
-    assert _mcp_spec(accepted).arguments["execution_id"] != (
-        deterministic_jarvis_execution_id(
-            cluster=submission.cluster,
-            idempotency_key=submission.idempotency_key,
-            job_id=caller_job_id,
-        )
-    )
+    assert queue.list_jobs() == []
 
 
 def test_typed_http_jarvis_run_retry_replays_server_identity(

--- a/tests/test_jarvis_recovery_scheduling.py
+++ b/tests/test_jarvis_recovery_scheduling.py
@@ -18,6 +18,7 @@ from clio_relay.models import (
     JobKind,
     JobState,
     Lease,
+    McpAdmissionClass,
     RelayJob,
     RelayTask,
 )
@@ -194,15 +195,15 @@ def test_only_worker_slot_zero_owns_cleanup_reconciliation(
             self.endpoint: object | None = None
             observed_ownership.append(reconcile_execution_cleanup)
 
-        def run_once(self) -> NoReturn:
+        def run_once(self, **_kwargs: object) -> NoReturn:
             raise StopSlot
 
     monkeypatch.setattr(endpoint_module, "EndpointWorker", FakeSlotWorker)
     try:
         with pytest.raises(StopSlot):
-            cast(Any, supervisor)._serve_worker_slot(0, 0)
+            cast(Any, supervisor)._serve_worker_slot(0, 0, McpAdmissionClass.WORKLOAD)
         with pytest.raises(StopSlot):
-            cast(Any, supervisor)._serve_worker_slot(1, 0)
+            cast(Any, supervisor)._serve_worker_slot(1, 0, McpAdmissionClass.WORKLOAD)
     finally:
         supervisor.close()
 

--- a/tests/test_jarvis_service_runtime.py
+++ b/tests/test_jarvis_service_runtime.py
@@ -15,24 +15,30 @@ from typing import Any, cast
 
 import httpx
 import pytest
+from fastapi.testclient import TestClient
 from typer.testing import CliRunner
 
 import clio_relay.cli as cli_module
+import clio_relay.http_api as http_api_module
 import clio_relay.jarvis_service_runtime as runtime_binding
 import clio_relay.mcp_server as mcp_server_module
 import clio_relay.owner_session_admission as owner_session_admission_module
 import clio_relay.remote_cli as remote_cli_module
 import clio_relay.service_runtime as service_runtime_module
+import clio_relay.session_api as session_api_module
 from clio_relay.browser_gateway import BrowserAttachmentGrant, BrowserDetachmentResult
 from clio_relay.cli import app
 from clio_relay.cluster_config import (
+    CLUSTER_REGISTRY_ENV,
     ClusterDefinition,
     ClusterRegistry,
     FrpTransportConfig,
+    cluster_route_revision,
 )
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.errors import ConfigurationError, QueueConflictError, RelayError
+from clio_relay.http_api import create_app
 from clio_relay.jarvis_mcp import jarvis_cd_lock_binding_expectation
 from clio_relay.jarvis_service_runtime import (
     RELAY_JARVIS_RUNTIME_BINDING_SCHEMA,
@@ -278,6 +284,329 @@ def test_private_authority_resolver_uses_exact_remote_identity_and_never_persist
     assert token not in verified.binding.model_dump_json()
     persisted_payloads = [path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()]
     assert all(token.encode("ascii") not in payload for payload in persisted_payloads)
+
+
+def test_owned_session_authority_uses_identity_bound_api_when_browser_attach_is_local(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Desktop-local browser attach must resolve authority on the receipt-owning cluster."""
+    queue, local_definition, job, artifact, envelope = _source_result(tmp_path)
+    definition = local_definition.model_copy(update={"ssh_host": "relay.example.test"})
+    monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
+    verified = resolve_jarvis_service_runtime(
+        queue=queue,
+        definition=local_definition,
+        source_job_id=job.job_id,
+        source_artifact_id=artifact.artifact_id,
+        package_id="paraview-1",
+        package_name="builtin.paraview",
+    )
+    settings = RelaySettings(
+        core_dir=tmp_path / "desktop-core",
+        spool_dir=tmp_path / "desktop-spool",
+        api_token="session-api-token",
+        owner_session_id="desktop-session-1",
+        owner_session_generation_id="generation-1",
+        owner_session_cluster=definition.name,
+    )
+    token = "a" * 64
+    requests: list[dict[str, object]] = []
+    lifecycle: list[str] = []
+
+    class FakeOwnedSessionApiClient:
+        def __init__(
+            self,
+            *,
+            definition: ClusterDefinition,
+            settings: RelaySettings,
+        ) -> None:
+            assert definition == local_definition.model_copy(
+                update={"ssh_host": "relay.example.test"}
+            )
+            assert settings == settings_for_assertion
+
+        def __enter__(self) -> FakeOwnedSessionApiClient:
+            lifecycle.append("entered")
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            lifecycle.append("exited")
+
+        def request_json(
+            self,
+            *,
+            method: str,
+            path: str,
+            body: dict[str, object] | None = None,
+        ) -> object:
+            requests.append({"method": method, "path": path, "body": body})
+            return _service_runtime_authority_document(token=token)
+
+    settings_for_assertion = settings
+
+    def forbidden(*_args: object, **_kwargs: object) -> Any:
+        raise AssertionError("owned-session authority must not use desktop JARVIS or direct SSH")
+
+    monkeypatch.setenv("CLIO_RELAY_CLI_MODE", "local")
+    monkeypatch.setattr(runtime_binding, "OwnedSessionApiClient", FakeOwnedSessionApiClient)
+    monkeypatch.setattr(runtime_binding, "should_execute_on_cluster", forbidden)
+    monkeypatch.setattr(runtime_binding, "run_remote_jarvis_runtime_authority", forbidden)
+    monkeypatch.setattr(
+        runtime_binding, "resolve_local_jarvis_service_runtime_authority", forbidden
+    )
+
+    assert (
+        session_api_module._validate_request(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            method="POST",
+            path=runtime_binding.OWNED_SESSION_JARVIS_RUNTIME_AUTHORITY_PATH,
+        )
+        == "POST"
+    )
+
+    header = runtime_binding.resolve_jarvis_service_runtime_authorization(
+        definition=definition,
+        settings=settings,
+        verified=verified,
+    )
+
+    assert header == f"Bearer {token}"
+    assert lifecycle == ["entered", "exited"]
+    assert requests == [
+        {
+            "method": "POST",
+            "path": runtime_binding.OWNED_SESSION_JARVIS_RUNTIME_AUTHORITY_PATH,
+            "body": {"binding": verified.binding.model_dump(mode="json")},
+        }
+    ]
+
+
+def test_owned_session_authority_endpoint_reverifies_owned_artifact_before_resolving(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The private endpoint must bind its answer to this session's durable receipt."""
+    queue, local_definition, job, artifact, envelope = _source_result(tmp_path)
+    definition = local_definition.model_copy(update={"ssh_host": "relay.example.test"})
+    monkeypatch.setenv("CLIO_RELAY_CLI_MODE", "local")
+    source_root = tmp_path / "spool" / job.job_id
+    source_root.mkdir(parents=True)
+    source_path = source_root / "mcp-result.json"
+    source_path.write_bytes(base64.b64decode(cast(str, envelope["data"]), validate=True))
+    artifact = artifact.model_copy(update={"uri": source_path.as_uri()})
+    envelope["artifact"] = artifact.model_dump(mode="json")
+    queue.append_artifact(artifact)
+    queue.update_job_metadata(
+        job.job_id,
+        {
+            "owner": "clio-relay",
+            "owner_session_id": "desktop-session-1",
+            "owner_session_generation_id": "generation-1",
+        },
+    )
+    verified = resolve_jarvis_service_runtime(
+        queue=queue,
+        definition=definition,
+        source_job_id=job.job_id,
+        source_artifact_id=artifact.artifact_id,
+        package_id="paraview-1",
+        package_name="builtin.paraview",
+    )
+    foreign_job = queue.submit_job(
+        RelayJob(
+            cluster=definition.name,
+            kind=JobKind.MCP_CALL,
+            spec=job.spec,
+            idempotency_key="foreign-runtime-authority-source",
+            metadata={
+                "owner": "clio-relay",
+                "owner_session_id": "another-desktop-session",
+                "owner_session_generation_id": "another-generation",
+            },
+        )
+    )
+    foreign_payload = b"foreign-session-artifact"
+    foreign_root = tmp_path / "spool" / foreign_job.job_id
+    foreign_root.mkdir(parents=True)
+    foreign_path = foreign_root / "foreign-mcp-result.json"
+    foreign_path.write_bytes(foreign_payload)
+    foreign_artifact = queue.append_artifact(
+        ArtifactRef(
+            job_id=foreign_job.job_id,
+            uri=foreign_path.as_uri(),
+            kind="mcp_result",
+            size_bytes=len(foreign_payload),
+            sha256=hashlib.sha256(foreign_payload).hexdigest(),
+        )
+    )
+    registry_path = tmp_path / "session-registry.json"
+    ClusterRegistry(clusters={definition.name: definition}).save(registry_path)
+    registry_payload = registry_path.read_bytes()
+    monkeypatch.setenv(CLUSTER_REGISTRY_ENV, str(registry_path))
+    monkeypatch.setenv(
+        "CLIO_RELAY_SESSION_REGISTRY_SHA256",
+        hashlib.sha256(registry_payload).hexdigest(),
+    )
+    monkeypatch.setenv(
+        "CLIO_RELAY_SESSION_ROUTE_REVISION",
+        cluster_route_revision(definition),
+    )
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        api_token="session-api-token",
+        owner_session_id="desktop-session-1",
+        owner_session_generation_id="generation-1",
+        owner_session_cluster=definition.name,
+        session_owner_token="o" * 32,
+        jarvis_bin="/released/bin/jarvis",
+    )
+    authority = runtime_binding.JarvisServiceRuntimeAuthority.model_validate(
+        _service_runtime_authority_document(token="a" * 64)
+    )
+    observed: dict[str, object] = {}
+
+    def forbidden(*_args: object, **_kwargs: object) -> Any:
+        raise AssertionError("cluster-local API must not recurse through owner API or direct SSH")
+
+    def resolve_local_verified(**kwargs: object) -> runtime_binding.JarvisServiceRuntimeAuthority:
+        observed.update(kwargs)
+        return authority
+
+    monkeypatch.setattr(
+        http_api_module,
+        "resolve_local_verified_jarvis_service_runtime_authority",
+        resolve_local_verified,
+    )
+    monkeypatch.setattr(runtime_binding, "OwnedSessionApiClient", forbidden)
+    monkeypatch.setattr(runtime_binding, "run_remote_clio", forbidden)
+    headers = {
+        "Authorization": "Bearer session-api-token",
+        "X-Clio-Relay-Owner-Session-Id": "desktop-session-1",
+        "X-Clio-Relay-Session-Generation-Id": "generation-1",
+    }
+    request = {"binding": verified.binding.model_dump(mode="json")}
+
+    client = cast(Any, TestClient(create_app(settings)))
+    with client:
+        assert (
+            client.post(
+                runtime_binding.OWNED_SESSION_JARVIS_RUNTIME_AUTHORITY_PATH,
+                json=request,
+            ).status_code
+            == 401
+        )
+        foreign_job_response = client.post(
+            runtime_binding.OWNED_SESSION_JARVIS_RUNTIME_AUTHORITY_PATH,
+            headers=headers,
+            json={
+                "binding": verified.binding.model_copy(
+                    update={"source_relay_job_id": foreign_job.job_id}
+                ).model_dump(mode="json")
+            },
+        )
+        foreign_artifact_response = client.post(
+            runtime_binding.OWNED_SESSION_JARVIS_RUNTIME_AUTHORITY_PATH,
+            headers=headers,
+            json={
+                "binding": verified.binding.model_copy(
+                    update={
+                        "source_relay_artifact_id": foreign_artifact.artifact_id,
+                        "source_relay_artifact_sha256": foreign_artifact.sha256,
+                    }
+                ).model_dump(mode="json")
+            },
+        )
+        drift_response = client.post(
+            runtime_binding.OWNED_SESSION_JARVIS_RUNTIME_AUTHORITY_PATH,
+            headers=headers,
+            json={
+                "binding": verified.binding.model_copy(
+                    update={"service_revision": verified.binding.service_revision + 1}
+                ).model_dump(mode="json")
+            },
+        )
+        response = client.post(
+            runtime_binding.OWNED_SESSION_JARVIS_RUNTIME_AUTHORITY_PATH,
+            headers=headers,
+            json=request,
+        )
+
+    assert foreign_job_response.status_code == 403
+    assert foreign_artifact_response.status_code == 403
+    assert drift_response.status_code == 409
+    assert "no longer matches its durable source" in drift_response.json()["detail"]
+    assert response.status_code == 200, response.text
+    assert response.json() == _service_runtime_authority_document(token="a" * 64)
+    assert observed["jarvis_bin"] == "/released/bin/jarvis"
+    resolved = cast(runtime_binding.VerifiedJarvisServiceRuntime, observed["verified"])
+    assert resolved.binding == verified.binding
+    token = ("a" * 64).encode("ascii")
+    assert token.decode("ascii") not in caplog.text
+    assert token not in verified.model_dump_json().encode("utf-8")
+    persisted = [path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()]
+    private_field = b'"token":"' + token + b'"'
+    assert all(private_field not in b"".join(payload.split()) for payload in persisted)
+
+
+def test_private_runtime_authority_endpoint_is_unavailable_on_non_owned_api(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An ordinary relay API must never expose the private authority transport."""
+    queue, definition, job, artifact, envelope = _source_result(tmp_path)
+    monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
+    verified = resolve_jarvis_service_runtime(
+        queue=queue,
+        definition=definition,
+        source_job_id=job.job_id,
+        source_artifact_id=artifact.artifact_id,
+        package_id="paraview-1",
+        package_name="builtin.paraview",
+    )
+
+    def forbidden(*_args: object, **_kwargs: object) -> Any:
+        raise AssertionError("ordinary API must not invoke a private authority resolver")
+
+    monkeypatch.setattr(
+        http_api_module,
+        "resolve_local_verified_jarvis_service_runtime_authority",
+        forbidden,
+    )
+    settings = RelaySettings(
+        core_dir=tmp_path / "ordinary-core",
+        spool_dir=tmp_path / "ordinary-spool",
+    )
+
+    client = cast(Any, TestClient(create_app(settings)))
+    with client:
+        response = client.post(
+            runtime_binding.OWNED_SESSION_JARVIS_RUNTIME_AUTHORITY_PATH,
+            json={"binding": verified.binding.model_dump(mode="json")},
+        )
+        assert (
+            runtime_binding.OWNED_SESSION_JARVIS_RUNTIME_AUTHORITY_PATH
+            not in (client.get("/openapi.json").json()["paths"])
+        )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "owned JARVIS runtime authority resolver is unavailable"
+
+
+def test_owned_private_authority_api_cannot_start_without_api_token(tmp_path: Path) -> None:
+    """A secret-returning owned API must fail before serving without authentication."""
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        owner_session_id="desktop-session-1",
+        owner_session_generation_id="generation-1",
+        owner_session_cluster="test-cluster",
+        session_owner_token="o" * 32,
+    )
+
+    with pytest.raises(ConfigurationError, match="CLIO_RELAY_API_TOKEN"):
+        create_app(settings)
 
 
 def test_private_authority_resolver_rejects_private_token_digest_mismatch(

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.6"
+    assert version == "1.4.7"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_service_runtime.py
+++ b/tests/test_service_runtime.py
@@ -2847,6 +2847,109 @@ def test_unobservable_local_connector_intent_remains_retryable_after_restart(
     assert result.session.metadata["cleanup_retryable"] is True
 
 
+def test_windows_connector_discovery_ignores_system_idle_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PID zero cannot own a connector and must not block marker discovery."""
+    owner_token = "owner-token"
+    generation_id = "generation-1"
+    config_path = r"D:\owned\desktop-frpc.toml"
+    command_line = (
+        f"frpc -c {config_path} {owner_token} CLIO_RELAY_CONNECTOR_GENERATION_ID={generation_id}"
+    )
+    payload = json.dumps(
+        [
+            {"ProcessId": 0, "CommandLine": None},
+            {"ProcessId": 555, "CommandLine": command_line},
+        ]
+    )
+
+    def enumerate_processes(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0, payload, "")
+
+    monkeypatch.setattr(service_runtime.os, "name", "nt")
+    monkeypatch.setattr(
+        service_runtime,
+        "_run_bounded_local_cleanup",
+        enumerate_processes,
+    )
+
+    assert service_runtime._local_process_ids(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        command_markers=(owner_token, generation_id, config_path),
+    ) == [555]
+
+
+def test_windows_system_idle_process_allows_connector_absence_proof(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restart cleanup can prove an unrecorded connector absent on Windows."""
+    payload = json.dumps({"ProcessId": 0, "CommandLine": None})
+
+    def enumerate_processes(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0, payload, "")
+
+    real_local_process_ids = service_runtime._local_process_ids  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+
+    def windows_process_ids(*, command_markers: tuple[str, ...] = ()) -> list[int]:
+        with monkeypatch.context() as windows:
+            windows.setattr(service_runtime.os, "name", "nt")
+            return real_local_process_ids(command_markers=command_markers)
+
+    def forbid_process_observation(_pid: int) -> object:
+        raise AssertionError("PID zero must never reach connector identity observation")
+
+    monkeypatch.setattr(
+        service_runtime,
+        "_run_bounded_local_cleanup",
+        enumerate_processes,
+    )
+    monkeypatch.setattr(service_runtime, "_local_process_ids", windows_process_ids)
+    monkeypatch.setattr(
+        service_runtime,
+        "_observe_local_process",
+        forbid_process_observation,
+    )
+    session_id = "owned-session"
+    connector, absence_verified = service_runtime._discover_local_connector(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        {
+            "owner_token": "owner-token",
+            "connector_generation_id": "generation-1",
+            "config_path": str(tmp_path / "desktop-frpc.toml"),
+            "metadata_path": str(tmp_path / "desktop-frpc-owner.json"),
+        },
+        session_id=session_id,
+    )
+
+    assert connector is None
+    assert absence_verified is True
+
+
+@pytest.mark.parametrize("process_id", [None, -1, True, "555"])
+def test_windows_connector_discovery_rejects_invalid_process_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    process_id: object,
+) -> None:
+    """Ignoring PID zero must not weaken fail-closed process identity parsing."""
+    payload = json.dumps({"ProcessId": process_id, "CommandLine": "frpc"})
+
+    def enumerate_processes(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0, payload, "")
+
+    monkeypatch.setattr(service_runtime.os, "name", "nt")
+    monkeypatch.setattr(
+        service_runtime,
+        "_run_bounded_local_cleanup",
+        enumerate_processes,
+    )
+
+    with pytest.raises(
+        RelayError,
+        match="local Windows process enumeration returned an invalid process id",
+    ):
+        service_runtime._local_process_ids()  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+
+
 def test_local_connector_pid_reuse_is_not_authorized(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1860,13 +1860,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.6-py3-none-any.whl",
+            resource_id="clio-relay-1.4.7-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.6.tar.gz",
+            resource_id="clio_relay-1.4.7.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2005,7 +2005,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.6"
+    assert policy.release_version == "1.4.7"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- resolve private JARVIS service authority on the exact receipt-owning cluster through the authenticated, generation-bound owned-session API
- keep browser attachment desktop-local while preventing fallback to a desktop JARVIS executable
- ignore the legitimate Windows System Idle Process PID 0 during owned connector cleanup without weakening malformed-process fail-closed checks
- align stale CI fixtures with hardened MCP admission and explicit worker lanes
- prepare the 1.4.7 release identity and acceptance-matrix binding

## Validation

- 14 focused runtime/cleanup/admission regression cases passed together
- 5 focused release-identity and policy cases passed
- Ruff check and format passed on the changed boundary
- Pyright: 0 errors, 0 warnings
- `uv lock --check` and `git diff --check` passed

No scheduler job was cancelled; live job 22077 remained preserve-only.