### PR TITLE
fix: allow long visualization commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.7` uses a release-first patch process. A maintainer builds the
+> Version `1.4.8` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.7"
+$Version = "1.4.8"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.7"
+release_version: "1.4.8"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 06df1af0350d54e090ae43c6005b6d081f1620547fd7dd6ed45710e790b07723
+acceptance_matrix_sha256: 3aebde455d7803f0b967bd4a6b893ede387f4a3273176f42041debb3bf8e7a50
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.7"
+$Tag = "v1.4.8"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.7" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.8" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.7",
-  "matrix_sha256": "06df1af0350d54e090ae43c6005b6d081f1620547fd7dd6ed45710e790b07723",
+  "release_version": "1.4.8",
+  "matrix_sha256": "3aebde455d7803f0b967bd4a6b893ede387f4a3273176f42041debb3bf8e7a50",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.7"
+version = "1.4.8"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.7"
+__version__ = "1.4.8"

--- a/src/clio_relay/browser_gateway.py
+++ b/src/clio_relay/browser_gateway.py
@@ -38,6 +38,7 @@ BROWSER_CLIENT_REQUEST_DEADLINE_SECONDS = 15.0
 BROWSER_OVERLOAD_IO_TIMEOUT_SECONDS = 1.0
 BROWSER_OVERLOAD_REQUEST_DEADLINE_SECONDS = 1.0
 UPSTREAM_CONNECT_TIMEOUT_SECONDS = 5.0
+UPSTREAM_COMMAND_RESPONSE_TIMEOUT_SECONDS = 900.0
 UPSTREAM_IDLE_TIMEOUT_SECONDS = 60.0
 _CAPABILITY_QUERY_KEY = "capability"
 _ALLOWED_REQUEST_HEADERS = frozenset({"accept", "cache-control", "content-type", "last-event-id"})
@@ -601,6 +602,17 @@ class CapabilityProxyHandler(BaseHTTPRequestHandler):
             request_headers["Authorization"] = self.capability_server.upstream_authorization
         response_started = False
         try:
+            # Keep connection establishment tightly bounded, then allow an
+            # authenticated command to perform real remote work before it emits
+            # response headers.  HTTPConnection otherwise reuses its connect
+            # timeout while getresponse() waits for those headers.
+            connection.connect()
+            if (
+                connection.sock is not None
+                and self.command == "POST"
+                and urllib.parse.urlsplit(target).path == config.command_path
+            ):
+                connection.sock.settimeout(UPSTREAM_COMMAND_RESPONSE_TIMEOUT_SECONDS)
             connection.request(self.command, target, body=body, headers=request_headers)
             response = connection.getresponse()
             if connection.sock is not None:

--- a/tests/test_browser_gateway.py
+++ b/tests/test_browser_gateway.py
@@ -7,7 +7,7 @@ import socket
 import threading
 import time
 from collections.abc import Generator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from datetime import UTC, datetime, timedelta
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from io import BytesIO
@@ -231,6 +231,49 @@ def test_browser_gateway_preflight_methods_stream_and_command_are_narrow(
                 ("POST", "/commands", b'{"operation":"render"}'),
                 ("GET", "/events", b""),
             ]
+
+
+def test_browser_gateway_extends_response_header_timeout_only_for_commands(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Long commands outlive connect timeout while ordinary reads remain bounded."""
+    monkeypatch.setattr(browser_gateway_module, "UPSTREAM_CONNECT_TIMEOUT_SECONDS", 0.1)
+    monkeypatch.setattr(
+        browser_gateway_module,
+        "UPSTREAM_COMMAND_RESPONSE_TIMEOUT_SECONDS",
+        0.75,
+        raising=False,
+    )
+    with _delayed_response_backend(delay_seconds=0.25) as (backend_port, requests):
+        capability = "d" * 43
+        with _capability_proxy(
+            backend_port=backend_port,
+            capability=capability,
+            revocation_path=tmp_path / "revoked-delayed-command",
+        ) as proxy_port:
+            query = urlencode({"capability": capability})
+            command = httpx.post(
+                f"http://127.0.0.1:{proxy_port}/commands?{query}",
+                headers={"Origin": "null", "Content-Type": "application/json"},
+                content=b'{"operation":"measure-field"}',
+                timeout=2.0,
+            )
+            assert command.status_code == 200
+            assert command.json() == {"accepted": True}
+
+            state = httpx.get(
+                f"http://127.0.0.1:{proxy_port}/state?{query}",
+                headers={"Origin": "null"},
+                timeout=2.0,
+            )
+            assert state.status_code == 502
+            assert state.json() == {"error": "upstream service is unavailable"}
+
+        assert requests == [
+            ("POST", "/commands", b'{"operation":"measure-field"}'),
+            ("GET", "/state", b""),
+        ]
 
 
 def test_browser_gateway_closes_ended_sse_and_reconnects_to_latest_revision(
@@ -628,6 +671,46 @@ def _backend_server() -> Generator[tuple[int, list[tuple[str, str, bytes]]]]:
             self.send_header("Content-Length", str(len(payload)))
             self.end_headers()
             self.wfile.write(payload)
+
+        def log_message(self, format: str, *args: Any) -> None:
+            del format, args
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), BackendHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield int(server.server_address[1]), requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@contextmanager
+def _delayed_response_backend(
+    *, delay_seconds: float
+) -> Generator[tuple[int, list[tuple[str, str, bytes]]]]:
+    requests: list[tuple[str, str, bytes]] = []
+
+    class BackendHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            requests.append(("GET", self.path, b""))
+            self._delayed_response(b'{"revision":1}')
+
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length)
+            requests.append(("POST", self.path, body))
+            self._delayed_response(b'{"accepted":true}')
+
+        def _delayed_response(self, payload: bytes) -> None:
+            threading.Event().wait(delay_seconds)
+            with suppress(BrokenPipeError, ConnectionResetError, OSError):
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
 
         def log_message(self, format: str, *args: Any) -> None:
             del format, args

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1699,7 +1699,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "06df1af0350d54e090ae43c6005b6d081f1620547fd7dd6ed45710e790b07723"
+        "3aebde455d7803f0b967bd4a6b893ede387f4a3273176f42041debb3bf8e7a50"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.7"
+    assert version == "1.4.8"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1860,13 +1860,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.7-py3-none-any.whl",
+            resource_id="clio-relay-1.4.8-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.7.tar.gz",
+            resource_id="clio_relay-1.4.8.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2005,7 +2005,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.7"
+    assert policy.release_version == "1.4.8"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.7"
+version = "1.4.8"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- keep browser-gateway upstream connection establishment bounded at 5 seconds
- allow authenticated `POST /commands` requests up to 900 seconds to produce response headers
- restore the existing 60-second response-body idle timeout after headers arrive
- advance release metadata to 1.4.8

## Why

The gateway constructed `HTTPConnection` with a 5-second connect timeout and then reused that timeout while `getresponse()` waited for command headers. Long ParaView operations could commit authoritative state remotely but receive a gateway-generated 502 locally, causing revision conflicts when clients retried.

## Impact

Long-running visualization measurements and mutations can now complete through the released relay path without weakening connection bounds or ordinary read-path timeouts.

## Validation

- `uv run pytest tests/test_browser_gateway.py::test_browser_gateway_extends_response_header_timeout_only_for_commands -q`
- Ruff check and format check on all touched Python files
- Pyright on all touched Python files: 0 errors, 0 warnings