### PR TITLE
fix: preserve browser SSE streams across long commands

### DIFF
--- a/src/clio_relay/browser_gateway.py
+++ b/src/clio_relay/browser_gateway.py
@@ -601,27 +601,30 @@ class CapabilityProxyHandler(BaseHTTPRequestHandler):
         if self.capability_server.upstream_authorization is not None:
             request_headers["Authorization"] = self.capability_server.upstream_authorization
         response_started = False
+        response: http.client.HTTPResponse | None = None
         try:
             # Keep connection establishment tightly bounded, then allow an
             # authenticated command to perform real remote work before it emits
             # response headers.  HTTPConnection otherwise reuses its connect
             # timeout while getresponse() waits for those headers.
             connection.connect()
-            if (
-                connection.sock is not None
-                and self.command == "POST"
-                and urllib.parse.urlsplit(target).path == config.command_path
+            upstream_socket = connection.sock
+            if upstream_socket is None:
+                raise OSError("upstream connection has no socket")
+            if self.command == "POST" and urllib.parse.urlsplit(target).path == (
+                config.command_path
             ):
-                connection.sock.settimeout(UPSTREAM_COMMAND_RESPONSE_TIMEOUT_SECONDS)
+                upstream_socket.settimeout(UPSTREAM_COMMAND_RESPONSE_TIMEOUT_SECONDS)
             connection.request(self.command, target, body=body, headers=request_headers)
             response = connection.getresponse()
-            if connection.sock is not None:
-                connection.sock.settimeout(UPSTREAM_IDLE_TIMEOUT_SECONDS)
             media_type = response.getheader("Content-Type", "").partition(";")[0].strip()
-            close_downstream = (
-                media_type.casefold() == "text/event-stream"
-                or response.getheader("Content-Length") is None
-            )
+            is_event_stream = media_type.casefold() == "text/event-stream"
+            # A no-length HTTP response transfers socket ownership from
+            # HTTPConnection to HTTPResponse, so connection.sock is commonly
+            # already None for SSE here.  Keep the exact connected socket and
+            # apply the post-header policy to it directly.
+            upstream_socket.settimeout(UPSTREAM_IDLE_TIMEOUT_SECONDS)
+            close_downstream = is_event_stream or response.getheader("Content-Length") is None
             self.send_response(response.status, response.reason)
             for name, value in response.getheaders():
                 if name.casefold() not in _STRIPPED_RESPONSE_HEADERS:
@@ -650,6 +653,9 @@ class CapabilityProxyHandler(BaseHTTPRequestHandler):
                 with suppress(BrokenPipeError, ConnectionResetError, OSError):
                     self._error(502, "upstream service is unavailable")
         finally:
+            if response is not None:
+                with suppress(OSError):
+                    response.close()
             connection.close()
 
     def _request_body(self) -> bytes | None:

--- a/tests/test_browser_gateway.py
+++ b/tests/test_browser_gateway.py
@@ -352,6 +352,105 @@ def test_browser_gateway_streams_post_command_revision_before_sse_closes(
             ]
 
 
+def test_browser_gateway_keeps_two_sse_streams_across_application_idle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A quiet state/frame pair receives a later revision without reconnecting."""
+
+    # HTTPResponse owns a no-length SSE socket after headers.  Before the fix it
+    # therefore retained this connect timeout instead of receiving the intended
+    # post-header stream policy.
+    monkeypatch.setattr(browser_gateway_module, "UPSTREAM_CONNECT_TIMEOUT_SECONDS", 0.1)
+    monkeypatch.setattr(browser_gateway_module, "UPSTREAM_IDLE_TIMEOUT_SECONDS", 0.75)
+    ownership: list[tuple[bool, bool, bool]] = []
+    closed_responses: list[int] = []
+    response_lock = threading.Lock()
+    original_getresponse = http.client.HTTPConnection.getresponse
+    original_close = http.client.HTTPResponse.close
+
+    def observed_getresponse(
+        connection: http.client.HTTPConnection,
+    ) -> http.client.HTTPResponse:
+        response = original_getresponse(connection)
+        with response_lock:
+            ownership.append(
+                (
+                    connection.sock is None,
+                    response.will_close,
+                    getattr(response, "fp", None) is not None,
+                )
+            )
+        return response
+
+    def observed_close(response: http.client.HTTPResponse) -> None:
+        with response_lock:
+            closed_responses.append(id(response))
+        original_close(response)
+
+    monkeypatch.setattr(http.client.HTTPConnection, "getresponse", observed_getresponse)
+    monkeypatch.setattr(http.client.HTTPResponse, "close", observed_close)
+    with _idle_sse_pair_backend() as (backend_port, release_revision, requests):
+        capability = "i" * 43
+        with _capability_proxy(
+            backend_port=backend_port,
+            capability=capability,
+            revocation_path=tmp_path / "revoked-idle-pair",
+        ) as proxy_port:
+            query = urlencode({"capability": capability})
+            received: dict[str, list[int]] = {"/events": [], "/live-data": []}
+            initial_pair = threading.Event()
+
+            def consume(path: str) -> None:
+                url = f"http://127.0.0.1:{proxy_port}{path}?{query}"
+                with httpx.stream(
+                    "GET",
+                    url,
+                    headers={"Origin": "null"},
+                    timeout=2.0,
+                ) as response:
+                    assert response.status_code == 200
+                    for line in response.iter_lines():
+                        if not line.startswith("data: "):
+                            continue
+                        revision = int(json.loads(line.removeprefix("data: "))["revision"])
+                        received[path].append(revision)
+                        if all(values for values in received.values()):
+                            initial_pair.set()
+                        if revision == 10:
+                            return
+
+            consumers = [
+                threading.Thread(target=consume, args=(path,), daemon=True) for path in received
+            ]
+            for consumer in consumers:
+                consumer.start()
+            assert initial_pair.wait(timeout=2.0)
+
+            # Exceed the connection-establishment timeout while remaining
+            # inside the post-header idle policy.  Both response-owned SSE
+            # sockets must receive that later policy instead of disconnecting.
+            time.sleep(0.25)
+            release_revision.set()
+            for consumer in consumers:
+                consumer.join(timeout=2.0)
+                assert not consumer.is_alive()
+
+            assert received == {"/events": [1, 10], "/live-data": [1, 10]}
+            assert requests == ["/events", "/live-data"] or requests == [
+                "/live-data",
+                "/events",
+            ]
+            assert ownership == [(True, True, True), (True, True, True)]
+            close_deadline = time.monotonic() + 2.0
+            while time.monotonic() < close_deadline:
+                with response_lock:
+                    if len(set(closed_responses)) == 2:
+                        break
+                time.sleep(0.01)
+            assert len(set(closed_responses)) == 2
+
+
 def test_browser_gateway_bounds_long_lived_requests_and_recovers_slots(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -800,6 +899,54 @@ def _revision_sse_backend(
     try:
         yield int(server.server_address[1]), requests
     finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@contextmanager
+def _idle_sse_pair_backend() -> Generator[tuple[int, threading.Event, list[str]]]:
+    requests: list[str] = []
+    requests_lock = threading.Lock()
+    release_revision = threading.Event()
+
+    class BackendHandler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_GET(self) -> None:  # noqa: N802
+            path = self.path.partition("?")[0]
+            with requests_lock:
+                requests.append(path)
+            if path not in {"/events", "/live-data"}:
+                self.send_error(404)
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("Connection", "keep-alive")
+            self.end_headers()
+            event_name = "state" if path == "/events" else "frame"
+            with suppress(BrokenPipeError, ConnectionResetError, OSError):
+                self.wfile.write(f'event: {event_name}\nid: 1\ndata: {{"revision":1}}\n\n'.encode())
+                self.wfile.flush()
+                if not release_revision.wait(timeout=2.0):
+                    return
+                self.wfile.write(
+                    f'event: {event_name}\nid: 10\ndata: {{"revision":10}}\n\n'.encode()
+                )
+                self.wfile.flush()
+                self.close_connection = True
+
+        def log_message(self, format: str, *args: Any) -> None:
+            del format, args
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), BackendHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield int(server.server_address[1]), release_revision, requests
+    finally:
+        release_revision.set()
         server.shutdown()
         server.server_close()
         thread.join(timeout=5)


### PR DESCRIPTION
## What changed

- retain the exact connected upstream socket after `HTTPResponse` takes ownership of no-length SSE responses
- apply the post-header idle timeout to that socket instead of the now-empty `HTTPConnection.sock`
- close the response-owned stream deterministically
- add a two-stream regression covering quiet state/frame streams and a later revision

## Root cause

For no-length HTTP/1.1 SSE responses, Python transfers the socket from `HTTPConnection` to `HTTPResponse`. The browser gateway therefore left the 5-second connection timeout on both VIGIL streams instead of applying its 60-second idle policy. Long ParaView mutations caused rapid EventSource reconnects and eventually exhausted JARVIS's bounded subscriber pool.

## Validation

- regression fails on v1.4.8 and passes three consecutive times with this patch
- six neighboring browser-gateway tests pass
- Chromium two-EventSource proof receives revision 1, reconnects only after the intended idle boundary with `Last-Event-ID`, and replays revision 10
- Ruff check and format check pass
- Pyright passes