### PR TITLE
fix: release bootstrap lifetime guard before restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.10` uses a release-first patch process. A maintainer builds the
+> Version `1.4.11` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.10"
+$Version = "1.4.11"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.10"
+release_version: "1.4.11"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 5c0d45798bc4c49830bd9c23865c284362b215830773347fbd25caa139d82cc9
+acceptance_matrix_sha256: 7337bcd46db1dd52c221c30f8808cf0c1fa84bd941a7bf0e8dcf1c854bc8c1bf
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.10"
+$Tag = "v1.4.11"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.10" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.11" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.10",
-  "matrix_sha256": "5c0d45798bc4c49830bd9c23865c284362b215830773347fbd25caa139d82cc9",
+  "release_version": "1.4.11",
+  "matrix_sha256": "7337bcd46db1dd52c221c30f8808cf0c1fa84bd941a7bf0e8dcf1c854bc8c1bf",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.10"
+version = "1.4.11"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.10"
+__version__ = "1.4.11"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -884,8 +884,25 @@ def _worker_upgrade_fence_script(
     fence = "\n".join(
         [
             declarations,
+            "bootstrap_release_worker_lifetime_guard() {",
+            '  case "$WORKER_LIFETIME_GUARD_FD" in',
+            "    '') return 0 ;;",
+            "    8)",
+            "      WORKER_LIFETIME_GUARD_FD=",
+            "      exec 8>&-",
+            "      ;;",
+            "    *)",
+            (
+                '      echo "refusing to release unexpected worker lifetime guard fd: '
+                '$WORKER_LIFETIME_GUARD_FD" >&2'
+            ),
+            "      return 1",
+            "      ;;",
+            "  esac",
+            "}",
             "bootstrap_bounded_worker_restart() {",
             "  WORKER_RESTART_ATTEMPTED=1",
+            "  bootstrap_release_worker_lifetime_guard",
             (
                 "  if ! timeout --signal=TERM --kill-after=5s 30s systemctl --user start "
                 '"$WORKER_SERVICE_NAME"; then'
@@ -907,9 +924,6 @@ def _worker_upgrade_fence_script(
             "bootstrap_worker_fence_exit() {",
             "  status=$?",
             "  trap - EXIT",
-            '  if [ -n "$WORKER_LIFETIME_GUARD_FD" ]; then',
-            "    exec 8>&- || true",
-            "  fi",
             (
                 '  if [ "$status" -ne 0 ] && [ "$WORKER_WAS_ACTIVE" = "1" ]'
                 ' && [ "$WORKER_RESTARTED" != "1" ]; then'
@@ -961,6 +975,7 @@ def _worker_upgrade_fence_script(
             ),
             "    fi",
             "  fi",
+            "  bootstrap_release_worker_lifetime_guard || true",
             '  exit "$status"',
             "}",
             "trap bootstrap_worker_fence_exit EXIT",

--- a/src/clio_relay/worker_lifetime_lock.py
+++ b/src/clio_relay/worker_lifetime_lock.py
@@ -122,9 +122,9 @@ class WorkerLifetimeLock:
     """Hold shared worker or exclusive migration ownership for one core directory.
 
     Worker processes use ``shared`` mode for their complete lifetime. Managed
-    bootstrap uses the same byte-range lock in ``exclusive`` mode so a newly
-    installed worker can start under systemd but cannot initialize its queue
-    until migration has finished and bootstrap releases the lock.
+    bootstrap uses the same byte-range lock in ``exclusive`` mode through
+    package replacement and migration, then releases it immediately before
+    starting the newly installed worker.
     """
 
     def __init__(
@@ -438,9 +438,9 @@ def exclusive_migration_lifetime(
     )
     # Do not unlock or close the inherited descriptor here. The bootstrap shell
     # owns the same open-file description and deliberately retains EX across
-    # package replacement, migration, service restart, and its EXIT trap. This
-    # process's inherited copy independently retains EX if that shell dies while
-    # migration is running.
+    # package replacement and migration, until immediately before a service
+    # start or its EXIT cleanup. This process's inherited copy independently
+    # retains EX if that shell dies while migration is running.
     try:
         yield locked_identity
     finally:

--- a/tests/test_bootstrap_cluster_paths.py
+++ b/tests/test_bootstrap_cluster_paths.py
@@ -82,6 +82,74 @@ def test_managed_bootstrap_fences_worker_around_migration() -> None:
     assert "worker state is unknown and requires operator verification" in script
 
 
+def test_managed_bootstrap_releases_lifetime_guard_before_normal_restart() -> None:
+    """The restarted worker can acquire its shared lifetime lock without timing out."""
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.fail("bash is required to validate the Linux bootstrap restart path")
+    worker_fence, worker_recheck, _init, worker_restart = bootstrap._worker_upgrade_fence_script(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        "test-cluster",
+        rendered_core_dir='"$test_root/core"',
+    )
+    harness = f"""set -euo pipefail
+test_root="$(mktemp -d)"
+trap 'rm -rf -- "$test_root"' EXIT
+mkdir -p "$test_root/bin"
+export BOOTSTRAP_TEST_STATE="$test_root/worker-state"
+echo active > "$BOOTSTRAP_TEST_STATE"
+cat > "$test_root/bin/python3" <<'__FAKE_PYTHON__'
+#!/usr/bin/env bash
+cat >/dev/null
+__FAKE_PYTHON__
+cat > "$test_root/bin/systemctl" <<'__FAKE_SYSTEMCTL__'
+#!/usr/bin/env bash
+set -u
+case "${{2:-}}" in
+  show)
+    case " $* " in
+      *" --property=LoadState "*) echo loaded ;;
+      *" --property=ActiveState "*) cat "$BOOTSTRAP_TEST_STATE" ;;
+      *) exit 2 ;;
+    esac
+    ;;
+  stop)
+    echo "fake-systemctl=stop" >&2
+    echo inactive > "$BOOTSTRAP_TEST_STATE"
+    ;;
+  start)
+    echo "fake-systemctl=start" >&2
+    if {{ true <&8; }} 2>/dev/null; then
+      echo "fake-systemctl=start-with-lifetime-guard" >&2
+      echo activating > "$BOOTSTRAP_TEST_STATE"
+      exit 99
+    fi
+    echo active > "$BOOTSTRAP_TEST_STATE"
+    ;;
+  *) exit 2 ;;
+esac
+__FAKE_SYSTEMCTL__
+chmod +x "$test_root/bin/python3" "$test_root/bin/systemctl"
+export PATH="$test_root/bin:$PATH"
+{worker_fence}
+{worker_recheck}
+{worker_restart}
+"""
+
+    result = subprocess.run(
+        [bash, "-s"],
+        input=harness.encode("utf-8"),
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 0, stderr
+    assert stderr.count("fake-systemctl=stop") == 1
+    assert stderr.count("fake-systemctl=start") == 1
+    assert "fake-systemctl=start-with-lifetime-guard" not in stderr
+
+
 @pytest.mark.parametrize("restart_succeeds", [True, False])
 def test_failed_managed_bootstrap_restores_previously_active_worker(
     restart_succeeds: bool,
@@ -130,6 +198,10 @@ case "${{2:-}}" in
     ;;
   start)
     echo "fake-systemctl=start" >&2
+    if {{ true <&8; }} 2>/dev/null; then
+      echo "fake-systemctl=start-with-lifetime-guard" >&2
+      exit 99
+    fi
     : > "$BOOTSTRAP_TEST_STARTED"
     {restart_result}
     ;;
@@ -156,6 +228,7 @@ exit 37
     assert "remote-bootstrap-step=sabotaged" in stderr
     assert stderr.count("fake-systemctl=stop") == 1
     assert "fake-systemctl=start" in stderr
+    assert "fake-systemctl=start-with-lifetime-guard" not in stderr
     if restart_succeeds:
         assert stderr.count("fake-systemctl=start") == 1
         assert "worker_recovery=restored" in stderr

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1699,7 +1699,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "5c0d45798bc4c49830bd9c23865c284362b215830773347fbd25caa139d82cc9"
+        "7337bcd46db1dd52c221c30f8808cf0c1fa84bd941a7bf0e8dcf1c854bc8c1bf"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.10"
+    assert version == "1.4.11"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1860,13 +1860,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.10-py3-none-any.whl",
+            resource_id="clio-relay-1.4.11-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.10.tar.gz",
+            resource_id="clio_relay-1.4.11.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2005,7 +2005,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.10"
+    assert policy.release_version == "1.4.11"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.10"
+version = "1.4.11"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- release the exclusive migration lifetime guard exactly once immediately before any normal or recovery worker start
- preserve writer proof, post-install recheck, and bootstrap receipt evidence
- add an executable rendered-shell regression for the normal restart path and strengthen recovery coverage
- bump the coordinated release surfaces to 1.4.11 and bind the canonical acceptance matrix digest

## Root cause

Bootstrap retained its exclusive `.clio-relay-worker-lifetime.lock` descriptor while `systemctl --user start` waited for the endpoint. Endpoint startup requires the shared side of that lock, so the service remained activating until the bounded start timed out. The EXIT trap released the descriptor only after failure, which is why recovery could subsequently start the worker.

## Validation

- 4 focused bootstrap behavioral cases passed with zero skips
- Ruff check and format passed on touched Python files
- scoped Pyright passed with zero errors or warnings
- `uv lock --check` passed
- canonical matrix digest validated as `7337bcd46db1dd52c221c30f8808cf0c1fa84bd941a7bf0e8dcf1c854bc8c1bf`

No cluster or scheduler state was changed by this patch.
