### PR TITLE
fix: observe endpoint startup through systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.11` uses a release-first patch process. A maintainer builds the
+> Version `1.4.12` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -48,6 +48,40 @@ and per-kind capacity arguments against the persisted cluster policy before it
 restarts anything. A legacy or drifted unit is left untouched and must be
 reinstalled with `cluster install-endpoint-service`.
 
+Service installation, restart, and managed bootstrap serialize an exact
+state/job preflight and optional enqueue under a short per-service `flock`.
+They fail closed without mutation if either inventory cannot be read, and a
+fresh process observes an already queued exact job instead of duplicating it.
+Relay enqueues only when `LoadState=loaded` and the preflight `ActiveState` is
+stable (`active`, `inactive`, or `failed`). Non-loaded units and transitional,
+maintenance, refreshing, or future active states are reported without mutation.
+A requested `start` can adopt an exact existing `start` or `restart` job. A
+requested `restart` can adopt an exact `restart` job, including its later
+`start` phase under the same systemd job ID; a standalone pre-existing `start`
+is not restart provenance. Relay pins the first adopted job ID and rejects a
+later different job. A `start` first observed after relay's own successful
+restart enqueue can be bound to that request. A timed-out or failed restart
+enqueue cannot adopt a newly observed `start` or a jobless transition. Queued
+`reload`, `stop`, `verify-active`, `nop`, and unknown jobs are likewise
+nonpassing `in-progress` evidence without mutation; retry after the exact job
+clears. A transitional unit state without an exact queued job is also
+nonpassing and requires retry after the unit reaches a stable state.
+After enqueueing at most one systemd job with `--no-block`, they observe the
+exact unit and job for up to 5 minutes 30 seconds. The generated unit bounds
+`ExecStartPre` queue-index migration and process startup with
+`TimeoutStartSec=5min`; the SSH lifecycle command retains an additional
+90-second transport margin. State transitions
+and 15-second progress snapshots are emitted as
+`endpoint_service.activation` key/value records. A terminal systemd failure is
+returned immediately. If the observer itself expires while systemd still owns
+an activating job, relay reports `outcome=in-progress`, leaves that job intact,
+and does not enqueue a duplicate recovery start. Structured failure output
+includes the exact operator `journalctl --user --unit=...` command without
+copying journal contents into relay output.
+For a restart, known initial and final systemd `InvocationID` values must differ;
+an observed, provenance-bound state transition is used only when either ID is
+unavailable. An always-active unit with no new invocation remains unverified.
+
 ### Upgrade durable queue indexes
 
 The worker service runs this preflight before it accepts work:
@@ -96,9 +130,12 @@ bootstrap` performs this sequence itself: it stops the configured worker before
 replacing packages, refuses to continue while any installed `clio-relay`
 process still owns the same physical queue, runs a final bounded source-to-index
 reconciliation under the queue lock, and restarts the service only if it was
-previously active. New managed queues hold shared core ownership for their full
-lifetime, so later migrations cannot overlap an API, MCP server, worker, or new
-queue-backed writer. Explicit migration returns a closed inspection object,
+previously active. The complete remote bootstrap script has a 30-minute outer
+bound, which outlives its 5-minute 30-second service observer while preventing a
+lost SSH session from waiting forever. New managed queues hold shared core
+ownership for their full lifetime, so later migrations cannot overlap an API,
+MCP server, worker, or new queue-backed writer. Explicit migration returns a
+closed inspection object,
 never an unfenced writable queue. The migration does not delete jobs, logs, or
 scheduler work.
 

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.11"
+$Version = "1.4.12"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.11"
+release_version: "1.4.12"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 7337bcd46db1dd52c221c30f8808cf0c1fa84bd941a7bf0e8dcf1c854bc8c1bf
+acceptance_matrix_sha256: 4ecea98055acdb4a69dd2d8992a466e26aa8291d975bb70f4bb91ff1894f90fe
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.11"
+$Tag = "v1.4.12"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -114,7 +114,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.11" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.12" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.11",
-  "matrix_sha256": "7337bcd46db1dd52c221c30f8808cf0c1fa84bd941a7bf0e8dcf1c854bc8c1bf",
+  "release_version": "1.4.12",
+  "matrix_sha256": "4ecea98055acdb4a69dd2d8992a466e26aa8291d975bb70f4bb91ff1894f90fe",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.11"
+version = "1.4.12"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.11"
+__version__ = "1.4.12"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -27,7 +27,10 @@ from packaging.utils import InvalidWheelFilename, canonicalize_name, parse_wheel
 from packaging.version import InvalidVersion, Version
 
 from clio_relay import __version__
-from clio_relay.deployment import endpoint_user_service_name
+from clio_relay.deployment import (
+    endpoint_user_service_name,
+    render_bounded_user_service_activation_helper,
+)
 from clio_relay.errors import ConfigurationError, RelayError
 from clio_relay.jarvis_mcp import (
     CLIO_KIT_JARVIS_MCP_VERSION,
@@ -61,6 +64,7 @@ JARVIS_CD_WHEEL_SHA256 = "321ee1a23e96a4c97b3b0d6107c5f5299d7db362396dd748e87a44
 DEFAULT_REMOTE_CORE_DIR = "$HOME/.local/share/clio-relay/core"
 DEFAULT_REMOTE_SPOOL_DIR = "$HOME/.local/share/clio-relay/spool"
 MAX_RELAY_WHEEL_METADATA_BYTES = 1024 * 1024
+BOOTSTRAP_REMOTE_SCRIPT_TIMEOUT_SECONDS = 1800.0
 
 _WORKER_WRITER_PROOF_PYTHON = r'''from __future__ import annotations
 
@@ -745,7 +749,10 @@ def bootstrap_cluster_over_ssh(
                 newline="\n",
             )
             _run(["scp", str(script_path), f"{ssh_host}:{remote_script}"])
-        result = _run(["ssh", ssh_host, "bash", remote_script])
+        result = _run(
+            ["ssh", ssh_host, "bash", remote_script],
+            timeout_seconds=BOOTSTRAP_REMOTE_SCRIPT_TIMEOUT_SECONDS,
+        )
         receipt_result = _run(
             ["ssh", ssh_host, "cat", "$HOME/.local/share/clio-relay/bootstrap-receipt.json"]
         )
@@ -837,6 +844,9 @@ def _worker_upgrade_fence_script(
     cluster: str | None,
     *,
     rendered_core_dir: str,
+    activation_observation_timeout_seconds: int | None = None,
+    activation_poll_seconds: int | None = None,
+    activation_progress_seconds: int | None = None,
 ) -> tuple[str, str, str, str]:
     """Render managed fencing, recheck, migration command, and restart step."""
     service_name = endpoint_user_service_name(cluster) if cluster is not None else ""
@@ -853,6 +863,9 @@ def _worker_upgrade_fence_script(
             "WORKER_LIFETIME_LOCK_PATH=",
             "WORKER_RESTART_ATTEMPTED=0",
             "WORKER_RESTARTED=0",
+            "WORKER_POST_START_STATE=unknown",
+            "WORKER_POST_START_SUB_STATE=unknown",
+            "WORKER_RESTART_OUTCOME=not-attempted",
         ]
     )
     if not service_name:
@@ -884,6 +897,13 @@ def _worker_upgrade_fence_script(
     fence = "\n".join(
         [
             declarations,
+            f"CLIO_RELAY_ENDPOINT_SERVICE_NAME={shlex.quote(service_name)}",
+            "CLIO_RELAY_ENDPOINT_ACTIVATION_ACTION=start",
+            render_bounded_user_service_activation_helper(
+                observation_timeout_seconds=activation_observation_timeout_seconds,
+                poll_seconds=activation_poll_seconds,
+                progress_seconds=activation_progress_seconds,
+            ),
             "bootstrap_release_worker_lifetime_guard() {",
             '  case "$WORKER_LIFETIME_GUARD_FD" in',
             "    '') return 0 ;;",
@@ -902,23 +922,16 @@ def _worker_upgrade_fence_script(
             "}",
             "bootstrap_bounded_worker_restart() {",
             "  WORKER_RESTART_ATTEMPTED=1",
-            "  bootstrap_release_worker_lifetime_guard",
-            (
-                "  if ! timeout --signal=TERM --kill-after=5s 30s systemctl --user start "
-                '"$WORKER_SERVICE_NAME"; then'
-            ),
+            "  bootstrap_release_worker_lifetime_guard || return 1",
+            "  if ! clio_relay_endpoint_activate_bounded; then",
+            '    WORKER_POST_START_STATE="$CLIO_RELAY_ENDPOINT_ACTIVE_STATE"',
+            '    WORKER_POST_START_SUB_STATE="$CLIO_RELAY_ENDPOINT_SUB_STATE"',
+            '    WORKER_RESTART_OUTCOME="$CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME"',
             "    return 1",
             "  fi",
-            (
-                '  if ! WORKER_POST_START_STATE="$(timeout --signal=TERM --kill-after=2s 5s '
-                'systemctl --user show "$WORKER_SERVICE_NAME" '
-                '--property=ActiveState --value)"; then'
-            ),
-            "    return 1",
-            "  fi",
-            '  if [ "$WORKER_POST_START_STATE" != "active" ]; then',
-            "    return 1",
-            "  fi",
+            '  WORKER_POST_START_STATE="$CLIO_RELAY_ENDPOINT_ACTIVE_STATE"',
+            '  WORKER_POST_START_SUB_STATE="$CLIO_RELAY_ENDPOINT_SUB_STATE"',
+            '  WORKER_RESTART_OUTCOME="$CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME"',
             "  WORKER_RESTARTED=1",
             "}",
             "bootstrap_worker_fence_exit() {",
@@ -929,44 +942,50 @@ def _worker_upgrade_fence_script(
                 ' && [ "$WORKER_RESTARTED" != "1" ]; then'
             ),
             '    if [ "$WORKER_STOP_CONFIRMED" = "1" ]; then',
+            '      if [ "$WORKER_RESTART_ATTEMPTED" = "1" ]; then',
             (
-                '      echo "bootstrap failed; attempting bounded recovery of '
+                '        echo "bootstrap failed after the worker start was already '
+                'enqueued; observing $WORKER_SERVICE_NAME without a duplicate start" >&2'
+            ),
+            "      else",
+            (
+                '        echo "bootstrap failed; attempting bounded recovery of '
                 '$WORKER_SERVICE_NAME" >&2'
             ),
+            "      fi",
             "      if bootstrap_bounded_worker_restart; then",
             (
                 '        echo "bootstrap worker_recovery=restored '
                 'service=$WORKER_SERVICE_NAME state=active" >&2'
             ),
             "      else",
+            '        case "$WORKER_RESTART_OUTCOME" in',
+            "          in-progress)",
             (
-                '        if WORKER_EXIT_STATE="$(timeout --signal=TERM --kill-after=2s 5s '
-                'systemctl --user show "$WORKER_SERVICE_NAME" '
-                '--property=ActiveState --value 2>/dev/null)"; then'
+                '            echo "bootstrap worker_recovery=in-progress '
+                "service=$WORKER_SERVICE_NAME state=$WORKER_POST_START_STATE "
+                "sub_state=$WORKER_POST_START_SUB_STATE; systemd start job retained "
+                'without a duplicate request" >&2'
             ),
-            '          case "$WORKER_EXIT_STATE" in',
-            "            inactive|failed)",
+            "            ;;",
+            "          failed)",
             (
-                '              echo "bootstrap worker_recovery=failed '
-                "service=$WORKER_SERVICE_NAME state=$WORKER_EXIT_STATE; "
+                '            echo "bootstrap worker_recovery=failed '
+                "service=$WORKER_SERVICE_NAME state=$WORKER_POST_START_STATE "
+                "sub_state=$WORKER_POST_START_SUB_STATE; "
                 'operator action is required" >&2'
             ),
-            "              ;;",
-            "            *)",
+            "            ;;",
+            "          *)",
             (
-                '              echo "bootstrap worker_recovery=unverified '
-                "service=$WORKER_SERVICE_NAME state=$WORKER_EXIT_STATE; "
+                '            echo "bootstrap worker_recovery=unverified '
+                "service=$WORKER_SERVICE_NAME state=$WORKER_POST_START_STATE "
+                "sub_state=$WORKER_POST_START_SUB_STATE "
+                "outcome=$WORKER_RESTART_OUTCOME; "
                 'operator verification is required" >&2'
             ),
-            "              ;;",
-            "          esac",
-            "        else",
-            (
-                '          echo "bootstrap worker_recovery=unverified '
-                "service=$WORKER_SERVICE_NAME state=unknown; "
-                'operator verification is required" >&2'
-            ),
-            "        fi",
+            "            ;;",
+            "        esac",
             "      fi",
             "    else",
             (
@@ -1054,7 +1073,10 @@ def _worker_upgrade_fence_script(
             "  if ! bootstrap_bounded_worker_restart; then",
             (
                 '    echo "relay worker did not become active '
-                '(${WORKER_POST_START_STATE:-unknown}): $WORKER_SERVICE_NAME" >&2'
+                "state=${WORKER_POST_START_STATE:-unknown} "
+                "sub_state=${WORKER_POST_START_SUB_STATE:-unknown} "
+                "outcome=${WORKER_RESTART_OUTCOME:-unverified}: "
+                '$WORKER_SERVICE_NAME" >&2'
             ),
             "    exit 1",
             "  fi",
@@ -1972,18 +1994,24 @@ def _run(
     command: list[str],
     *,
     cwd: Path | None = None,
+    timeout_seconds: float | None = None,
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
-    result = subprocess.run(
-        command,
-        cwd=cwd,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        capture_output=True,
-        check=False,
-        env=env,
-    )
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            capture_output=True,
+            check=False,
+            env=env,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        timeout_label = "unbounded" if timeout_seconds is None else f"{timeout_seconds:g}"
+        raise RelayError(f"command exceeded {timeout_label} seconds ({' '.join(command)})") from exc
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip()
         raise RelayError(f"command failed ({' '.join(command)}): {detail}")

--- a/src/clio_relay/deployment.py
+++ b/src/clio_relay/deployment.py
@@ -25,6 +25,640 @@ from clio_relay.worker_concurrency import KindConcurrencyInput, kind_concurrency
 _SYSTEMD_UNQUOTED_ARGUMENT = re.compile(r"[A-Za-z0-9_./:@%+=,{}-]+\Z")
 _SYSTEMD_SERVICE_NAME = re.compile(r"clio-relay-worker-[a-z0-9_-]+\.service\Z")
 
+ENDPOINT_SERVICE_SYSTEMD_START_TIMEOUT_SECONDS = 300
+ENDPOINT_SERVICE_START_OBSERVATION_TIMEOUT_SECONDS = 330
+ENDPOINT_SERVICE_START_POLL_SECONDS = 2
+ENDPOINT_SERVICE_START_PROGRESS_SECONDS = 15
+ENDPOINT_SERVICE_CONTROL_TIMEOUT_SECONDS = 10
+ENDPOINT_SERVICE_SSH_SETUP_MARGIN_SECONDS = 90
+ENDPOINT_SERVICE_SSH_TIMEOUT_SECONDS = float(
+    ENDPOINT_SERVICE_START_OBSERVATION_TIMEOUT_SECONDS + ENDPOINT_SERVICE_SSH_SETUP_MARGIN_SECONDS
+)
+
+
+def render_bounded_user_service_activation_helper(
+    *,
+    observation_timeout_seconds: int | None = None,
+    poll_seconds: int | None = None,
+    progress_seconds: int | None = None,
+) -> str:
+    """Render one asynchronous, bounded systemd activation observer.
+
+    Callers set ``CLIO_RELAY_ENDPOINT_SERVICE_NAME`` and
+    ``CLIO_RELAY_ENDPOINT_ACTIVATION_ACTION`` to ``start`` or ``restart``, then
+    invoke ``clio_relay_endpoint_activate_bounded``. A per-service file lock
+    serializes the exact state/job preflight and optional enqueue across
+    processes. The helper enqueues at most one systemd job. A timed-out observer
+    never cancels or duplicates an activation that systemd still reports as in
+    progress.
+    """
+    observation_timeout = (
+        ENDPOINT_SERVICE_START_OBSERVATION_TIMEOUT_SECONDS
+        if observation_timeout_seconds is None
+        else observation_timeout_seconds
+    )
+    selected_poll_seconds = (
+        ENDPOINT_SERVICE_START_POLL_SECONDS if poll_seconds is None else poll_seconds
+    )
+    selected_progress_seconds = (
+        ENDPOINT_SERVICE_START_PROGRESS_SECONDS if progress_seconds is None else progress_seconds
+    )
+    for name, value in (
+        ("observation timeout", observation_timeout),
+        ("poll interval", selected_poll_seconds),
+        ("progress interval", selected_progress_seconds),
+    ):
+        if type(value) is not int or value < 1:
+            raise RelayError(f"endpoint service {name} must be a positive integer")
+    if observation_timeout <= selected_poll_seconds:
+        raise RelayError("endpoint service observation timeout must exceed its poll interval")
+
+    return f"""CLIO_RELAY_ENDPOINT_ACTIVATION_ATTEMPTED=0
+CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=not-attempted
+CLIO_RELAY_ENDPOINT_INITIAL_STATE_VERIFIED=0
+CLIO_RELAY_ENDPOINT_INITIAL_ACTIVE_STATE=unknown
+CLIO_RELAY_ENDPOINT_INITIAL_INVOCATION_ID=unknown
+CLIO_RELAY_ENDPOINT_INITIAL_RESULT=unknown
+CLIO_RELAY_ENDPOINT_LOAD_STATE=unknown
+CLIO_RELAY_ENDPOINT_ACTIVE_STATE=unknown
+CLIO_RELAY_ENDPOINT_SUB_STATE=unknown
+CLIO_RELAY_ENDPOINT_RESULT=unknown
+CLIO_RELAY_ENDPOINT_CONTROL_PID=unknown
+CLIO_RELAY_ENDPOINT_EXEC_MAIN_CODE=unknown
+CLIO_RELAY_ENDPOINT_EXEC_MAIN_STATUS=unknown
+CLIO_RELAY_ENDPOINT_TIMEOUT_START_USEC=unknown
+CLIO_RELAY_ENDPOINT_INVOCATION_ID=unknown
+CLIO_RELAY_ENDPOINT_JOB_ID=unknown
+CLIO_RELAY_ENDPOINT_JOB_TYPE=unknown
+CLIO_RELAY_ENDPOINT_JOB_STATE=unknown
+CLIO_RELAY_ENDPOINT_JOB_OBSERVED=0
+CLIO_RELAY_ENDPOINT_ENQUEUE_CONFIRMED=0
+CLIO_RELAY_ENDPOINT_PROVENANCE_VERIFIED=0
+CLIO_RELAY_ENDPOINT_PROVENANCE_REJECTED=0
+CLIO_RELAY_ENDPOINT_TRACKED_JOB_ID=none
+CLIO_RELAY_ENDPOINT_RESTART_JOB_OBSERVED=0
+CLIO_RELAY_ENDPOINT_OBSERVED_TRANSITION=0
+CLIO_RELAY_ENDPOINT_ELAPSED_SECONDS=0
+CLIO_RELAY_ENDPOINT_ALLOW_ENQUEUE_GRACE=0
+
+clio_relay_endpoint_read_activation_state() {{
+  CLIO_RELAY_ENDPOINT_LOAD_STATE=unknown
+  CLIO_RELAY_ENDPOINT_ACTIVE_STATE=unknown
+  CLIO_RELAY_ENDPOINT_SUB_STATE=unknown
+  CLIO_RELAY_ENDPOINT_RESULT=unknown
+  CLIO_RELAY_ENDPOINT_CONTROL_PID=unknown
+  CLIO_RELAY_ENDPOINT_EXEC_MAIN_CODE=unknown
+  CLIO_RELAY_ENDPOINT_EXEC_MAIN_STATUS=unknown
+  CLIO_RELAY_ENDPOINT_TIMEOUT_START_USEC=unknown
+  CLIO_RELAY_ENDPOINT_INVOCATION_ID=unknown
+  if ! CLIO_RELAY_ENDPOINT_SHOW_OUTPUT="$(
+    timeout --signal=TERM --kill-after=2s 5s \
+      systemctl --user show "$CLIO_RELAY_ENDPOINT_SERVICE_NAME" --no-pager \
+      --property=LoadState --property=ActiveState --property=SubState \
+      --property=Result --property=ControlPID --property=ExecMainCode \
+      --property=ExecMainStatus --property=TimeoutStartUSec \
+      --property=InvocationID
+  )"; then
+    return 1
+  fi
+  while IFS='=' read -r key value; do
+    case "$key" in
+      LoadState) CLIO_RELAY_ENDPOINT_LOAD_STATE="$value" ;;
+      ActiveState) CLIO_RELAY_ENDPOINT_ACTIVE_STATE="$value" ;;
+      SubState) CLIO_RELAY_ENDPOINT_SUB_STATE="$value" ;;
+      Result) CLIO_RELAY_ENDPOINT_RESULT="$value" ;;
+      ControlPID) CLIO_RELAY_ENDPOINT_CONTROL_PID="$value" ;;
+      ExecMainCode) CLIO_RELAY_ENDPOINT_EXEC_MAIN_CODE="$value" ;;
+      ExecMainStatus) CLIO_RELAY_ENDPOINT_EXEC_MAIN_STATUS="$value" ;;
+      TimeoutStartUSec) CLIO_RELAY_ENDPOINT_TIMEOUT_START_USEC="$value" ;;
+      InvocationID) CLIO_RELAY_ENDPOINT_INVOCATION_ID="$value" ;;
+    esac
+  done < <(printf '%s\n' "$CLIO_RELAY_ENDPOINT_SHOW_OUTPUT")
+  [ "$CLIO_RELAY_ENDPOINT_LOAD_STATE" != unknown ] && \
+    [ "$CLIO_RELAY_ENDPOINT_ACTIVE_STATE" != unknown ]
+}}
+
+clio_relay_endpoint_read_activation_job() {{
+  CLIO_RELAY_ENDPOINT_JOB_ID=unknown
+  CLIO_RELAY_ENDPOINT_JOB_TYPE=unknown
+  CLIO_RELAY_ENDPOINT_JOB_STATE=unknown
+  if ! CLIO_RELAY_ENDPOINT_JOB_OUTPUT="$(
+    timeout --signal=TERM --kill-after=2s 5s \
+      systemctl --user list-jobs --no-legend --plain --no-pager \
+      "$CLIO_RELAY_ENDPOINT_SERVICE_NAME"
+  )"; then
+    return 1
+  fi
+  CLIO_RELAY_ENDPOINT_JOB_MATCHES=0
+  while read -r job_id unit_name job_type job_state _remaining; do
+    [ -n "${{job_id:-}}" ] || continue
+    [ "${{unit_name:-}}" = "$CLIO_RELAY_ENDPOINT_SERVICE_NAME" ] || continue
+    CLIO_RELAY_ENDPOINT_JOB_MATCHES=$((CLIO_RELAY_ENDPOINT_JOB_MATCHES + 1))
+    CLIO_RELAY_ENDPOINT_JOB_ID="$job_id"
+    CLIO_RELAY_ENDPOINT_JOB_TYPE="${{job_type:-unknown}}"
+    CLIO_RELAY_ENDPOINT_JOB_STATE="${{job_state:-unknown}}"
+  done < <(printf '%s\n' "$CLIO_RELAY_ENDPOINT_JOB_OUTPUT")
+  if [ "$CLIO_RELAY_ENDPOINT_JOB_MATCHES" -gt 1 ]; then
+    CLIO_RELAY_ENDPOINT_JOB_ID=ambiguous
+    CLIO_RELAY_ENDPOINT_JOB_TYPE=ambiguous
+    CLIO_RELAY_ENDPOINT_JOB_STATE=ambiguous
+    return 1
+  fi
+  if [ "$CLIO_RELAY_ENDPOINT_JOB_MATCHES" = 1 ]; then
+    CLIO_RELAY_ENDPOINT_JOB_OBSERVED=1
+  else
+    CLIO_RELAY_ENDPOINT_JOB_ID=none
+    CLIO_RELAY_ENDPOINT_JOB_TYPE=none
+    CLIO_RELAY_ENDPOINT_JOB_STATE=none
+  fi
+  return 0
+}}
+
+clio_relay_endpoint_emit_activation_observation() {{
+  printf 'endpoint_service.activation service=%s action=%s elapsed_seconds=%s '\
+'load_state=%s active_state=%s sub_state=%s result=%s control_pid=%s '\
+'exec_main_code=%s exec_main_status=%s timeout_start_usec=%s invocation_id=%s '\
+'job_id=%s job_type=%s job_state=%s outcome=%s\n' \
+    "$CLIO_RELAY_ENDPOINT_SERVICE_NAME" \
+    "$CLIO_RELAY_ENDPOINT_ACTIVATION_ACTION" \
+    "$CLIO_RELAY_ENDPOINT_ELAPSED_SECONDS" \
+    "$CLIO_RELAY_ENDPOINT_LOAD_STATE" \
+    "$CLIO_RELAY_ENDPOINT_ACTIVE_STATE" \
+    "$CLIO_RELAY_ENDPOINT_SUB_STATE" \
+    "$CLIO_RELAY_ENDPOINT_RESULT" \
+    "$CLIO_RELAY_ENDPOINT_CONTROL_PID" \
+    "$CLIO_RELAY_ENDPOINT_EXEC_MAIN_CODE" \
+    "$CLIO_RELAY_ENDPOINT_EXEC_MAIN_STATUS" \
+    "$CLIO_RELAY_ENDPOINT_TIMEOUT_START_USEC" \
+    "$CLIO_RELAY_ENDPOINT_INVOCATION_ID" \
+    "$CLIO_RELAY_ENDPOINT_JOB_ID" \
+    "$CLIO_RELAY_ENDPOINT_JOB_TYPE" \
+    "$CLIO_RELAY_ENDPOINT_JOB_STATE" \
+    "$CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME"
+}}
+
+clio_relay_endpoint_emit_activation_failure() {{
+  clio_relay_endpoint_emit_activation_observation >&2
+  printf 'endpoint_service.activation.operator_hint=journalctl --user '\
+'--unit=%s --lines=50 --no-pager\n' \
+    "$CLIO_RELAY_ENDPOINT_SERVICE_NAME" >&2
+}}
+
+clio_relay_endpoint_reject_activation_provenance() {{
+  CLIO_RELAY_ENDPOINT_PROVENANCE_VERIFIED=0
+  CLIO_RELAY_ENDPOINT_PROVENANCE_REJECTED=1
+}}
+
+clio_relay_endpoint_activation_job_is_compatible() {{
+  [ "$CLIO_RELAY_ENDPOINT_PROVENANCE_REJECTED" = 0 ] || return 1
+  if [ "$CLIO_RELAY_ENDPOINT_TRACKED_JOB_ID" != none ] && \
+     [ "$CLIO_RELAY_ENDPOINT_JOB_ID" != \
+       "$CLIO_RELAY_ENDPOINT_TRACKED_JOB_ID" ]; then
+    clio_relay_endpoint_reject_activation_provenance
+    return 1
+  fi
+  case "$CLIO_RELAY_ENDPOINT_ACTIVATION_ACTION:$CLIO_RELAY_ENDPOINT_JOB_TYPE" in
+    start:start|start:restart) ;;
+    restart:restart)
+      CLIO_RELAY_ENDPOINT_RESTART_JOB_OBSERVED=1
+      ;;
+    restart:start)
+      if [ "$CLIO_RELAY_ENDPOINT_RESTART_JOB_OBSERVED" != 1 ] && \
+         [ "$CLIO_RELAY_ENDPOINT_ENQUEUE_CONFIRMED" != 1 ]; then
+        clio_relay_endpoint_reject_activation_provenance
+        return 1
+      fi
+      ;;
+    *)
+      clio_relay_endpoint_reject_activation_provenance
+      return 1
+      ;;
+  esac
+  if [ "$CLIO_RELAY_ENDPOINT_TRACKED_JOB_ID" = none ]; then
+    CLIO_RELAY_ENDPOINT_TRACKED_JOB_ID="$CLIO_RELAY_ENDPOINT_JOB_ID"
+  fi
+  CLIO_RELAY_ENDPOINT_PROVENANCE_VERIFIED=1
+  return 0
+}}
+
+clio_relay_endpoint_activation_is_complete() {{
+  [ "$CLIO_RELAY_ENDPOINT_LOAD_STATE" = loaded ] || return 1
+  [ "$CLIO_RELAY_ENDPOINT_ACTIVE_STATE" = active ] || return 1
+  [ "$CLIO_RELAY_ENDPOINT_PROVENANCE_VERIFIED" = 1 ] || return 1
+  [ "$CLIO_RELAY_ENDPOINT_PROVENANCE_REJECTED" = 0 ] || return 1
+  if [ "$CLIO_RELAY_ENDPOINT_ACTIVATION_ACTION" != restart ]; then
+    return 0
+  fi
+  [ "$CLIO_RELAY_ENDPOINT_INITIAL_STATE_VERIFIED" = 1 ] || return 1
+  if [ "$CLIO_RELAY_ENDPOINT_INITIAL_INVOCATION_ID" != unknown ] && \
+     [ -n "$CLIO_RELAY_ENDPOINT_INITIAL_INVOCATION_ID" ] && \
+     [ "$CLIO_RELAY_ENDPOINT_INVOCATION_ID" != unknown ] && \
+     [ -n "$CLIO_RELAY_ENDPOINT_INVOCATION_ID" ]; then
+    [ "$CLIO_RELAY_ENDPOINT_INVOCATION_ID" != \
+      "$CLIO_RELAY_ENDPOINT_INITIAL_INVOCATION_ID" ]
+    return
+  fi
+  [ "$CLIO_RELAY_ENDPOINT_OBSERVED_TRANSITION" = 1 ]
+}}
+
+clio_relay_endpoint_inactive_is_terminal() {{
+  [ "$CLIO_RELAY_ENDPOINT_JOB_OBSERVED" = 1 ] && return 0
+  [ "$CLIO_RELAY_ENDPOINT_INVOCATION_ID" != unknown ] && \
+    [ -n "$CLIO_RELAY_ENDPOINT_INVOCATION_ID" ] && \
+    [ "$CLIO_RELAY_ENDPOINT_INVOCATION_ID" != \
+      "$CLIO_RELAY_ENDPOINT_INITIAL_INVOCATION_ID" ]
+}}
+
+clio_relay_endpoint_failed_is_terminal() {{
+  [ "$CLIO_RELAY_ENDPOINT_JOB_OBSERVED" = 1 ] && return 0
+  if [ "$CLIO_RELAY_ENDPOINT_RESULT" != \
+       "$CLIO_RELAY_ENDPOINT_INITIAL_RESULT" ] && \
+     [ "$CLIO_RELAY_ENDPOINT_RESULT" != unknown ]; then
+    return 0
+  fi
+  [ "$CLIO_RELAY_ENDPOINT_INITIAL_INVOCATION_ID" != unknown ] && \
+    [ -n "$CLIO_RELAY_ENDPOINT_INITIAL_INVOCATION_ID" ] && \
+    [ "$CLIO_RELAY_ENDPOINT_INVOCATION_ID" != unknown ] && \
+    [ -n "$CLIO_RELAY_ENDPOINT_INVOCATION_ID" ] && \
+    [ "$CLIO_RELAY_ENDPOINT_INVOCATION_ID" != \
+      "$CLIO_RELAY_ENDPOINT_INITIAL_INVOCATION_ID" ]
+}}
+
+clio_relay_endpoint_update_observed_transition() {{
+  [ "$CLIO_RELAY_ENDPOINT_PROVENANCE_VERIFIED" = 1 ] || return 0
+  [ "$CLIO_RELAY_ENDPOINT_PROVENANCE_REJECTED" = 0 ] || return 0
+  if [ "$CLIO_RELAY_ENDPOINT_LOAD_STATE" = loaded ] && \
+     [ "$CLIO_RELAY_ENDPOINT_INITIAL_ACTIVE_STATE" != active ] && \
+     [ "$CLIO_RELAY_ENDPOINT_ACTIVE_STATE" = active ]; then
+    CLIO_RELAY_ENDPOINT_OBSERVED_TRANSITION=1
+    return 0
+  fi
+  case "$CLIO_RELAY_ENDPOINT_LOAD_STATE:$CLIO_RELAY_ENDPOINT_ACTIVE_STATE" in
+    loaded:activating|loaded:deactivating|loaded:reloading|loaded:maintenance|loaded:refreshing|loaded:inactive|loaded:failed)
+      CLIO_RELAY_ENDPOINT_OBSERVED_TRANSITION=1
+      ;;
+  esac
+}}
+
+clio_relay_endpoint_classify_activation_snapshot() {{
+  CLIO_RELAY_ENDPOINT_SNAPSHOT_TERMINAL=0
+  CLIO_RELAY_ENDPOINT_SNAPSHOT_SUCCESS=0
+  CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=unverified
+  if [ "$CLIO_RELAY_ENDPOINT_JOB_ID" = ambiguous ]; then
+    clio_relay_endpoint_reject_activation_provenance
+    CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=in-progress
+    CLIO_RELAY_ENDPOINT_SNAPSHOT_TERMINAL=1
+    return 0
+  fi
+  if [ "$CLIO_RELAY_ENDPOINT_JOB_READ" = 0 ] && \
+     [ "$CLIO_RELAY_ENDPOINT_JOB_ID" != none ] && \
+     ! clio_relay_endpoint_activation_job_is_compatible; then
+    CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=in-progress
+    CLIO_RELAY_ENDPOINT_SNAPSHOT_TERMINAL=1
+    return 0
+  fi
+  if [ "$CLIO_RELAY_ENDPOINT_STATE_READ" != 0 ]; then
+    return 0
+  fi
+  if [ "$CLIO_RELAY_ENDPOINT_JOB_READ" != 0 ]; then
+    case "$CLIO_RELAY_ENDPOINT_LOAD_STATE:$CLIO_RELAY_ENDPOINT_ACTIVE_STATE" in
+      loaded:activating|loaded:deactivating|loaded:reloading|loaded:maintenance|loaded:refreshing)
+        CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=in-progress
+        ;;
+      masked:*|not-found:*|bad-setting:*|error:*)
+        clio_relay_endpoint_reject_activation_provenance
+        CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=failed
+        CLIO_RELAY_ENDPOINT_SNAPSHOT_TERMINAL=1
+        ;;
+    esac
+    return 0
+  fi
+  clio_relay_endpoint_update_observed_transition
+  if [ "$CLIO_RELAY_ENDPOINT_JOB_ID" = none ] && \
+     clio_relay_endpoint_activation_is_complete; then
+    CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=active
+    CLIO_RELAY_ENDPOINT_SNAPSHOT_TERMINAL=1
+    CLIO_RELAY_ENDPOINT_SNAPSHOT_SUCCESS=1
+    return 0
+  fi
+  case "$CLIO_RELAY_ENDPOINT_LOAD_STATE:$CLIO_RELAY_ENDPOINT_ACTIVE_STATE" in
+    masked:*|not-found:*|bad-setting:*|error:*)
+      clio_relay_endpoint_reject_activation_provenance
+      CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=failed
+      CLIO_RELAY_ENDPOINT_SNAPSHOT_TERMINAL=1
+      ;;
+    loaded:activating|loaded:deactivating|loaded:reloading|loaded:maintenance|loaded:refreshing)
+      CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=in-progress
+      ;;
+    loaded:inactive)
+      if [ "$CLIO_RELAY_ENDPOINT_JOB_ID" != none ]; then
+        CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=in-progress
+      elif [ "$CLIO_RELAY_ENDPOINT_PROVENANCE_VERIFIED" = 1 ] && \
+           [ "$CLIO_RELAY_ENDPOINT_PROVENANCE_REJECTED" = 0 ] && \
+           clio_relay_endpoint_inactive_is_terminal; then
+        CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=failed
+        CLIO_RELAY_ENDPOINT_SNAPSHOT_TERMINAL=1
+      elif [ "$CLIO_RELAY_ENDPOINT_ALLOW_ENQUEUE_GRACE" = 1 ] && \
+           [ "$CLIO_RELAY_ENDPOINT_ENQUEUE_CONFIRMED" = 1 ] && \
+           [ "$CLIO_RELAY_ENDPOINT_PROVENANCE_VERIFIED" = 1 ] && \
+           [ "$CLIO_RELAY_ENDPOINT_PROVENANCE_REJECTED" = 0 ] && \
+           [ "$CLIO_RELAY_ENDPOINT_JOB_OBSERVED" = 0 ]; then
+        CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=in-progress
+      fi
+      ;;
+    loaded:failed)
+      if [ "$CLIO_RELAY_ENDPOINT_JOB_ID" != none ]; then
+        CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=in-progress
+      elif [ "$CLIO_RELAY_ENDPOINT_PROVENANCE_VERIFIED" = 1 ] && \
+           [ "$CLIO_RELAY_ENDPOINT_PROVENANCE_REJECTED" = 0 ] && \
+           clio_relay_endpoint_failed_is_terminal; then
+        CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=failed
+        CLIO_RELAY_ENDPOINT_SNAPSHOT_TERMINAL=1
+      elif [ "$CLIO_RELAY_ENDPOINT_ALLOW_ENQUEUE_GRACE" = 1 ] && \
+           [ "$CLIO_RELAY_ENDPOINT_ENQUEUE_CONFIRMED" = 1 ] && \
+           [ "$CLIO_RELAY_ENDPOINT_PROVENANCE_VERIFIED" = 1 ] && \
+           [ "$CLIO_RELAY_ENDPOINT_PROVENANCE_REJECTED" = 0 ] && \
+           [ "$CLIO_RELAY_ENDPOINT_JOB_OBSERVED" = 0 ]; then
+        CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=in-progress
+      fi
+      ;;
+    loaded:active)
+      if [ "$CLIO_RELAY_ENDPOINT_JOB_ID" != none ]; then
+        CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=in-progress
+      elif [ "$CLIO_RELAY_ENDPOINT_ALLOW_ENQUEUE_GRACE" = 1 ] && \
+           [ "$CLIO_RELAY_ENDPOINT_ENQUEUE_CONFIRMED" = 1 ] && \
+           [ "$CLIO_RELAY_ENDPOINT_PROVENANCE_VERIFIED" = 1 ] && \
+           [ "$CLIO_RELAY_ENDPOINT_PROVENANCE_REJECTED" = 0 ] && \
+           [ "$CLIO_RELAY_ENDPOINT_JOB_OBSERVED" = 0 ]; then
+        CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=in-progress
+      fi
+      ;;
+    *)
+      if [ "$CLIO_RELAY_ENDPOINT_JOB_ID" != none ]; then
+        CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=in-progress
+      fi
+      ;;
+  esac
+}}
+
+clio_relay_endpoint_wait_for_active() {{
+  CLIO_RELAY_ENDPOINT_WAIT_STARTED=$SECONDS
+  CLIO_RELAY_ENDPOINT_NEXT_PROGRESS=0
+  CLIO_RELAY_ENDPOINT_LAST_SIGNATURE=
+  while true; do
+    CLIO_RELAY_ENDPOINT_ELAPSED_SECONDS=$((SECONDS - CLIO_RELAY_ENDPOINT_WAIT_STARTED))
+    CLIO_RELAY_ENDPOINT_STATE_READ=1
+    if clio_relay_endpoint_read_activation_state; then
+      CLIO_RELAY_ENDPOINT_STATE_READ=0
+    fi
+    CLIO_RELAY_ENDPOINT_JOB_READ=1
+    if clio_relay_endpoint_read_activation_job; then
+      CLIO_RELAY_ENDPOINT_JOB_READ=0
+    fi
+    CLIO_RELAY_ENDPOINT_ALLOW_ENQUEUE_GRACE=1
+    clio_relay_endpoint_classify_activation_snapshot
+    if [ "$CLIO_RELAY_ENDPOINT_SNAPSHOT_TERMINAL" = 1 ]; then
+      if [ "$CLIO_RELAY_ENDPOINT_SNAPSHOT_SUCCESS" = 1 ]; then
+        clio_relay_endpoint_emit_activation_observation
+        return 0
+      fi
+      clio_relay_endpoint_emit_activation_failure
+      return 1
+    fi
+    if [ "$CLIO_RELAY_ENDPOINT_ELAPSED_SECONDS" -ge {observation_timeout} ]; then
+      if [ "$CLIO_RELAY_ENDPOINT_STATE_READ" != 0 ]; then
+        CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=unverified
+      elif [ "$CLIO_RELAY_ENDPOINT_JOB_READ" != 0 ]; then
+        case "$CLIO_RELAY_ENDPOINT_LOAD_STATE:$CLIO_RELAY_ENDPOINT_ACTIVE_STATE" in
+          loaded:activating|loaded:deactivating|loaded:reloading|loaded:maintenance|loaded:refreshing)
+            CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=in-progress
+            ;;
+          *)
+            CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=unverified
+            ;;
+        esac
+      elif [ "$CLIO_RELAY_ENDPOINT_JOB_ID" = none ]; then
+        case "$CLIO_RELAY_ENDPOINT_LOAD_STATE:$CLIO_RELAY_ENDPOINT_ACTIVE_STATE" in
+          loaded:activating|loaded:deactivating|loaded:reloading|loaded:maintenance|loaded:refreshing)
+            CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=in-progress
+            ;;
+          *)
+            CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=unverified
+            ;;
+        esac
+      fi
+      clio_relay_endpoint_emit_activation_failure
+      return 1
+    fi
+    CLIO_RELAY_ENDPOINT_SIGNATURE="$CLIO_RELAY_ENDPOINT_LOAD_STATE:"\
+"$CLIO_RELAY_ENDPOINT_ACTIVE_STATE:$CLIO_RELAY_ENDPOINT_SUB_STATE:"\
+"$CLIO_RELAY_ENDPOINT_RESULT:$CLIO_RELAY_ENDPOINT_INVOCATION_ID:"\
+"$CLIO_RELAY_ENDPOINT_JOB_ID:$CLIO_RELAY_ENDPOINT_JOB_TYPE:"\
+"$CLIO_RELAY_ENDPOINT_JOB_STATE:$CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME"
+    if [ "$CLIO_RELAY_ENDPOINT_SIGNATURE" != \
+         "$CLIO_RELAY_ENDPOINT_LAST_SIGNATURE" ] || \
+       [ "$CLIO_RELAY_ENDPOINT_ELAPSED_SECONDS" -ge \
+         "$CLIO_RELAY_ENDPOINT_NEXT_PROGRESS" ]; then
+      clio_relay_endpoint_emit_activation_observation
+      CLIO_RELAY_ENDPOINT_LAST_SIGNATURE="$CLIO_RELAY_ENDPOINT_SIGNATURE"
+      CLIO_RELAY_ENDPOINT_NEXT_PROGRESS=$((
+        CLIO_RELAY_ENDPOINT_ELAPSED_SECONDS + {selected_progress_seconds}
+      ))
+    fi
+    sleep {selected_poll_seconds}
+  done
+}}
+
+clio_relay_endpoint_activate_bounded() {{
+  case "${{CLIO_RELAY_ENDPOINT_SERVICE_NAME:-}}" in
+    '') echo "endpoint service name is required" >&2; return 2 ;;
+    *[!A-Za-z0-9_.@-]*) echo "endpoint service name is unsafe" >&2; return 2 ;;
+  esac
+  case "${{CLIO_RELAY_ENDPOINT_ACTIVATION_ACTION:-}}" in
+    start|restart) ;;
+    *) echo "endpoint service activation action must be start or restart" >&2; return 2 ;;
+  esac
+  command -v timeout >/dev/null 2>&1 || {{
+    echo "timeout is required to bound endpoint service activation" >&2
+    return 2
+  }}
+  command -v systemctl >/dev/null 2>&1 || {{
+    echo "systemctl is required to activate the endpoint service" >&2
+    return 2
+  }}
+  command -v flock >/dev/null 2>&1 || {{
+    echo "flock is required to serialize endpoint service activation" >&2
+    return 2
+  }}
+  if [ "$CLIO_RELAY_ENDPOINT_ACTIVATION_ATTEMPTED" = 1 ]; then
+    CLIO_RELAY_ENDPOINT_STATE_READ=1
+    if clio_relay_endpoint_read_activation_state; then
+      CLIO_RELAY_ENDPOINT_STATE_READ=0
+    fi
+    CLIO_RELAY_ENDPOINT_JOB_READ=1
+    if clio_relay_endpoint_read_activation_job; then
+      CLIO_RELAY_ENDPOINT_JOB_READ=0
+    fi
+    CLIO_RELAY_ENDPOINT_ALLOW_ENQUEUE_GRACE=0
+    clio_relay_endpoint_classify_activation_snapshot
+    if [ "$CLIO_RELAY_ENDPOINT_SNAPSHOT_TERMINAL" = 1 ]; then
+      if [ "$CLIO_RELAY_ENDPOINT_SNAPSHOT_SUCCESS" = 1 ]; then
+        clio_relay_endpoint_emit_activation_observation
+        return 0
+      fi
+      clio_relay_endpoint_emit_activation_failure
+      return 1
+    fi
+    if [ "$CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME" = in-progress ]; then
+      clio_relay_endpoint_emit_activation_observation
+    else
+      clio_relay_endpoint_emit_activation_failure
+    fi
+    return 1
+  fi
+  CLIO_RELAY_ENDPOINT_ACTIVATION_ATTEMPTED=1
+  if [ -n "${{XDG_RUNTIME_DIR:-}}" ]; then
+    CLIO_RELAY_ENDPOINT_ACTIVATION_LOCK_DIR="$XDG_RUNTIME_DIR/clio-relay/activation-locks"
+  elif [ -n "${{HOME:-}}" ]; then
+    CLIO_RELAY_ENDPOINT_ACTIVATION_LOCK_DIR="$HOME/.local/share/clio-relay/activation-locks"
+  else
+    CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=preflight-unverified
+    clio_relay_endpoint_emit_activation_failure
+    return 1
+  fi
+  CLIO_RELAY_ENDPOINT_ACTIVATION_LOCK_PATH="$CLIO_RELAY_ENDPOINT_ACTIVATION_LOCK_DIR/$CLIO_RELAY_ENDPOINT_SERVICE_NAME.lock"
+  if ! (umask 077 && mkdir -p -- "$CLIO_RELAY_ENDPOINT_ACTIVATION_LOCK_DIR") || \
+     ! chmod 700 -- "$CLIO_RELAY_ENDPOINT_ACTIVATION_LOCK_DIR"; then
+    CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=preflight-unverified
+    clio_relay_endpoint_emit_activation_failure
+    return 1
+  fi
+  if ! exec 7>"$CLIO_RELAY_ENDPOINT_ACTIVATION_LOCK_PATH"; then
+    CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=preflight-unverified
+    clio_relay_endpoint_emit_activation_failure
+    return 1
+  fi
+  if ! timeout --signal=TERM --kill-after=2s \
+       {ENDPOINT_SERVICE_CONTROL_TIMEOUT_SECONDS}s flock --exclusive 7; then
+    exec 7>&-
+    CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=preflight-unverified
+    clio_relay_endpoint_emit_activation_failure
+    return 1
+  fi
+  if ! clio_relay_endpoint_read_activation_state; then
+    flock --unlock 7 || true
+    exec 7>&-
+    CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=preflight-unverified
+    clio_relay_endpoint_emit_activation_failure
+    return 1
+  fi
+  CLIO_RELAY_ENDPOINT_INITIAL_STATE_VERIFIED=1
+  CLIO_RELAY_ENDPOINT_INITIAL_ACTIVE_STATE="$CLIO_RELAY_ENDPOINT_ACTIVE_STATE"
+  CLIO_RELAY_ENDPOINT_INITIAL_INVOCATION_ID="$CLIO_RELAY_ENDPOINT_INVOCATION_ID"
+  CLIO_RELAY_ENDPOINT_INITIAL_RESULT="$CLIO_RELAY_ENDPOINT_RESULT"
+  if ! clio_relay_endpoint_read_activation_job; then
+    if [ "$CLIO_RELAY_ENDPOINT_JOB_ID" = ambiguous ]; then
+      clio_relay_endpoint_reject_activation_provenance
+    fi
+    flock --unlock 7 || true
+    exec 7>&-
+    CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=preflight-unverified
+    clio_relay_endpoint_emit_activation_failure
+    return 1
+  fi
+  if [ "$CLIO_RELAY_ENDPOINT_LOAD_STATE" != loaded ]; then
+    flock --unlock 7 || true
+    exec 7>&-
+    case "$CLIO_RELAY_ENDPOINT_LOAD_STATE" in
+      masked|not-found|bad-setting|error)
+        clio_relay_endpoint_reject_activation_provenance
+        CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=failed
+        ;;
+      *)
+        CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=preflight-unverified
+        ;;
+    esac
+    clio_relay_endpoint_emit_activation_failure
+    return 1
+  fi
+  case "$CLIO_RELAY_ENDPOINT_JOB_ID" in
+    none) ;;
+    *)
+      flock --unlock 7 || true
+      exec 7>&-
+      CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=in-progress
+      if ! clio_relay_endpoint_activation_job_is_compatible; then
+        clio_relay_endpoint_emit_activation_failure
+        return 1
+      fi
+      clio_relay_endpoint_emit_activation_observation
+      clio_relay_endpoint_wait_for_active
+      return
+      ;;
+  esac
+  case "$CLIO_RELAY_ENDPOINT_ACTIVE_STATE" in
+    active|inactive|failed) ;;
+    *)
+      flock --unlock 7 || true
+      exec 7>&-
+      CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=in-progress
+      clio_relay_endpoint_emit_activation_failure
+      return 1
+      ;;
+  esac
+  if timeout --signal=TERM --kill-after=2s \
+       {ENDPOINT_SERVICE_CONTROL_TIMEOUT_SECONDS}s \
+       systemctl --user "$CLIO_RELAY_ENDPOINT_ACTIVATION_ACTION" --no-block \
+       "$CLIO_RELAY_ENDPOINT_SERVICE_NAME"; then
+    CLIO_RELAY_ENDPOINT_ENQUEUE_CONFIRMED=1
+    CLIO_RELAY_ENDPOINT_PROVENANCE_VERIFIED=1
+    CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=in-progress
+    flock --unlock 7 || true
+    exec 7>&-
+  else
+    CLIO_RELAY_ENDPOINT_ENQUEUE_STATUS=$?
+    case "$CLIO_RELAY_ENDPOINT_ENQUEUE_STATUS" in
+      124|137) CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=enqueue-unverified ;;
+      *) CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=failed ;;
+    esac
+    CLIO_RELAY_ENDPOINT_POST_ENQUEUE_INVENTORY=verified
+    clio_relay_endpoint_read_activation_state || \
+      CLIO_RELAY_ENDPOINT_POST_ENQUEUE_INVENTORY=unverified
+    if ! clio_relay_endpoint_read_activation_job; then
+      CLIO_RELAY_ENDPOINT_POST_ENQUEUE_INVENTORY=unverified
+      if [ "$CLIO_RELAY_ENDPOINT_JOB_ID" = ambiguous ]; then
+        clio_relay_endpoint_reject_activation_provenance
+      fi
+    fi
+    flock --unlock 7 || true
+    exec 7>&-
+    if [ "$CLIO_RELAY_ENDPOINT_POST_ENQUEUE_INVENTORY" != verified ]; then
+      CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=enqueue-unverified
+      clio_relay_endpoint_emit_activation_failure
+      return 1
+    fi
+    case "$CLIO_RELAY_ENDPOINT_LOAD_STATE" in
+      masked|not-found|bad-setting|error)
+        clio_relay_endpoint_reject_activation_provenance
+        CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=failed
+        clio_relay_endpoint_emit_activation_failure
+        return 1
+        ;;
+    esac
+    if [ "$CLIO_RELAY_ENDPOINT_JOB_ID" = none ]; then
+      clio_relay_endpoint_emit_activation_failure
+      return 1
+    fi
+    if ! clio_relay_endpoint_activation_job_is_compatible; then
+      clio_relay_endpoint_emit_activation_failure
+      return 1
+    fi
+    CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME=in-progress
+  fi
+  clio_relay_endpoint_wait_for_active
+}}
+""".replace("\r\n", "\n")
+
 
 def render_endpoint_user_service(
     *,
@@ -166,6 +800,10 @@ Environment="{INSTALL_RECEIPT_PATH_ENV}=%h/.local/share/clio-relay/install-recei
 {jarvis_mcp_spack_unset_line}
 ExecStartPre={exec_start_pre}
 ExecStart={exec_start}
+# Queue-index migration runs in ExecStartPre. Give systemd a finite bound that
+# is longer than normal migration, while keeping the external observer bounded
+# slightly beyond this deadline for a definitive terminal state.
+TimeoutStartSec={ENDPOINT_SERVICE_SYSTEMD_START_TIMEOUT_SECONDS}s
 # Keep an enabled persistent endpoint available after clean or failed process
 # exits. Explicit systemd stop operations are not restarted by this policy.
 Restart=always
@@ -184,7 +822,7 @@ def install_endpoint_user_service_over_ssh(
     start: bool,
     enable: bool,
     require_persistent: bool = True,
-    timeout_seconds: float = 120.0,
+    timeout_seconds: float = ENDPOINT_SERVICE_SSH_TIMEOUT_SECONDS,
 ) -> list[str]:
     """Install a user-level systemd service on a remote cluster without sudo.
 
@@ -217,7 +855,7 @@ def restart_endpoint_user_service_over_ssh(
     ssh_host: str,
     expected_capacity: WorkerCapacityPolicy,
     require_persistent: bool = True,
-    timeout_seconds: float = 120.0,
+    timeout_seconds: float = ENDPOINT_SERVICE_SSH_TIMEOUT_SECONDS,
 ) -> list[str]:
     """Restart an installed endpoint unit after verifying its persisted policy."""
     _validate_ssh_destination(ssh_host)
@@ -282,7 +920,21 @@ def _remote_install_script(
     if enable:
         command += f"systemctl --user enable {shlex.quote(service_name)}\n"
     if start:
-        command += f"systemctl --user restart {shlex.quote(service_name)}\n"
+        command += (
+            f"CLIO_RELAY_ENDPOINT_SERVICE_NAME={shlex.quote(service_name)}\n"
+            "CLIO_RELAY_ENDPOINT_ACTIVATION_ACTION=restart\n"
+            + render_bounded_user_service_activation_helper()
+            + "\nif ! clio_relay_endpoint_activate_bounded; then\n"
+            + (
+                '  echo "endpoint service did not become active: '
+                f"{service_name} "
+                "$CLIO_RELAY_ENDPOINT_ACTIVE_STATE/"
+                "$CLIO_RELAY_ENDPOINT_SUB_STATE "
+                'outcome=$CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME" >&2\n'
+            )
+            + "  exit 1\n"
+            + "fi\n"
+        )
     command += (
         'service_enabled="$(systemctl --user is-enabled '
         f'{shlex.quote(service_name)} 2>/dev/null || true)"\n'
@@ -462,7 +1114,15 @@ if [ "$argv_count" -ne 1 ] || [ -n "$policy_parse_error" ] || \
   echo "to reinstall the managed unit" >&2
   exit 79
 fi
-systemctl --user restart {service_literal}
+CLIO_RELAY_ENDPOINT_SERVICE_NAME={service_literal}
+CLIO_RELAY_ENDPOINT_ACTIVATION_ACTION=restart
+{render_bounded_user_service_activation_helper()}
+if ! clio_relay_endpoint_activate_bounded; then
+  echo "endpoint service did not become active after restart: {service_name} \
+$CLIO_RELAY_ENDPOINT_ACTIVE_STATE/$CLIO_RELAY_ENDPOINT_SUB_STATE \
+outcome=$CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME" >&2
+  exit 1
+fi
 service_active="$(systemctl --user is-active {service_literal} 2>/dev/null || true)"
 if [ "$service_active" != "active" ]; then
   echo "endpoint service is not active after restart: {service_name} $service_active" >&2

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -14,6 +14,7 @@ from typing import Any
 import pytest
 import yaml
 
+import clio_relay.deployment as deployment
 from clio_relay import __version__
 from clio_relay.application_profiles import (
     install_cluster_app_over_ssh,
@@ -496,8 +497,15 @@ def test_bootstrap_over_ssh_returns_the_matching_durable_invocation_receipt(
         archive.write_bytes(b"bootstrap archive")
         return bootstrap.BootstrapArchive(archive=archive, install_spec="clio-relay==1.0.0")
 
-    def fake_run(command: list[str]) -> subprocess.CompletedProcess[str]:
+    observed_timeouts: list[float | None] = []
+
+    def fake_run(
+        command: list[str],
+        *,
+        timeout_seconds: float | None = None,
+    ) -> subprocess.CompletedProcess[str]:
         calls.append(command)
+        observed_timeouts.append(timeout_seconds)
         if command[0] == "scp" and command[-1].endswith("/clio-relay-bootstrap.sh"):
             uploaded_scripts.append(Path(command[1]).read_text(encoding="utf-8"))
         if command[-2:] == [
@@ -556,6 +564,16 @@ def test_bootstrap_over_ssh_returns_the_matching_durable_invocation_receipt(
         command[-1] == "ares:/tmp/clio-relay-bootstrap_abc/clio-relay-head.tar" for command in calls
     )
     assert uploaded_scripts
+    remote_script_call = calls.index(
+        ["ssh", "ares", "bash", "/tmp/clio-relay-bootstrap_abc/clio-relay-bootstrap.sh"]
+    )
+    assert (
+        observed_timeouts[remote_script_call] == bootstrap.BOOTSTRAP_REMOTE_SCRIPT_TIMEOUT_SECONDS
+    )
+    assert (
+        bootstrap.BOOTSTRAP_REMOTE_SCRIPT_TIMEOUT_SECONDS
+        >= deployment.ENDPOINT_SERVICE_START_OBSERVATION_TIMEOUT_SECONDS + 60
+    )
     assert 'exec 9>"$HOME/.local/share/clio-relay/bootstrap.lock"' in uploaded_scripts[0]
     assert "sha256sum --check --strict" in uploaded_scripts[0]
     assert "/tmp/clio-relay-head.tar" not in uploaded_scripts[0]

--- a/tests/test_bootstrap_cluster_paths.py
+++ b/tests/test_bootstrap_cluster_paths.py
@@ -58,7 +58,7 @@ def test_managed_bootstrap_fences_worker_around_migration() -> None:
     install = 'install -m 0755 "frp_${FRP_VERSION}_linux_amd64/frpc"'
     relay_replace = "uv tool install --force --python 3.12 --no-config"
     migrate = "clio-relay init --migrate-legacy-output"
-    restart = 'systemctl --user start "$WORKER_SERVICE_NAME"'
+    restart = 'systemctl --user "$CLIO_RELAY_ENDPOINT_ACTIVATION_ACTION" --no-block'
     first_proof = script.index(writer_proof)
     second_proof = script.index(writer_proof, first_proof + 1)
     relay_replacement = script.rindex(relay_replace)
@@ -71,6 +71,7 @@ def test_managed_bootstrap_fences_worker_around_migration() -> None:
         < script.rindex("if ! bootstrap_bounded_worker_restart; then")
     )
     assert restart in script
+    assert '"$CLIO_RELAY_ENDPOINT_SERVICE_NAME"' in script
     assert "WORKER_WRITER_PROOF=1" in script
     assert 'exec 9>"$HOME/.local/share/clio-relay/bootstrap.lock"' in script
     assert "if ! flock -n 9; then" in script
@@ -78,6 +79,8 @@ def test_managed_bootstrap_fences_worker_around_migration() -> None:
     assert "WORKER_LIFETIME_GUARD_FD=8" in script
     assert 'exec 9<>"$WORKER_LIFETIME_LOCK_PATH"' not in script
     assert "bootstrap_bounded_worker_restart" in script
+    assert "CLIO_RELAY_ENDPOINT_ACTIVATION_ACTION=start" in script
+    assert "list-jobs --no-legend --plain --no-pager" in script
     assert "worker_recovery=restored" in script
     assert "worker state is unknown and requires operator verification" in script
 
@@ -90,11 +93,15 @@ def test_managed_bootstrap_releases_lifetime_guard_before_normal_restart() -> No
     worker_fence, worker_recheck, _init, worker_restart = bootstrap._worker_upgrade_fence_script(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
         "test-cluster",
         rendered_core_dir='"$test_root/core"',
+        activation_observation_timeout_seconds=2,
+        activation_poll_seconds=1,
+        activation_progress_seconds=1,
     )
     harness = f"""set -euo pipefail
 test_root="$(mktemp -d)"
 trap 'rm -rf -- "$test_root"' EXIT
-mkdir -p "$test_root/bin"
+mkdir -p "$test_root/bin" "$test_root/home"
+export HOME="$test_root/home"
 export BOOTSTRAP_TEST_STATE="$test_root/worker-state"
 echo active > "$BOOTSTRAP_TEST_STATE"
 cat > "$test_root/bin/python3" <<'__FAKE_PYTHON__'
@@ -106,12 +113,25 @@ cat > "$test_root/bin/systemctl" <<'__FAKE_SYSTEMCTL__'
 set -u
 case "${{2:-}}" in
   show)
+    state="$(cat "$BOOTSTRAP_TEST_STATE")"
     case " $* " in
-      *" --property=LoadState "*) echo loaded ;;
-      *" --property=ActiveState "*) cat "$BOOTSTRAP_TEST_STATE" ;;
-      *) exit 2 ;;
+      *--property=LoadState*--value*) echo loaded ;;
+      *--property=ActiveState*--value*) echo "$state" ;;
+      *)
+        invocation=old-invocation
+        sub_state=dead
+        if [ "$state" = active ]; then
+          invocation=new-invocation
+          sub_state=running
+        fi
+        printf '%s\n' 'LoadState=loaded' "ActiveState=$state" \
+          "SubState=$sub_state" 'Result=success' 'ControlPID=0' \
+          'ExecMainCode=0' 'ExecMainStatus=0' 'TimeoutStartUSec=5min' \
+          "InvocationID=$invocation"
+        ;;
     esac
     ;;
+  list-jobs) ;;
   stop)
     echo "fake-systemctl=stop" >&2
     echo inactive > "$BOOTSTRAP_TEST_STATE"
@@ -128,7 +148,11 @@ case "${{2:-}}" in
   *) exit 2 ;;
 esac
 __FAKE_SYSTEMCTL__
-chmod +x "$test_root/bin/python3" "$test_root/bin/systemctl"
+cat > "$test_root/bin/flock" <<'__FAKE_FLOCK__'
+#!/usr/bin/env bash
+case "${{1:-}}" in --exclusive|--unlock) exit 0 ;; *) exit 2 ;; esac
+__FAKE_FLOCK__
+chmod +x "$test_root/bin/python3" "$test_root/bin/systemctl" "$test_root/bin/flock"
 export PATH="$test_root/bin:$PATH"
 {worker_fence}
 {worker_recheck}
@@ -161,13 +185,17 @@ def test_failed_managed_bootstrap_restores_previously_active_worker(
     worker_fence, _recheck, _init, _restart = bootstrap._worker_upgrade_fence_script(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
         "ares",
         rendered_core_dir='"$test_root/core"',
+        activation_observation_timeout_seconds=2,
+        activation_poll_seconds=1,
+        activation_progress_seconds=1,
     )
     restart_result = (
         'echo active > "$BOOTSTRAP_TEST_STATE"\nexit 0' if restart_succeeds else "exit 1"
     )
     harness = f"""set -euo pipefail
 test_root="$(mktemp -d)"
-mkdir -p "$test_root/bin"
+mkdir -p "$test_root/bin" "$test_root/home"
+export HOME="$test_root/home"
 export BOOTSTRAP_TEST_STATE="$test_root/worker-state"
 export BOOTSTRAP_TEST_STARTED="$test_root/start-attempted"
 echo active > "$BOOTSTRAP_TEST_STATE"
@@ -180,18 +208,28 @@ cat > "$test_root/bin/systemctl" <<'__FAKE_SYSTEMCTL__'
 set -u
 case "${{2:-}}" in
   show)
+    state="$(cat "$BOOTSTRAP_TEST_STATE")"
     case " $* " in
-      *" --property=LoadState "*) echo loaded ;;
-      *" --property=ActiveState "*)
-        state="$(cat "$BOOTSTRAP_TEST_STATE")"
-        echo "$state"
-        if [ -f "$BOOTSTRAP_TEST_STARTED" ]; then
-          rm -rf -- "$(dirname "$BOOTSTRAP_TEST_STATE")"
+      *--property=LoadState*--value*) echo loaded ;;
+      *--property=ActiveState*--value*) echo "$state" ;;
+      *)
+        invocation=old-invocation
+        sub_state=dead
+        result=success
+        if [ "$state" = active ]; then
+          invocation=new-invocation
+          sub_state=running
+        elif [ "$state" = failed ]; then
+          result=exit-code
         fi
+        printf '%s\n' 'LoadState=loaded' "ActiveState=$state" \
+          "SubState=$sub_state" "Result=$result" 'ControlPID=0' \
+          'ExecMainCode=0' 'ExecMainStatus=0' 'TimeoutStartUSec=5min' \
+          "InvocationID=$invocation"
         ;;
-      *) exit 2 ;;
     esac
     ;;
+  list-jobs) ;;
   stop)
     echo "fake-systemctl=stop" >&2
     echo inactive > "$BOOTSTRAP_TEST_STATE"
@@ -208,7 +246,11 @@ case "${{2:-}}" in
   *) exit 2 ;;
 esac
 __FAKE_SYSTEMCTL__
-chmod +x "$test_root/bin/python3" "$test_root/bin/systemctl"
+cat > "$test_root/bin/flock" <<'__FAKE_FLOCK__'
+#!/usr/bin/env bash
+case "${{1:-}}" in --exclusive|--unlock) exit 0 ;; *) exit 2 ;; esac
+__FAKE_FLOCK__
+chmod +x "$test_root/bin/python3" "$test_root/bin/systemctl" "$test_root/bin/flock"
 export PATH="$test_root/bin:$PATH"
 {worker_fence}
 echo "remote-bootstrap-step=sabotaged" >&2
@@ -810,7 +852,12 @@ def test_bootstrap_over_ssh_forwards_configured_data_directories(
         "completed_at": "2026-07-14T00:00:00Z",
     }
 
-    def fake_run(command: list[str]) -> subprocess.CompletedProcess[str]:
+    def fake_run(
+        command: list[str],
+        *,
+        timeout_seconds: float | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        del timeout_seconds
         stdout = (
             json.dumps(receipt)
             if command[-2:] == ["cat", "$HOME/.local/share/clio-relay/bootstrap-receipt.json"]

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1699,7 +1699,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "7337bcd46db1dd52c221c30f8808cf0c1fa84bd941a7bf0e8dcf1c854bc8c1bf"
+        "4ecea98055acdb4a69dd2d8992a466e26aa8291d975bb70f4bb91ff1894f90fe"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_doctor_and_relay_host.py
+++ b/tests/test_doctor_and_relay_host.py
@@ -43,6 +43,15 @@ def test_render_frps_config_has_no_application_state() -> None:
     assert "queue" not in rendered.lower()
 
 
+def test_endpoint_service_transport_budget_outlives_activation_observer() -> None:
+    """SSH setup and teardown cannot truncate the bounded systemd observer."""
+    assert deployment.ENDPOINT_SERVICE_SSH_SETUP_MARGIN_SECONDS >= 60
+    assert deployment.ENDPOINT_SERVICE_SSH_TIMEOUT_SECONDS == (
+        deployment.ENDPOINT_SERVICE_START_OBSERVATION_TIMEOUT_SECONDS
+        + deployment.ENDPOINT_SERVICE_SSH_SETUP_MARGIN_SECONDS
+    )
+
+
 def test_render_frpc_config_uses_configured_websocket_transport() -> None:
     rendered = render_frpc_config(
         FrpcConfig(
@@ -199,7 +208,1387 @@ def test_endpoint_user_service_is_sudo_less_and_configured() -> None:
     assert "Restart=always" in rendered
     assert "Restart=on-failure" not in rendered
     assert "RestartSec=5" in rendered
+    assert "TimeoutStartSec=300s" in rendered
     assert "sudo" not in rendered
+
+
+def _run_activation_observer_fixture(
+    *,
+    scenario: str,
+    observation_timeout_seconds: int,
+    activation_action: str = "start",
+    repeat_after_failure_count: int = 0,
+) -> subprocess.CompletedProcess[bytes]:
+    """Execute the rendered activation observer against a stateful fake systemd."""
+    if scenario not in {
+        "active-masked-no-job",
+        "ambiguous-replacement",
+        "confirmed-restart-first-start",
+        "confirmed-no-job-inactive",
+        "delayed",
+        "delayed-job-after-failed",
+        "delayed-job-after-inactive",
+        "failed",
+        "failed-same-result",
+        "job-read-failure-active",
+        "maintenance-after-enqueue",
+        "preexisting-future-active-no-job",
+        "preexisting-future-load-no-job",
+        "preflight-ambiguous-survivor",
+        "preexisting-maintenance-no-job",
+        "preexisting-masked-active-no-job",
+        "preexisting-masked-inactive-no-job",
+        "preexisting-merged-active-no-job",
+        "preexisting-reload",
+        "preexisting-restart-different-id",
+        "preexisting-restart-same-id",
+        "preexisting-restart-stable",
+        "preexisting-reloading-no-job",
+        "preexisting-start-activating",
+        "preexisting-start-stable",
+        "preexisting-refreshing-no-job",
+        "preexisting-stub-inactive-no-job",
+        "refreshing-after-enqueue",
+        "restart-active-unknown-invocation",
+        "restart-same-invocation",
+        "stuck",
+        "timeout-restart-start-job",
+        "timeout-restart-exact-job",
+        "timeout-restart-transition-no-job",
+        "timeout-restart-ambiguous-survivor",
+        "timeout-tracked-job-completes-on-retry",
+        "timeout-tracked-job-active-equal",
+        "timeout-tracked-job-active-unknown",
+        "timeout-tracked-job-failed",
+        "timeout-tracked-job-inactive",
+        "timeout-tracked-job-masked",
+        "timeout-tracked-job-replaced",
+        "timeout-tracked-job-transition-retry",
+        "unknown-initial",
+        "unknown-job-initial",
+    }:
+        raise ValueError(f"unsupported activation fixture scenario: {scenario}")
+    if activation_action not in {"start", "restart"}:
+        raise ValueError(f"unsupported activation fixture action: {activation_action}")
+    if type(repeat_after_failure_count) is not int or repeat_after_failure_count < 0:
+        raise ValueError("repeat_after_failure_count must be a non-negative integer")
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.fail("bash is required to validate bounded systemd activation")
+    helper = deployment.render_bounded_user_service_activation_helper(
+        observation_timeout_seconds=observation_timeout_seconds,
+        poll_seconds=1,
+        progress_seconds=1,
+    )
+    repeat = "clio_relay_endpoint_activate_bounded || true\n" * repeat_after_failure_count
+    harness = f"""set -u
+test_root="$(mktemp -d)"
+trap 'rm -rf -- "$test_root"' EXIT
+mkdir -p "$test_root/bin" "$test_root/home"
+export HOME="$test_root/home"
+export FAKE_SYSTEMD_ROOT="$test_root" FAKE_SYSTEMD_SCENARIO={scenario}
+cat > "$test_root/bin/systemctl" <<'__FAKE_SYSTEMCTL__'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "$FAKE_SYSTEMD_ROOT/calls"
+action="${{2:-}}"
+case "$action" in
+  start|restart)
+    attempts=0
+    if [ -f "$FAKE_SYSTEMD_ROOT/attempts" ]; then
+      attempts="$(cat "$FAKE_SYSTEMD_ROOT/attempts")"
+    fi
+    attempts=$((attempts + 1))
+    printf '%s\n' "$attempts" > "$FAKE_SYSTEMD_ROOT/attempts"
+    : > "$FAKE_SYSTEMD_ROOT/enqueued"
+    case "$FAKE_SYSTEMD_SCENARIO" in
+      timeout-restart-start-job|timeout-restart-exact-job|timeout-restart-transition-no-job|timeout-restart-ambiguous-survivor)
+        exit 124
+        ;;
+    esac
+    ;;
+  show)
+    if [ "$FAKE_SYSTEMD_SCENARIO" = unknown-initial ] && \
+       [ ! -f "$FAKE_SYSTEMD_ROOT/enqueued" ]; then
+      exit 1
+    fi
+    state=inactive
+    sub_state=dead
+    load_state=loaded
+    result=success
+    invocation_id=old-invocation
+    control_pid=0
+    post_count=0
+    if [ "$FAKE_SYSTEMD_SCENARIO" = failed-same-result ]; then
+      state=failed
+      sub_state=failed
+      result=exit-code
+    elif [ "$FAKE_SYSTEMD_SCENARIO" = delayed-job-after-failed ]; then
+      state=failed
+      sub_state=failed
+      result=exit-code
+    elif [ "$FAKE_SYSTEMD_SCENARIO" = preexisting-maintenance-no-job ]; then
+      state=maintenance
+      sub_state=maintenance
+    elif [ "$FAKE_SYSTEMD_SCENARIO" = preexisting-refreshing-no-job ]; then
+      state=refreshing
+      sub_state=refreshing
+    elif [ "$FAKE_SYSTEMD_SCENARIO" = preexisting-future-active-no-job ]; then
+      state=future-active
+      sub_state=future
+    elif [ "$FAKE_SYSTEMD_SCENARIO" = preexisting-masked-inactive-no-job ]; then
+      load_state=masked
+      state=inactive
+      sub_state=dead
+    elif [ "$FAKE_SYSTEMD_SCENARIO" = preexisting-masked-active-no-job ]; then
+      load_state=masked
+      state=active
+      sub_state=running
+    elif [ "$FAKE_SYSTEMD_SCENARIO" = preexisting-stub-inactive-no-job ]; then
+      load_state=stub
+      state=inactive
+      sub_state=dead
+    elif [ "$FAKE_SYSTEMD_SCENARIO" = preexisting-merged-active-no-job ]; then
+      load_state=merged
+      state=active
+      sub_state=running
+    elif [ "$FAKE_SYSTEMD_SCENARIO" = preexisting-future-load-no-job ]; then
+      load_state=future-load
+      state=inactive
+      sub_state=dead
+    elif [ "$FAKE_SYSTEMD_SCENARIO" = preflight-ambiguous-survivor ]; then
+      state=active
+      sub_state=running
+      if [ -f "$FAKE_SYSTEMD_ROOT/first-finished" ]; then
+        invocation_id=new-invocation
+      fi
+    elif [[ "$FAKE_SYSTEMD_SCENARIO" = timeout-tracked-job-active-equal ||
+            "$FAKE_SYSTEMD_SCENARIO" = timeout-tracked-job-active-unknown ||
+            "$FAKE_SYSTEMD_SCENARIO" = timeout-tracked-job-failed ||
+            "$FAKE_SYSTEMD_SCENARIO" = timeout-tracked-job-inactive ||
+            "$FAKE_SYSTEMD_SCENARIO" = timeout-tracked-job-masked ||
+            "$FAKE_SYSTEMD_SCENARIO" = timeout-tracked-job-transition-retry ]]; then
+      state=active
+      sub_state=running
+      if [[ "$FAKE_SYSTEMD_SCENARIO" = timeout-tracked-job-active-unknown ||
+            "$FAKE_SYSTEMD_SCENARIO" = timeout-tracked-job-transition-retry ]]; then
+        invocation_id=
+      fi
+    elif [ "$FAKE_SYSTEMD_SCENARIO" = preexisting-reload ]; then
+      state=active
+      sub_state=running
+    elif [ "$FAKE_SYSTEMD_SCENARIO" = preexisting-reloading-no-job ]; then
+      show_count=0
+      if [ -f "$FAKE_SYSTEMD_ROOT/show-count" ]; then
+        show_count="$(cat "$FAKE_SYSTEMD_ROOT/show-count")"
+      fi
+      show_count=$((show_count + 1))
+      printf '%s\n' "$show_count" > "$FAKE_SYSTEMD_ROOT/show-count"
+      if [ "$show_count" = 1 ]; then
+        state=reloading
+        sub_state=reload
+      else
+        state=active
+        sub_state=running
+      fi
+    elif [[ "$FAKE_SYSTEMD_SCENARIO" = preexisting-start-activating ||
+            "$FAKE_SYSTEMD_SCENARIO" = ambiguous-replacement ||
+            "$FAKE_SYSTEMD_SCENARIO" = preexisting-restart-same-id ||
+            "$FAKE_SYSTEMD_SCENARIO" = preexisting-restart-different-id ||
+            "$FAKE_SYSTEMD_SCENARIO" = preexisting-start-stable ||
+            "$FAKE_SYSTEMD_SCENARIO" = preexisting-restart-stable ||
+            "$FAKE_SYSTEMD_SCENARIO" = restart-active-unknown-invocation ||
+            "$FAKE_SYSTEMD_SCENARIO" = restart-same-invocation ]]; then
+      show_count=0
+      if [ -f "$FAKE_SYSTEMD_ROOT/show-count" ]; then
+        show_count="$(cat "$FAKE_SYSTEMD_ROOT/show-count")"
+      fi
+      show_count=$((show_count + 1))
+      printf '%s\n' "$show_count" > "$FAKE_SYSTEMD_ROOT/show-count"
+      case "$FAKE_SYSTEMD_SCENARIO:$show_count" in
+        restart-active-unknown-invocation:*)
+          state=active; sub_state=running; invocation_id=
+          ;;
+        preexisting-start-activating:1)
+          state=activating; sub_state=start
+          ;;
+        preexisting-start-stable:1)
+          state=inactive; sub_state=dead
+          ;;
+        *:1)
+          state=active; sub_state=running
+          ;;
+        *:2)
+          state=activating; sub_state=start
+          ;;
+        restart-same-invocation:*)
+          state=active; sub_state=running
+          ;;
+        *)
+          state=active; sub_state=running; invocation_id=new-invocation
+          ;;
+      esac
+    fi
+    if [ -f "$FAKE_SYSTEMD_ROOT/enqueued" ]; then
+      if [ -f "$FAKE_SYSTEMD_ROOT/post-count" ]; then
+        post_count="$(cat "$FAKE_SYSTEMD_ROOT/post-count")"
+      fi
+      post_count=$((post_count + 1))
+      printf '%s\n' "$post_count" > "$FAKE_SYSTEMD_ROOT/post-count"
+      invocation_id=new-invocation
+      case "$FAKE_SYSTEMD_SCENARIO:$post_count" in
+        delayed:1) state=inactive; sub_state=dead ;;
+        delayed:2) state=activating; sub_state=start-pre; control_pid=41 ;;
+        delayed:*) state=active; sub_state=running; control_pid=42 ;;
+        delayed-job-after-inactive:1)
+          state=inactive; sub_state=dead; invocation_id=old-invocation
+          ;;
+        delayed-job-after-failed:1)
+          state=failed; sub_state=failed; result=exit-code; invocation_id=old-invocation
+          ;;
+        delayed-job-after-inactive:2|delayed-job-after-failed:2)
+          state=activating; sub_state=start-pre; control_pid=43
+          ;;
+        delayed-job-after-inactive:*|delayed-job-after-failed:*)
+          state=active; sub_state=running; control_pid=44
+          ;;
+        failed:1) state=activating; sub_state=start-pre; control_pid=51 ;;
+        failed:*) state=failed; sub_state=failed; result=exit-code ;;
+        failed-same-result:*) state=failed; sub_state=failed; result=exit-code ;;
+        maintenance-after-enqueue:*)
+          state=maintenance; sub_state=maintenance; control_pid=65
+          ;;
+        refreshing-after-enqueue:*)
+          state=refreshing; sub_state=refreshing; control_pid=66
+          ;;
+        confirmed-restart-first-start:1)
+          state=activating; sub_state=start; control_pid=71
+          ;;
+        confirmed-restart-first-start:*)
+          state=active; sub_state=running; control_pid=72
+          ;;
+        confirmed-no-job-inactive:*)
+          state=inactive; sub_state=dead; invocation_id=old-invocation
+          ;;
+        active-masked-no-job:*)
+          state=active; sub_state=running
+          if [ ! -f "$FAKE_SYSTEMD_ROOT/first-finished" ]; then
+            load_state=masked
+          fi
+          ;;
+        job-read-failure-active:*) state=active; sub_state=running ;;
+        stuck:*) state=activating; sub_state=start-pre; control_pid=61 ;;
+        timeout-restart-start-job:1)
+          state=activating; sub_state=start; control_pid=81
+          ;;
+        timeout-restart-start-job:*) state=active; sub_state=running ;;
+        timeout-restart-exact-job:1|timeout-restart-exact-job:2)
+          state=activating; sub_state=start; control_pid=83
+          ;;
+        timeout-restart-exact-job:*) state=active; sub_state=running ;;
+        timeout-restart-ambiguous-survivor:*)
+          if [ -f "$FAKE_SYSTEMD_ROOT/first-finished" ]; then
+            state=active; sub_state=running; invocation_id=new-invocation
+          else
+            state=activating; sub_state=start; control_pid=85
+          fi
+          ;;
+        timeout-restart-transition-no-job:1)
+          state=reloading; sub_state=reload; control_pid=91
+          ;;
+        timeout-restart-transition-no-job:*) state=active; sub_state=running ;;
+        timeout-tracked-job-replaced:*)
+          if [ -f "$FAKE_SYSTEMD_ROOT/first-finished" ]; then
+            state=active; sub_state=running; invocation_id=replacement-invocation
+          else
+            state=activating; sub_state=start; invocation_id=old-invocation
+          fi
+          ;;
+        timeout-tracked-job-completes-on-retry:*)
+          if [ -f "$FAKE_SYSTEMD_ROOT/first-finished" ]; then
+            state=active; sub_state=running; invocation_id=new-invocation
+          else
+            state=activating; sub_state=start; invocation_id=old-invocation
+          fi
+          ;;
+        timeout-tracked-job-active-equal:*)
+          state=active; sub_state=running; invocation_id=old-invocation
+          ;;
+        timeout-tracked-job-active-unknown:*)
+          state=active; sub_state=running; invocation_id=
+          ;;
+        timeout-tracked-job-failed:*)
+          if [ -f "$FAKE_SYSTEMD_ROOT/first-finished" ]; then
+            state=failed; sub_state=failed; result=exit-code
+          else
+            state=active; sub_state=running; invocation_id=old-invocation
+          fi
+          ;;
+        timeout-tracked-job-inactive:*)
+          if [ -f "$FAKE_SYSTEMD_ROOT/first-finished" ]; then
+            state=inactive; sub_state=dead
+          else
+            state=active; sub_state=running; invocation_id=old-invocation
+          fi
+          ;;
+        timeout-tracked-job-masked:*)
+          state=active; sub_state=running; invocation_id=old-invocation
+          if [ -f "$FAKE_SYSTEMD_ROOT/first-finished" ]; then
+            load_state=masked
+          fi
+          ;;
+        timeout-tracked-job-transition-retry:*)
+          invocation_id=
+          if [ ! -f "$FAKE_SYSTEMD_ROOT/first-finished" ]; then
+            state=active; sub_state=running
+          elif [ ! -f "$FAKE_SYSTEMD_ROOT/transition-served" ]; then
+            state=activating; sub_state=start
+          else
+            state=active; sub_state=running
+          fi
+          ;;
+      esac
+    fi
+    printf '%s\n' \
+      "LoadState=$load_state" \
+      "ActiveState=$state" \
+      "SubState=$sub_state" \
+      "Result=$result" \
+      "ControlPID=$control_pid" \
+      'ExecMainCode=0' \
+      'ExecMainStatus=0' \
+      'TimeoutStartUSec=5min' \
+      "InvocationID=$invocation_id"
+    ;;
+  list-jobs)
+    if [ "$FAKE_SYSTEMD_SCENARIO" = unknown-job-initial ]; then
+      exit 1
+    fi
+    if [ "$FAKE_SYSTEMD_SCENARIO" = job-read-failure-active ] && \
+       [ -f "$FAKE_SYSTEMD_ROOT/enqueued" ]; then
+      exit 1
+    fi
+    post_count=0
+    if [ -f "$FAKE_SYSTEMD_ROOT/post-count" ]; then
+      post_count="$(cat "$FAKE_SYSTEMD_ROOT/post-count")"
+    fi
+    show_count=0
+    if [ -f "$FAKE_SYSTEMD_ROOT/show-count" ]; then
+      show_count="$(cat "$FAKE_SYSTEMD_ROOT/show-count")"
+    fi
+    case "$FAKE_SYSTEMD_SCENARIO:$post_count" in
+      delayed:1|delayed:2|failed:1)
+        printf '101 clio-relay-worker-test.service start running\n'
+        ;;
+      delayed-job-after-inactive:2|delayed-job-after-failed:2)
+        printf '102 clio-relay-worker-test.service start running\n'
+        ;;
+      stuck:*)
+        if [ -f "$FAKE_SYSTEMD_ROOT/enqueued" ]; then
+          printf '101 clio-relay-worker-test.service start running\n'
+        fi
+        ;;
+      preexisting-reload:*)
+        printf '202 clio-relay-worker-test.service reload waiting\n'
+        ;;
+      confirmed-restart-first-start:1)
+        printf '401 clio-relay-worker-test.service start running\n'
+        ;;
+      timeout-restart-start-job:1)
+        printf '501 clio-relay-worker-test.service start running\n'
+        ;;
+      timeout-restart-exact-job:1)
+        printf '502 clio-relay-worker-test.service restart running\n'
+        ;;
+      timeout-restart-exact-job:2)
+        printf '502 clio-relay-worker-test.service start running\n'
+        ;;
+      timeout-restart-ambiguous-survivor:*)
+        if [ -f "$FAKE_SYSTEMD_ROOT/enqueued" ] && \
+           [ ! -f "$FAKE_SYSTEMD_ROOT/first-finished" ]; then
+          printf '%s\n' \
+            '801 clio-relay-worker-test.service restart running' \
+            '802 clio-relay-worker-test.service start waiting'
+        elif [ -f "$FAKE_SYSTEMD_ROOT/first-finished" ] && \
+             [ ! -f "$FAKE_SYSTEMD_ROOT/survivor-served" ]; then
+          printf '801 clio-relay-worker-test.service restart running\n'
+          : > "$FAKE_SYSTEMD_ROOT/survivor-served"
+        fi
+        ;;
+      timeout-tracked-job-replaced:*)
+        if [ -f "$FAKE_SYSTEMD_ROOT/enqueued" ] && \
+           [ ! -f "$FAKE_SYSTEMD_ROOT/first-finished" ]; then
+          printf '601 clio-relay-worker-test.service restart running\n'
+        elif [ -f "$FAKE_SYSTEMD_ROOT/first-finished" ] && \
+             [ ! -f "$FAKE_SYSTEMD_ROOT/replacement-served" ]; then
+          printf '602 clio-relay-worker-test.service restart running\n'
+          : > "$FAKE_SYSTEMD_ROOT/replacement-served"
+        fi
+        ;;
+    esac
+    case "$FAKE_SYSTEMD_SCENARIO:$show_count" in
+      preexisting-start-activating:1)
+        printf '203 clio-relay-worker-test.service start running\n'
+        ;;
+      ambiguous-replacement:1)
+        printf '301 clio-relay-worker-test.service restart running\n'
+        ;;
+      ambiguous-replacement:2)
+        printf '%s\n' \
+          '301 clio-relay-worker-test.service restart running' \
+          '302 clio-relay-worker-test.service start waiting'
+        ;;
+      preexisting-restart-same-id:1|restart-same-invocation:1)
+        printf '301 clio-relay-worker-test.service restart running\n'
+        ;;
+      restart-active-unknown-invocation:1)
+        printf '301 clio-relay-worker-test.service restart running\n'
+        ;;
+      preexisting-restart-same-id:2|restart-same-invocation:2)
+        printf '301 clio-relay-worker-test.service start running\n'
+        ;;
+      preexisting-restart-different-id:1)
+        printf '301 clio-relay-worker-test.service restart running\n'
+        ;;
+      preexisting-restart-different-id:2)
+        printf '302 clio-relay-worker-test.service start running\n'
+        ;;
+      preexisting-start-stable:1|preexisting-start-stable:2)
+        printf '310 clio-relay-worker-test.service start running\n'
+        ;;
+      preexisting-restart-stable:1|preexisting-restart-stable:2)
+        printf '311 clio-relay-worker-test.service restart running\n'
+        ;;
+      preflight-ambiguous-survivor:*)
+        if [ ! -f "$FAKE_SYSTEMD_ROOT/first-finished" ]; then
+          printf '%s\n' \
+            '701 clio-relay-worker-test.service restart running' \
+            '702 clio-relay-worker-test.service start waiting'
+        elif [ ! -f "$FAKE_SYSTEMD_ROOT/survivor-served" ]; then
+          printf '701 clio-relay-worker-test.service restart running\n'
+          : > "$FAKE_SYSTEMD_ROOT/survivor-served"
+        fi
+        ;;
+      timeout-tracked-job-active-equal:*|timeout-tracked-job-active-unknown:*|timeout-tracked-job-failed:*|timeout-tracked-job-inactive:*|timeout-tracked-job-masked:*)
+        if [ -f "$FAKE_SYSTEMD_ROOT/enqueued" ] && \
+           {{ [ ! -f "$FAKE_SYSTEMD_ROOT/first-finished" ] || \
+              [ "$FAKE_SYSTEMD_SCENARIO" = timeout-tracked-job-masked ]; }}; then
+          printf '910 clio-relay-worker-test.service restart running\n'
+        fi
+        ;;
+      timeout-tracked-job-transition-retry:*)
+        if [ -f "$FAKE_SYSTEMD_ROOT/enqueued" ] && \
+           {{ [ ! -f "$FAKE_SYSTEMD_ROOT/first-finished" ] || \
+              [ ! -f "$FAKE_SYSTEMD_ROOT/transition-served" ]; }}; then
+          printf '920 clio-relay-worker-test.service restart running\n'
+          if [ -f "$FAKE_SYSTEMD_ROOT/first-finished" ]; then
+            : > "$FAKE_SYSTEMD_ROOT/transition-served"
+          fi
+        fi
+        ;;
+      timeout-tracked-job-completes-on-retry:*)
+        if [ -f "$FAKE_SYSTEMD_ROOT/enqueued" ] && \
+           [ ! -f "$FAKE_SYSTEMD_ROOT/first-finished" ]; then
+          printf '901 clio-relay-worker-test.service restart running\n'
+        fi
+        ;;
+    esac
+    ;;
+  *) exit 2 ;;
+esac
+__FAKE_SYSTEMCTL__
+cat > "$test_root/bin/flock" <<'__FAKE_FLOCK__'
+#!/usr/bin/env bash
+set -u
+case "${{1:-}}" in
+  --exclusive)
+    while ! mkdir "$FAKE_SYSTEMD_ROOT/activation-flock" 2>/dev/null; do sleep 0.05; done
+    ;;
+  --unlock) rmdir "$FAKE_SYSTEMD_ROOT/activation-flock" ;;
+  *) exit 2 ;;
+esac
+__FAKE_FLOCK__
+chmod +x "$test_root/bin/systemctl" "$test_root/bin/flock"
+export PATH="$test_root/bin:$PATH"
+CLIO_RELAY_ENDPOINT_SERVICE_NAME=clio-relay-worker-test.service
+CLIO_RELAY_ENDPOINT_ACTIVATION_ACTION={activation_action}
+{helper}
+fixture_started=$SECONDS
+first_status=0
+clio_relay_endpoint_activate_bounded || first_status=$?
+first_outcome="$CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME"
+if [[ "$FAKE_SYSTEMD_SCENARIO" = timeout-tracked-job-replaced ||
+      "$FAKE_SYSTEMD_SCENARIO" = active-masked-no-job ||
+      "$FAKE_SYSTEMD_SCENARIO" = timeout-tracked-job-completes-on-retry ||
+      "$FAKE_SYSTEMD_SCENARIO" = timeout-tracked-job-active-equal ||
+      "$FAKE_SYSTEMD_SCENARIO" = timeout-tracked-job-active-unknown ||
+      "$FAKE_SYSTEMD_SCENARIO" = timeout-tracked-job-failed ||
+      "$FAKE_SYSTEMD_SCENARIO" = timeout-tracked-job-inactive ||
+      "$FAKE_SYSTEMD_SCENARIO" = timeout-tracked-job-masked ||
+      "$FAKE_SYSTEMD_SCENARIO" = timeout-tracked-job-transition-retry ||
+      "$FAKE_SYSTEMD_SCENARIO" = preflight-ambiguous-survivor ||
+      "$FAKE_SYSTEMD_SCENARIO" = timeout-restart-ambiguous-survivor ]]; then
+  : > "$FAKE_SYSTEMD_ROOT/first-finished"
+fi
+{repeat}printf 'fixture.first_status=%s\n' "$first_status"
+printf 'fixture.first_outcome=%s\n' "$first_outcome"
+printf 'fixture.final_outcome=%s\n' "$CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME"
+printf 'fixture.elapsed=%s\n' "$((SECONDS - fixture_started))"
+attempts=0
+if [ -f "$test_root/attempts" ]; then attempts="$(cat "$test_root/attempts")"; fi
+printf 'fixture.attempts=%s\n' "$attempts"
+exit "$first_status"
+"""
+    return subprocess.run(
+        [bash, "-s"],
+        input=harness.encode("utf-8"),
+        capture_output=True,
+        check=False,
+        timeout=observation_timeout_seconds + 10,
+    )
+
+
+def test_endpoint_activation_waits_for_queued_delayed_dispatch() -> None:
+    """An inactive unit with an exact queued job is not a startup failure."""
+    result = _run_activation_observer_fixture(
+        scenario="delayed",
+        observation_timeout_seconds=5,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 0, stderr
+    assert "active_state=inactive" in stdout
+    assert "job_id=101" in stdout
+    assert "active_state=activating" in stdout
+    assert "active_state=active" in stdout
+    assert "outcome=not-attempted" not in stdout
+    assert "fixture.first_outcome=active" in stdout
+    assert "fixture.attempts=1" in stdout
+
+
+@pytest.mark.parametrize(
+    ("scenario", "active_state"),
+    [
+        ("delayed-job-after-inactive", "inactive"),
+        ("delayed-job-after-failed", "failed"),
+    ],
+)
+def test_endpoint_activation_enqueue_grace_precedes_late_exact_job(
+    scenario: str,
+    active_state: str,
+) -> None:
+    """A confirmed enqueue reports grace before its exact job becomes visible."""
+    result = _run_activation_observer_fixture(
+        scenario=scenario,
+        observation_timeout_seconds=5,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    grace_records = [
+        line
+        for line in stdout.splitlines()
+        if line.startswith("endpoint_service.activation ")
+        and f"active_state={active_state}" in line
+        and "job_id=none" in line
+        and "outcome=in-progress" in line
+    ]
+    assert result.returncode == 0, stderr
+    assert grace_records
+    assert "job_id=102 job_type=start" in stdout
+    assert "fixture.first_outcome=active" in stdout
+    assert "fixture.attempts=1" in stdout
+
+
+def test_endpoint_activation_reports_terminal_systemd_failure() -> None:
+    """A vanished observed job plus failed state is terminal evidence."""
+    result = _run_activation_observer_fixture(
+        scenario="failed",
+        observation_timeout_seconds=5,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=failed" in stdout
+    assert "active_state=failed" in stderr
+    assert "result=exit-code" in stderr
+    assert "activation.operator_hint=journalctl --user" in stderr
+    assert "fixture.attempts=1" in stdout
+
+
+def test_endpoint_activation_rejects_active_masked_unit() -> None:
+    """ActiveState cannot override a terminal non-loaded unit state."""
+    result = _run_activation_observer_fixture(
+        scenario="active-masked-no-job",
+        observation_timeout_seconds=5,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=failed" in stdout
+    assert "fixture.attempts=1" in stdout
+    assert "load_state=masked" in stderr
+    assert "active_state=active" in stderr
+    assert "job_id=none" in stderr
+    assert "outcome=active" not in stdout
+
+
+def test_endpoint_activation_masked_failure_requires_fresh_process_after_repair() -> None:
+    """A repaired unit cannot reuse provenance rejected by a masked snapshot."""
+    result = _run_activation_observer_fixture(
+        scenario="active-masked-no-job",
+        observation_timeout_seconds=5,
+        repeat_after_failure_count=1,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=failed" in stdout
+    assert "fixture.final_outcome=unverified" in stdout
+    assert "fixture.attempts=1" in stdout
+    assert "load_state=masked" in stderr
+    assert "load_state=loaded" in stderr
+    assert "active_state=active" in stderr
+    assert "outcome=active" not in stdout
+
+
+@pytest.mark.parametrize(
+    ("scenario", "active_state"),
+    [
+        ("preexisting-maintenance-no-job", "maintenance"),
+        ("preexisting-refreshing-no-job", "refreshing"),
+        ("preexisting-future-active-no-job", "future-active"),
+    ],
+)
+def test_endpoint_activation_preflight_rejects_nonstable_active_state(
+    scenario: str,
+    active_state: str,
+) -> None:
+    """Only stable systemd ActiveState values may reach the enqueue boundary."""
+    result = _run_activation_observer_fixture(
+        scenario=scenario,
+        observation_timeout_seconds=5,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=in-progress" in stdout
+    assert "fixture.attempts=0" in stdout
+    assert f"active_state={active_state}" in stderr
+    assert "job_id=none" in stderr
+    assert "outcome=active" not in stdout
+
+
+@pytest.mark.parametrize(
+    ("scenario", "active_state"),
+    [
+        ("maintenance-after-enqueue", "maintenance"),
+        ("refreshing-after-enqueue", "refreshing"),
+    ],
+)
+def test_endpoint_activation_observes_extended_transitional_state(
+    scenario: str,
+    active_state: str,
+) -> None:
+    """Maintenance and refreshing remain in-progress after a proven enqueue."""
+    result = _run_activation_observer_fixture(
+        scenario=scenario,
+        observation_timeout_seconds=2,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=in-progress" in stdout
+    assert "fixture.attempts=1" in stdout
+    assert f"active_state={active_state}" in stderr
+    assert "outcome=active" not in stdout
+
+
+@pytest.mark.parametrize(
+    ("scenario", "load_state", "active_state", "outcome"),
+    [
+        ("preexisting-masked-inactive-no-job", "masked", "inactive", "failed"),
+        ("preexisting-masked-active-no-job", "masked", "active", "failed"),
+        (
+            "preexisting-stub-inactive-no-job",
+            "stub",
+            "inactive",
+            "preflight-unverified",
+        ),
+        (
+            "preexisting-merged-active-no-job",
+            "merged",
+            "active",
+            "preflight-unverified",
+        ),
+        (
+            "preexisting-future-load-no-job",
+            "future-load",
+            "inactive",
+            "preflight-unverified",
+        ),
+    ],
+)
+def test_endpoint_activation_preflight_rejects_nonloaded_unit(
+    scenario: str,
+    load_state: str,
+    active_state: str,
+    outcome: str,
+) -> None:
+    """Every non-loaded systemd LoadState fails closed before mutation."""
+    result = _run_activation_observer_fixture(
+        scenario=scenario,
+        observation_timeout_seconds=5,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 1
+    assert f"fixture.first_outcome={outcome}" in stdout
+    assert "fixture.attempts=0" in stdout
+    assert f"load_state={load_state}" in stderr
+    assert f"active_state={active_state}" in stderr
+    assert "job_id=none" in stderr
+    assert "outcome=active" not in stdout
+
+
+def test_endpoint_activation_initial_state_failure_does_not_enqueue() -> None:
+    """An unreadable initial state fails closed before systemd mutation."""
+    result = _run_activation_observer_fixture(
+        scenario="unknown-initial",
+        observation_timeout_seconds=2,
+        activation_action="restart",
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=preflight-unverified" in stdout
+    assert "fixture.attempts=0" in stdout
+    assert "active_state=unknown" in stderr
+
+
+def test_endpoint_activation_initial_job_read_failure_reports_unknown_inventory() -> None:
+    """A failed list-jobs read cannot be represented as a proven empty inventory."""
+    result = _run_activation_observer_fixture(
+        scenario="unknown-job-initial",
+        observation_timeout_seconds=2,
+        activation_action="restart",
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=preflight-unverified" in stdout
+    assert "fixture.attempts=0" in stdout
+    assert "job_id=unknown" in stderr
+    assert "job_type=unknown" in stderr
+    assert "job_state=unknown" in stderr
+    assert "job_id=none" not in stderr
+
+
+def test_endpoint_activation_active_with_unreadable_job_inventory_is_unverified() -> None:
+    """Active state cannot pass while the exact job inventory is unreadable."""
+    result = _run_activation_observer_fixture(
+        scenario="job-read-failure-active",
+        observation_timeout_seconds=2,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=unverified" in stdout
+    assert "fixture.attempts=1" in stdout
+    assert "active_state=active" in stderr
+    assert "job_id=unknown" in stderr
+    assert "job_type=unknown" in stderr
+    assert "outcome=active" not in stdout
+
+
+def test_endpoint_activation_repeated_failure_uses_new_invocation_evidence() -> None:
+    """A new failed invocation is terminal even when Result stays unchanged."""
+    result = _run_activation_observer_fixture(
+        scenario="failed-same-result",
+        observation_timeout_seconds=5,
+        activation_action="restart",
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+    elapsed = int(
+        next(line for line in stdout.splitlines() if line.startswith("fixture.elapsed=")).split(
+            "=", 1
+        )[1]
+    )
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=failed" in stdout
+    assert elapsed < 5
+    assert "fixture.attempts=1" in stdout
+    assert "result=exit-code" in stderr
+    assert "invocation_id=new-invocation" in stderr
+
+
+def test_endpoint_activation_rejects_incompatible_preexisting_job() -> None:
+    """A queued reload is reported without mutating a requested restart."""
+    result = _run_activation_observer_fixture(
+        scenario="preexisting-reload",
+        observation_timeout_seconds=5,
+        activation_action="restart",
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+    elapsed = int(
+        next(line for line in stdout.splitlines() if line.startswith("fixture.elapsed=")).split(
+            "=", 1
+        )[1]
+    )
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=in-progress" in stdout
+    assert "fixture.attempts=0" in stdout
+    assert elapsed < 5
+    assert "active_state=active" in stderr
+    assert "job_id=202" in stderr
+    assert "job_type=reload" in stderr
+
+
+def test_endpoint_activation_rejects_bare_transitional_preflight_state() -> None:
+    """A jobless reload cannot be mistaken for evidence of our requested restart."""
+    result = _run_activation_observer_fixture(
+        scenario="preexisting-reloading-no-job",
+        observation_timeout_seconds=5,
+        activation_action="restart",
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+    elapsed = int(
+        next(line for line in stdout.splitlines() if line.startswith("fixture.elapsed=")).split(
+            "=", 1
+        )[1]
+    )
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=in-progress" in stdout
+    assert "fixture.attempts=0" in stdout
+    assert elapsed < 5
+    assert "active_state=reloading" in stderr
+    assert "job_id=none" in stderr
+    assert "active_state=active" not in stdout
+
+
+def test_endpoint_restart_rejects_preexisting_standalone_start() -> None:
+    """A standalone start job cannot prove the requested restart is in progress."""
+    result = _run_activation_observer_fixture(
+        scenario="preexisting-start-activating",
+        observation_timeout_seconds=5,
+        activation_action="restart",
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=in-progress" in stdout
+    assert "fixture.attempts=0" in stdout
+    assert "active_state=activating" in stderr
+    assert "job_id=203" in stderr
+    assert "job_type=start" in stderr
+    assert "outcome=active" not in stdout
+
+
+def test_endpoint_restart_adopts_same_job_restart_to_start_transition() -> None:
+    """An adopted restart may become start only while retaining its job ID."""
+    result = _run_activation_observer_fixture(
+        scenario="preexisting-restart-same-id",
+        observation_timeout_seconds=5,
+        activation_action="restart",
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 0, stderr
+    assert "job_id=301 job_type=restart" in stdout
+    assert "job_id=301 job_type=start" in stdout
+    assert "fixture.first_outcome=active" in stdout
+    assert "fixture.attempts=0" in stdout
+
+
+@pytest.mark.parametrize("activation_action", ["start", "restart"])
+def test_endpoint_activation_rejects_changed_adopted_job_id(
+    activation_action: str,
+) -> None:
+    """An unrelated job cannot replace the exact job first adopted by a request."""
+    result = _run_activation_observer_fixture(
+        scenario="preexisting-restart-different-id",
+        observation_timeout_seconds=5,
+        activation_action=activation_action,
+        repeat_after_failure_count=1,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=in-progress" in stdout
+    assert "fixture.final_outcome=unverified" in stdout
+    assert "fixture.attempts=0" in stdout
+    assert "job_id=302" in stderr
+    assert "job_type=start" in stderr
+    assert "outcome=active" not in stdout
+
+
+def test_endpoint_restart_rejects_ambiguous_replacement_jobs() -> None:
+    """Multiple replacement jobs invalidate an adopted restart's provenance."""
+    result = _run_activation_observer_fixture(
+        scenario="ambiguous-replacement",
+        observation_timeout_seconds=5,
+        activation_action="restart",
+        repeat_after_failure_count=1,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=in-progress" in stdout
+    assert "fixture.final_outcome=unverified" in stdout
+    assert "fixture.attempts=0" in stdout
+    assert "job_id=ambiguous" in stderr
+    assert "job_type=ambiguous" in stderr
+    assert "outcome=active" not in stdout
+
+
+@pytest.mark.parametrize(
+    ("scenario", "first_outcome", "attempts", "survivor_job_id"),
+    [
+        ("preflight-ambiguous-survivor", "preflight-unverified", 0, "701"),
+        ("timeout-restart-ambiguous-survivor", "enqueue-unverified", 1, "801"),
+    ],
+)
+def test_endpoint_restart_ambiguous_inventory_rejects_later_survivor(
+    scenario: str,
+    first_outcome: str,
+    attempts: int,
+    survivor_job_id: str,
+) -> None:
+    """Ambiguous inventory permanently rejects a later survivor and active state."""
+    result = _run_activation_observer_fixture(
+        scenario=scenario,
+        observation_timeout_seconds=5,
+        activation_action="restart",
+        repeat_after_failure_count=2,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 1
+    assert f"fixture.first_outcome={first_outcome}" in stdout
+    assert "fixture.final_outcome=unverified" in stdout
+    assert f"fixture.attempts={attempts}" in stdout
+    assert "job_id=ambiguous" in stderr
+    assert f"job_id={survivor_job_id}" in stderr
+    assert "outcome=active" not in stdout
+
+
+def test_endpoint_restart_confirmed_enqueue_can_bind_first_start_job() -> None:
+    """A successful restart enqueue may first expose its systemd job as start."""
+    result = _run_activation_observer_fixture(
+        scenario="confirmed-restart-first-start",
+        observation_timeout_seconds=5,
+        activation_action="restart",
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 0, stderr
+    assert "job_id=401 job_type=start" in stdout
+    assert "outcome=not-attempted" not in stdout
+    assert "fixture.first_outcome=active" in stdout
+    assert "fixture.attempts=1" in stdout
+
+
+def test_endpoint_restart_enqueue_grace_expires_before_retry() -> None:
+    """Confirmed enqueue grace does not survive timeout into a same-shell retry."""
+    result = _run_activation_observer_fixture(
+        scenario="confirmed-no-job-inactive",
+        observation_timeout_seconds=2,
+        activation_action="restart",
+        repeat_after_failure_count=1,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    progress_records = [
+        line
+        for line in stdout.splitlines()
+        if line.startswith("endpoint_service.activation ") and "outcome=in-progress" in line
+    ]
+    assert result.returncode == 1
+    assert progress_records
+    assert "fixture.first_outcome=unverified" in stdout
+    assert "fixture.final_outcome=unverified" in stdout
+    assert "fixture.attempts=1" in stdout
+    assert "active_state=inactive" in stderr
+    assert "job_id=none" in stderr
+    assert "outcome=active" not in stdout
+
+
+def test_endpoint_restart_timeout_does_not_adopt_start_job() -> None:
+    """A timed-out restart has no provenance for a newly observed start job."""
+    result = _run_activation_observer_fixture(
+        scenario="timeout-restart-start-job",
+        observation_timeout_seconds=5,
+        activation_action="restart",
+        repeat_after_failure_count=1,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=enqueue-unverified" in stdout
+    assert "fixture.final_outcome=unverified" in stdout
+    assert "fixture.attempts=1" in stdout
+    assert "active_state=activating" in stderr
+    assert "job_id=501" in stderr
+    assert "job_type=start" in stderr
+    assert "outcome=active" not in stdout
+
+
+def test_endpoint_restart_timeout_adopts_exact_restart_job() -> None:
+    """A timed-out enqueue can adopt an exact restart and its same-ID start phase."""
+    result = _run_activation_observer_fixture(
+        scenario="timeout-restart-exact-job",
+        observation_timeout_seconds=5,
+        activation_action="restart",
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 0, stderr
+    assert "job_id=502 job_type=start" in stdout
+    assert "outcome=in-progress" in stdout
+    assert "outcome=enqueue-unverified" not in stdout
+    assert "outcome=failed" not in stdout
+    assert "fixture.first_outcome=active" in stdout
+    assert "fixture.attempts=1" in stdout
+
+
+def test_endpoint_restart_timeout_does_not_adopt_bare_transition() -> None:
+    """A timed-out restart cannot claim a jobless transition or later active state."""
+    result = _run_activation_observer_fixture(
+        scenario="timeout-restart-transition-no-job",
+        observation_timeout_seconds=5,
+        activation_action="restart",
+        repeat_after_failure_count=1,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=enqueue-unverified" in stdout
+    assert "fixture.final_outcome=unverified" in stdout
+    assert "fixture.attempts=1" in stdout
+    assert "active_state=reloading" in stderr
+    assert "job_id=none" in stderr
+    assert "outcome=active" not in stdout
+
+
+def test_endpoint_restart_retry_rejects_replacement_after_timeout() -> None:
+    """A retry latches a replacement job before a later no-job active state."""
+    result = _run_activation_observer_fixture(
+        scenario="timeout-tracked-job-replaced",
+        observation_timeout_seconds=2,
+        activation_action="restart",
+        repeat_after_failure_count=2,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=in-progress" in stdout
+    assert "fixture.final_outcome=unverified" in stdout
+    assert "fixture.attempts=1" in stdout
+    assert "job_id=601" in stderr
+    assert "job_id=602" in stderr
+    assert "outcome=active" not in stdout
+
+
+def test_endpoint_restart_retry_emits_terminal_active_observation() -> None:
+    """A timed-out observer emits terminal evidence when a retry proves completion."""
+    result = _run_activation_observer_fixture(
+        scenario="timeout-tracked-job-completes-on-retry",
+        observation_timeout_seconds=2,
+        activation_action="restart",
+        repeat_after_failure_count=1,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+
+    terminal_records = [
+        line
+        for line in stdout.splitlines()
+        if line.startswith("endpoint_service.activation ") and "outcome=active" in line
+    ]
+    assert result.returncode == 1
+    assert "fixture.first_outcome=in-progress" in stdout
+    assert "fixture.final_outcome=active" in stdout
+    assert "fixture.attempts=1" in stdout
+    assert len(terminal_records) == 1
+    assert "active_state=active" in terminal_records[0]
+    assert "job_id=none" in terminal_records[0]
+
+
+def test_endpoint_restart_retry_preserves_same_job_transition_evidence() -> None:
+    """A same-job retry transition proves restart when InvocationID is unavailable."""
+    result = _run_activation_observer_fixture(
+        scenario="timeout-tracked-job-transition-retry",
+        observation_timeout_seconds=2,
+        activation_action="restart",
+        repeat_after_failure_count=2,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+
+    terminal_records = [
+        line
+        for line in stdout.splitlines()
+        if line.startswith("endpoint_service.activation ") and "outcome=active" in line
+    ]
+    assert result.returncode == 1
+    assert "fixture.first_outcome=in-progress" in stdout
+    assert "job_id=920 job_type=restart" in stdout
+    assert "active_state=activating" in stdout
+    assert "fixture.final_outcome=active" in stdout
+    assert "fixture.attempts=1" in stdout
+    assert len(terminal_records) == 1
+    assert "invocation_id=" in terminal_records[0]
+    assert "job_id=none" in terminal_records[0]
+
+
+@pytest.mark.parametrize(
+    ("scenario", "active_state", "final_outcome", "final_job_id"),
+    [
+        ("timeout-tracked-job-active-equal", "active", "unverified", "none"),
+        ("timeout-tracked-job-active-unknown", "active", "unverified", "none"),
+        ("timeout-tracked-job-failed", "failed", "failed", "none"),
+        ("timeout-tracked-job-inactive", "inactive", "failed", "none"),
+        ("timeout-tracked-job-masked", "active", "failed", "910"),
+    ],
+)
+def test_endpoint_restart_retry_classifies_fresh_terminal_evidence(
+    scenario: str,
+    active_state: str,
+    final_outcome: str,
+    final_job_id: str,
+) -> None:
+    """A retry replaces the prior timeout outcome with its current exact evidence."""
+    result = _run_activation_observer_fixture(
+        scenario=scenario,
+        observation_timeout_seconds=2,
+        activation_action="restart",
+        repeat_after_failure_count=1,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=in-progress" in stdout
+    assert f"fixture.final_outcome={final_outcome}" in stdout
+    assert "fixture.attempts=1" in stdout
+    assert f"active_state={active_state}" in stderr
+    assert f"job_id={final_job_id}" in stderr
+    assert "outcome=active" not in stdout
+
+
+@pytest.mark.parametrize(
+    ("scenario", "job_type"),
+    [
+        ("preexisting-start-stable", "start"),
+        ("preexisting-restart-stable", "restart"),
+    ],
+)
+def test_endpoint_start_adopts_stable_compatible_job(
+    scenario: str,
+    job_type: str,
+) -> None:
+    """A start request can observe an exact stable start or restart job."""
+    result = _run_activation_observer_fixture(
+        scenario=scenario,
+        observation_timeout_seconds=5,
+        activation_action="start",
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 0, stderr
+    assert f"job_type={job_type}" in stdout
+    assert "fixture.first_outcome=active" in stdout
+    assert "fixture.attempts=0" in stdout
+
+
+def test_endpoint_restart_known_equal_invocation_does_not_use_transition_fallback() -> None:
+    """Known-equal invocation IDs disprove restart completion after a transition."""
+    result = _run_activation_observer_fixture(
+        scenario="restart-same-invocation",
+        observation_timeout_seconds=2,
+        activation_action="restart",
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=unverified" in stdout
+    assert "fixture.attempts=0" in stdout
+    assert "active_state=active" in stderr
+    assert "invocation_id=old-invocation" in stderr
+    assert "outcome=active" not in stdout
+
+
+def test_endpoint_restart_without_invocation_or_transition_remains_unverified() -> None:
+    """A vanished restart job alone cannot prove an always-active unit restarted."""
+    result = _run_activation_observer_fixture(
+        scenario="restart-active-unknown-invocation",
+        observation_timeout_seconds=2,
+        activation_action="restart",
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=unverified" in stdout
+    assert "fixture.attempts=0" in stdout
+    assert "active_state=active" in stderr
+    assert "invocation_id=" in stderr
+    assert "outcome=active" not in stdout
+
+
+def test_endpoint_activation_timeout_preserves_job_without_duplicate_start() -> None:
+    """Observer expiry leaves an activating job intact and retry only observes it."""
+    result = _run_activation_observer_fixture(
+        scenario="stuck",
+        observation_timeout_seconds=2,
+        repeat_after_failure_count=1,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 1
+    assert "fixture.first_outcome=in-progress" in stdout
+    assert "fixture.final_outcome=in-progress" in stdout
+    assert "fixture.attempts=1" in stdout
+    assert "active_state=activating" in stderr
+    assert "job_id=101" in stderr
+
+
+def test_endpoint_activation_concurrent_fresh_shell_does_not_duplicate_job() -> None:
+    """The per-service lock closes preflight/enqueue TOCTOU across processes."""
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.fail("bash is required to validate cross-process activation locking")
+    helper = deployment.render_bounded_user_service_activation_helper(
+        observation_timeout_seconds=2,
+        poll_seconds=1,
+        progress_seconds=1,
+    )
+    harness = f"""set -u
+test_root="$(mktemp -d)"
+trap 'rm -rf -- "$test_root"' EXIT
+mkdir -p "$test_root/bin" "$test_root/home"
+export HOME="$test_root/home" FAKE_SYSTEMD_ROOT="$test_root"
+cat > "$test_root/bin/systemctl" <<'__FAKE_SYSTEMCTL__'
+#!/usr/bin/env bash
+set -u
+case "${{2:-}}" in
+  start|restart)
+    attempts=0
+    if [ -f "$FAKE_SYSTEMD_ROOT/attempts" ]; then
+      attempts="$(cat "$FAKE_SYSTEMD_ROOT/attempts")"
+    fi
+    printf '%s\n' "$((attempts + 1))" > "$FAKE_SYSTEMD_ROOT/attempts"
+    : > "$FAKE_SYSTEMD_ROOT/start-entered"
+    sleep 1
+    : > "$FAKE_SYSTEMD_ROOT/enqueued"
+    ;;
+  show)
+    state=inactive
+    sub_state=dead
+    invocation=old-invocation
+    control_pid=0
+    if [ -f "$FAKE_SYSTEMD_ROOT/enqueued" ]; then
+      state=active
+      sub_state=running
+      invocation=new-invocation
+      control_pid=61
+    fi
+    printf '%s\n' 'LoadState=loaded' "ActiveState=$state" \
+      "SubState=$sub_state" 'Result=success' "ControlPID=$control_pid" \
+      'ExecMainCode=0' 'ExecMainStatus=0' 'TimeoutStartUSec=5min' \
+      "InvocationID=$invocation"
+    ;;
+  list-jobs)
+    if [ -f "$FAKE_SYSTEMD_ROOT/enqueued" ]; then
+      printf '101 clio-relay-worker-test.service start running\n'
+    fi
+    ;;
+  *) exit 2 ;;
+esac
+__FAKE_SYSTEMCTL__
+cat > "$test_root/bin/flock" <<'__FAKE_FLOCK__'
+#!/usr/bin/env bash
+set -u
+case "${{1:-}}" in
+  --exclusive)
+    while ! mkdir "$FAKE_SYSTEMD_ROOT/activation-flock" 2>/dev/null; do sleep 0.05; done
+    ;;
+  --unlock) rmdir "$FAKE_SYSTEMD_ROOT/activation-flock" ;;
+  *) exit 2 ;;
+esac
+__FAKE_FLOCK__
+chmod +x "$test_root/bin/systemctl" "$test_root/bin/flock"
+export PATH="$test_root/bin:$PATH"
+cat > "$test_root/run-helper" <<'__RUN_HELPER__'
+set -u
+CLIO_RELAY_ENDPOINT_SERVICE_NAME=clio-relay-worker-test.service
+CLIO_RELAY_ENDPOINT_ACTIVATION_ACTION=start
+{helper}
+status=0
+clio_relay_endpoint_activate_bounded || status=$?
+printf 'fresh.outcome=%s\n' "$CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME"
+exit "$status"
+__RUN_HELPER__
+bash "$test_root/run-helper" > "$test_root/first.out" 2> "$test_root/first.err" &
+first_pid=$!
+while [ ! -f "$test_root/start-entered" ]; do sleep 0.05; done
+bash "$test_root/run-helper" > "$test_root/second.out" 2> "$test_root/second.err" &
+second_pid=$!
+first_status=0
+wait "$first_pid" || first_status=$?
+second_status=0
+wait "$second_pid" || second_status=$?
+cat "$test_root/first.out" "$test_root/second.out"
+cat "$test_root/first.err" "$test_root/second.err" >&2
+printf 'fixture.first_status=%s\n' "$first_status"
+printf 'fixture.second_status=%s\n' "$second_status"
+printf 'fixture.attempts=%s\n' "$(cat "$test_root/attempts")"
+"""
+    result = subprocess.run(
+        [bash, "-s"],
+        input=harness.encode("utf-8"),
+        capture_output=True,
+        check=False,
+        timeout=15,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 0, stderr
+    assert "fixture.first_status=1" in stdout
+    assert "fixture.second_status=1" in stdout
+    assert stdout.count("fresh.outcome=in-progress") == 2
+    assert "fixture.attempts=1" in stdout
+    assert "active_state=active" in stderr
+    assert "job_id=101" in stderr
 
 
 def test_cluster_doctor_rejects_enabled_but_inactive_endpoint_service(
@@ -440,14 +1829,36 @@ test_root="$(mktemp -d)"
 trap 'rm -rf "$test_root"' EXIT
 export HOME="$test_root/home" USER=test-user FAKE_LINGER={linger}
 loginctl() {{ echo "$FAKE_LINGER"; }}
-systemctl() {{
-  echo "systemctl=$*" >&2
-  case "${{2:-}}" in
-    is-enabled) echo enabled ;;
-    is-active) echo active ;;
-    is-system-running) echo running ;;
-  esac
-}}
+mkdir -p "$test_root/bin"
+export FAKE_SYSTEMD_ROOT="$test_root"
+cat > "$test_root/bin/systemctl" <<'__FAKE_SYSTEMCTL__'
+#!/usr/bin/env bash
+set -u
+echo "systemctl=$*" >&2
+case "${{2:-}}" in
+  is-enabled) echo enabled ;;
+  is-active) echo active ;;
+  is-system-running) echo running ;;
+  restart) : > "$FAKE_SYSTEMD_ROOT/restarted" ;;
+  list-jobs) ;;
+  show)
+    invocation=old-invocation
+    if [ -f "$FAKE_SYSTEMD_ROOT/restarted" ]; then
+      invocation=new-invocation
+    fi
+    printf '%s\n' 'LoadState=loaded' 'ActiveState=active' \
+      'SubState=running' 'Result=success' 'ControlPID=42' \
+      'ExecMainCode=0' 'ExecMainStatus=0' 'TimeoutStartUSec=5min' \
+      "InvocationID=$invocation"
+    ;;
+esac
+__FAKE_SYSTEMCTL__
+cat > "$test_root/bin/flock" <<'__FAKE_FLOCK__'
+#!/usr/bin/env bash
+case "${{1:-}}" in --exclusive|--unlock) exit 0 ;; *) exit 2 ;; esac
+__FAKE_FLOCK__
+chmod +x "$test_root/bin/systemctl" "$test_root/bin/flock"
+export PATH="$test_root/bin:$PATH"
 {script}
 """
 
@@ -468,7 +1879,7 @@ systemctl() {{
     assert "endpoint_service.active=active" in stdout
     assert "systemctl=--user daemon-reload" in stderr
     assert "systemctl=--user enable clio-relay-worker-test.service" in stderr
-    assert "systemctl=--user restart clio-relay-worker-test.service" in stderr
+    assert "systemctl=--user restart --no-block clio-relay-worker-test.service" in stderr
     if expected_warning is None:
         assert "login-scoped" not in stderr
     else:
@@ -503,13 +1914,35 @@ test_root="$(mktemp -d)"
 trap 'rm -rf "$test_root"' EXIT
 export HOME="$test_root/home" USER=test-user
 loginctl() {{ echo yes; }}
-systemctl() {{
-  case "${{2:-}}" in
-    is-enabled) echo {enabled_state} ;;
-    is-active) echo {active_state} ;;
-    is-system-running) echo running ;;
-  esac
-}}
+mkdir -p "$test_root/bin"
+export FAKE_SYSTEMD_ROOT="$test_root"
+cat > "$test_root/bin/systemctl" <<'__FAKE_SYSTEMCTL__'
+#!/usr/bin/env bash
+set -u
+case "${{2:-}}" in
+  is-enabled) echo {enabled_state} ;;
+  is-active) echo {active_state} ;;
+  is-system-running) echo running ;;
+  restart) : > "$FAKE_SYSTEMD_ROOT/restarted" ;;
+  list-jobs) ;;
+  show)
+    invocation=old-invocation
+    if [ -f "$FAKE_SYSTEMD_ROOT/restarted" ]; then
+      invocation=new-invocation
+    fi
+    printf '%s\n' 'LoadState=loaded' 'ActiveState=active' \
+      'SubState=running' 'Result=success' 'ControlPID=42' \
+      'ExecMainCode=0' 'ExecMainStatus=0' 'TimeoutStartUSec=5min' \
+      "InvocationID=$invocation"
+    ;;
+esac
+__FAKE_SYSTEMCTL__
+cat > "$test_root/bin/flock" <<'__FAKE_FLOCK__'
+#!/usr/bin/env bash
+case "${{1:-}}" in --exclusive|--unlock) exit 0 ;; *) exit 2 ;; esac
+__FAKE_FLOCK__
+chmod +x "$test_root/bin/systemctl" "$test_root/bin/flock"
+export PATH="$test_root/bin:$PATH"
 {script}
 """
 

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.11"
+    assert version == "1.4.12"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_service_runtime.py
+++ b/tests/test_service_runtime.py
@@ -4503,7 +4503,7 @@ def test_authenticated_jarvis_health_failure_redacts_echoed_bearer_from_error_an
     with pytest.raises(RelayError, match="authenticated health status=503") as caught:
         supervisor._wait_for_jarvis_health(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
             "http://127.0.0.1:28777/healthz",
-            timeout_seconds=0.03,
+            timeout_seconds=1.0,
             poll_seconds=1.0,
             runtime_schema_version="jarvis.service-runtime.v2",
             authorization=authorization,

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1860,13 +1860,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.11-py3-none-any.whl",
+            resource_id="clio-relay-1.4.12-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.11.tar.gz",
+            resource_id="clio_relay-1.4.12.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2005,7 +2005,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.11"
+    assert policy.release_version == "1.4.12"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/tests/test_worker_service_policy.py
+++ b/tests/test_worker_service_policy.py
@@ -313,22 +313,49 @@ def test_remote_restart_script_controls_existing_unit_without_rewriting_it() -> 
     assert "daemon-reload" not in script
     assert "systemctl --user enable" not in script
     harness = f"""set -u
-export USER=test-user
+test_root="$(mktemp -d)"
+trap 'rm -rf -- "$test_root"' EXIT
+mkdir -p "$test_root/bin" "$test_root/home"
+export HOME="$test_root/home" USER=test-user FAKE_SYSTEMD_ROOT="$test_root"
 loginctl() {{ echo yes; }}
-systemctl() {{
-  echo "systemctl=$*" >&2
-  case "${{2:-}}" in
-    is-enabled) echo enabled ;;
-    show)
-      echo "argv[]=/home/test/.local/bin/clio-relay endpoint start --role worker" \
-        "--cluster test --concurrency 7 --control-query-concurrency 2" \
-        "--kind-concurrency jarvis=3 --kind-concurrency remote_agent=2" \
-        "--scheduler-provider external ;"
-      ;;
-    is-active) echo active ;;
-    is-system-running) echo running ;;
-  esac
-}}
+cat > "$test_root/bin/systemctl" <<'__FAKE_SYSTEMCTL__'
+#!/usr/bin/env bash
+set -u
+echo "systemctl=$*" >&2
+case "${{2:-}}" in
+  is-enabled) echo enabled ;;
+  show)
+    case " $* " in
+      *--property=ExecStart*--value*)
+        echo "argv[]=/home/test/.local/bin/clio-relay endpoint start --role worker" \
+          "--cluster test --concurrency 7 --control-query-concurrency 2" \
+          "--kind-concurrency jarvis=3 --kind-concurrency remote_agent=2" \
+          "--scheduler-provider external ;"
+        ;;
+      *)
+        invocation=old-invocation
+        if [ -f "$FAKE_SYSTEMD_ROOT/restarted" ]; then
+          invocation=new-invocation
+        fi
+        printf '%s\n' 'LoadState=loaded' 'ActiveState=active' \
+          'SubState=running' 'Result=success' 'ControlPID=42' \
+          'ExecMainCode=0' 'ExecMainStatus=0' 'TimeoutStartUSec=5min' \
+          "InvocationID=$invocation"
+        ;;
+    esac
+    ;;
+  restart) : > "$FAKE_SYSTEMD_ROOT/restarted" ;;
+  list-jobs) ;;
+  is-active) echo active ;;
+  is-system-running) echo running ;;
+esac
+__FAKE_SYSTEMCTL__
+cat > "$test_root/bin/flock" <<'__FAKE_FLOCK__'
+#!/usr/bin/env bash
+case "${{1:-}}" in --exclusive|--unlock) exit 0 ;; *) exit 2 ;; esac
+__FAKE_FLOCK__
+chmod +x "$test_root/bin/systemctl" "$test_root/bin/flock"
+export PATH="$test_root/bin:$PATH"
 {script}
 """
 
@@ -346,7 +373,7 @@ systemctl() {{
     assert "endpoint_service.unit_rewritten=false" in stdout
     assert "endpoint_service.policy_source=installed-unit" in stdout
     assert "endpoint_service.policy_validated=true" in stdout
-    assert "systemctl=--user restart clio-relay-worker-test.service" in stderr
+    assert "systemctl=--user restart --no-block clio-relay-worker-test.service" in stderr
     assert "daemon-reload" not in stderr
     assert "systemctl=--user enable " not in stderr
 

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.11"
+version = "1.4.12"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- observes endpoint-service start/restart through bounded structured systemd state and exact job evidence
- serializes activation preflight/enqueue across processes and refuses incompatible or ambiguous in-flight jobs without mutation
- gives queue-index migration a finite five-minute systemd startup bound and the remote transport enough time to observe it
- emits actionable operator evidence while preserving jobs and avoiding journal payload leakage
- hardens one Windows health-redaction test deadline without changing product timeouts

## Why

Ares queue-index migration can legitimately outlive the previous 30-second bootstrap observer. The service eventually became active, but bootstrap reported a false failure and could encourage duplicate restarts. The new state machine waits within explicit bounds, proves completion, and fails closed on races.

## Validation

- 23 focused activation/bootstrap/Windows regression tests passed
- Ruff check and format passed
- Pyright passed with 0 errors
- ShellCheck and Bash syntax checks passed
- independent full-diff review approved commit c809650fb5df2199ca4ceaaf356c3d39c041cc43