### PR TITLE
fix: repair legacy bootstrap lock permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.13` uses a release-first patch process. A maintainer builds the
+> Version `1.4.14` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.13"
+$Version = "1.4.14"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.13"
+release_version: "1.4.14"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 3e590c824cf11b3d153f5a751c13cb12f2f5efa28351b200861938d57527fc0d
+acceptance_matrix_sha256: 6e75b609423fac9bb283a9ca8b593182d6481fb8f830d8836ee1c2c1a392e2b8
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.13"
+$Tag = "v1.4.14"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.13" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.14" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.13",
-  "matrix_sha256": "3e590c824cf11b3d153f5a751c13cb12f2f5efa28351b200861938d57527fc0d",
+  "release_version": "1.4.14",
+  "matrix_sha256": "6e75b609423fac9bb283a9ca8b593182d6481fb8f830d8836ee1c2c1a392e2b8",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.13"
+version = "1.4.14"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.13"
+__version__ = "1.4.14"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -3512,36 +3512,86 @@ import sys
 from pathlib import Path
 
 directory = Path.home() / ".local/share/clio-relay"
-lock_path = directory / "bootstrap.lock"
-directory_details = directory.lstat()
-if (
-    not stat.S_ISDIR(directory_details.st_mode)
-    or directory_details.st_uid != os.getuid()
-    or stat.S_IMODE(directory_details.st_mode) & 0o077
-):
-    raise SystemExit("bootstrap lock directory must be owner-private")
-flags = os.O_RDWR | os.O_CREAT
-if hasattr(os, "O_NOFOLLOW"):
-    flags |= os.O_NOFOLLOW
-descriptor = os.open(lock_path, flags, 0o600)
-os.fchmod(descriptor, 0o600)
-opened = os.fstat(descriptor)
-linked = lock_path.lstat()
-if (
-    not stat.S_ISREG(opened.st_mode)
-    or opened.st_nlink != 1
-    or opened.st_uid != os.getuid()
-    or stat.S_IMODE(opened.st_mode) & 0o077
-    or (opened.st_dev, opened.st_ino) != (linked.st_dev, linked.st_ino)
-):
-    raise SystemExit("bootstrap lock must be one owner-private regular file")
+directory_flags = os.O_RDONLY
+for flag_name in ("O_CLOEXEC", "O_DIRECTORY", "O_NOFOLLOW"):
+    directory_flags |= getattr(os, flag_name, 0)
 try:
-    fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
-except BlockingIOError as exc:
-    raise SystemExit("another clio-relay bootstrap is already running") from exc
-os.dup2(descriptor, 9, inheritable=True)
-if descriptor != 9:
-    os.close(descriptor)
+    directory_descriptor = os.open(directory, directory_flags)
+except OSError as exc:
+    raise SystemExit("bootstrap lock directory must be a real directory") from exc
+if directory_descriptor == 9:
+    replacement_descriptor = os.dup(directory_descriptor)
+    os.close(directory_descriptor)
+    directory_descriptor = replacement_descriptor
+descriptor = None
+try:
+    opened_directory = os.fstat(directory_descriptor)
+    linked_directory = directory.lstat()
+    if (
+        not stat.S_ISDIR(opened_directory.st_mode)
+        or not stat.S_ISDIR(linked_directory.st_mode)
+        or opened_directory.st_uid != os.getuid()
+        or (opened_directory.st_dev, opened_directory.st_ino)
+        != (linked_directory.st_dev, linked_directory.st_ino)
+    ):
+        raise SystemExit("bootstrap lock directory must be an owned real directory")
+    if stat.S_IMODE(opened_directory.st_mode) != 0o700:
+        os.fchmod(directory_descriptor, 0o700)
+    repaired_directory = os.fstat(directory_descriptor)
+    relinked_directory = directory.lstat()
+    if (
+        not stat.S_ISDIR(repaired_directory.st_mode)
+        or not stat.S_ISDIR(relinked_directory.st_mode)
+        or repaired_directory.st_uid != os.getuid()
+        or stat.S_IMODE(repaired_directory.st_mode) != 0o700
+        or (repaired_directory.st_dev, repaired_directory.st_ino)
+        != (relinked_directory.st_dev, relinked_directory.st_ino)
+    ):
+        raise SystemExit("bootstrap lock directory could not be made owner-private")
+    flags = os.O_RDWR | os.O_CREAT
+    for flag_name in ("O_CLOEXEC", "O_NOFOLLOW"):
+        flags |= getattr(os, flag_name, 0)
+    descriptor = os.open("bootstrap.lock", flags, 0o600, dir_fd=directory_descriptor)
+    opened = os.fstat(descriptor)
+    linked = os.stat(
+        "bootstrap.lock",
+        dir_fd=directory_descriptor,
+        follow_symlinks=False,
+    )
+    if (
+        not stat.S_ISREG(opened.st_mode)
+        or not stat.S_ISREG(linked.st_mode)
+        or opened.st_nlink != 1
+        or opened.st_uid != os.getuid()
+        or (opened.st_dev, opened.st_ino) != (linked.st_dev, linked.st_ino)
+    ):
+        raise SystemExit("bootstrap lock must be one owned regular file")
+    if stat.S_IMODE(opened.st_mode) != 0o600:
+        os.fchmod(descriptor, 0o600)
+    repaired = os.fstat(descriptor)
+    relinked = os.stat(
+        "bootstrap.lock",
+        dir_fd=directory_descriptor,
+        follow_symlinks=False,
+    )
+    if (
+        not stat.S_ISREG(repaired.st_mode)
+        or not stat.S_ISREG(relinked.st_mode)
+        or repaired.st_nlink != 1
+        or repaired.st_uid != os.getuid()
+        or stat.S_IMODE(repaired.st_mode) != 0o600
+        or (repaired.st_dev, repaired.st_ino) != (relinked.st_dev, relinked.st_ino)
+    ):
+        raise SystemExit("bootstrap lock could not be made owner-private")
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as exc:
+        raise SystemExit("another clio-relay bootstrap is already running") from exc
+    os.dup2(descriptor, 9, inheritable=True)
+finally:
+    os.close(directory_descriptor)
+    if descriptor is not None and descriptor != 9:
+        os.close(descriptor)
 environment = dict(os.environ)
 environment["CLIO_RELAY_BOOTSTRAP_LOCK_FD"] = "9"
 script = str(Path(sys.argv[1]).resolve(strict=True))
@@ -3555,18 +3605,41 @@ import os
 import stat
 from pathlib import Path
 
-lock_path = Path.home() / ".local/share/clio-relay/bootstrap.lock"
+directory = Path.home() / ".local/share/clio-relay"
+directory_flags = os.O_RDONLY
+for flag_name in ("O_CLOEXEC", "O_DIRECTORY", "O_NOFOLLOW"):
+    directory_flags |= getattr(os, flag_name, 0)
+try:
+    directory_descriptor = os.open(directory, directory_flags)
+except OSError as exc:
+    raise SystemExit("inherited bootstrap lock directory changed") from exc
 opened = os.fstat(9)
-linked = lock_path.lstat()
-if (
-    not stat.S_ISREG(opened.st_mode)
-    or opened.st_nlink != 1
-    or opened.st_uid != os.getuid()
-    or stat.S_IMODE(opened.st_mode) & 0o077
-    or (opened.st_dev, opened.st_ino) != (linked.st_dev, linked.st_ino)
-):
-    raise SystemExit("inherited bootstrap lock identity changed")
-fcntl.flock(9, fcntl.LOCK_EX | fcntl.LOCK_NB)
+try:
+    opened_directory = os.fstat(directory_descriptor)
+    linked_directory = directory.lstat()
+    linked = os.stat(
+        "bootstrap.lock",
+        dir_fd=directory_descriptor,
+        follow_symlinks=False,
+    )
+    if (
+        not stat.S_ISDIR(opened_directory.st_mode)
+        or not stat.S_ISDIR(linked_directory.st_mode)
+        or opened_directory.st_uid != os.getuid()
+        or stat.S_IMODE(opened_directory.st_mode) != 0o700
+        or (opened_directory.st_dev, opened_directory.st_ino)
+        != (linked_directory.st_dev, linked_directory.st_ino)
+        or not stat.S_ISREG(opened.st_mode)
+        or not stat.S_ISREG(linked.st_mode)
+        or opened.st_nlink != 1
+        or opened.st_uid != os.getuid()
+        or stat.S_IMODE(opened.st_mode) != 0o600
+        or (opened.st_dev, opened.st_ino) != (linked.st_dev, linked.st_ino)
+    ):
+        raise SystemExit("inherited bootstrap lock identity changed")
+    fcntl.flock(9, fcntl.LOCK_EX | fcntl.LOCK_NB)
+finally:
+    os.close(directory_descriptor)
 __CLIO_RELAY_BOOTSTRAP_LOCK_VERIFY__
 BOOTSTRAP_INVOCATION_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%S.%NZ)"
 BOOTSTRAP_INVOCATION_STARTED_NS="$(python3 -c 'import time; print(time.monotonic_ns())')"

--- a/tests/test_bootstrap_cluster_paths.py
+++ b/tests/test_bootstrap_cluster_paths.py
@@ -76,7 +76,9 @@ def test_managed_bootstrap_fences_worker_around_migration() -> None:
     assert '"$CLIO_RELAY_ENDPOINT_SERVICE_NAME"' in script
     assert "WORKER_WRITER_PROOF=1" in script
     assert 'environment["CLIO_RELAY_BOOTSTRAP_LOCK_FD"] = "9"' in script
-    assert "flags |= os.O_NOFOLLOW" in script
+    assert 'flag_name in ("O_CLOEXEC", "O_DIRECTORY", "O_NOFOLLOW")' in script
+    assert "os.fchmod(directory_descriptor, 0o700)" in script
+    assert 'os.open("bootstrap.lock", flags, 0o600, dir_fd=directory_descriptor)' in script
     assert "fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)" in script
     assert 'exec 8<>"$WORKER_LIFETIME_LOCK_PATH"' in script
     assert "WORKER_LIFETIME_GUARD_FD=8" in script

--- a/tests/test_bootstrap_fast_path.py
+++ b/tests/test_bootstrap_fast_path.py
@@ -634,7 +634,7 @@ def test_future_release_identity_does_not_require_network_or_a_digest(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(bootstrap, "__version__", "1.4.13")
+    monkeypatch.setattr(bootstrap, "__version__", "1.4.14")
 
     identity = bootstrap.bootstrap_relay_identity(
         source_root=tmp_path / "not-a-checkout",
@@ -642,8 +642,8 @@ def test_future_release_identity_does_not_require_network_or_a_digest(
         relay_artifact_sha256="1" * 64,
     )
 
-    assert identity.install_spec == "clio-relay==1.4.13"
-    assert identity.source_identity == f"release:clio-relay==1.4.13:sha256:{'1' * 64}"
+    assert identity.install_spec == "clio-relay==1.4.14"
+    assert identity.source_identity == f"release:clio-relay==1.4.14:sha256:{'1' * 64}"
     assert identity.deployment_artifact_sha256 == "1" * 64
 
 

--- a/tests/test_bootstrap_lock_upgrade.py
+++ b/tests/test_bootstrap_lock_upgrade.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+from clio_relay.bootstrap import render_linux_user_bootstrap_script
+
+
+def _embedded_python(script: str, marker: str) -> str:
+    """Extract one exact Python heredoc from the rendered Linux bootstrap."""
+    opening = f"<<'{marker}'\n"
+    start = script.index(opening) + len(opening)
+    end = script.index(f"\n{marker}\n", start)
+    return script[start:end]
+
+
+def _lock_acquisition_source() -> str:
+    """Return the exact initial lock acquisition program shipped to a cluster."""
+    return _embedded_python(
+        render_linux_user_bootstrap_script(),
+        "__CLIO_RELAY_BOOTSTRAP_LOCK_AND_REEXEC__",
+    )
+
+
+def _lock_verification_source() -> str:
+    """Return the exact inherited-lock verifier shipped to a cluster."""
+    return _embedded_python(
+        render_linux_user_bootstrap_script(),
+        "__CLIO_RELAY_BOOTSTRAP_LOCK_VERIFY__",
+    )
+
+
+def _lock_test_target(path: Path, *, verification_source: str) -> None:
+    """Write a target that proves the inherited descriptor owns the live lock."""
+    path.write_text(
+        """set -euo pipefail
+python3 - <<'__CLIO_RELAY_EXACT_LOCK_VERIFY__'
+"""
+        + verification_source
+        + """
+__CLIO_RELAY_EXACT_LOCK_VERIFY__
+python3 - <<'__CLIO_RELAY_LOCK_TEST__'
+import fcntl
+import os
+import stat
+from pathlib import Path
+
+directory = Path.home() / ".local/share/clio-relay"
+lock_path = directory / "bootstrap.lock"
+assert os.environ["CLIO_RELAY_BOOTSTRAP_LOCK_FD"] == "9"
+assert stat.S_IMODE(directory.stat().st_mode) == 0o700
+assert stat.S_IMODE(lock_path.stat().st_mode) == 0o600
+assert os.fstat(9).st_ino == lock_path.stat().st_ino
+probe = os.open(lock_path, os.O_RDWR)
+try:
+    try:
+        fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        pass
+    else:
+        raise AssertionError("a second open file description acquired the bootstrap lock")
+finally:
+    os.close(probe)
+print("bootstrap_lock_upgrade=ready")
+__CLIO_RELAY_LOCK_TEST__
+""",
+        encoding="utf-8",
+    )
+
+
+def test_embedded_bootstrap_lock_repairs_owned_legacy_directory_and_holds_lock(
+    tmp_path: Path,
+) -> None:
+    """An owner-controlled legacy 0755 directory is safely upgraded before locking."""
+    source = _lock_acquisition_source()
+    assert "dir_fd=directory_descriptor" in source
+    assert source.index("opened_directory.st_uid != os.getuid()") < source.index(
+        "os.fchmod(directory_descriptor, 0o700)"
+    )
+    assert source.index("opened.st_uid != os.getuid()") < source.index(
+        "os.fchmod(descriptor, 0o600)"
+    )
+    if os.name != "posix":
+        return
+
+    home = tmp_path / "home"
+    directory = home / ".local/share/clio-relay"
+    directory.mkdir(parents=True)
+    directory.chmod(0o755)
+    lock_path = directory / "bootstrap.lock"
+    lock_path.write_bytes(b"")
+    lock_path.chmod(0o644)
+    target = tmp_path / "lock-target.sh"
+    _lock_test_target(target, verification_source=_lock_verification_source())
+    environment = {**os.environ, "HOME": str(home)}
+    environment.pop("CLIO_RELAY_BOOTSTRAP_LOCK_FD", None)
+
+    result = subprocess.run(
+        [sys.executable, "-c", source, str(target)],
+        capture_output=True,
+        check=False,
+        env=environment,
+        text=True,
+        timeout=15,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "bootstrap_lock_upgrade=ready"
+    assert stat.S_IMODE(directory.stat().st_mode) == 0o700
+    assert stat.S_IMODE(lock_path.stat().st_mode) == 0o600
+
+
+def test_embedded_bootstrap_lock_does_not_follow_or_chmod_directory_symlink(
+    tmp_path: Path,
+) -> None:
+    """A redirected state path remains rejected without modifying its target."""
+    source = _lock_acquisition_source()
+    assert "getattr(os, flag_name, 0)" in source
+    assert 'flag_name in ("O_CLOEXEC", "O_DIRECTORY", "O_NOFOLLOW")' in source
+    if os.name != "posix":
+        return
+
+    home = tmp_path / "home"
+    share = home / ".local/share"
+    share.mkdir(parents=True)
+    redirected = tmp_path / "redirected"
+    redirected.mkdir()
+    redirected.chmod(0o755)
+    (share / "clio-relay").symlink_to(redirected, target_is_directory=True)
+    target = tmp_path / "must-not-run.sh"
+    target.write_text("exit 99\n", encoding="utf-8")
+    environment = {**os.environ, "HOME": str(home)}
+    environment.pop("CLIO_RELAY_BOOTSTRAP_LOCK_FD", None)
+
+    result = subprocess.run(
+        [sys.executable, "-c", source, str(target)],
+        capture_output=True,
+        check=False,
+        env=environment,
+        text=True,
+        timeout=15,
+    )
+
+    assert result.returncode != 0
+    assert "bootstrap lock directory must be a real directory" in result.stderr
+    assert stat.S_IMODE(redirected.stat().st_mode) == 0o755
+    assert not (redirected / "bootstrap.lock").exists()

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1699,7 +1699,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "4ecea98055acdb4a69dd2d8992a466e26aa8291d975bb70f4bb91ff1894f90fe"
+        "6e75b609423fac9bb283a9ca8b593182d6481fb8f830d8836ee1c2c1a392e2b8"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.13"
+    assert version == "1.4.14"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2340,13 +2340,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.13-py3-none-any.whl",
+            resource_id="clio-relay-1.4.14-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.13.tar.gz",
+            resource_id="clio_relay-1.4.14.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2485,7 +2485,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.13"
+    assert policy.release_version == "1.4.14"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.13"
+version = "1.4.14"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- repair a legacy user-owned `0755` bootstrap state directory to `0700` after pinning and verifying it, instead of refusing an otherwise safe upgrade
- keep the bootstrap lock descriptor-relative and fail closed for symlinked, unowned, redirected, or non-directory paths
- bump the release identity and acceptance matrix to 1.4.14

## Focused validation

- executed legacy-permission bootstrap-lock reproduction and hostile path checks
- release version and acceptance-matrix identity checks
- Ruff formatting/lint and Pyright on changed source

The exact 1.4.13 wheel reproduced this failure live on Ares before any JARVIS or scheduler job was created. The full regression matrix remains asynchronous on the published tag.
