### PR TITLE
fix: ship bootstrap reconciliation dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.14` uses a release-first patch process. A maintainer builds the
+> Version `1.4.15` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.14"
+$Version = "1.4.15"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.14"
+release_version: "1.4.15"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 6e75b609423fac9bb283a9ca8b593182d6481fb8f830d8836ee1c2c1a392e2b8
+acceptance_matrix_sha256: 3c3fe2516e915b970c97b56377a26a9cfa4c6ee6d04dad50368228914b1e4099
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.14"
+$Tag = "v1.4.15"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.14" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.15" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.14",
-  "matrix_sha256": "6e75b609423fac9bb283a9ca8b593182d6481fb8f830d8836ee1c2c1a392e2b8",
+  "release_version": "1.4.15",
+  "matrix_sha256": "3c3fe2516e915b970c97b56377a26a9cfa4c6ee6d04dad50368228914b1e4099",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.14"
+version = "1.4.15"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.14"
+__version__ = "1.4.15"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -80,6 +80,30 @@ BOOTSTRAP_REMOTE_SCRIPT_TIMEOUT_SECONDS = 1800.0
 BOOTSTRAP_PUBLIC_EXACT_DEADLINE_SECONDS = 29.0
 BOOTSTRAP_PUBLIC_REPAIR_DEADLINE_SECONDS = 58.0
 
+_BOOTSTRAP_CANDIDATE_PACKAGE_OVERLAY = (
+    b"\nfrom pkgutil import extend_path\n\n__path__ = extend_path(__path__, __name__)\n"
+)
+_BOOTSTRAP_CANDIDATE_SOURCE_NAMES = (
+    "bootstrap_reconcile.py",
+    "bounded_process.py",
+    "errors.py",
+    "process_containment.py",
+    "safe_archive.py",
+)
+
+
+def _bootstrap_candidate_package_sources() -> dict[str, bytes]:
+    """Return the exact sources overlaid during candidate reconciliation."""
+    package_root = Path(__file__).parent
+    sources = {
+        "__init__.py": (package_root / "__init__.py").read_bytes()
+        + _BOOTSTRAP_CANDIDATE_PACKAGE_OVERLAY
+    }
+    for name in _BOOTSTRAP_CANDIDATE_SOURCE_NAMES:
+        sources[name] = (package_root / name).read_bytes()
+    return sources
+
+
 _WORKER_WRITER_PROOF_PYTHON = r'''from __future__ import annotations
 
 import errno
@@ -2018,6 +2042,9 @@ import sys
 from pathlib import Path
 
 path, action, *arguments = sys.argv[1:]
+candidate_root = os.environ["BOOTSTRAP_CANDIDATE_PYTHON_ROOT"]
+if not sys.path or sys.path[0] != candidate_root:
+    sys.path.insert(0, candidate_root)
 name = "clio_relay.bootstrap_reconcile_candidate_action"
 spec = importlib.util.spec_from_file_location(name, path)
 if spec is None or spec.loader is None:
@@ -3454,19 +3481,24 @@ def render_linux_user_bootstrap_script(
     rendered_desired_state = shlex.quote(
         json.dumps(desired_state.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
     )
-    candidate_reconcile_source = Path(__file__).with_name("bootstrap_reconcile.py").read_bytes()
-    rendered_candidate_reconcile_source = base64.b64encode(candidate_reconcile_source).decode(
-        "ascii"
+    candidate_package_sources = _bootstrap_candidate_package_sources()
+    rendered_candidate_package_sources = json.dumps(
+        {
+            name: base64.b64encode(payload).decode("ascii")
+            for name, payload in sorted(candidate_package_sources.items())
+        },
+        sort_keys=True,
+        separators=(",", ":"),
     )
-    candidate_reconcile_sha256 = hashlib.sha256(candidate_reconcile_source).hexdigest()
-    candidate_safe_archive_source = Path(__file__).with_name("safe_archive.py").read_bytes()
-    rendered_candidate_safe_archive_source = base64.b64encode(candidate_safe_archive_source).decode(
-        "ascii"
-    )
-    candidate_safe_archive_sha256 = hashlib.sha256(candidate_safe_archive_source).hexdigest()
-    candidate_errors_source = Path(__file__).with_name("errors.py").read_bytes()
-    rendered_candidate_errors_source = base64.b64encode(candidate_errors_source).decode("ascii")
-    candidate_errors_sha256 = hashlib.sha256(candidate_errors_source).hexdigest()
+    candidate_package_sha256 = {
+        name: hashlib.sha256(payload).hexdigest()
+        for name, payload in candidate_package_sources.items()
+    }
+    candidate_reconcile_sha256 = candidate_package_sha256["bootstrap_reconcile.py"]
+    candidate_bounded_process_sha256 = candidate_package_sha256["bounded_process.py"]
+    candidate_errors_sha256 = candidate_package_sha256["errors.py"]
+    candidate_process_containment_sha256 = candidate_package_sha256["process_containment.py"]
+    candidate_safe_archive_sha256 = candidate_package_sha256["safe_archive.py"]
     bootstrap_journal_source = Path(__file__).with_name("bootstrap_journal.py").read_bytes()
     rendered_bootstrap_journal_source = base64.b64encode(bootstrap_journal_source).decode("ascii")
     relay_only_reconcile = _relay_only_reconcile_script(
@@ -4002,32 +4034,6 @@ fi
 {relay_only_reconcile}
 BOOTSTRAP_PREPARING_ROOT="$HOME/.local/share/clio-relay/preparing/{invocation_id}"
 mkdir -p "$BOOTSTRAP_PREPARING_ROOT"
-BOOTSTRAP_CANDIDATE_RECONCILE="$BOOTSTRAP_PREPARING_ROOT/bootstrap_reconcile.py"
-if [ -L "$BOOTSTRAP_CANDIDATE_RECONCILE" ]; then
-  echo "bootstrap candidate reconciler must not be a symbolic link" >&2
-  exit 1
-fi
-if [ ! -f "$BOOTSTRAP_CANDIDATE_RECONCILE" ]; then
-  python3 - "$BOOTSTRAP_CANDIDATE_RECONCILE" <<'__CLIO_RELAY_CANDIDATE_RECONCILE__'
-import base64
-import os
-import sys
-from pathlib import Path
-
-destination = Path(sys.argv[1])
-payload = base64.b64decode(
-    "{rendered_candidate_reconcile_source}",
-    validate=True,
-)
-with destination.open("xb") as stream:
-    stream.write(payload)
-    stream.flush()
-    os.fsync(stream.fileno())
-os.chmod(destination, 0o600)
-__CLIO_RELAY_CANDIDATE_RECONCILE__
-fi
-echo "{candidate_reconcile_sha256} *$BOOTSTRAP_CANDIDATE_RECONCILE" | \
-  sha256sum --check --strict -
 BOOTSTRAP_CANDIDATE_PYTHON_ROOT="$BOOTSTRAP_PREPARING_ROOT/candidate-python"
 BOOTSTRAP_CANDIDATE_PACKAGE="$BOOTSTRAP_CANDIDATE_PYTHON_ROOT/clio_relay"
 if [ -L "$BOOTSTRAP_CANDIDATE_PYTHON_ROOT" ] || \
@@ -4036,27 +4042,26 @@ if [ -L "$BOOTSTRAP_CANDIDATE_PYTHON_ROOT" ] || \
   exit 1
 fi
 mkdir -m 0700 -p "$BOOTSTRAP_CANDIDATE_PACKAGE"
-python3 - "$BOOTSTRAP_CANDIDATE_PACKAGE" <<'__CLIO_RELAY_CANDIDATE_SAFE_ARCHIVE__'
+python3 - "$BOOTSTRAP_CANDIDATE_PACKAGE" <<'__CLIO_RELAY_CANDIDATE_PACKAGE__'
 import base64
 import hashlib
+import json
 import os
 import sys
 from pathlib import Path
 
 destination = Path(sys.argv[1])
+encoded_sources = json.loads(r'''{rendered_candidate_package_sources}''')
+if not isinstance(encoded_sources, dict):
+    raise SystemExit("bootstrap candidate source manifest is invalid")
 sources = {{
-    "__init__.py": b"# Bootstrap candidate package.\\n",
-    "errors.py": base64.b64decode(
-        "{rendered_candidate_errors_source}",
-        validate=True,
-    ),
-    "safe_archive.py": base64.b64decode(
-        "{rendered_candidate_safe_archive_source}",
-        validate=True,
-    ),
+    name: base64.b64decode(encoded, validate=True)
+    for name, encoded in encoded_sources.items()
 }}
 for name, payload in sources.items():
     path = destination / name
+    if path.is_symlink():
+        raise SystemExit(f"bootstrap candidate source must not be a symbolic link: {{name}}")
     try:
         observed = path.read_bytes()
     except FileNotFoundError:
@@ -4069,12 +4074,20 @@ for name, payload in sources.items():
     if observed != payload:
         raise SystemExit(f"bootstrap candidate source identity changed: {{name}}")
     print(f"bootstrap_candidate_source={{name}}:{{hashlib.sha256(observed).hexdigest()}}")
-__CLIO_RELAY_CANDIDATE_SAFE_ARCHIVE__
+__CLIO_RELAY_CANDIDATE_PACKAGE__
+BOOTSTRAP_CANDIDATE_RECONCILE="$BOOTSTRAP_CANDIDATE_PACKAGE/bootstrap_reconcile.py"
+BOOTSTRAP_CANDIDATE_PROCESS_CONTAINMENT="$BOOTSTRAP_CANDIDATE_PACKAGE/process_containment.py"
+echo "{candidate_reconcile_sha256} *$BOOTSTRAP_CANDIDATE_RECONCILE" | \
+  sha256sum --check --strict -
+echo "{candidate_bounded_process_sha256} *$BOOTSTRAP_CANDIDATE_PACKAGE/bounded_process.py" | \
+  sha256sum --check --strict -
 echo "{candidate_errors_sha256} *$BOOTSTRAP_CANDIDATE_PACKAGE/errors.py" | \
+  sha256sum --check --strict -
+echo "{candidate_process_containment_sha256} *$BOOTSTRAP_CANDIDATE_PROCESS_CONTAINMENT" | \
   sha256sum --check --strict -
 echo "{candidate_safe_archive_sha256} *$BOOTSTRAP_CANDIDATE_PACKAGE/safe_archive.py" | \
   sha256sum --check --strict -
-export BOOTSTRAP_CANDIDATE_PYTHON_ROOT
+export BOOTSTRAP_CANDIDATE_PYTHON_ROOT BOOTSTRAP_CANDIDATE_RECONCILE
 bootstrap_safe_extract() {{
   local provider="$1"
   local archive="$2"
@@ -4136,6 +4149,9 @@ import os
 import sys
 
 path = os.environ["BOOTSTRAP_CANDIDATE_RECONCILE"]
+candidate_root = os.environ["BOOTSTRAP_CANDIDATE_PYTHON_ROOT"]
+if not sys.path or sys.path[0] != candidate_root:
+    sys.path.insert(0, candidate_root)
 name = "clio_relay.bootstrap_reconcile_candidate"
 spec = importlib.util.spec_from_file_location(name, path)
 if spec is None or spec.loader is None:

--- a/tests/test_bootstrap_candidate_payload.py
+++ b/tests/test_bootstrap_candidate_payload.py
@@ -1,0 +1,123 @@
+"""Execution coverage for the shipped bootstrap reconciliation overlay."""
+
+from __future__ import annotations
+
+import base64
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import cast
+
+from clio_relay import bootstrap
+
+
+def _extract_candidate_sources(script: str) -> dict[str, bytes]:
+    """Extract the exact source manifest embedded in one rendered bootstrap."""
+    prefix = "encoded_sources = json.loads(r'''"
+    start = script.index(prefix) + len(prefix)
+    end = script.index("''')", start)
+    raw = cast(object, json.loads(script[start:end]))
+    assert isinstance(raw, dict)
+    encoded = cast(dict[str, object], raw)
+    sources: dict[str, bytes] = {}
+    for name, value in encoded.items():
+        assert isinstance(value, str)
+        sources[name] = base64.b64decode(value, validate=True)
+    return sources
+
+
+def test_extracted_candidate_reconciler_runs_without_provider_bounded_process(
+    tmp_path: Path,
+) -> None:
+    """The candidate overlay supplies its complete bounded-process subsystem."""
+    sources = _extract_candidate_sources(
+        bootstrap.render_linux_user_bootstrap_script(cluster="candidate-test")
+    )
+    assert set(sources) == {
+        "__init__.py",
+        "bootstrap_reconcile.py",
+        "bounded_process.py",
+        "errors.py",
+        "process_containment.py",
+        "safe_archive.py",
+    }
+
+    candidate_root = tmp_path / "candidate-python"
+    candidate_package = candidate_root / "clio_relay"
+    candidate_package.mkdir(parents=True)
+    for name, payload in sources.items():
+        (candidate_package / name).write_bytes(payload)
+
+    installed_package = Path(bootstrap.__file__).resolve().parent
+    legacy_root = tmp_path / "legacy-provider"
+    shutil.copytree(
+        installed_package,
+        legacy_root / "clio_relay",
+        ignore=shutil.ignore_patterns(
+            "__pycache__",
+            "bootstrap_reconcile.py",
+            "bounded_process.py",
+            "errors.py",
+            "process_containment.py",
+            "safe_archive.py",
+        ),
+    )
+    probe = r"""
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+candidate_root = Path(sys.argv[1]).resolve()
+legacy_root = Path(sys.argv[2]).resolve()
+sys.path.insert(0, str(legacy_root))
+sys.path.insert(0, str(candidate_root))
+reconciler_path = candidate_root / "clio_relay/bootstrap_reconcile.py"
+name = "clio_relay.bootstrap_reconcile_candidate"
+spec = importlib.util.spec_from_file_location(name, reconciler_path)
+if spec is None or spec.loader is None:
+    raise SystemExit("candidate reconciler spec was unavailable")
+module = importlib.util.module_from_spec(spec)
+sys.modules[name] = module
+spec.loader.exec_module(module)
+
+from clio_relay import bounded_process, process_containment
+
+completed = bounded_process.run_bounded_process(
+    [sys.executable, "-c", "print('candidate-ok')"],
+    timeout_seconds=10,
+    stdout_maximum_bytes=4096,
+    stderr_maximum_bytes=4096,
+)
+if completed.returncode != 0 or completed.stdout.strip() != "candidate-ok":
+    raise SystemExit("candidate bounded-process probe failed")
+print(json.dumps({
+    "bounded_process": str(Path(bounded_process.__file__).resolve()),
+    "process_containment": str(Path(process_containment.__file__).resolve()),
+    "reconcile_digest": module.canonical_json_sha256({"candidate": True}),
+}, sort_keys=True))
+"""
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-c",
+            probe,
+            str(candidate_root),
+            str(legacy_root),
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+    assert completed.returncode == 0, completed.stderr
+    evidence = json.loads(completed.stdout)
+    assert Path(evidence["bounded_process"]) == (candidate_package / "bounded_process.py").resolve()
+    assert (
+        Path(evidence["process_containment"])
+        == (candidate_package / "process_containment.py").resolve()
+    )
+    assert len(evidence["reconcile_digest"]) == 64

--- a/tests/test_bootstrap_fast_path.py
+++ b/tests/test_bootstrap_fast_path.py
@@ -634,7 +634,7 @@ def test_future_release_identity_does_not_require_network_or_a_digest(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(bootstrap, "__version__", "1.4.14")
+    monkeypatch.setattr(bootstrap, "__version__", "1.4.15")
 
     identity = bootstrap.bootstrap_relay_identity(
         source_root=tmp_path / "not-a-checkout",
@@ -642,8 +642,8 @@ def test_future_release_identity_does_not_require_network_or_a_digest(
         relay_artifact_sha256="1" * 64,
     )
 
-    assert identity.install_spec == "clio-relay==1.4.14"
-    assert identity.source_identity == f"release:clio-relay==1.4.14:sha256:{'1' * 64}"
+    assert identity.install_spec == "clio-relay==1.4.15"
+    assert identity.source_identity == f"release:clio-relay==1.4.15:sha256:{'1' * 64}"
     assert identity.deployment_artifact_sha256 == "1" * 64
 
 

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1699,7 +1699,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "6e75b609423fac9bb283a9ca8b593182d6481fb8f830d8836ee1c2c1a392e2b8"
+        "3c3fe2516e915b970c97b56377a26a9cfa4c6ee6d04dad50368228914b1e4099"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.14"
+    assert version == "1.4.15"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2340,13 +2340,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.14-py3-none-any.whl",
+            resource_id="clio-relay-1.4.15-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.14.tar.gz",
+            resource_id="clio_relay-1.4.15.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2485,7 +2485,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.14"
+    assert policy.release_version == "1.4.15"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.14"
+version = "1.4.15"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- ship the complete candidate reconciliation overlay needed by the rendered cluster bootstrap
- keep unchanged dependencies available from the trusted installed provider package
- add a focused executable regression for the exact extracted/imported payload
- bump the release identity and acceptance matrix to 1.4.15

## Focused validation

- exact rendered candidate payload extraction/import regression
- release version and acceptance-matrix identity checks
- Ruff formatting/lint and Pyright on changed source

The exact 1.4.14 release reproduced the missing-module failure live on Ares after the secure lock upgrade and before any JARVIS or scheduler job was created. The full regression matrix remains asynchronous on the published tag.
