### PR TITLE
fix: preserve bootstrap provider identity during upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.15` uses a release-first patch process. A maintainer builds the
+> Version `1.4.16` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.15"
+$Version = "1.4.16"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.15"
+release_version: "1.4.16"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 3c3fe2516e915b970c97b56377a26a9cfa4c6ee6d04dad50368228914b1e4099
+acceptance_matrix_sha256: f578eb2bde1da9171014e5f78997e5d9f01a00a1b04edfbf7a6e30261d01e32a
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.15"
+$Tag = "v1.4.16"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.15" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.16" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.15",
-  "matrix_sha256": "3c3fe2516e915b970c97b56377a26a9cfa4c6ee6d04dad50368228914b1e4099",
+  "release_version": "1.4.16",
+  "matrix_sha256": "f578eb2bde1da9171014e5f78997e5d9f01a00a1b04edfbf7a6e30261d01e32a",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.15"
+version = "1.4.16"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.15"
+__version__ = "1.4.16"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -81,7 +81,13 @@ BOOTSTRAP_PUBLIC_EXACT_DEADLINE_SECONDS = 29.0
 BOOTSTRAP_PUBLIC_REPAIR_DEADLINE_SECONDS = 58.0
 
 _BOOTSTRAP_CANDIDATE_PACKAGE_OVERLAY = (
-    b"\nfrom pkgutil import extend_path\n\n__path__ = extend_path(__path__, __name__)\n"
+    b"\nfrom importlib import metadata as _clio_relay_metadata\n"
+    b"from pkgutil import extend_path\n\n"
+    b"__path__ = extend_path(__path__, __name__)\n"
+    b"try:\n"
+    b"    __version__ = _clio_relay_metadata.version('clio-relay')\n"
+    b"except _clio_relay_metadata.PackageNotFoundError:\n"
+    b"    pass\n"
 )
 _BOOTSTRAP_CANDIDATE_SOURCE_NAMES = (
     "bootstrap_reconcile.py",

--- a/tests/test_bootstrap_candidate_payload.py
+++ b/tests/test_bootstrap_candidate_payload.py
@@ -7,6 +7,7 @@ import json
 import shutil
 import subprocess
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
 
@@ -121,3 +122,104 @@ print(json.dumps({
         == (candidate_package / "process_containment.py").resolve()
     )
     assert len(evidence["reconcile_digest"]) == 64
+
+
+def test_candidate_overlay_preserves_legacy_provider_install_identity(
+    tmp_path: Path,
+) -> None:
+    """Candidate reconciliation must inspect the installed provider as itself."""
+    sources = _extract_candidate_sources(
+        bootstrap.render_linux_user_bootstrap_script(cluster="candidate-test")
+    )
+    candidate_root = tmp_path / "candidate-python"
+    candidate_package = candidate_root / "clio_relay"
+    candidate_package.mkdir(parents=True)
+    for name, payload in sources.items():
+        (candidate_package / name).write_bytes(payload)
+
+    legacy_version = "1.4.12"
+    legacy_root = tmp_path / "legacy-provider"
+    installed_package = Path(bootstrap.__file__).resolve().parent
+    shutil.copytree(
+        installed_package,
+        legacy_root / "clio_relay",
+        ignore=shutil.ignore_patterns("__pycache__", *sources),
+    )
+    distribution_metadata = legacy_root / f"clio_relay-{legacy_version}.dist-info"
+    distribution_metadata.mkdir()
+    (distribution_metadata / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: clio-relay\nVersion: {legacy_version}\n",
+        encoding="utf-8",
+    )
+    receipt = tmp_path / "install-receipt.json"
+    receipt.write_text(
+        json.dumps(
+            {
+                "schema_version": "clio-relay.install-receipt.v1",
+                "installed_at": datetime.now(UTC).isoformat(),
+                "install_spec": f"clio-relay=={legacy_version}",
+                "requested_source": "wheel",
+                "artifact_filename": None,
+                "artifact_sha256": None,
+                "distribution_version": legacy_version,
+                "software": {
+                    "version": legacy_version,
+                    "commit": None,
+                    "tag": None,
+                    "dirty": None,
+                },
+                "components": {},
+                "component_artifacts": {},
+                "deployment_fingerprint": None,
+                "deployment_manifest": None,
+                "generation": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    probe = r"""
+import json
+import sys
+from pathlib import Path
+
+candidate_root = Path(sys.argv[1]).resolve()
+legacy_root = Path(sys.argv[2]).resolve()
+receipt = Path(sys.argv[3]).resolve()
+sys.path.insert(0, str(legacy_root))
+sys.path.insert(0, str(candidate_root))
+
+import clio_relay
+from clio_relay.installation import installation_info
+
+info = installation_info(receipt)
+print(json.dumps({
+    "package_version": clio_relay.__version__,
+    "distribution_version": info["distribution_version"],
+    "software_version": info["software"]["version"],
+    "receipt_matches_install": info["receipt_matches_install"],
+}, sort_keys=True))
+"""
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-c",
+            probe,
+            str(candidate_root),
+            str(legacy_root),
+            str(receipt),
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+    assert completed.returncode == 0, completed.stderr
+    evidence = json.loads(completed.stdout)
+    assert evidence == {
+        "distribution_version": legacy_version,
+        "package_version": legacy_version,
+        "receipt_matches_install": True,
+        "software_version": legacy_version,
+    }

--- a/tests/test_bootstrap_fast_path.py
+++ b/tests/test_bootstrap_fast_path.py
@@ -634,7 +634,7 @@ def test_future_release_identity_does_not_require_network_or_a_digest(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(bootstrap, "__version__", "1.4.15")
+    monkeypatch.setattr(bootstrap, "__version__", "1.4.16")
 
     identity = bootstrap.bootstrap_relay_identity(
         source_root=tmp_path / "not-a-checkout",
@@ -642,8 +642,8 @@ def test_future_release_identity_does_not_require_network_or_a_digest(
         relay_artifact_sha256="1" * 64,
     )
 
-    assert identity.install_spec == "clio-relay==1.4.15"
-    assert identity.source_identity == f"release:clio-relay==1.4.15:sha256:{'1' * 64}"
+    assert identity.install_spec == "clio-relay==1.4.16"
+    assert identity.source_identity == f"release:clio-relay==1.4.16:sha256:{'1' * 64}"
     assert identity.deployment_artifact_sha256 == "1" * 64
 
 

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1699,7 +1699,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "3c3fe2516e915b970c97b56377a26a9cfa4c6ee6d04dad50368228914b1e4099"
+        "f578eb2bde1da9171014e5f78997e5d9f01a00a1b04edfbf7a6e30261d01e32a"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.15"
+    assert version == "1.4.16"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2340,13 +2340,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.15-py3-none-any.whl",
+            resource_id="clio-relay-1.4.16-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.15.tar.gz",
+            resource_id="clio_relay-1.4.16.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2485,7 +2485,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.15"
+    assert policy.release_version == "1.4.16"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.15"
+version = "1.4.16"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- keep candidate reconciliation code separate from the installed provider identity it is inspecting
- prevent false `install receipt does not match the running relay` results during managed upgrades
- retain a safe candidate-version fallback for fresh bootstrap helpers
- add focused legacy-provider identity coverage and bump the release identity to 1.4.16

## Focused validation

- isolated candidate-overlay subprocess with distinct legacy dist-info
- exact receipt/provider software identity comparison
- release version and acceptance-matrix identity checks
- Ruff formatting/lint and Pyright on changed source

The exact 1.4.15 release exposed this false full-reconcile plan live on Ares and correctly refused to clear the retained JARVIS environment. No JARVIS mutation or scheduler job was created. Full regression remains asynchronous on the published tag.
