### PR TITLE
fix: preserve bootstrap provider build identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.16` uses a release-first patch process. A maintainer builds the
+> Version `1.4.17` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.16"
+$Version = "1.4.17"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.16"
+release_version: "1.4.17"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: f578eb2bde1da9171014e5f78997e5d9f01a00a1b04edfbf7a6e30261d01e32a
+acceptance_matrix_sha256: 04525a0c0fe2e944d49e4e40a77b9f746aa51b9725c6e470ed2d3bca4db809c5
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.16"
+$Tag = "v1.4.17"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.16" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.17" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.16",
-  "matrix_sha256": "f578eb2bde1da9171014e5f78997e5d9f01a00a1b04edfbf7a6e30261d01e32a",
+  "release_version": "1.4.17",
+  "matrix_sha256": "04525a0c0fe2e944d49e4e40a77b9f746aa51b9725c6e470ed2d3bca4db809c5",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.16"
+version = "1.4.17"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.16"
+__version__ = "1.4.17"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -90,6 +90,7 @@ _BOOTSTRAP_CANDIDATE_PACKAGE_OVERLAY = (
     b"    pass\n"
 )
 _BOOTSTRAP_CANDIDATE_SOURCE_NAMES = (
+    "bootstrap_provider_build_info.py",
     "bootstrap_reconcile.py",
     "bounded_process.py",
     "errors.py",
@@ -3501,6 +3502,9 @@ def render_linux_user_bootstrap_script(
         for name, payload in candidate_package_sources.items()
     }
     candidate_reconcile_sha256 = candidate_package_sha256["bootstrap_reconcile.py"]
+    candidate_provider_build_info_sha256 = candidate_package_sha256[
+        "bootstrap_provider_build_info.py"
+    ]
     candidate_bounded_process_sha256 = candidate_package_sha256["bounded_process.py"]
     candidate_errors_sha256 = candidate_package_sha256["errors.py"]
     candidate_process_containment_sha256 = candidate_package_sha256["process_containment.py"]
@@ -4082,8 +4086,11 @@ for name, payload in sources.items():
     print(f"bootstrap_candidate_source={{name}}:{{hashlib.sha256(observed).hexdigest()}}")
 __CLIO_RELAY_CANDIDATE_PACKAGE__
 BOOTSTRAP_CANDIDATE_RECONCILE="$BOOTSTRAP_CANDIDATE_PACKAGE/bootstrap_reconcile.py"
+BOOTSTRAP_CANDIDATE_PROVIDER_BUILD_INFO="$BOOTSTRAP_CANDIDATE_PACKAGE/bootstrap_provider_build_info.py"
 BOOTSTRAP_CANDIDATE_PROCESS_CONTAINMENT="$BOOTSTRAP_CANDIDATE_PACKAGE/process_containment.py"
 echo "{candidate_reconcile_sha256} *$BOOTSTRAP_CANDIDATE_RECONCILE" | \
+  sha256sum --check --strict -
+echo "{candidate_provider_build_info_sha256} *$BOOTSTRAP_CANDIDATE_PROVIDER_BUILD_INFO" | \
   sha256sum --check --strict -
 echo "{candidate_bounded_process_sha256} *$BOOTSTRAP_CANDIDATE_PACKAGE/bounded_process.py" | \
   sha256sum --check --strict -
@@ -4134,6 +4141,10 @@ elif [ -x "$HOME/.local/share/clio-relay/jarvis-venv/bin/python" ]; then
   BOOTSTRAP_PLAN_PROVIDER="$HOME/.local/share/clio-relay/jarvis-venv/bin/python"
 fi
 export BOOTSTRAP_PLAN_PROVIDER BOOTSTRAP_CANDIDATE_RECONCILE
+if [ -n "$BOOTSTRAP_PLAN_PROVIDER" ]; then
+  "$BOOTSTRAP_PLAN_PROVIDER" -I "$BOOTSTRAP_CANDIDATE_PROVIDER_BUILD_INFO" \
+    "$BOOTSTRAP_CANDIDATE_PACKAGE"
+fi
 if [ "$BOOTSTRAP_RECOVERY_REQUIRED" = "1" ]; then
   if [ -z "$BOOTSTRAP_PLAN_PROVIDER" ]; then
     echo "bootstrap recovery has no trusted installed Python provider" >&2

--- a/src/clio_relay/bootstrap_provider_build_info.py
+++ b/src/clio_relay/bootstrap_provider_build_info.py
@@ -1,0 +1,218 @@
+"""Safely stage installed-provider build identity into a bootstrap overlay."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+import sys
+from csv import Error as CsvError
+from csv import reader as csv_reader
+from importlib import metadata
+from io import StringIO
+from pathlib import Path, PurePosixPath
+from typing import cast
+
+_BUILD_INFO_PARTS = ("clio_relay", "_build_info.json")
+_MAX_BUILD_INFO_BYTES = 64 * 1024
+_MAX_RECORD_BYTES = 8 * 1024 * 1024
+
+
+def _identity(details: os.stat_result) -> tuple[int, int, int, int, int]:
+    """Return the fields used to detect replacement or mutation."""
+    return (
+        details.st_dev,
+        details.st_ino,
+        details.st_mode,
+        details.st_size,
+        details.st_mtime_ns,
+    )
+
+
+def _read_pinned_regular(path: Path, *, require_single_link: bool) -> tuple[bytes, os.stat_result]:
+    """Read one bounded regular file while pinning and reverifying its inode."""
+    before = path.lstat()
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or not 0 < before.st_size <= _MAX_BUILD_INFO_BYTES
+        or (require_single_link and before.st_nlink != 1)
+    ):
+        raise RuntimeError("provider build info must be one bounded regular file")
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode) or _identity(opened) != _identity(before):
+            raise RuntimeError("provider build info changed before its pinned read")
+        chunks: list[bytes] = []
+        remaining = _MAX_BUILD_INFO_BYTES + 1
+        while remaining:
+            chunk = os.read(descriptor, min(remaining, 16 * 1024))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        payload = b"".join(chunks)
+        after_descriptor = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    after_path = path.lstat()
+    if (
+        len(payload) > _MAX_BUILD_INFO_BYTES
+        or _identity(after_descriptor) != _identity(opened)
+        or _identity(after_path) != _identity(opened)
+    ):
+        raise RuntimeError("provider build info changed during its pinned read")
+    return payload, opened
+
+
+def _validate_build_info(payload: bytes, *, distribution_version: str) -> None:
+    """Require the exact build-info schema emitted by the release build hook."""
+    try:
+        loaded = cast(object, json.loads(payload.decode("utf-8")))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("provider build info is not valid UTF-8 JSON") from exc
+    if not isinstance(loaded, dict):
+        raise RuntimeError("provider build info must be one JSON object")
+    document = cast(dict[str, object], loaded)
+    if set(document) != {"version", "commit", "tag", "dirty"}:
+        raise RuntimeError("provider build info has an unsupported schema")
+    if document["version"] != distribution_version:
+        raise RuntimeError("provider build info version does not match its distribution")
+    commit = document["commit"]
+    tag = document["tag"]
+    dirty = document["dirty"]
+    if commit is not None and (
+        not isinstance(commit, str) or re.fullmatch(r"[0-9a-f]{40}", commit) is None
+    ):
+        raise RuntimeError("provider build info commit is invalid")
+    if tag is not None and (
+        not isinstance(tag, str)
+        or not tag
+        or len(tag) > 256
+        or any(ord(character) < 0x21 or ord(character) == 0x7F for character in tag)
+    ):
+        raise RuntimeError("provider build info tag is invalid")
+    if dirty is not None and not isinstance(dirty, bool):
+        raise RuntimeError("provider build info dirty flag is invalid")
+
+
+def _write_candidate_copy(
+    destination: Path,
+    payload: bytes,
+    *,
+    source_details: os.stat_result,
+) -> None:
+    """Create or verify the private candidate copy without following links."""
+    try:
+        existing, candidate_details = _read_pinned_regular(
+            destination,
+            require_single_link=True,
+        )
+    except FileNotFoundError:
+        flags = (
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
+        descriptor = os.open(destination, flags, 0o600)
+        try:
+            view = memoryview(payload)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise RuntimeError("provider build info candidate write made no progress")
+                view = view[written:]
+            os.fsync(descriptor)
+            descriptor_chmod = getattr(os, "fchmod", None)
+            if descriptor_chmod is not None:
+                descriptor_chmod(descriptor, 0o600)
+        finally:
+            os.close(descriptor)
+        existing, candidate_details = _read_pinned_regular(
+            destination,
+            require_single_link=True,
+        )
+    if existing != payload:
+        raise RuntimeError("candidate build info does not match the installed provider")
+    if (candidate_details.st_dev, candidate_details.st_ino) == (
+        source_details.st_dev,
+        source_details.st_ino,
+    ):
+        raise RuntimeError("candidate build info must be an independent private copy")
+
+
+def stage_installed_provider_build_info(destination_package: Path) -> bool:
+    """Stage exact embedded identity from the interpreter's installed relay provider.
+
+    A provider distribution without an embedded build-info record is supported for
+    legacy upgrades, but an unexplained candidate build-info file is never used.
+    """
+    destination_details = destination_package.lstat()
+    if not stat.S_ISDIR(destination_details.st_mode):
+        raise RuntimeError("bootstrap candidate package must be one real directory")
+    destination = destination_package / "_build_info.json"
+    try:
+        distribution = metadata.distribution("clio-relay")
+    except metadata.PackageNotFoundError:
+        try:
+            destination.lstat()
+        except FileNotFoundError:
+            return False
+        raise RuntimeError("candidate build info exists without an installed provider") from None
+
+    record = distribution.read_text("RECORD")
+    if record is not None:
+        if len(record.encode("utf-8")) > _MAX_RECORD_BYTES:
+            raise RuntimeError("provider distribution record exceeds its bound")
+        try:
+            rows = list(csv_reader(StringIO(record), strict=True))
+        except CsvError as exc:
+            raise RuntimeError("provider distribution record is malformed") from exc
+        matches = [
+            metadata.PackagePath(row[0])
+            for row in rows
+            if row and PurePosixPath(row[0].replace("\\", "/")).parts == _BUILD_INFO_PARTS
+        ]
+    else:
+        matches = [
+            item
+            for item in distribution.files or []
+            if PurePosixPath(str(item).replace("\\", "/")).parts == _BUILD_INFO_PARTS
+        ]
+    if not matches:
+        try:
+            destination.lstat()
+        except FileNotFoundError:
+            return False
+        raise RuntimeError("candidate build info exists without provider metadata") from None
+    if len(matches) != 1:
+        raise RuntimeError("provider metadata contains ambiguous build-info records")
+    source = Path(str(distribution.locate_file(matches[0])))
+    try:
+        payload, source_details = _read_pinned_regular(source, require_single_link=False)
+    except FileNotFoundError:
+        raise RuntimeError("provider build info recorded source is missing") from None
+    _validate_build_info(payload, distribution_version=distribution.version)
+    _write_candidate_copy(destination, payload, source_details=source_details)
+    return True
+
+
+def main(arguments: list[str] | None = None) -> int:
+    """Stage provider build info for the rendered bootstrap script."""
+    values = list(sys.argv[1:] if arguments is None else arguments)
+    if len(values) != 1:
+        raise SystemExit("expected exactly one candidate package path")
+    try:
+        staged = stage_installed_provider_build_info(Path(values[0]))
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise SystemExit(f"provider build info staging failed: {exc}") from exc
+    print("bootstrap_provider_build_info=" + ("staged" if staged else "unavailable"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bootstrap_candidate_payload.py
+++ b/tests/test_bootstrap_candidate_payload.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 import base64
 import json
 import shutil
+import stat
 import subprocess
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
+
+import pytest
 
 from clio_relay import bootstrap
+from clio_relay import bootstrap_provider_build_info as provider_build_info
 
 
 def _extract_candidate_sources(script: str) -> dict[str, bytes]:
@@ -38,6 +42,7 @@ def test_extracted_candidate_reconciler_runs_without_provider_bounded_process(
     )
     assert set(sources) == {
         "__init__.py",
+        "bootstrap_provider_build_info.py",
         "bootstrap_reconcile.py",
         "bounded_process.py",
         "errors.py",
@@ -115,7 +120,7 @@ print(json.dumps({
         timeout=30,
     )
     assert completed.returncode == 0, completed.stderr
-    evidence = json.loads(completed.stdout)
+    evidence = json.loads(completed.stdout.splitlines()[-1])
     assert Path(evidence["bounded_process"]) == (candidate_package / "bounded_process.py").resolve()
     assert (
         Path(evidence["process_containment"])
@@ -138,6 +143,7 @@ def test_candidate_overlay_preserves_legacy_provider_install_identity(
         (candidate_package / name).write_bytes(payload)
 
     legacy_version = "1.4.12"
+    legacy_commit = "dc6d36682598d466f8512f8082edfaf5c92af02b"
     legacy_root = tmp_path / "legacy-provider"
     installed_package = Path(bootstrap.__file__).resolve().parent
     shutil.copytree(
@@ -149,6 +155,20 @@ def test_candidate_overlay_preserves_legacy_provider_install_identity(
     distribution_metadata.mkdir()
     (distribution_metadata / "METADATA").write_text(
         f"Metadata-Version: 2.1\nName: clio-relay\nVersion: {legacy_version}\n",
+        encoding="utf-8",
+    )
+    build_info = {
+        "version": legacy_version,
+        "commit": legacy_commit,
+        "tag": f"v{legacy_version}",
+        "dirty": False,
+    }
+    (legacy_root / "clio_relay" / "_build_info.json").write_text(
+        json.dumps(build_info),
+        encoding="utf-8",
+    )
+    (distribution_metadata / "RECORD").write_text(
+        "clio_relay/_build_info.json,,\n",
         encoding="utf-8",
     )
     receipt = tmp_path / "install-receipt.json"
@@ -164,9 +184,9 @@ def test_candidate_overlay_preserves_legacy_provider_install_identity(
                 "distribution_version": legacy_version,
                 "software": {
                     "version": legacy_version,
-                    "commit": None,
-                    "tag": None,
-                    "dirty": None,
+                    "commit": legacy_commit,
+                    "tag": f"v{legacy_version}",
+                    "dirty": False,
                 },
                 "components": {},
                 "component_artifacts": {},
@@ -180,13 +200,21 @@ def test_candidate_overlay_preserves_legacy_provider_install_identity(
 
     probe = r"""
 import json
+import runpy
 import sys
 from pathlib import Path
 
-candidate_root = Path(sys.argv[1]).resolve()
-legacy_root = Path(sys.argv[2]).resolve()
-receipt = Path(sys.argv[3]).resolve()
+stager = Path(sys.argv[1]).resolve()
+candidate_root = Path(sys.argv[2]).resolve()
+legacy_root = Path(sys.argv[3]).resolve()
+receipt = Path(sys.argv[4]).resolve()
 sys.path.insert(0, str(legacy_root))
+sys.argv = [str(stager), str(candidate_root / "clio_relay")]
+try:
+    runpy.run_path(str(stager), run_name="__main__")
+except SystemExit as exc:
+    if exc.code not in (None, 0):
+        raise
 sys.path.insert(0, str(candidate_root))
 
 import clio_relay
@@ -196,7 +224,7 @@ info = installation_info(receipt)
 print(json.dumps({
     "package_version": clio_relay.__version__,
     "distribution_version": info["distribution_version"],
-    "software_version": info["software"]["version"],
+    "software": info["software"],
     "receipt_matches_install": info["receipt_matches_install"],
 }, sort_keys=True))
 """
@@ -206,6 +234,7 @@ print(json.dumps({
             "-I",
             "-c",
             probe,
+            str(candidate_package / "bootstrap_provider_build_info.py"),
             str(candidate_root),
             str(legacy_root),
             str(receipt),
@@ -216,10 +245,142 @@ print(json.dumps({
         timeout=30,
     )
     assert completed.returncode == 0, completed.stderr
-    evidence = json.loads(completed.stdout)
+    evidence = json.loads(completed.stdout.splitlines()[-1])
     assert evidence == {
         "distribution_version": legacy_version,
         "package_version": legacy_version,
         "receipt_matches_install": True,
-        "software_version": legacy_version,
+        "software": build_info,
     }
+
+
+def test_provider_build_info_stager_rejects_hostile_provider_records(tmp_path: Path) -> None:
+    """Missing, malformed, and oversized recorded provider files are fatal."""
+    sources = _extract_candidate_sources(
+        bootstrap.render_linux_user_bootstrap_script(cluster="candidate-test")
+    )
+    stager = tmp_path / "bootstrap_provider_build_info.py"
+    stager.write_bytes(sources["bootstrap_provider_build_info.py"])
+    candidate_package = tmp_path / "candidate-python" / "clio_relay"
+    candidate_package.mkdir(parents=True)
+
+    probe = r"""
+import runpy
+import sys
+from pathlib import Path
+
+stager = Path(sys.argv[1]).resolve()
+provider_root = Path(sys.argv[2]).resolve()
+candidate_package = Path(sys.argv[3]).resolve()
+sys.path.insert(0, str(provider_root))
+sys.argv = [str(stager), str(candidate_package)]
+runpy.run_path(str(stager), run_name="__main__")
+"""
+    for case, payload in (
+        ("missing", None),
+        ("malformed", b"not-json"),
+        ("oversized", b"{" + b"x" * (64 * 1024)),
+    ):
+        provider_root = tmp_path / f"provider-{case}"
+        provider_package = provider_root / "clio_relay"
+        provider_package.mkdir(parents=True)
+        metadata = provider_root / "clio_relay-1.4.12.dist-info"
+        metadata.mkdir()
+        (metadata / "METADATA").write_text(
+            "Metadata-Version: 2.1\nName: clio-relay\nVersion: 1.4.12\n",
+            encoding="utf-8",
+        )
+        (metadata / "RECORD").write_text(
+            "clio_relay/_build_info.json,,\n",
+            encoding="utf-8",
+        )
+        if payload is not None:
+            (provider_package / "_build_info.json").write_bytes(payload)
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-I",
+                "-c",
+                probe,
+                str(stager),
+                str(provider_root),
+                str(candidate_package),
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=30,
+        )
+        assert completed.returncode != 0, case
+        assert "provider build info" in completed.stderr, (case, completed.stderr)
+
+
+def test_provider_build_info_stager_keeps_fresh_bootstrap_free_of_candidate_identity(
+    tmp_path: Path,
+) -> None:
+    """No-provider bootstrap is safe and cannot consume a candidate identity."""
+    sources = _extract_candidate_sources(
+        bootstrap.render_linux_user_bootstrap_script(cluster="candidate-test")
+    )
+    stager = tmp_path / "bootstrap_provider_build_info.py"
+    stager.write_bytes(sources["bootstrap_provider_build_info.py"])
+    candidate_package = tmp_path / "candidate-python" / "clio_relay"
+    candidate_package.mkdir(parents=True)
+
+    clean = subprocess.run(
+        [sys.executable, "-I", "-S", str(stager), str(candidate_package)],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+    assert clean.returncode == 0, clean.stderr
+    assert clean.stdout.strip() == "bootstrap_provider_build_info=unavailable"
+
+    (candidate_package / "_build_info.json").write_text(
+        '{"version":"candidate"}',
+        encoding="utf-8",
+    )
+    substituted = subprocess.run(
+        [sys.executable, "-I", "-S", str(stager), str(candidate_package)],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+    assert substituted.returncode != 0
+    assert "candidate build info exists without an installed provider" in substituted.stderr
+
+
+def test_provider_build_info_stager_rejects_existing_candidate_links_and_mismatches(
+    tmp_path: Path,
+) -> None:
+    """A preexisting candidate must be an exact independent regular copy."""
+    source = tmp_path / "provider-build-info.json"
+    source.write_text("provider", encoding="utf-8")
+    candidate = tmp_path / "candidate-build-info.json"
+    candidate.write_text("candidate", encoding="utf-8")
+    write_candidate_copy = cast(Any, provider_build_info)._write_candidate_copy
+    with pytest.raises(RuntimeError, match="does not match the installed provider"):
+        write_candidate_copy(
+            candidate,
+            b"provider",
+            source_details=source.lstat(),
+        )
+
+    class SyntheticSymlink:
+        """Path-shaped hostile candidate used where Windows cannot create symlinks."""
+
+        def lstat(self) -> object:
+            return type(
+                "SymlinkDetails",
+                (),
+                {"st_mode": stat.S_IFLNK, "st_size": 8, "st_nlink": 1},
+            )()
+
+    with pytest.raises(RuntimeError, match="bounded regular file"):
+        write_candidate_copy(
+            cast(Path, SyntheticSymlink()),
+            b"provider",
+            source_details=source.lstat(),
+        )

--- a/tests/test_bootstrap_fast_path.py
+++ b/tests/test_bootstrap_fast_path.py
@@ -634,7 +634,7 @@ def test_future_release_identity_does_not_require_network_or_a_digest(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(bootstrap, "__version__", "1.4.16")
+    monkeypatch.setattr(bootstrap, "__version__", "1.4.17")
 
     identity = bootstrap.bootstrap_relay_identity(
         source_root=tmp_path / "not-a-checkout",
@@ -642,8 +642,8 @@ def test_future_release_identity_does_not_require_network_or_a_digest(
         relay_artifact_sha256="1" * 64,
     )
 
-    assert identity.install_spec == "clio-relay==1.4.16"
-    assert identity.source_identity == f"release:clio-relay==1.4.16:sha256:{'1' * 64}"
+    assert identity.install_spec == "clio-relay==1.4.17"
+    assert identity.source_identity == f"release:clio-relay==1.4.17:sha256:{'1' * 64}"
     assert identity.deployment_artifact_sha256 == "1" * 64
 
 

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1699,7 +1699,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "f578eb2bde1da9171014e5f78997e5d9f01a00a1b04edfbf7a6e30261d01e32a"
+        "04525a0c0fe2e944d49e4e40a77b9f746aa51b9725c6e470ed2d3bca4db809c5"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.16"
+    assert version == "1.4.17"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2340,13 +2340,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.16-py3-none-any.whl",
+            resource_id="clio-relay-1.4.17-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.16.tar.gz",
+            resource_id="clio_relay-1.4.17.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2485,7 +2485,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.16"
+    assert policy.release_version == "1.4.17"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.16"
+version = "1.4.17"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- preserve the installed provider's embedded commit/tag/dirty identity inside the candidate overlay
- keep exact receipt matching enabled during cross-version component upgrades
- fail closed for missing, redirected, malformed, oversized, or unstable provider build metadata
- add focused rendered-payload regressions and bump the release identity to 1.4.17

## Focused validation

- isolated candidate overlay with a distinct legacy distribution and embedded build identity
- hostile build-info path and content cases
- release version and acceptance-matrix identity checks
- Ruff formatting/lint and Pyright on changed source

The exact 1.4.16 release reproduced the remaining identity mismatch live on Ares and safely refused before JARVIS or scheduler mutation. Full regression remains asynchronous on the published tag.
