### PR TITLE
fix: preserve durable HPC execution across observations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,9 @@ jobs:
           source_commit="$(gh api "repos/$REPOSITORY/commits/$TAG_NAME" --jq .sha)"
           test "$source_commit" = "$SOURCE_COMMIT"
           test "$source_commit" = "$(git rev-parse HEAD)"
-          test "$(jq -r .target_commitish "$RUNNER_TEMP/release.json")" = "$source_commit"
+          # GitHub may retain the default-branch spelling in target_commitish when a
+          # Release is created for an existing tag. The authoritative source
+          # identity is the tag resolution above, not this display field.
 
           version="$(python - "$TAG_NAME" <<'PY'
           import re

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.17` uses a release-first patch process. A maintainer builds the
+> Version `1.4.18` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.17"
+$Version = "1.4.18"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.17"
+release_version: "1.4.18"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 04525a0c0fe2e944d49e4e40a77b9f746aa51b9725c6e470ed2d3bca4db809c5
+acceptance_matrix_sha256: 40dfa7ad56a9137be1a705e54621109c3ef535c1c084394597553514710f784c
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.17"
+$Tag = "v1.4.18"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.17" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.18" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.17",
-  "matrix_sha256": "04525a0c0fe2e944d49e4e40a77b9f746aa51b9725c6e470ed2d3bca4db809c5",
+  "release_version": "1.4.18",
+  "matrix_sha256": "40dfa7ad56a9137be1a705e54621109c3ef535c1c084394597553514710f784c",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.17"
+version = "1.4.18"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.17"
+__version__ = "1.4.18"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -78,6 +78,408 @@ JARVIS_CD_WHEEL_URL = (
 JARVIS_CD_WHEEL_SHA256 = "ebf5e5f375b921f20c79075d461926431a5a017ca8b45e598878a89b229b3935"
 DEFAULT_REMOTE_CORE_DIR = "$HOME/.local/share/clio-relay/core"
 DEFAULT_REMOTE_SPOOL_DIR = "$HOME/.local/share/clio-relay/spool"
+_STAGED_PROVIDER_ENVIRONMENT_SANITIZER = r"""
+while IFS= read -r bootstrap_environment_name; do
+  case "$bootstrap_environment_name" in
+    LD_*|PYTHON*) unset "$bootstrap_environment_name" ;;
+  esac
+done < <(compgen -e)
+""".strip()
+_STAGED_PROVIDER_EXEC_PROGRAM = r"""
+import ctypes
+import fcntl
+import hashlib
+import json
+import os
+import stat
+import struct
+import sys
+
+MAX_STATE = 4 * 1024 * 1024
+MAX_PROVIDER = 256 * 1024 * 1024
+MAX_RUNTIME_LIBRARY = 512 * 1024 * 1024
+
+
+def create_memfd(name, flags):
+    creator = getattr(os, "memfd_create", None)
+    if creator is not None:
+        return creator(name, flags)
+    library = ctypes.CDLL(None, use_errno=True)
+    creator = library.memfd_create
+    creator.argtypes = (ctypes.c_char_p, ctypes.c_uint)
+    creator.restype = ctypes.c_int
+    descriptor = creator(name.encode(), flags)
+    if descriptor < 0:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+    return descriptor
+
+
+def read_bounded(descriptor, maximum, label):
+    before = os.fstat(descriptor)
+    if not stat.S_ISREG(before.st_mode) or before.st_size < 1 or before.st_size > maximum:
+        raise SystemExit(f"{label} is not one bounded regular file")
+    chunks = []
+    remaining = maximum + 1
+    while remaining:
+        chunk = os.read(descriptor, min(1024 * 1024, remaining))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    payload = b"".join(chunks)
+    after = os.fstat(descriptor)
+    identity = lambda value: (
+        value.st_dev,
+        value.st_ino,
+        value.st_mode,
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_ctime_ns,
+    )
+    if (
+        len(payload) != before.st_size
+        or len(payload) > maximum
+        or identity(before) != identity(after)
+    ):
+        raise SystemExit(f"{label} changed while it was read")
+    return payload
+
+
+def origin_dependency_relocations(payload):
+    if payload[:4] != b"\x7fELF":
+        return []
+    if len(payload) < 64 or payload[4:6] != b"\x02\x01":
+        raise SystemExit("staged provider is not a supported ELF64 executable")
+    program_offset = struct.unpack_from("<Q", payload, 32)[0]
+    program_entry_size = struct.unpack_from("<H", payload, 54)[0]
+    program_count = struct.unpack_from("<H", payload, 56)[0]
+    if (
+        program_entry_size < 56
+        or program_count < 1
+        or program_offset + program_entry_size * program_count > len(payload)
+    ):
+        raise SystemExit("staged provider ELF program table is invalid")
+    load_segments = []
+    dynamic_segment = None
+    for index in range(program_count):
+        offset = program_offset + index * program_entry_size
+        (
+            program_type,
+            _flags,
+            file_offset,
+            virtual_address,
+            _physical_address,
+            file_size,
+            _memory_size,
+            _alignment,
+        ) = struct.unpack_from("<IIQQQQQQ", payload, offset)
+        if file_offset + file_size > len(payload):
+            raise SystemExit("staged provider ELF segment is out of bounds")
+        if program_type == 1:
+            load_segments.append((file_offset, virtual_address, file_size))
+        elif program_type == 2:
+            if dynamic_segment is not None:
+                raise SystemExit("staged provider has multiple ELF dynamic segments")
+            dynamic_segment = (file_offset, file_size)
+    if dynamic_segment is None:
+        return []
+    dynamic_offset, dynamic_size = dynamic_segment
+    if dynamic_size % 16:
+        raise SystemExit("staged provider ELF dynamic segment is invalid")
+    string_address = None
+    string_size = None
+    needed_offsets = []
+    for offset in range(dynamic_offset, dynamic_offset + dynamic_size, 16):
+        tag, value = struct.unpack_from("<qQ", payload, offset)
+        if tag == 0:
+            break
+        if tag == 1:
+            needed_offsets.append(value)
+        elif tag == 5:
+            string_address = value
+        elif tag == 10:
+            string_size = value
+    if not needed_offsets:
+        return []
+    if string_address is None or string_size is None or string_size < 1:
+        raise SystemExit("staged provider ELF string table is missing")
+    string_candidates = [
+        file_offset + string_address - virtual_address
+        for file_offset, virtual_address, file_size in load_segments
+        if virtual_address <= string_address
+        and string_address + string_size <= virtual_address + file_size
+    ]
+    if len(string_candidates) != 1:
+        raise SystemExit("staged provider ELF string table is ambiguous")
+    string_offset = string_candidates[0]
+    string_end = string_offset + string_size
+    origin_prefix = b"$ORIGIN/../lib/"
+    relocations = []
+    for needed_offset in needed_offsets:
+        start = string_offset + needed_offset
+        if start < string_offset or start >= string_end:
+            raise SystemExit("staged provider ELF dependency is out of bounds")
+        end = payload.find(b"\0", start, string_end)
+        if end < 0:
+            raise SystemExit("staged provider ELF dependency is unterminated")
+        dependency = payload[start:end]
+        if not dependency.startswith(origin_prefix):
+            continue
+        library_name_bytes = dependency[len(origin_prefix) :]
+        try:
+            library_name = library_name_bytes.decode("ascii")
+        except UnicodeDecodeError as error:
+            raise SystemExit("staged provider ELF origin dependency is invalid") from error
+        if (
+            not library_name
+            or library_name != os.path.basename(library_name)
+            or any(
+                character
+                not in (
+                    "abcdefghijklmnopqrstuvwxyz"
+                    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                    "0123456789._+-"
+                )
+                for character in library_name
+            )
+        ):
+            raise SystemExit("staged provider ELF origin dependency is unsafe")
+        relocations.append((start, len(dependency), library_name))
+    return relocations
+
+
+def sealed_memfd(name, payload, *, inheritable):
+    flags = getattr(os, "MFD_ALLOW_SEALING", 2) | getattr(os, "MFD_EXEC", 0)
+    if not inheritable:
+        flags |= getattr(os, "MFD_CLOEXEC", 1)
+    descriptor = create_memfd(name, flags)
+    try:
+        view = memoryview(payload)
+        while view:
+            written = os.write(descriptor, view)
+            if written < 1:
+                raise SystemExit(f"could not copy {name} into sealed memory")
+            view = view[written:]
+        os.fchmod(descriptor, 0o500)
+        seals = (
+            getattr(fcntl, "F_SEAL_WRITE", 0x0008)
+            | getattr(fcntl, "F_SEAL_GROW", 0x0004)
+            | getattr(fcntl, "F_SEAL_SHRINK", 0x0002)
+            | getattr(fcntl, "F_SEAL_SEAL", 0x0001)
+        )
+        add_seals = getattr(fcntl, "F_ADD_SEALS", 1033)
+        get_seals = getattr(fcntl, "F_GET_SEALS", 1034)
+        fcntl.fcntl(descriptor, add_seals, seals)
+        if fcntl.fcntl(descriptor, get_seals) & seals != seals:
+            raise SystemExit(f"{name} memfd did not seal")
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        os.set_inheritable(descriptor, inheritable)
+        return descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+generation, expected_manifest_sha256, *provider_arguments = sys.argv[1:]
+if len(expected_manifest_sha256) != 64 or any(
+    character not in "0123456789abcdef" for character in expected_manifest_sha256
+):
+    raise SystemExit("staged manifest digest is invalid")
+generation = os.path.abspath(generation)
+generation_descriptor = os.open(
+    generation,
+    os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_NOFOLLOW", 0),
+)
+try:
+    manifest_descriptor = os.open(
+        "manifest.json",
+        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+        dir_fd=generation_descriptor,
+    )
+    try:
+        manifest_payload = read_bounded(manifest_descriptor, MAX_STATE, "staged manifest")
+    finally:
+        os.close(manifest_descriptor)
+    if hashlib.sha256(manifest_payload).hexdigest() != expected_manifest_sha256:
+        raise SystemExit("staged manifest changed before provider execution")
+    manifest = json.loads(manifest_payload)
+    receipt_path = os.path.join(generation, "install-receipt.json")
+    if manifest.get("install_receipt") != receipt_path:
+        raise SystemExit("staged receipt path is not bound to its manifest")
+    receipt_descriptor = os.open(
+        "install-receipt.json",
+        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+        dir_fd=generation_descriptor,
+    )
+    try:
+        receipt_payload = read_bounded(receipt_descriptor, MAX_STATE, "staged receipt")
+    finally:
+        os.close(receipt_descriptor)
+    if manifest.get("install_receipt_sha256") != hashlib.sha256(receipt_payload).hexdigest():
+        raise SystemExit("staged receipt is not bound to its manifest")
+    receipt = json.loads(receipt_payload)
+    component = receipt["component_artifacts"]["clio-relay"]
+    persistent = component["persistent_tool"]
+    provider = component["runtime_interpreters"]["provider"]
+    relay = component["runtime_executables"]["clio-relay"]
+    provider_sha256 = persistent["provider_interpreter_sha256"]
+    relay_sha256 = persistent["tool_executable_sha256"]
+    if provider != persistent["provider_interpreter"]:
+        raise SystemExit("staged provider receipt paths disagree")
+    expected_relay = os.path.join(generation, "bin", "clio-relay")
+    if relay != persistent["tool_executable"] or relay != expected_relay:
+        raise SystemExit("staged relay receipt paths disagree")
+    provider_prefix = os.path.join(generation, "tools") + os.sep
+    if (
+        not isinstance(provider, str)
+        or not provider.startswith(provider_prefix)
+        or os.path.normpath(provider) != provider
+        or any(character in provider for character in "\x00\r\n")
+    ):
+        raise SystemExit("staged provider path is outside its generation")
+    for digest, label in (
+        (provider_sha256, "provider"),
+        (relay_sha256, "relay"),
+    ):
+        if not isinstance(digest, str) or len(digest) != 64 or any(
+            character not in "0123456789abcdef" for character in digest
+        ):
+            raise SystemExit(f"staged {label} digest is invalid")
+    relay_descriptor = os.open(
+        os.path.relpath(relay, generation),
+        os.O_RDONLY,
+        dir_fd=generation_descriptor,
+    )
+    try:
+        relay_payload = read_bounded(relay_descriptor, MAX_STATE, "staged relay launcher")
+    finally:
+        os.close(relay_descriptor)
+    if hashlib.sha256(relay_payload).hexdigest() != relay_sha256:
+        raise SystemExit("staged relay launcher digest changed")
+    first_line = relay_payload.splitlines()[0].decode("utf-8")
+    if first_line != "#!" + provider:
+        raise SystemExit("staged relay launcher is not bound to its provider")
+    provider_descriptor = os.open(
+        os.path.relpath(provider, generation),
+        os.O_RDONLY,
+        dir_fd=generation_descriptor,
+    )
+    try:
+        provider_details = os.fstat(provider_descriptor)
+        if provider_details.st_mode & 0o111 == 0:
+            raise SystemExit("staged provider is not executable")
+        descriptor_path = f"/proc/self/fd/{provider_descriptor}"
+        source_provider = os.path.realpath(descriptor_path)
+        if (
+            not source_provider
+            or source_provider.endswith(" (deleted)")
+            or not os.path.isfile(source_provider)
+        ):
+            raise SystemExit("staged provider backing path is unavailable")
+        source_details = os.stat(source_provider, follow_symlinks=False)
+        if (source_details.st_dev, source_details.st_ino) != (
+            provider_details.st_dev,
+            provider_details.st_ino,
+        ):
+            raise SystemExit("staged provider backing path changed")
+        provider_library = os.path.normpath(
+            os.path.join(os.path.dirname(source_provider), "..", "lib")
+        )
+        runtime_library_memfds = []
+        try:
+            provider_payload = read_bounded(
+                provider_descriptor,
+                MAX_PROVIDER,
+                "staged provider",
+            )
+            if hashlib.sha256(provider_payload).hexdigest() != provider_sha256:
+                raise SystemExit("staged provider digest changed")
+            relocations = origin_dependency_relocations(provider_payload)
+            relocated_provider = bytearray(provider_payload)
+            library_memfds_by_name = {}
+            if relocations:
+                try:
+                    library_directory_descriptor = os.open(
+                        provider_library,
+                        os.O_RDONLY
+                        | os.O_DIRECTORY
+                        | getattr(os, "O_NOFOLLOW", 0),
+                    )
+                except OSError as error:
+                    raise SystemExit(
+                        "staged provider origin library directory is unavailable"
+                    ) from error
+                try:
+                    for _start, _size, library_name in relocations:
+                        if library_name in library_memfds_by_name:
+                            continue
+                        try:
+                            library_descriptor = os.open(
+                                library_name,
+                                os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+                                dir_fd=library_directory_descriptor,
+                            )
+                        except OSError as error:
+                            raise SystemExit(
+                                f"staged provider origin dependency is unavailable: {library_name}"
+                            ) from error
+                        try:
+                            library_payload = read_bounded(
+                                library_descriptor,
+                                MAX_RUNTIME_LIBRARY,
+                                f"staged provider origin dependency {library_name}",
+                            )
+                        finally:
+                            os.close(library_descriptor)
+                        library_memfd = sealed_memfd(
+                            f"clio-relay-{library_name}",
+                            library_payload,
+                            inheritable=True,
+                        )
+                        runtime_library_memfds.append(library_memfd)
+                        library_memfds_by_name[library_name] = library_memfd
+                finally:
+                    os.close(library_directory_descriptor)
+                for start, size, library_name in relocations:
+                    replacement = (
+                        f"/proc/self/fd/{library_memfds_by_name[library_name]}".encode()
+                    )
+                    if len(replacement) > size:
+                        raise SystemExit(
+                            "staged provider origin dependency fd path is too long"
+                        )
+                    relocated_provider[start : start + size] = replacement + b"\0" * (
+                        size - len(replacement)
+                    )
+            provider_memfd = sealed_memfd(
+                "clio-relay-staged-provider",
+                relocated_provider,
+                inheritable=False,
+            )
+            try:
+                if os.execve not in os.supports_fd:
+                    raise SystemExit("provider fd execution is unavailable")
+                provider_environment = {
+                    name: value
+                    for name, value in os.environ.items()
+                    if not name.startswith("LD_") and not name.startswith("PYTHON")
+                }
+                os.execve(
+                    provider_memfd,
+                    [provider, "-I", *provider_arguments],
+                    provider_environment,
+                )
+            finally:
+                os.close(provider_memfd)
+        finally:
+            for runtime_library_memfd in runtime_library_memfds:
+                os.close(runtime_library_memfd)
+    finally:
+        os.close(provider_descriptor)
+finally:
+    os.close(generation_descriptor)
+"""
 MAX_RELAY_WHEEL_METADATA_BYTES = 1024 * 1024
 BOOTSTRAP_REMOTE_SCRIPT_TIMEOUT_SECONDS = 1800.0
 BOOTSTRAP_PUBLIC_EXACT_DEADLINE_SECONDS = 29.0
@@ -1692,54 +2094,63 @@ def _validate_bootstrap_receipt(
             raise RelayError("staged reconcile reported JARVIS initialization")
         if jarvis_graph_action != "preserved" or command_count != 0:
             raise RelayError("staged reconcile reported JARVIS commands")
-        if transaction_mode == "component-upgrade":
+        previous_generation = typed_generation.get("previous")
+        link_action = binding.get("link_action")
+        previous_generation_is_proven = bool(
+            previous_generation == "legacy" or _is_sha256_value(previous_generation)
+        )
+        link_action_is_proven = bool(
+            link_action == "reused"
+            or (link_action in {"created", "retargeted"} and previous_generation_is_proven)
+        )
+        if (
+            typed_jarvis_preservation.get("config_byte_identical") is not True
+            or typed_jarvis_preservation.get("resource_graph_byte_identical") is not True
+            or not link_action_is_proven
+        ):
+            raise RelayError("staged reconcile did not preserve existing JARVIS state")
+        managed_repo = repository_update.get("managed_repo")
+        added_repositories = repository_update.get("added_managed_repos")
+        removed_repositories = repository_update.get("removed_previous_managed_repos")
+        if (
+            not isinstance(managed_repo, str)
+            or not PurePosixPath(managed_repo).is_absolute()
+            or any(character in managed_repo for character in "\x00\r\n")
+            or binding.get("link") != managed_repo
+        ):
+            raise RelayError("staged reconcile repository binding is invalid")
+        managed_suffix = "/.local/share/clio-relay/managed-jarvis-repo"
+        if not managed_repo.endswith(managed_suffix):
+            raise RelayError("staged reconcile repository binding is invalid")
+        remote_home = managed_repo[: -len(managed_suffix)]
+        expected_target = (
+            remote_home + "/.local/share/clio-relay/current/source/jarvis-packages/clio_relay"
+        )
+        expected_previous = remote_home + "/.local/src/clio-relay/jarvis-packages/clio_relay"
+        repository_action = repository_update.get("action")
+        if (
+            binding.get("target") != expected_target
+            or not isinstance(added_repositories, list)
+            or not isinstance(removed_repositories, list)
+        ):
+            raise RelayError("staged reconcile repository binding is invalid")
+        if repository_action == "reused":
             if (
-                typed_jarvis_preservation.get("config_byte_identical") is not True
-                or typed_jarvis_preservation.get("resource_graph_byte_identical") is not True
-                or binding.get("link_action") != "reused"
+                typed_jarvis_preservation.get("repositories_byte_identical") is not True
+                or added_repositories
+                or removed_repositories
             ):
-                raise RelayError("component upgrade did not preserve existing JARVIS state")
-            managed_repo = repository_update.get("managed_repo")
-            added_repositories = repository_update.get("added_managed_repos")
-            removed_repositories = repository_update.get("removed_previous_managed_repos")
+                raise RelayError("staged reconcile repository reuse is invalid")
+        elif repository_action == "updated":
             if (
-                not isinstance(managed_repo, str)
-                or not PurePosixPath(managed_repo).is_absolute()
-                or any(character in managed_repo for character in "\x00\r\n")
-                or binding.get("link") != managed_repo
+                typed_jarvis_preservation.get("repositories_byte_identical") is not False
+                or added_repositories not in ([], [managed_repo])
+                or removed_repositories not in ([], [expected_previous])
+                or (not added_repositories and removed_repositories != [expected_previous])
             ):
-                raise RelayError("component upgrade repository binding is invalid")
-            managed_suffix = "/.local/share/clio-relay/managed-jarvis-repo"
-            if not managed_repo.endswith(managed_suffix):
-                raise RelayError("component upgrade repository binding is invalid")
-            remote_home = managed_repo[: -len(managed_suffix)]
-            expected_target = (
-                remote_home + "/.local/share/clio-relay/current/source/jarvis-packages/clio_relay"
-            )
-            expected_previous = remote_home + "/.local/src/clio-relay/jarvis-packages/clio_relay"
-            repository_action = repository_update.get("action")
-            if (
-                binding.get("target") != expected_target
-                or not isinstance(added_repositories, list)
-                or not isinstance(removed_repositories, list)
-            ):
-                raise RelayError("component upgrade repository binding is invalid")
-            if repository_action == "reused":
-                if (
-                    typed_jarvis_preservation.get("repositories_byte_identical") is not True
-                    or added_repositories
-                    or removed_repositories
-                ):
-                    raise RelayError("component upgrade repository reuse is invalid")
-            elif repository_action == "updated":
-                if (
-                    typed_jarvis_preservation.get("repositories_byte_identical") is not False
-                    or added_repositories != [managed_repo]
-                    or removed_repositories not in ([], [expected_previous])
-                ):
-                    raise RelayError("component upgrade repository migration is invalid")
-            else:  # pragma: no cover - rejected by the generic evidence contract above
-                raise RelayError("component upgrade repository action is invalid")
+                raise RelayError("staged reconcile repository migration is invalid")
+        else:  # pragma: no cover - rejected by the generic evidence contract above
+            raise RelayError("staged reconcile repository action is invalid")
         if payload_count != 2 or payload_bytes <= 0:
             raise RelayError("staged reconcile omitted its transferred payload evidence")
     elif outcome == "full":
@@ -2063,6 +2474,8 @@ def _relay_only_reconcile_script(
     invocation_id: str,
 ) -> str:
     """Render the staged relay-only generation transaction."""
+    staged_provider_exec_program = shlex.quote(_STAGED_PROVIDER_EXEC_PROGRAM)
+    staged_provider_environment_sanitizer = _STAGED_PROVIDER_ENVIRONMENT_SANITIZER
     return f"""
 bootstrap_plan_value() {{
   local field="$1"
@@ -2080,10 +2493,21 @@ print(value)
 __CLIO_RELAY_PLAN_VALUE__
 }}
 
+bootstrap_provider_exec() (
+{staged_provider_environment_sanitizer}
+  if [ -n "${{BOOTSTRAP_STAGED_GENERATION:-}}" ]; then
+    exec python3 -I -c {staged_provider_exec_program} \
+      "$BOOTSTRAP_STAGED_GENERATION" \
+      "$BOOTSTRAP_STAGED_MANIFEST_SHA256" "$@"
+  else
+    exec "$BOOTSTRAP_PLAN_PROVIDER" "$@"
+  fi
+)
+
 bootstrap_candidate_action() {{
   local action="$1"
   shift
-  "$BOOTSTRAP_PLAN_PROVIDER" - "$BOOTSTRAP_CANDIDATE_RECONCILE" "$action" "$@" \
+  bootstrap_provider_exec - "$BOOTSTRAP_CANDIDATE_RECONCILE" "$action" "$@" \
     <<'__CLIO_RELAY_CANDIDATE_ACTION__'
 import importlib.util
 import json
@@ -2172,9 +2596,57 @@ elif action == "jarvis-wrapper":
             separators=(",", ":"),
         )
     )
+elif action == "finish-activation":
+    desired_payload = json.loads(os.environ["BOOTSTRAP_DESIRED_STATE"])
+    desired_payload["agent_npm_package"] = os.environ["AGENT_NPM_PACKAGE"] or None
+    desired_payload["agent_npm_bin"] = os.environ["AGENT_NPM_BIN"] or None
+    desired = module.BootstrapDesiredState.model_validate(desired_payload)
+    print(
+        json.dumps(
+            module.finish_staged_activation(
+                desired,
+                generation=Path(arguments[0]),
+                expected_manifest_sha256=arguments[1],
+            ),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+elif action == "exchange-preflight":
+    print(
+        json.dumps(
+            module.verify_atomic_exchange_support(
+                tuple(Path(value) for value in arguments),
+                identity=os.environ["BOOTSTRAP_DESIRED_FINGERPRINT"],
+            ),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
 else:
     raise SystemExit(f"unknown candidate bootstrap action: {{action}}")
 __CLIO_RELAY_CANDIDATE_ACTION__
+}}
+
+bootstrap_use_staged_provider() {{
+  local generation="$1"
+  local expected_manifest_sha256="$2"
+  if [ -L "$generation" ] || [ ! -d "$generation" ]; then
+    echo "staged bootstrap generation is not one owned directory" >&2
+    return 1
+  fi
+  case "$expected_manifest_sha256" in
+    (*[!0-9a-f]*|'') echo "staged manifest digest is invalid" >&2; return 1 ;;
+  esac
+  if [ "${{#expected_manifest_sha256}}" -ne 64 ]; then
+    echo "staged manifest digest has an invalid length" >&2
+    return 1
+  fi
+  BOOTSTRAP_STAGED_GENERATION="$generation"
+  BOOTSTRAP_STAGED_MANIFEST_SHA256="$expected_manifest_sha256"
+  export BOOTSTRAP_STAGED_GENERATION BOOTSTRAP_STAGED_MANIFEST_SHA256
+  bootstrap_provider_exec -c \
+    'import clio_relay,jarvis_cd; print("staged_provider=sealed_memfd")' >/dev/null
 }}
 
 bootstrap_require_stable_link() {{
@@ -2196,7 +2668,36 @@ bootstrap_verify_stable_activation_links() {{
     "$HOME/.local/share/clio-relay/current/bin/jarvis"
   bootstrap_require_stable_link \
     "$HOME/.local/share/clio-relay/managed-jarvis-repo" \
-    "$HOME/.local/share/clio-relay/current/source/jarvis-packages/clio_relay"
+      "$HOME/.local/share/clio-relay/current/source/jarvis-packages/clio_relay"
+}}
+
+bootstrap_active_generation_identity() {{
+  local current target prefix identity
+  current="$HOME/.local/share/clio-relay/current"
+  if [ ! -L "$current" ]; then
+    echo "bootstrap current generation pointer is not a symbolic link" >&2
+    return 1
+  fi
+  target="$(readlink -f "$current")"
+  prefix="$HOME/.local/share/clio-relay/generations/"
+  case "$target" in
+    "$prefix"*) identity="${{target#"$prefix"}}" ;;
+    *)
+      echo "bootstrap current pointer does not name one managed generation" >&2
+      return 1
+      ;;
+  esac
+  case "$identity" in
+    (*[!0-9a-f]*|'')
+      echo "bootstrap current generation identity is invalid" >&2
+      return 1
+      ;;
+  esac
+  if [ "${{#identity}}" -ne 64 ]; then
+    echo "bootstrap current generation identity has an invalid length" >&2
+    return 1
+  fi
+  echo "$identity"
 }}
 
 bootstrap_reconcile_transaction_exit() {{
@@ -2296,7 +2797,7 @@ bootstrap_recover_previous_transaction() {{
       return 1
       ;;
     forward)
-      local prepared_generation current_target
+      local prepared_generation prepared_manifest_sha256 recovery_generation
       prepared_generation="$(bootstrap_recovery_value prepared_generation)"
       case "$prepared_generation" in
         (*[!0-9a-f]*|'')
@@ -2305,17 +2806,48 @@ bootstrap_recover_previous_transaction() {{
           ;;
       esac
       [ "${{#prepared_generation}}" -eq 64 ] || return 1
-      [ -L "$HOME/.local/share/clio-relay/current" ] || {{
-        echo "bootstrap forward recovery has no active generation pointer" >&2
-        return 1
-      }}
-      current_target="$(readlink -f "$HOME/.local/share/clio-relay/current")"
-      if [ "$current_target" != \
-           "$HOME/.local/share/clio-relay/generations/$prepared_generation" ]; then
+      prepared_manifest_sha256="$(
+        python3 - <<'__CLIO_RELAY_RECOVERY_MANIFEST__'
+import json
+import os
+
+value = json.loads(os.environ["BOOTSTRAP_RECOVERY_JSON"])
+identity = value.get("phase_identities", {{}}).get("prepared_manifest")
+if not isinstance(identity, str):
+    raise SystemExit("bootstrap recovery omitted prepared manifest identity")
+print(identity)
+__CLIO_RELAY_RECOVERY_MANIFEST__
+      )"
+      case "$prepared_manifest_sha256" in
+        (*[!0-9a-f]*|'')
+          echo "bootstrap forward recovery has an invalid manifest identity" >&2
+          return 1
+          ;;
+      esac
+      [ "${{#prepared_manifest_sha256}}" -eq 64 ] || return 1
+      recovery_generation="$HOME/.local/share/clio-relay/generations/$prepared_generation"
+      if [ -L "$recovery_generation" ] || [ ! -d "$recovery_generation" ]; then
         echo "bootstrap forward recovery generation identity changed" >&2
         return 1
       fi
+      if [ "$JARVIS_EXISTING_FILE_COUNT" -ne 3 ] || \
+         [ -z "$BOOTSTRAP_JARVIS_CONFIG_SHA256_BEFORE" ] || \
+         [ -z "$BOOTSTRAP_JARVIS_GRAPH_SHA256_BEFORE" ]; then
+        echo "bootstrap forward recovery cannot prove preserved JARVIS state" >&2
+        return 1
+      fi
+      echo "$BOOTSTRAP_JARVIS_CONFIG_SHA256_BEFORE *$JARVIS_CONFIG_FILE" | \
+        sha256sum --check --strict -
+      echo "$BOOTSTRAP_JARVIS_GRAPH_SHA256_BEFORE *$JARVIS_GRAPH_FILE" | \
+        sha256sum --check --strict -
+      bootstrap_use_staged_provider "$recovery_generation" "$prepared_manifest_sha256"
+      bootstrap_candidate_action finish-activation \
+        "$recovery_generation" "$prepared_manifest_sha256" >/dev/null
       bootstrap_verify_stable_activation_links
+      echo "$BOOTSTRAP_JARVIS_CONFIG_SHA256_BEFORE *$JARVIS_CONFIG_FILE" | \
+        sha256sum --check --strict -
+      echo "$BOOTSTRAP_JARVIS_GRAPH_SHA256_BEFORE *$JARVIS_GRAPH_FILE" | \
+        sha256sum --check --strict -
       mkdir -p -- {rendered_core_dir}
       exec 8<>"{rendered_core_dir}/{WORKER_LIFETIME_LOCK_NAME}"
       if ! flock -n 8; then
@@ -2389,7 +2921,7 @@ bootstrap_relay_only_reconcile() {{
   BOOTSTRAP_ROLLBACK_DIR="$BOOTSTRAP_TRANSACTION_ROOT/rollback"
   BOOTSTRAP_PREVIOUS_GENERATION="legacy"
   if [ -L "$HOME/.local/share/clio-relay/current" ]; then
-    BOOTSTRAP_PREVIOUS_GENERATION="$(readlink "$HOME/.local/share/clio-relay/current")"
+    BOOTSTRAP_PREVIOUS_GENERATION="$(bootstrap_active_generation_identity)"
   elif [ -e "$HOME/.local/share/clio-relay/current" ]; then
     echo "bootstrap current generation pointer is not a symbolic link" >&2
     return 1
@@ -2421,10 +2953,19 @@ bootstrap_relay_only_reconcile() {{
 
   if [ -e "$BOOTSTRAP_GENERATION" ]; then
     if [ ! -f "$BOOTSTRAP_GENERATION/.prepared" ]; then
-      if [ -L "$HOME/.local/share/clio-relay/current" ] && \
-         [ "$(readlink "$HOME/.local/share/clio-relay/current")" = "$BOOTSTRAP_GENERATION" ]; then
-        echo "incomplete generation is active; recovery is required" >&2
-        return 1
+      if [ -L "$HOME/.local/share/clio-relay/current" ]; then
+        BOOTSTRAP_INCOMPLETE_CURRENT_TARGET="$(
+          readlink -f "$HOME/.local/share/clio-relay/current" || true
+        )"
+        if [ -z "$BOOTSTRAP_INCOMPLETE_CURRENT_TARGET" ]; then
+          echo "active generation pointer could not be resolved" >&2
+          return 1
+        fi
+        if [ "$BOOTSTRAP_INCOMPLETE_CURRENT_TARGET" = \
+             "$(readlink -f "$BOOTSTRAP_GENERATION")" ]; then
+          echo "incomplete generation is active; recovery is required" >&2
+          return 1
+        fi
       fi
       rm -rf -- "$BOOTSTRAP_GENERATION"
     fi
@@ -2442,6 +2983,7 @@ bootstrap_relay_only_reconcile() {{
   fi
   JARVIS_CD_WHEEL=""
   CLIO_KIT_EXECUTABLE=""
+  ACTIVE_JARVIS_VENV="$LEGACY_JARVIS_VENV"
   ACTIVE_JARVIS_PYTHON="$LEGACY_JARVIS_PYTHON"
   JARVIS_MCP_INSTALL_SPEC=""
   JARVIS_MCP_ARTIFACT_SHA256=""
@@ -2455,6 +2997,7 @@ bootstrap_relay_only_reconcile() {{
   else
     JARVIS_CD_WHEEL="$BOOTSTRAP_GENERATION/artifacts/{JARVIS_CD_WHEEL_FILENAME}"
     CLIO_KIT_EXECUTABLE="$BOOTSTRAP_GENERATION/bin/clio-kit"
+    ACTIVE_JARVIS_VENV="$BOOTSTRAP_GENERATION/jarvis-venv"
     ACTIVE_JARVIS_PYTHON="$BOOTSTRAP_GENERATION/jarvis-venv/bin/python"
     JARVIS_MCP_INSTALL_SPEC={rendered_jarvis_mcp_install_spec}
     JARVIS_MCP_ARTIFACT_SHA256={rendered_jarvis_mcp_artifact_sha256}
@@ -2601,6 +3144,12 @@ __CLIO_RELAY_RECONCILE_PYPI_DIGEST__
     test -x "$RELAY_EXECUTABLE" -a -x "$RELAY_PROVIDER_PYTHON"
     bootstrap_candidate_action jarvis-wrapper \
       "$BOOTSTRAP_GENERATION/bin/jarvis" "$ACTIVE_JARVIS_PYTHON"
+    ACTIVE_JARVIS_EXECUTABLE="$ACTIVE_JARVIS_VENV/bin/jarvis"
+    BOOTSTRAP_ACTIVE_IDENTITY="$(
+      bootstrap_candidate_action execution-boundary \
+        "$ACTIVE_JARVIS_VENV" "$ACTIVE_JARVIS_PYTHON" "$ACTIVE_JARVIS_EXECUTABLE"
+    )"
+    export BOOTSTRAP_ACTIVE_IDENTITY
     if [ "$BOOTSTRAP_PLAN_MODE" = "relay-only" ]; then
       ln -s "$CLIO_KIT_EXECUTABLE" "$BOOTSTRAP_GENERATION/bin/clio-kit"
     fi
@@ -2802,8 +3351,10 @@ manifest = {{
     "fingerprint": os.environ["BOOTSTRAP_DESIRED_FINGERPRINT"],
     "plan": json.loads(os.environ["BOOTSTRAP_PLAN_JSON"]),
     "legacy_execution_identity": json.loads(os.environ["BOOTSTRAP_LEGACY_IDENTITY"]),
+    "active_execution_identity": json.loads(os.environ["BOOTSTRAP_ACTIVE_IDENTITY"]),
     "jarvis_wrapper_sha256": sha256_file(generation / "bin/jarvis"),
     "install_receipt": str(generation / "install-receipt.json"),
+    "install_receipt_sha256": sha256_file(generation / "install-receipt.json"),
 }}
 path = generation / "manifest.json"
 temporary = generation / ".manifest.tmp"
@@ -2852,8 +3403,9 @@ __CLIO_RELAY_GENERATION_MANIFEST__
     echo "legacy JARVIS execution environment changed before activation" >&2
     return 1
   fi
-  CLIO_RELAY_INSTALL_RECEIPT="$BOOTSTRAP_GENERATION/install-receipt.json" \
-    "$RELAY_PROVIDER_PYTHON" - <<'__CLIO_RELAY_VERIFY_PREPARED_GENERATION__'
+  BOOTSTRAP_PREPARED_INSPECTION="$(
+    CLIO_RELAY_INSTALL_RECEIPT="$BOOTSTRAP_GENERATION/install-receipt.json" \
+      "$RELAY_PROVIDER_PYTHON" - <<'__CLIO_RELAY_VERIFY_PREPARED_GENERATION__'
 import json
 import os
 from pathlib import Path
@@ -2867,12 +3419,43 @@ desired_payload = json.loads(os.environ["BOOTSTRAP_DESIRED_STATE"])
 desired_payload["agent_npm_package"] = os.environ["AGENT_NPM_PACKAGE"] or None
 desired_payload["agent_npm_bin"] = os.environ["AGENT_NPM_BIN"] or None
 desired = BootstrapDesiredState.model_validate(desired_payload)
-inspect_prepared_generation(
+inspection = inspect_prepared_generation(
     desired,
     generation=Path(os.environ["BOOTSTRAP_GENERATION"]),
     legacy_execution_identity=json.loads(os.environ["BOOTSTRAP_LEGACY_IDENTITY"]),
 )
+print(json.dumps(inspection, sort_keys=True, separators=(",", ":")))
 __CLIO_RELAY_VERIFY_PREPARED_GENERATION__
+  )"
+  export BOOTSTRAP_PREPARED_INSPECTION
+  BOOTSTRAP_PREPARED_MANIFEST_SHA256="$(
+    python3 - <<'__CLIO_RELAY_PREPARED_MANIFEST_SHA256__'
+import json
+import os
+
+print(json.loads(os.environ["BOOTSTRAP_PREPARED_INSPECTION"])["manifest_sha256"])
+__CLIO_RELAY_PREPARED_MANIFEST_SHA256__
+  )"
+  case "$BOOTSTRAP_PREPARED_MANIFEST_SHA256" in
+    (*[!0-9a-f]*|'') echo "prepared manifest identity is invalid" >&2; return 1 ;;
+  esac
+  if [ "${{#BOOTSTRAP_PREPARED_MANIFEST_SHA256}}" -ne 64 ]; then
+    echo "prepared manifest identity has an invalid length" >&2
+    return 1
+  fi
+  (
+    BOOTSTRAP_STAGED_GENERATION="$BOOTSTRAP_GENERATION"
+    BOOTSTRAP_STAGED_MANIFEST_SHA256="$BOOTSTRAP_PREPARED_MANIFEST_SHA256"
+    export BOOTSTRAP_STAGED_GENERATION BOOTSTRAP_STAGED_MANIFEST_SHA256
+    bootstrap_provider_exec -c \
+      'import clio_relay,jarvis_cd; print("staged_provider=sealed_memfd")'
+  ) >/dev/null
+  bootstrap_candidate_action journal-phase prepared_manifest \
+    "$BOOTSTRAP_PREPARED_MANIFEST_SHA256"
+  bootstrap_candidate_action exchange-preflight \
+    "$HOME/.local/share/clio-relay" \
+    "$HOME/.local/bin" \
+    "$(dirname "$JARVIS_REPOS_FILE")" >/dev/null
   BOOTSTRAP_PREPARE_COMPLETED_NS="$(python3 -c 'import time; print(time.monotonic_ns())')"
   export BOOTSTRAP_PREPARE_STARTED_NS BOOTSTRAP_PREPARE_COMPLETED_NS
   bootstrap_candidate_action journal-advance prepared
@@ -2890,64 +3473,37 @@ __CLIO_RELAY_VERIFY_PREPARED_GENERATION__
   fi
   bootstrap_candidate_action journal-advance fenced
   trap bootstrap_reconcile_transaction_exit EXIT
+  echo "$BOOTSTRAP_JARVIS_CONFIG_SHA256_BEFORE *$JARVIS_CONFIG_FILE" | \
+    sha256sum --check --strict -
+  echo "$BOOTSTRAP_JARVIS_GRAPH_SHA256_BEFORE *$JARVIS_GRAPH_FILE" | \
+    sha256sum --check --strict -
   bootstrap_candidate_action journal-advance activating
 
-  bootstrap_verify_stable_activation_links
-  if [ "$(readlink -f "$HOME/.local/share/clio-relay/current")" != \
-       "$HOME/.local/share/clio-relay/generations/$BOOTSTRAP_PREVIOUS_GENERATION" ]; then
-    echo "bootstrap previous generation pointer changed before activation" >&2
-    return 1
-  fi
-  ln -s "$BOOTSTRAP_GENERATION" \
-    "$HOME/.local/share/clio-relay/.current.$BOOTSTRAP_INVOCATION_ID"
-  if [ "$(readlink -f "$HOME/.local/share/clio-relay/current")" != \
-       "$HOME/.local/share/clio-relay/generations/$BOOTSTRAP_PREVIOUS_GENERATION" ]; then
-    echo "bootstrap previous generation pointer changed during activation" >&2
-    return 1
-  fi
-  mv -Tf "$HOME/.local/share/clio-relay/.current.$BOOTSTRAP_INVOCATION_ID" \
-    "$HOME/.local/share/clio-relay/current"
-  bootstrap_candidate_action journal-advance activated
-
-  export MANAGED_JARVIS_REPO="$HOME/.local/share/clio-relay/managed-jarvis-repo"
-  export JARVIS_REPOS_FILE="$JARVIS_STATE_ROOT/repos.yaml"
-  "$HOME/.local/share/clio-relay/current/bin/clio-relay" installation-info >/dev/null
-  "$HOME/.local/share/clio-relay/current/bin/clio-relay" --help >/dev/null
-  CURRENT_RELAY_PROVIDER="$(
-    sed -n '1{{s/^#!//;p;}}' "$HOME/.local/share/clio-relay/current/bin/clio-relay"
+  bootstrap_use_staged_provider \
+    "$BOOTSTRAP_GENERATION" "$BOOTSTRAP_PREPARED_MANIFEST_SHA256"
+  BOOTSTRAP_STAGED_ACTIVATION="$(
+    bootstrap_candidate_action finish-activation \
+      "$BOOTSTRAP_GENERATION" "$BOOTSTRAP_PREPARED_MANIFEST_SHA256"
   )"
+  export BOOTSTRAP_STAGED_ACTIVATION
   BOOTSTRAP_JARVIS_REPO_RECONCILIATION="$(
-    "$CURRENT_RELAY_PROVIDER" - "$HOME/.local/src/clio-relay/jarvis-packages/clio_relay" \
-      <<'__CLIO_RELAY_GENERATION_REPO__'
+    python3 - <<'__CLIO_RELAY_STAGED_REPOSITORY_EVIDENCE__'
 import json
 import os
-import sys
-from pathlib import Path
 
-from clio_relay.bootstrap_reconcile import reconcile_managed_jarvis_repository
-
-managed_repo = Path(os.environ["MANAGED_JARVIS_REPO"])
-repositories = reconcile_managed_jarvis_repository(
-    Path(os.environ["JARVIS_REPOS_FILE"]),
-    managed_repo,
-    previous_managed_repos=(Path(sys.argv[1]),),
-)
-result = {{
-    "link_action": "reused",
-    "link": str(managed_repo),
-    "target": os.readlink(managed_repo),
-    "repositories": repositories,
-}}
-print(json.dumps(result, sort_keys=True, separators=(",", ":")))
-__CLIO_RELAY_GENERATION_REPO__
+activation = json.loads(os.environ["BOOTSTRAP_STAGED_ACTIVATION"])
+print(json.dumps(activation["jarvis_repository"], sort_keys=True, separators=(",", ":")))
+__CLIO_RELAY_STAGED_REPOSITORY_EVIDENCE__
   )"
   export BOOTSTRAP_JARVIS_REPO_RECONCILIATION
-  if [ "$BOOTSTRAP_PLAN_MODE" = "component-upgrade" ]; then
-    echo "$BOOTSTRAP_JARVIS_CONFIG_SHA256_BEFORE *$JARVIS_CONFIG_FILE" | \
-      sha256sum --check --strict -
-    echo "$BOOTSTRAP_JARVIS_GRAPH_SHA256_BEFORE *$JARVIS_GRAPH_FILE" | \
-      sha256sum --check --strict -
-  fi
+  bootstrap_verify_stable_activation_links
+  "$HOME/.local/share/clio-relay/current/bin/clio-relay" installation-info >/dev/null
+  "$HOME/.local/share/clio-relay/current/bin/clio-relay" --help >/dev/null
+  bootstrap_candidate_action journal-advance activated
+  echo "$BOOTSTRAP_JARVIS_CONFIG_SHA256_BEFORE *$JARVIS_CONFIG_FILE" | \
+    sha256sum --check --strict -
+  echo "$BOOTSTRAP_JARVIS_GRAPH_SHA256_BEFORE *$JARVIS_GRAPH_FILE" | \
+    sha256sum --check --strict -
 
   bootstrap_candidate_action journal-advance migration_started
 {worker_recheck}
@@ -3212,7 +3768,7 @@ bootstrap_reuse_repair() {{
   BOOTSTRAP_TRANSACTION_JOURNAL="$HOME/.local/share/clio-relay/bootstrap-transaction.json"
   BOOTSTRAP_PREVIOUS_GENERATION="legacy"
   if [ -L "$HOME/.local/share/clio-relay/current" ]; then
-    BOOTSTRAP_PREVIOUS_GENERATION="$(readlink "$HOME/.local/share/clio-relay/current")"
+    BOOTSTRAP_PREVIOUS_GENERATION="$(bootstrap_active_generation_identity)"
   fi
   BOOTSTRAP_SERVICE_ACTIVE_BEFORE="unknown"
   BOOTSTRAP_SERVICE_ENABLED_BEFORE=0
@@ -5165,7 +5721,7 @@ else
   BOOTSTRAP_JARVIS_COMMANDS_JSON='[]'
 fi
 MANAGED_JARVIS_REPO="$HOME/.local/share/clio-relay/managed-jarvis-repo"
-MANAGED_JARVIS_REPO_TARGET="$DEST/jarvis-packages/clio_relay"
+MANAGED_JARVIS_REPO_TARGET="$HOME/.local/share/clio-relay/current/source/jarvis-packages/clio_relay"
 if [ -L "$MANAGED_JARVIS_REPO" ]; then
   if [ "$(readlink "$MANAGED_JARVIS_REPO")" != "$MANAGED_JARVIS_REPO_TARGET" ]; then
     echo "relay-managed JARVIS repository link points to an unexpected target" >&2
@@ -5238,6 +5794,7 @@ from clio_relay.bootstrap_reconcile import (
     execution_environment_identity,
     write_jarvis_wrapper,
 )
+from clio_relay.validation_report import sha256_file
 
 generation = Path(sys.argv[1])
 execution_root = Path(os.environ["JARVIS_VENV"])
@@ -5270,8 +5827,10 @@ manifest = {{
     "fingerprint": fingerprint,
     "plan": plan.model_dump(mode="json"),
     "legacy_execution_identity": execution_identity,
+    "active_execution_identity": execution_identity,
     "jarvis_wrapper_sha256": wrapper["sha256"],
     "install_receipt": str(generation / "install-receipt.json"),
+    "install_receipt_sha256": sha256_file(generation / "install-receipt.json"),
 }}
 for name, payload in (
     ("manifest.json", json.dumps(manifest, indent=2, sort_keys=True) + "\\n"),

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -64,7 +64,10 @@ FRPS_LINUX_AMD64_SHA256 = "68d2908bb73fe7a03c29d9227d2acc2104bff3fea6b1cece0b838
 FRPC_WINDOWS_AMD64_SHA256 = "1d1c4f988b1808bb458a4ba38f00359052d14636023a504520e0afed127d636d"
 FRPS_WINDOWS_AMD64_SHA256 = "bd463ef89370abc6973c86258256fa65776baa5f515ef91ebeabd6070b92e229"
 UV_VERSION = "0.11.28"
-UV_LINUX_AMD64_SHA256 = "e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224"
+UV_LINUX_AMD64_ARCHIVE_SHA256 = "e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224"
+UV_LINUX_AMD64_EXECUTABLE_SHA256 = (
+    "1cb9cd0a1749debf6049d7d2bb933882cc52d81016326ee6d99a786d6c988b03"
+)
 JARVIS_UTIL_COMMIT = "c91bfdc9bba802e4b03bfb1babe614ffa3e09644"
 JARVIS_CD_VERSION = "1.4.8"
 JARVIS_CD_WHEEL_FILENAME = f"jarvis_cd-{JARVIS_CD_VERSION}-py3-none-any.whl"
@@ -756,7 +759,7 @@ def _bootstrap_desired_state(
         frpc_sha256=FRPC_LINUX_AMD64_SHA256,
         frps_sha256=FRPS_LINUX_AMD64_SHA256,
         uv_version=UV_VERSION,
-        uv_sha256=UV_LINUX_AMD64_SHA256,
+        uv_sha256=UV_LINUX_AMD64_EXECUTABLE_SHA256,
         jarvis_util_commit=JARVIS_UTIL_COMMIT,
         jarvis_cd_version=JARVIS_CD_VERSION,
         jarvis_cd_wheel_url=JARVIS_CD_WHEEL_URL,
@@ -1689,14 +1692,54 @@ def _validate_bootstrap_receipt(
             raise RelayError("staged reconcile reported JARVIS initialization")
         if jarvis_graph_action != "preserved" or command_count != 0:
             raise RelayError("staged reconcile reported JARVIS commands")
-        if transaction_mode == "component-upgrade" and (
-            typed_jarvis_preservation.get("config_byte_identical") is not True
-            or typed_jarvis_preservation.get("resource_graph_byte_identical") is not True
-            or typed_jarvis_preservation.get("repositories_byte_identical") is not True
-            or binding.get("link_action") != "reused"
-            or repository_update.get("action") != "reused"
-        ):
-            raise RelayError("component upgrade did not preserve existing JARVIS state")
+        if transaction_mode == "component-upgrade":
+            if (
+                typed_jarvis_preservation.get("config_byte_identical") is not True
+                or typed_jarvis_preservation.get("resource_graph_byte_identical") is not True
+                or binding.get("link_action") != "reused"
+            ):
+                raise RelayError("component upgrade did not preserve existing JARVIS state")
+            managed_repo = repository_update.get("managed_repo")
+            added_repositories = repository_update.get("added_managed_repos")
+            removed_repositories = repository_update.get("removed_previous_managed_repos")
+            if (
+                not isinstance(managed_repo, str)
+                or not PurePosixPath(managed_repo).is_absolute()
+                or any(character in managed_repo for character in "\x00\r\n")
+                or binding.get("link") != managed_repo
+            ):
+                raise RelayError("component upgrade repository binding is invalid")
+            managed_suffix = "/.local/share/clio-relay/managed-jarvis-repo"
+            if not managed_repo.endswith(managed_suffix):
+                raise RelayError("component upgrade repository binding is invalid")
+            remote_home = managed_repo[: -len(managed_suffix)]
+            expected_target = (
+                remote_home + "/.local/share/clio-relay/current/source/jarvis-packages/clio_relay"
+            )
+            expected_previous = remote_home + "/.local/src/clio-relay/jarvis-packages/clio_relay"
+            repository_action = repository_update.get("action")
+            if (
+                binding.get("target") != expected_target
+                or not isinstance(added_repositories, list)
+                or not isinstance(removed_repositories, list)
+            ):
+                raise RelayError("component upgrade repository binding is invalid")
+            if repository_action == "reused":
+                if (
+                    typed_jarvis_preservation.get("repositories_byte_identical") is not True
+                    or added_repositories
+                    or removed_repositories
+                ):
+                    raise RelayError("component upgrade repository reuse is invalid")
+            elif repository_action == "updated":
+                if (
+                    typed_jarvis_preservation.get("repositories_byte_identical") is not False
+                    or added_repositories != [managed_repo]
+                    or removed_repositories not in ([], [expected_previous])
+                ):
+                    raise RelayError("component upgrade repository migration is invalid")
+            else:  # pragma: no cover - rejected by the generic evidence contract above
+                raise RelayError("component upgrade repository action is invalid")
         if payload_count != 2 or payload_bytes <= 0:
             raise RelayError("staged reconcile omitted its transferred payload evidence")
     elif outcome == "full":
@@ -2901,8 +2944,6 @@ __CLIO_RELAY_GENERATION_REPO__
   export BOOTSTRAP_JARVIS_REPO_RECONCILIATION
   if [ "$BOOTSTRAP_PLAN_MODE" = "component-upgrade" ]; then
     echo "$BOOTSTRAP_JARVIS_CONFIG_SHA256_BEFORE *$JARVIS_CONFIG_FILE" | \
-      sha256sum --check --strict -
-    echo "$BOOTSTRAP_JARVIS_REPOS_SHA256_BEFORE *$JARVIS_REPOS_FILE" | \
       sha256sum --check --strict -
     echo "$BOOTSTRAP_JARVIS_GRAPH_SHA256_BEFORE *$JARVIS_GRAPH_FILE" | \
       sha256sum --check --strict -
@@ -4310,7 +4351,7 @@ if classify(uv) is None and classify(uvx) is None:
     owned["uv"] = {{"path": str(uv), "kind": "file"}}
     owned["uvx"] = {{"path": str(uvx), "kind": "file"}}
 else:
-    require_regular_executable(uv, "{UV_LINUX_AMD64_SHA256}")
+    require_regular_executable(uv, "{UV_LINUX_AMD64_EXECUTABLE_SHA256}")
     require_regular_executable(uvx)
     completed = subprocess.run(
         [str(uv), "--version"],
@@ -4454,13 +4495,16 @@ if [ ! -x "$HOME/.local/bin/frpc" ] \
 fi
 
 UV_VERSION="{UV_VERSION}"
-UV_SHA256="{UV_LINUX_AMD64_SHA256}"
+UV_ARCHIVE_SHA256="{UV_LINUX_AMD64_ARCHIVE_SHA256}"
+UV_EXECUTABLE_SHA256="{UV_LINUX_AMD64_EXECUTABLE_SHA256}"
 UV_ARCHIVE="uv-x86_64-unknown-linux-gnu.tar.gz"
 if [ ! -x "$HOME/.local/bin/uv" ] \
-  || [ "$("$HOME/.local/bin/uv" --version | awk '{{print $1 " " $2}}')" != "uv $UV_VERSION" ]; then
+  || [ "$("$HOME/.local/bin/uv" --version | awk '{{print $1 " " $2}}')" != "uv $UV_VERSION" ] \
+  || ! echo "$UV_EXECUTABLE_SHA256 *$HOME/.local/bin/uv" | \
+       sha256sum --check --status -; then
   curl -L --fail --retry 3 -o "$UV_ARCHIVE" \
     "https://github.com/astral-sh/uv/releases/download/$UV_VERSION/$UV_ARCHIVE"
-  echo "$UV_SHA256 *$UV_ARCHIVE" | sha256sum --check --strict -
+  echo "$UV_ARCHIVE_SHA256 *$UV_ARCHIVE" | sha256sum --check --strict -
   tar -xzf "$UV_ARCHIVE"
   install -m 0755 "uv-x86_64-unknown-linux-gnu/uv" \
     "$BOOTSTRAP_TRANSACTION_ROOT/downloads/uv.install"
@@ -4470,6 +4514,7 @@ if [ ! -x "$HOME/.local/bin/uv" ] \
     "$BOOTSTRAP_TRANSACTION_ROOT/downloads/uv.install" 0755
   bootstrap_journal_action copy-owned "$BOOTSTRAP_TRANSACTION_JOURNAL" uvx \
     "$BOOTSTRAP_TRANSACTION_ROOT/downloads/uvx.install" 0755
+  echo "$UV_EXECUTABLE_SHA256 *$HOME/.local/bin/uv" | sha256sum --check --strict -
   BOOTSTRAP_UV_DOWNLOADED=1
 fi
 bootstrap_journal_action mkdir-owned "$BOOTSTRAP_TRANSACTION_JOURNAL" uv_python

--- a/src/clio_relay/bootstrap_reconcile.py
+++ b/src/clio_relay/bootstrap_reconcile.py
@@ -931,6 +931,7 @@ def plan_bootstrap_reconcile(
     resolved_home = (home or Path.home()).resolve()
     reasons: list[str] = []
     upgrade_reasons: list[str] = []
+    upgrade_components: set[str] = set()
     reusable_paths: dict[str, str] = {}
     receipt_path = resolved_home / ".local/share/clio-relay/install-receipt.json"
     try:
@@ -973,6 +974,7 @@ def plan_bootstrap_reconcile(
             reason = f"{component} version requires a staged upgrade"
             reasons.append(reason)
             upgrade_reasons.append(reason)
+            upgrade_components.add(component)
             continue
         if not isinstance(raw_artifact, dict):
             reasons.append(f"{component} artifact identity is missing")
@@ -1006,18 +1008,19 @@ def plan_bootstrap_reconcile(
             reasons=reasons,
         )
 
-    clio_kit_runtime = runtime.get("clio-kit")
-    if not isinstance(clio_kit_runtime, dict) or any(
-        cast(dict[str, object], clio_kit_runtime).get(flag) is not True
-        for flag in (
-            "artifact_identity_verified",
-            "command_matches_receipt",
-            "locked_server_runtime_verified",
-            "native_execution_capability_verified",
-            "persistent_tool_verified",
-        )
-    ):
-        reasons.append("clio-kit live runtime is not reusable")
+    if "clio-kit" not in upgrade_components:
+        clio_kit_runtime = runtime.get("clio-kit")
+        if not isinstance(clio_kit_runtime, dict) or any(
+            cast(dict[str, object], clio_kit_runtime).get(flag) is not True
+            for flag in (
+                "artifact_identity_verified",
+                "command_matches_receipt",
+                "locked_server_runtime_verified",
+                "native_execution_capability_verified",
+                "persistent_tool_verified",
+            )
+        ):
+            reasons.append("clio-kit live runtime is not reusable")
     jarvis_runtime = runtime.get("jarvis-cd")
     if (
         not isinstance(jarvis_runtime, dict)
@@ -1046,8 +1049,6 @@ def plan_bootstrap_reconcile(
         ) from exc
     if not jarvis_state.initialized:
         reasons.append("JARVIS is not initialized")
-    elif upgrade_reasons and not jarvis_state.managed_repo_registered:
-        reasons.append("JARVIS managed repository binding requires separate reconciliation")
     legacy_python_text = reusable_paths.get("jarvis-cd_execution_interpreter")
     legacy_executable_text = reusable_paths.get("jarvis-cd_jarvis_executable")
     legacy_python = (
@@ -1062,18 +1063,56 @@ def plan_bootstrap_reconcile(
         if legacy_executable_text is not None
         else legacy_python.parent / ("jarvis.exe" if os.name == "nt" else "jarvis")
     )
-    legacy_venv = legacy_python.parent.parent
-    if (
-        legacy_venv.is_symlink()
-        or not legacy_python.is_file()
-        or not legacy_executable.is_file()
-        or legacy_executable.parent != legacy_python.parent
-    ):
+    lexical_legacy_venv = legacy_python.parent.parent
+    supported_legacy_venv = resolved_home / ".local/share/clio-relay/jarvis-venv"
+    expected_legacy_executable = legacy_python.parent / (
+        "jarvis.exe" if os.name == "nt" else "jarvis"
+    )
+    resolved_legacy_executable: Path | None = None
+    try:
+        legacy_python_before = legacy_python.lstat()
+        legacy_executable_before = legacy_executable.lstat()
+        expected_executable_before = expected_legacy_executable.lstat()
+        resolved_legacy_venv = lexical_legacy_venv.resolve(strict=True)
+        resolved_supported_venv = supported_legacy_venv.resolve(strict=True)
+        resolved_legacy_python_target = legacy_python.resolve(strict=True)
+        legacy_python_target_before = resolved_legacy_python_target.lstat()
+        resolved_legacy_executable = legacy_executable.resolve(strict=True)
+        resolved_expected_executable = expected_legacy_executable.resolve(strict=True)
+        executable_target_before = resolved_expected_executable.lstat()
+        executable_payload, _executable_target_identity = _read_regular_bounded_with_identity(
+            resolved_expected_executable,
+            maximum=1024 * 1024,
+        )
+        legacy_boundary_reusable = (
+            lexical_legacy_venv.is_absolute()
+            and ".." not in lexical_legacy_venv.parts
+            and not lexical_legacy_venv.is_symlink()
+            and resolved_legacy_venv == resolved_supported_venv
+            and legacy_python.is_file()
+            and expected_legacy_executable.is_file()
+            and bool(executable_payload)
+            and os.access(legacy_python, os.X_OK)
+            and os.access(expected_legacy_executable, os.X_OK)
+            and resolved_legacy_executable == resolved_expected_executable
+            and _stat_identity(legacy_python.lstat()) == _stat_identity(legacy_python_before)
+            and _stat_identity(legacy_executable.lstat())
+            == _stat_identity(legacy_executable_before)
+            and _stat_identity(expected_legacy_executable.lstat())
+            == _stat_identity(expected_executable_before)
+            and _stat_identity(resolved_legacy_python_target.lstat())
+            == _stat_identity(legacy_python_target_before)
+            and _stat_identity(resolved_expected_executable.lstat())
+            == _stat_identity(executable_target_before)
+        )
+    except (ConfigurationError, OSError, RuntimeError, ValueError):
+        legacy_boundary_reusable = False
+    if not legacy_boundary_reusable or resolved_legacy_executable is None:
         reasons.append("legacy JARVIS execution environment is not reusable")
     else:
-        reusable_paths["jarvis_execution_environment"] = str(legacy_venv.resolve())
-        reusable_paths["jarvis_execution_python"] = str(legacy_python.resolve())
-        reusable_paths["jarvis_execution_executable"] = str(legacy_executable.resolve())
+        reusable_paths["jarvis_execution_environment"] = str(lexical_legacy_venv)
+        reusable_paths["jarvis_execution_python"] = str(legacy_python)
+        reusable_paths["jarvis_execution_executable"] = str(expected_legacy_executable)
 
     if reasons:
         if upgrade_reasons and reasons == upgrade_reasons:
@@ -2159,13 +2198,14 @@ def _stat_identity(value: os.stat_result) -> tuple[int, int, int, int, int, int]
 def _cross_handle_stat_identity(value: os.stat_result) -> tuple[int, ...]:
     """Return fields stable across descriptor/path stat handles on this platform."""
     if os.name == "nt":
-        # Windows may report ctime_ns with different rounding through fstat and
-        # lstat for the same open file. Device/inode still bind the file object;
-        # size and mtime retain change detection across the two handles.
+        # Windows may report ctime_ns with different rounding and synthesize
+        # execute permission bits from a path's extension only for lstat.
+        # Device/inode and file type still bind the file object; size and mtime
+        # retain change detection across descriptor and path handles.
         return (
             value.st_dev,
             value.st_ino,
-            value.st_mode,
+            stat.S_IFMT(value.st_mode),
             value.st_size,
             value.st_mtime_ns,
         )

--- a/src/clio_relay/bootstrap_reconcile.py
+++ b/src/clio_relay/bootstrap_reconcile.py
@@ -8,12 +8,14 @@ and the fsync-backed transaction journal.
 
 from __future__ import annotations
 
+import ctypes
 import hashlib
 import json
 import os
 import shlex
 import stat
 import subprocess
+import sys
 from collections.abc import Callable, Generator
 from contextlib import contextmanager, suppress
 from datetime import UTC, datetime
@@ -51,6 +53,8 @@ _FCHMOD = cast(
     Callable[[int, int], None] | None,
     getattr(os, "fchmod", None),  # noqa: B009 - absent from Windows typing/runtime
 )
+_AT_FDCWD = -100
+_RENAME_EXCHANGE = 2
 
 
 @contextmanager
@@ -210,6 +214,62 @@ class BootstrapInspection(BaseModel):
     readiness: BootstrapReadinessEvidence
 
 
+class BootstrapActivationPathIdentity(BaseModel):
+    """Immutable identity of one pre-activation path."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    device: int = Field(ge=0)
+    inode: int = Field(ge=0)
+    mode: int = Field(ge=0)
+    size: int = Field(ge=0)
+    modified_ns: int = Field(ge=0)
+    changed_ns: int = Field(ge=0)
+    file_type: Literal["file", "symlink"]
+    sha256: str | None = None
+    symlink_target: str | None = None
+
+    @model_validator(mode="after")
+    def validate_content_identity(self) -> BootstrapActivationPathIdentity:
+        """Require content evidence appropriate to the captured file type."""
+        if self.file_type == "file":
+            if self.sha256 is None or self.symlink_target is not None:
+                raise ValueError("bootstrap activation file identity is incomplete")
+            _require_sha256(self.sha256, field="activation_path.sha256")
+        elif self.sha256 is not None or not self.symlink_target:
+            raise ValueError("bootstrap activation symlink identity is incomplete")
+        return self
+
+
+class BootstrapActivationPath(BaseModel):
+    """One stable activation path and its exact state before fencing."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    path: str
+    kind: Literal["file", "file_or_symlink", "symlink"]
+    before: BootstrapActivationPathIdentity | None = None
+
+    @model_validator(mode="after")
+    def validate_path(self) -> BootstrapActivationPath:
+        """Require an absolute normalized path and a compatible identity."""
+        candidate = Path(self.path)
+        if (
+            not candidate.is_absolute()
+            or ".." in candidate.parts
+            or os.path.normpath(self.path) != self.path
+            or any(character in self.path for character in "\x00\r\n")
+        ):
+            raise ValueError("bootstrap activation path must be absolute and normalized")
+        if self.before is not None and not (
+            (self.kind == "file" and self.before.file_type == "file")
+            or (self.kind == "symlink" and self.before.file_type == "symlink")
+            or self.kind == "file_or_symlink"
+        ):
+            raise ValueError("bootstrap activation path identity has an invalid type")
+        return self
+
+
 class BootstrapReconcilePlan(BaseModel):
     """Read-only component plan produced before preparation or fencing."""
 
@@ -220,6 +280,7 @@ class BootstrapReconcilePlan(BaseModel):
     reasons: list[str] = Field(default_factory=list)
     component_actions: dict[str, Literal["reuse", "replace"]]
     reusable_paths: dict[str, str] = Field(default_factory=dict)
+    activation_paths: dict[str, BootstrapActivationPath] = Field(default_factory=dict)
 
 
 class BootstrapTransactionState(StrEnum):
@@ -560,15 +621,22 @@ def execution_environment_identity(
 
 def jarvis_wrapper_payload(execution_python: Path) -> bytes:
     """Return the deterministic relay-owned JARVIS launcher payload."""
+    lexical_python = Path(os.path.abspath(execution_python.expanduser()))
     try:
-        resolved_python = execution_python.resolve(strict=True)
+        before = lexical_python.lstat()
+        resolved_python = lexical_python.resolve(strict=True)
     except (OSError, RuntimeError, ValueError) as exc:
         raise ConfigurationError("JARVIS execution interpreter is unavailable") from exc
-    if not resolved_python.is_file() or not os.access(resolved_python, os.X_OK):
+    if (
+        any(character in str(lexical_python) for character in "\x00\r\n")
+        or not resolved_python.is_file()
+        or not os.access(lexical_python, os.X_OK)
+        or _stat_identity(lexical_python.lstat()) != _stat_identity(before)
+    ):
         raise ConfigurationError("JARVIS execution interpreter is not executable")
     invocation = "from jarvis_cd.core.cli import main; raise SystemExit(main())"
     return (
-        f'#!/bin/sh\nexec {shlex.quote(str(resolved_python))} -c {shlex.quote(invocation)} "$@"\n'
+        f'#!/bin/sh\nexec {shlex.quote(str(lexical_python))} -c {shlex.quote(invocation)} "$@"\n'
     ).encode()
 
 
@@ -822,8 +890,10 @@ def inspect_prepared_generation(
         "fingerprint",
         "plan",
         "legacy_execution_identity",
+        "active_execution_identity",
         "jarvis_wrapper_sha256",
         "install_receipt",
+        "install_receipt_sha256",
     }:
         raise ConfigurationError("prepared generation manifest has an unknown shape")
     if not (
@@ -831,6 +901,7 @@ def inspect_prepared_generation(
         and manifest.get("fingerprint") == desired.fingerprint
         and manifest.get("legacy_execution_identity") == legacy_execution_identity
         and manifest.get("install_receipt") == str(receipt_path)
+        and manifest.get("install_receipt_sha256") == sha256_file(receipt_path)
     ):
         raise ConfigurationError("prepared generation manifest identity changed")
     plan = manifest.get("plan")
@@ -839,19 +910,40 @@ def inspect_prepared_generation(
         or cast(dict[str, object], plan).get("desired_fingerprint") != desired.fingerprint
     ):
         raise ConfigurationError("prepared generation plan identity changed")
-    raw_executables = legacy_execution_identity.get("executables")
-    raw_python = (
-        cast(dict[str, object], raw_executables).get("python")
-        if isinstance(raw_executables, dict)
-        else None
-    )
+    raw_active_identity = manifest.get("active_execution_identity")
+    if not isinstance(raw_active_identity, dict):
+        raise ConfigurationError("prepared generation omitted active execution identity")
+    active_identity = cast(dict[str, object], raw_active_identity)
+    raw_active_root = active_identity.get("root")
+    raw_executables = active_identity.get("executables")
+    if not isinstance(raw_active_root, str) or not isinstance(raw_executables, dict):
+        raise ConfigurationError("prepared generation omitted active execution boundary")
+    typed_executables = cast(dict[str, object], raw_executables)
+    if set(typed_executables) != {"python", "jarvis"}:
+        raise ConfigurationError("prepared generation active executable set changed")
+    raw_python = typed_executables.get("python")
+    raw_jarvis = typed_executables.get("jarvis")
     raw_python_path = (
-        cast(dict[str, object], raw_python).get("resolved_path")
+        cast(dict[str, object], raw_python).get("lexical_path")
         if isinstance(raw_python, dict)
         else None
     )
-    if not isinstance(raw_python_path, str):
-        raise ConfigurationError("prepared generation omitted JARVIS interpreter identity")
+    raw_jarvis_path = (
+        cast(dict[str, object], raw_jarvis).get("lexical_path")
+        if isinstance(raw_jarvis, dict)
+        else None
+    )
+    if not isinstance(raw_python_path, str) or not isinstance(raw_jarvis_path, str):
+        raise ConfigurationError("prepared generation omitted active interpreter identity")
+    recomputed_active_identity = execution_environment_identity(
+        Path(raw_active_root),
+        executables={
+            "python": Path(raw_python_path),
+            "jarvis": Path(raw_jarvis_path),
+        },
+    )
+    if recomputed_active_identity != active_identity:
+        raise ConfigurationError("prepared generation active execution identity changed")
     jarvis_payload = jarvis_wrapper_payload(Path(raw_python_path))
     jarvis_wrapper = generation / "bin/jarvis"
     wrapper_bytes = _read_regular_bounded(jarvis_wrapper, maximum=64 * 1024)
@@ -877,6 +969,32 @@ def inspect_prepared_generation(
         and typed_receipt.get("generation") == desired.fingerprint
     ):
         raise ConfigurationError("prepared generation install receipt identity changed")
+    raw_artifacts = typed_receipt.get("component_artifacts")
+    raw_jarvis_artifact = (
+        cast(dict[str, object], raw_artifacts).get("jarvis-cd")
+        if isinstance(raw_artifacts, dict)
+        else None
+    )
+    raw_interpreters = (
+        cast(dict[str, object], raw_jarvis_artifact).get("runtime_interpreters")
+        if isinstance(raw_jarvis_artifact, dict)
+        else None
+    )
+    receipt_execution_python = (
+        cast(dict[str, object], raw_interpreters).get("execution")
+        if isinstance(raw_interpreters, dict)
+        else None
+    )
+    if (
+        not isinstance(receipt_execution_python, str)
+        or receipt_execution_python != raw_python_path
+        or not Path(receipt_execution_python).is_absolute()
+        or os.path.normpath(receipt_execution_python) != receipt_execution_python
+        or any(character in receipt_execution_python for character in "\x00\r\n")
+    ):
+        raise ConfigurationError(
+            "prepared active JARVIS interpreter is not bound to its install receipt"
+        )
     relay_runtime = typed_runtime.get("clio-relay")
     clio_kit_runtime = typed_runtime.get("clio-kit")
     jarvis_runtime = typed_runtime.get("jarvis-cd")
@@ -917,6 +1035,94 @@ def inspect_prepared_generation(
     }
 
 
+def finish_staged_activation(
+    desired: BootstrapDesiredState,
+    *,
+    generation: Path,
+    expected_manifest_sha256: str,
+    home: Path | None = None,
+) -> dict[str, object]:
+    """Reverify and idempotently finish activation plus exact repo migration."""
+    try:
+        _require_sha256(expected_manifest_sha256, field="expected_manifest_sha256")
+    except ValueError as exc:
+        raise ConfigurationError(str(exc)) from exc
+    raw_manifest = _read_regular_bounded(generation / "manifest.json", maximum=4 * 1024 * 1024)
+    if hashlib.sha256(raw_manifest).hexdigest() != expected_manifest_sha256:
+        raise ConfigurationError("prepared generation manifest changed before activation")
+    try:
+        raw_value = cast(object, json.loads(raw_manifest))
+    except json.JSONDecodeError as exc:
+        raise ConfigurationError("prepared generation manifest is invalid") from exc
+    if not isinstance(raw_value, dict):
+        raise ConfigurationError("prepared generation manifest is not an object")
+    manifest = cast(dict[str, object], raw_value)
+    try:
+        plan = BootstrapReconcilePlan.model_validate(manifest.get("plan"))
+    except ValueError as exc:
+        raise ConfigurationError("prepared generation reconcile plan is invalid") from exc
+    if plan.desired_fingerprint != desired.fingerprint or plan.mode not in {
+        "relay-only",
+        "component-upgrade",
+    }:
+        raise ConfigurationError("prepared generation reconcile plan changed")
+    legacy_venv = plan.reusable_paths.get("jarvis_execution_environment")
+    legacy_python = plan.reusable_paths.get("jarvis_execution_python")
+    legacy_jarvis = plan.reusable_paths.get("jarvis_execution_executable")
+    if not all(
+        isinstance(value, str) and value for value in (legacy_venv, legacy_python, legacy_jarvis)
+    ):
+        raise ConfigurationError("prepared generation omitted its legacy execution boundary")
+    assert legacy_venv is not None
+    assert legacy_python is not None
+    assert legacy_jarvis is not None
+    legacy_identity = execution_environment_identity(
+        Path(legacy_venv),
+        executables={"python": Path(legacy_python), "jarvis": Path(legacy_jarvis)},
+    )
+    if manifest.get("legacy_execution_identity") != legacy_identity:
+        raise ConfigurationError("legacy execution environment changed before activation")
+    inspection = inspect_prepared_generation(
+        desired,
+        generation=generation,
+        legacy_execution_identity=legacy_identity,
+    )
+    if inspection.get("manifest_sha256") != expected_manifest_sha256:
+        raise ConfigurationError("prepared generation inspection did not bind its manifest")
+    activation = reconcile_staged_activation_links(plan, generation=generation, home=home)
+    lexical_home = Path(os.path.abspath((home or Path.home()).expanduser()))
+    managed_repo = lexical_home / ".local/share/clio-relay/managed-jarvis-repo"
+    previous_repo = lexical_home / ".local/src/clio-relay/jarvis-packages/clio_relay"
+    repositories = reconcile_managed_jarvis_repository(
+        _expand_home(desired.jarvis_root, lexical_home) / "repos.yaml",
+        managed_repo,
+        previous_managed_repos=(previous_repo,),
+        exchange_identity=desired.fingerprint,
+    )
+    expected_managed_target = (
+        lexical_home / ".local/share/clio-relay/current/source/jarvis-packages/clio_relay"
+    )
+    _verify_stable_symlink(
+        managed_repo,
+        expected=expected_managed_target,
+        label="relay-managed repository",
+    )
+    actions = activation.get("actions")
+    if not isinstance(actions, dict):  # pragma: no cover - produced above
+        raise ConfigurationError("staged activation omitted link actions")
+    return {
+        "schema_version": "clio-relay.bootstrap-staged-activation.v1",
+        "prepared_inspection": inspection,
+        "activation": activation,
+        "jarvis_repository": {
+            "link_action": cast(dict[str, object], actions).get("managed_repo"),
+            "link": str(managed_repo),
+            "target": os.readlink(managed_repo),
+            "repositories": repositories,
+        },
+    }
+
+
 def plan_bootstrap_reconcile(
     desired: BootstrapDesiredState,
     *,
@@ -928,7 +1134,8 @@ def plan_bootstrap_reconcile(
     an older receipt need not contain a deployment manifest, but every reusable
     component must have exact artifact and live-runtime evidence.
     """
-    resolved_home = (home or Path.home()).resolve()
+    lexical_home = Path(os.path.abspath((home or Path.home()).expanduser()))
+    resolved_home = lexical_home.resolve()
     reasons: list[str] = []
     upgrade_reasons: list[str] = []
     upgrade_components: set[str] = set()
@@ -946,12 +1153,29 @@ def plan_bootstrap_reconcile(
         return _full_plan(desired, "installation identity omitted component evidence")
     receipt = cast(dict[str, object], raw_receipt)
     runtime = cast(dict[str, object], raw_runtime)
+    relay_runtime = runtime.get("clio-relay")
+    if (
+        not isinstance(relay_runtime, dict)
+        or cast(dict[str, object], relay_runtime).get("persistent_tool_verified") is not True
+    ):
+        return _full_plan(desired, "clio-relay live provider is not reusable")
     raw_components = receipt.get("components")
     raw_artifacts = receipt.get("component_artifacts")
     if not isinstance(raw_components, dict) or not isinstance(raw_artifacts, dict):
         return _full_plan(desired, "install receipt omitted reusable component artifacts")
     components = cast(dict[str, object], raw_components)
     artifacts = cast(dict[str, object], raw_artifacts)
+    raw_relay_artifact = artifacts.get("clio-relay")
+    relay_executable = None
+    if isinstance(raw_relay_artifact, dict):
+        raw_relay_executables = cast(dict[str, object], raw_relay_artifact).get(
+            "runtime_executables"
+        )
+        if isinstance(raw_relay_executables, dict):
+            relay_executable = cast(dict[str, object], raw_relay_executables).get("clio-relay")
+    expected_relay_executable = lexical_home / ".local/bin/clio-relay"
+    if not isinstance(relay_executable, str) or relay_executable != str(expected_relay_executable):
+        return _full_plan(desired, "clio-relay launcher is not bound to its install receipt")
     expected_components = {
         "clio-kit": (desired.clio_kit_version, desired.clio_kit_artifact_sha256),
         "jarvis-cd": (desired.jarvis_cd_version, desired.jarvis_cd_wheel_sha256),
@@ -1116,6 +1340,10 @@ def plan_bootstrap_reconcile(
 
     if reasons:
         if upgrade_reasons and reasons == upgrade_reasons:
+            try:
+                activation_paths = _capture_reconcile_activation_paths(home=lexical_home)
+            except (ConfigurationError, OSError, RuntimeError, ValueError) as exc:
+                return _full_plan(desired, f"legacy activation boundary is not reusable: {exc}")
             return BootstrapReconcilePlan(
                 mode="component-upgrade",
                 desired_fingerprint=desired.fingerprint,
@@ -1129,6 +1357,7 @@ def plan_bootstrap_reconcile(
                     "uv": "reuse",
                 },
                 reusable_paths=reusable_paths,
+                activation_paths=activation_paths,
             )
         return BootstrapReconcilePlan(
             mode="full",
@@ -1160,6 +1389,10 @@ def plan_bootstrap_reconcile(
             },
             reusable_paths=reusable_paths,
         )
+    try:
+        activation_paths = _capture_reconcile_activation_paths(home=lexical_home)
+    except (ConfigurationError, OSError, RuntimeError, ValueError) as exc:
+        return _full_plan(desired, f"legacy activation boundary is not reusable: {exc}")
     return BootstrapReconcilePlan(
         mode="relay-only",
         desired_fingerprint=desired.fingerprint,
@@ -1173,6 +1406,7 @@ def plan_bootstrap_reconcile(
             "uv": "reuse",
         },
         reusable_paths=reusable_paths,
+        activation_paths=activation_paths,
     )
 
 
@@ -1634,11 +1868,50 @@ def write_bootstrap_receipt(path: Path, receipt: dict[str, object]) -> None:
     _atomic_json(path, receipt)
 
 
+def _managed_repository_payload(
+    raw: bytes,
+    *,
+    managed: str,
+    previous: set[str],
+) -> tuple[bytes, list[str], list[str]]:
+    """Return the exact converged repository bytes and mutation evidence."""
+    document = _yaml_mapping(raw, label="JARVIS repositories")
+    raw_repos = document.get("repos")
+    typed_repos = cast(list[object], raw_repos) if isinstance(raw_repos, list) else []
+    if not isinstance(raw_repos, list) or any(
+        not isinstance(value, str) or not value for value in typed_repos
+    ):
+        raise ConfigurationError("JARVIS repositories must contain a string list")
+    repos = list(cast(list[str], raw_repos))
+    managed_count = repos.count(managed)
+    if managed_count > 1:
+        raise ConfigurationError("relay-managed JARVIS repository is registered more than once")
+    if any(repos.count(value) > 1 for value in previous):
+        raise ConfigurationError(
+            "a proven previous relay-managed JARVIS repository is registered more than once"
+        )
+    removed_previous = sorted(previous.intersection(repos))
+    if managed_count == 1 and not removed_previous:
+        return raw, [], []
+    updated = [value for value in repos if value not in previous]
+    added_managed: list[str] = []
+    if managed_count == 0:
+        updated.insert(0, managed)
+        added_managed.append(managed)
+    document["repos"] = updated
+    return (
+        yaml.safe_dump(document, sort_keys=False).encode("utf-8"),
+        added_managed,
+        removed_previous,
+    )
+
+
 def reconcile_managed_jarvis_repository(
     repos_file: Path,
     managed_repo: Path,
     *,
     previous_managed_repos: tuple[Path, ...] = (),
+    exchange_identity: str | None = None,
 ) -> dict[str, object]:
     """Register only the exact relay-owned repository without basename matching.
 
@@ -1651,20 +1924,54 @@ def reconcile_managed_jarvis_repository(
     bootstrap lock; the final byte-and-file-identity comparison also detects
     non-cooperating writers before the atomic replacement.
     """
+    managed = str(managed_repo.absolute())
+    previous = {str(path.absolute()) for path in previous_managed_repos}
+    previous.discard(managed)
+    token = exchange_identity or hashlib.sha256(managed.encode("utf-8")).hexdigest()
+    try:
+        _require_sha256(token, field="repository_exchange_identity")
+    except ValueError as exc:
+        raise ConfigurationError(str(exc)) from exc
+    temporary = repos_file.with_name(f".{repos_file.name}.{token}.exchange")
     raw, before_identity = _read_regular_bounded_with_identity(
         repos_file,
         maximum=MAX_JARVIS_REPOS_BYTES,
     )
-    document = _yaml_mapping(raw, label="JARVIS repositories")
-    raw_repos = document.get("repos")
-    typed_repos = cast(list[object], raw_repos) if isinstance(raw_repos, list) else []
-    if not isinstance(raw_repos, list) or any(
-        not isinstance(value, str) or not value for value in typed_repos
-    ):
-        raise ConfigurationError("JARVIS repositories must contain a string list")
-    repos = list(cast(list[str], raw_repos))
-    managed = str(managed_repo.absolute())
-    if repos.count(managed) == 1:
+    payload, added_managed, removed_previous = _managed_repository_payload(
+        raw,
+        managed=managed,
+        previous=previous,
+    )
+    if temporary.exists() or temporary.is_symlink():
+        displaced, _displaced_identity = _read_regular_bounded_with_identity(
+            temporary,
+            maximum=MAX_JARVIS_REPOS_BYTES,
+        )
+        displaced_payload, displaced_added, displaced_removed = _managed_repository_payload(
+            displaced,
+            managed=managed,
+            previous=previous,
+        )
+        if displaced != displaced_payload and displaced_payload == raw:
+            temporary.unlink()
+            _fsync_directory(repos_file.parent)
+            return {
+                "action": "updated",
+                "managed_repo": managed,
+                "added_managed_repos": displaced_added,
+                "removed_previous_managed_repos": displaced_removed,
+                "before_sha256": hashlib.sha256(displaced).hexdigest(),
+                "after_sha256": hashlib.sha256(raw).hexdigest(),
+            }
+        if raw != payload and payload == displaced:
+            temporary.unlink()
+            _fsync_directory(repos_file.parent)
+        else:
+            raise ConfigurationError(
+                "JARVIS repository exchange recovery found unproven path states: "
+                f"{repos_file}, {temporary}"
+            )
+    if payload == raw:
         return {
             "action": "reused",
             "managed_repo": managed,
@@ -1673,42 +1980,80 @@ def reconcile_managed_jarvis_repository(
             "before_sha256": hashlib.sha256(raw).hexdigest(),
             "after_sha256": hashlib.sha256(raw).hexdigest(),
         }
-    if repos.count(managed) > 1:
-        raise ConfigurationError("relay-managed JARVIS repository is registered more than once")
-    previous = {str(path.absolute()) for path in previous_managed_repos}
-    previous.discard(managed)
-    if any(repos.count(value) > 1 for value in previous):
-        raise ConfigurationError(
-            "a proven previous relay-managed JARVIS repository is registered more than once"
-        )
-    updated = [value for value in repos if value not in previous]
-    updated.insert(0, managed)
-    document["repos"] = updated
-    payload = yaml.safe_dump(document, sort_keys=False).encode("utf-8")
-    temporary = repos_file.with_name(f".{repos_file.name}.{os.getpid()}.tmp")
+    exchanged = False
     try:
         with temporary.open("xb") as stream:
             os.chmod(temporary, 0o600)
             stream.write(payload)
             stream.flush()
             os.fsync(stream.fileno())
-        current, current_identity = _read_regular_bounded_with_identity(
-            repos_file,
-            maximum=MAX_JARVIS_REPOS_BYTES,
-        )
-        if current != raw or current_identity != before_identity:
+        desired_identity = _stat_identity(temporary.lstat())
+        exchanged = True
+        _atomic_exchange_paths(temporary, repos_file)
+        try:
+            displaced, displaced_identity = _read_regular_bounded_with_identity(
+                temporary,
+                maximum=MAX_JARVIS_REPOS_BYTES,
+            )
+        except ConfigurationError:
+            displaced = b""
+            displaced_identity = (-1, -1, -1, -1, -1, -1)
+        if displaced != raw or not _identity_matches_after_rename(
+            before_identity, displaced_identity
+        ):
+            try:
+                active, active_identity = _read_regular_bounded_with_identity(
+                    repos_file,
+                    maximum=MAX_JARVIS_REPOS_BYTES,
+                )
+            except ConfigurationError as exc:
+                raise ConfigurationError(
+                    "JARVIS repositories changed during atomic reconciliation; "
+                    f"displaced state retained at {temporary}"
+                ) from exc
+            if active != payload or not _identity_matches_after_rename(
+                desired_identity, active_identity
+            ):
+                raise ConfigurationError(
+                    "JARVIS repositories changed during atomic reconciliation; "
+                    f"displaced state retained at {temporary}"
+                )
+            _atomic_exchange_paths(temporary, repos_file)
+            exchanged = False
+            _fsync_directory(repos_file.parent)
             raise ConfigurationError("JARVIS repositories changed during reconciliation")
-        os.replace(temporary, repos_file)
+        try:
+            active, active_identity = _read_regular_bounded_with_identity(
+                repos_file,
+                maximum=MAX_JARVIS_REPOS_BYTES,
+            )
+        except ConfigurationError as exc:
+            temporary.unlink()
+            exchanged = False
+            _fsync_directory(repos_file.parent)
+            raise ConfigurationError(
+                "JARVIS repositories changed after atomic reconciliation"
+            ) from exc
+        if active != payload or not _identity_matches_after_rename(
+            desired_identity, active_identity
+        ):
+            temporary.unlink()
+            exchanged = False
+            _fsync_directory(repos_file.parent)
+            raise ConfigurationError("JARVIS repositories changed after atomic reconciliation")
+        temporary.unlink()
+        exchanged = False
         _fsync_directory(repos_file.parent)
     except BaseException:
-        with suppress(OSError):
-            temporary.unlink(missing_ok=True)
+        if not exchanged:
+            with suppress(OSError):
+                temporary.unlink(missing_ok=True)
         raise
     return {
         "action": "updated",
         "managed_repo": managed,
-        "added_managed_repos": [managed],
-        "removed_previous_managed_repos": sorted(previous.intersection(repos)),
+        "added_managed_repos": added_managed,
+        "removed_previous_managed_repos": removed_previous,
         "before_sha256": hashlib.sha256(raw).hexdigest(),
         "after_sha256": hashlib.sha256(payload).hexdigest(),
     }
@@ -1721,65 +2066,50 @@ def repair_managed_jarvis_binding(
     previous_managed_repos: tuple[Path, ...] = (),
 ) -> dict[str, object]:
     """Repair only relay's stable package link and exact repository registration."""
-    resolved_home = (home or Path.home()).resolve()
-    generation = (
-        resolved_home / ".local/share/clio-relay/generations" / desired.fingerprint
-    ).resolve(strict=True)
-    expected_target = (generation / "source/jarvis-packages/clio_relay").resolve(strict=True)
-    if not expected_target.is_dir():
+    lexical_home = Path(os.path.abspath((home or Path.home()).expanduser()))
+    resolved_home = lexical_home.resolve(strict=True)
+    generation_path = lexical_home / ".local/share/clio-relay/generations" / desired.fingerprint
+    generation = generation_path.resolve(strict=True)
+    if generation_path.is_symlink() or generation != generation_path:
+        raise ConfigurationError("desired generation path is not one owned directory")
+    current = lexical_home / ".local/share/clio-relay/current"
+    _verify_stable_symlink(current, expected=generation, label="active generation")
+    expected_target = current / "source/jarvis-packages/clio_relay"
+    if not expected_target.resolve(strict=True).is_dir():
         raise ConfigurationError("desired generation has no relay JARVIS package repository")
-    managed = _expand_home(desired.managed_jarvis_repo, resolved_home)
+    managed = _expand_home(desired.managed_jarvis_repo, lexical_home)
     managed.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-    link_action = "reused"
-    try:
-        managed_details = managed.lstat()
-    except FileNotFoundError:
-        link_action = "created"
-    except OSError as exc:
-        raise ConfigurationError("relay-managed repository link could not be classified") from exc
-    else:
-        if not stat.S_ISLNK(managed_details.st_mode):
-            raise ConfigurationError(
-                "relay-managed repository path is not a replaceable symbolic link"
-            )
-        raw_target = Path(os.readlink(managed))
-        if not raw_target.is_absolute():
-            raw_target = managed.parent / raw_target
-        lexical_target = Path(os.path.abspath(raw_target))
-        if lexical_target == expected_target:
-            _verify_stable_symlink(
-                managed,
-                expected=expected_target,
-                label="relay-managed repository",
-            )
-        else:
+    snapshot = _capture_activation_path(
+        managed,
+        kind="symlink",
+        maximum=4096,
+        allow_absent=True,
+    )
+    if snapshot.before is not None:
+        lexical_target = _activation_symlink_lexical_target(snapshot)
+        if lexical_target != expected_target:
             proven_targets = {
                 Path(os.path.abspath(path.expanduser())) for path in previous_managed_repos
             }
             if lexical_target not in proven_targets or not _is_generation_repository_target(
-                lexical_target,
+                lexical_target.resolve(strict=True),
                 home=resolved_home,
             ):
                 raise ConfigurationError(
                     "relay-managed repository link target is not proven by an earlier receipt"
                 )
-            link_action = "retargeted"
-    if link_action != "reused":
-        temporary = managed.with_name(f".{managed.name}.{os.getpid()}.tmp")
-        try:
-            temporary.symlink_to(expected_target, target_is_directory=True)
-            os.replace(temporary, managed)
-            _fsync_directory(managed.parent)
-        except BaseException:
-            with suppress(OSError):
-                temporary.unlink(missing_ok=True)
-            raise
-        _verify_stable_symlink(managed, expected=expected_target, label="relay-managed repository")
-    repos_file = _expand_home(desired.jarvis_root, resolved_home) / "repos.yaml"
+    link_action = _reconcile_activation_symlink(
+        snapshot,
+        expected_target=expected_target,
+        label="relay-managed repository",
+        exchange_identity=desired.fingerprint,
+    )
+    repos_file = _expand_home(desired.jarvis_root, lexical_home) / "repos.yaml"
     repo_evidence = reconcile_managed_jarvis_repository(
         repos_file,
         managed,
         previous_managed_repos=previous_managed_repos,
+        exchange_identity=desired.fingerprint,
     )
     return {
         "link_action": link_action,
@@ -1948,8 +2278,10 @@ def _verify_active_generation_jarvis_wrapper(
         "fingerprint",
         "plan",
         "legacy_execution_identity",
+        "active_execution_identity",
         "jarvis_wrapper_sha256",
         "install_receipt",
+        "install_receipt_sha256",
     }
     if set(manifest) != expected_manifest_keys:
         raise ConfigurationError("active generation manifest has an unknown shape")
@@ -1958,6 +2290,7 @@ def _verify_active_generation_jarvis_wrapper(
         manifest.get("schema_version") == "clio-relay.bootstrap-generation.v1"
         and manifest.get("fingerprint") == desired.fingerprint
         and manifest.get("install_receipt") == str(expected_receipt_path)
+        and manifest.get("install_receipt_sha256") == sha256_file(expected_receipt_path)
     ):
         raise ConfigurationError("active generation manifest identity changed")
     raw_plan = manifest.get("plan")
@@ -1967,17 +2300,17 @@ def _verify_active_generation_jarvis_wrapper(
         raise ConfigurationError("active generation reconcile plan is invalid") from exc
     if plan.desired_fingerprint != desired.fingerprint:
         raise ConfigurationError("active generation reconcile plan identity changed")
-    raw_identity = manifest.get("legacy_execution_identity")
+    raw_identity = manifest.get("active_execution_identity")
     if not isinstance(raw_identity, dict):
-        raise ConfigurationError("active generation omitted JARVIS execution identity")
+        raise ConfigurationError("active generation omitted active execution identity")
     identity = cast(dict[str, object], raw_identity)
     raw_root = identity.get("root")
     raw_executables = identity.get("executables")
     if not isinstance(raw_root, str) or not isinstance(raw_executables, dict):
-        raise ConfigurationError("active generation omitted JARVIS execution boundary")
+        raise ConfigurationError("active generation omitted active execution boundary")
     typed_executables = cast(dict[str, object], raw_executables)
     if set(typed_executables) != {"python", "jarvis"}:
-        raise ConfigurationError("active generation JARVIS executable set changed")
+        raise ConfigurationError("active generation executable set changed")
     raw_python = typed_executables.get("python")
     raw_jarvis = typed_executables.get("jarvis")
     python_path = (
@@ -2022,9 +2355,12 @@ def _verify_active_generation_jarvis_wrapper(
         if isinstance(raw_interpreters, dict)
         else None
     )
-    if not isinstance(receipt_execution_python, str) or (
-        Path(receipt_execution_python).resolve(strict=True)
-        != Path(python_path).resolve(strict=True)
+    if (
+        not isinstance(receipt_execution_python, str)
+        or receipt_execution_python != python_path
+        or not Path(receipt_execution_python).is_absolute()
+        or os.path.normpath(receipt_execution_python) != receipt_execution_python
+        or any(character in receipt_execution_python for character in "\x00\r\n")
     ):
         raise ConfigurationError("active JARVIS interpreter is not bound to its install receipt")
     expected_payload = jarvis_wrapper_payload(Path(python_path))
@@ -2055,6 +2391,456 @@ def _verify_stable_symlink(path: Path, *, expected: Path, label: str) -> Path:
     if _stat_identity(path.lstat()) != _stat_identity(before):
         raise ConfigurationError(f"{label} changed during inspection")
     return resolved
+
+
+def _capture_activation_path(
+    path: Path,
+    *,
+    kind: Literal["file", "file_or_symlink", "symlink"],
+    maximum: int,
+    allow_absent: bool,
+) -> BootstrapActivationPath:
+    """Capture one exact pre-fence path without following its final link."""
+    lexical = Path(os.path.abspath(path.expanduser()))
+    try:
+        before = lexical.lstat()
+    except FileNotFoundError:
+        if not allow_absent:
+            raise ConfigurationError(
+                f"required activation path is unavailable: {lexical}"
+            ) from None
+        return BootstrapActivationPath(path=str(lexical), kind=kind)
+    except OSError as exc:
+        raise ConfigurationError(f"activation path could not be classified: {lexical}") from exc
+    file_type: Literal["file", "symlink"]
+    digest: str | None = None
+    link_target: str | None = None
+    if stat.S_ISLNK(before.st_mode):
+        if kind == "file":
+            raise ConfigurationError(f"activation path must be a regular file: {lexical}")
+        try:
+            link_target = os.readlink(lexical)
+            after = lexical.lstat()
+        except OSError as exc:
+            raise ConfigurationError(f"activation symlink could not be read: {lexical}") from exc
+        if (
+            not link_target
+            or any(character in link_target for character in "\x00\r\n")
+            or _stat_identity(before) != _stat_identity(after)
+        ):
+            raise ConfigurationError(f"activation symlink changed while inspected: {lexical}")
+        file_type = "symlink"
+    elif stat.S_ISREG(before.st_mode):
+        if kind == "symlink":
+            raise ConfigurationError(f"activation path must be a symbolic link: {lexical}")
+        raw, _identity = _read_regular_bounded_with_identity(lexical, maximum=maximum)
+        try:
+            after = lexical.lstat()
+        except OSError as exc:
+            raise ConfigurationError(f"activation file changed while inspected: {lexical}") from exc
+        if _stat_identity(before) != _stat_identity(after):
+            raise ConfigurationError(f"activation file changed while inspected: {lexical}")
+        digest = hashlib.sha256(raw).hexdigest()
+        file_type = "file"
+    else:
+        raise ConfigurationError(f"activation path has an unsafe type: {lexical}")
+    return BootstrapActivationPath(
+        path=str(lexical),
+        kind=kind,
+        before=BootstrapActivationPathIdentity(
+            device=before.st_dev,
+            inode=before.st_ino,
+            mode=before.st_mode,
+            size=before.st_size,
+            modified_ns=before.st_mtime_ns,
+            changed_ns=before.st_ctime_ns,
+            file_type=file_type,
+            sha256=digest,
+            symlink_target=link_target,
+        ),
+    )
+
+
+def _activation_path_identity(path: BootstrapActivationPath) -> BootstrapActivationPathIdentity:
+    """Re-capture an existing activation path using its original contract."""
+    captured = _capture_activation_path(
+        Path(path.path),
+        kind=path.kind,
+        maximum=4 * 1024 * 1024,
+        allow_absent=False,
+    )
+    if captured.before is None:  # pragma: no cover - excluded by allow_absent
+        raise ConfigurationError(f"activation path disappeared: {path.path}")
+    return captured.before
+
+
+def _capture_activation_object(
+    path: Path,
+    *,
+    kind: Literal["file", "file_or_symlink", "symlink"],
+    maximum: int,
+) -> BootstrapActivationPathIdentity:
+    """Capture a file or link, including the Windows symlink test representation."""
+    lexical = Path(os.path.abspath(path.expanduser()))
+    try:
+        before = lexical.lstat()
+        raw_target = os.readlink(lexical)
+        after = lexical.lstat()
+    except OSError:
+        captured = _capture_activation_path(
+            lexical,
+            kind=kind,
+            maximum=maximum,
+            allow_absent=False,
+        )
+        if captured.before is None:  # pragma: no cover - excluded by allow_absent
+            raise ConfigurationError(f"activation path disappeared: {lexical}") from None
+        return captured.before
+    if (
+        kind == "file"
+        or not raw_target
+        or any(character in raw_target for character in "\x00\r\n")
+        or _stat_identity(before) != _stat_identity(after)
+    ):
+        raise ConfigurationError(f"activation symlink changed while inspected: {lexical}")
+    return BootstrapActivationPathIdentity(
+        device=before.st_dev,
+        inode=before.st_ino,
+        mode=before.st_mode,
+        size=before.st_size,
+        modified_ns=before.st_mtime_ns,
+        changed_ns=before.st_ctime_ns,
+        file_type="symlink",
+        symlink_target=raw_target,
+    )
+
+
+def _capture_reconcile_activation_paths(
+    *,
+    home: Path,
+) -> dict[str, BootstrapActivationPath]:
+    """Capture the exact legacy/stable paths a staged activation may replace."""
+    lexical_home = Path(os.path.abspath(home.expanduser()))
+    share = lexical_home / ".local/share/clio-relay"
+    current = _capture_activation_path(
+        share / "current",
+        kind="symlink",
+        maximum=4096,
+        allow_absent=True,
+    )
+    if current.before is not None:
+        current_target = _activation_symlink_lexical_target(current)
+        try:
+            relative = current_target.resolve(strict=True).relative_to(
+                (share / "generations").resolve(strict=True)
+            )
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise ConfigurationError(
+                "active generation pointer does not name one managed generation"
+            ) from exc
+        if (
+            len(relative.parts) != 1
+            or len(relative.name) != 64
+            or any(character not in "0123456789abcdef" for character in relative.name)
+        ):
+            raise ConfigurationError(
+                "active generation pointer does not name one managed generation"
+            )
+    managed = _capture_activation_path(
+        share / "managed-jarvis-repo",
+        kind="symlink",
+        maximum=4096,
+        allow_absent=True,
+    )
+    if managed.before is not None:
+        managed_target = _activation_symlink_lexical_target(managed)
+        allowed_targets = {
+            lexical_home / ".local/src/clio-relay/jarvis-packages/clio_relay",
+            share / "current/source/jarvis-packages/clio_relay",
+        }
+        if managed_target not in allowed_targets and not _is_generation_repository_target(
+            managed_target.resolve(strict=True),
+            home=lexical_home.resolve(strict=True),
+        ):
+            raise ConfigurationError(
+                "relay-managed repository link is not one proven legacy binding"
+            )
+    paths = {
+        "current": current,
+        "install_receipt": _capture_activation_path(
+            share / "install-receipt.json",
+            kind="file_or_symlink",
+            maximum=4 * 1024 * 1024,
+            allow_absent=False,
+        ),
+        "relay_launcher": _capture_activation_path(
+            lexical_home / ".local/bin/clio-relay",
+            kind="file_or_symlink",
+            maximum=1024 * 1024,
+            allow_absent=False,
+        ),
+        "jarvis_launcher": _capture_activation_path(
+            lexical_home / ".local/bin/jarvis",
+            kind="file_or_symlink",
+            maximum=1024 * 1024,
+            allow_absent=False,
+        ),
+        "managed_repo": managed,
+    }
+    for name in ("relay_launcher", "jarvis_launcher"):
+        launcher = Path(paths[name].path)
+        try:
+            target = launcher.resolve(strict=True)
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise ConfigurationError(f"legacy activation launcher is unavailable: {name}") from exc
+        if not target.is_file() or not os.access(target, os.X_OK):
+            raise ConfigurationError(f"legacy activation launcher is not executable: {name}")
+    return paths
+
+
+def _activation_symlink_lexical_target(path: BootstrapActivationPath) -> Path:
+    """Return one captured symlink target without resolving its final object."""
+    if path.before is None or path.before.file_type != "symlink":
+        raise ConfigurationError(f"activation path is not a captured symlink: {path.path}")
+    raw_target = path.before.symlink_target
+    if raw_target is None:  # pragma: no cover - enforced by the model
+        raise ConfigurationError(f"activation path omitted its symlink target: {path.path}")
+    candidate = Path(raw_target)
+    if not candidate.is_absolute():
+        candidate = Path(path.path).parent / candidate
+    return Path(os.path.abspath(candidate))
+
+
+def _reconcile_activation_symlink(
+    snapshot: BootstrapActivationPath,
+    *,
+    expected_target: Path,
+    label: str,
+    exchange_identity: str | None = None,
+) -> str:
+    """Atomically publish one stable link from either its snapshot or desired state."""
+    path = Path(snapshot.path)
+    target = Path(os.path.abspath(expected_target.expanduser()))
+    token = exchange_identity or hashlib.sha256(f"{snapshot.path}\0{target}".encode()).hexdigest()
+    try:
+        _require_sha256(token, field="activation_exchange_identity")
+    except ValueError as exc:
+        raise ConfigurationError(str(exc)) from exc
+    temporary = path.with_name(f".{path.name}.{token}.exchange")
+    action = "created" if snapshot.before is None else "retargeted"
+    if temporary.exists() or temporary.is_symlink():
+        try:
+            active = _capture_activation_object(
+                path,
+                kind=snapshot.kind,
+                maximum=4 * 1024 * 1024,
+            )
+            displaced = _capture_activation_object(
+                temporary,
+                kind=snapshot.kind,
+                maximum=4 * 1024 * 1024,
+            )
+        except ConfigurationError as exc:
+            raise ConfigurationError(
+                f"{label} exchange recovery found an invalid path state"
+            ) from exc
+        active_is_desired = bool(
+            active.file_type == "symlink" and active.symlink_target == str(target)
+        )
+        displaced_is_desired = bool(
+            displaced.file_type == "symlink" and displaced.symlink_target == str(target)
+        )
+        active_is_before = bool(
+            snapshot.before is not None
+            and _activation_identity_matches_after_rename(snapshot.before, active)
+        )
+        displaced_is_before = bool(
+            snapshot.before is not None
+            and _activation_identity_matches_after_rename(snapshot.before, displaced)
+        )
+        if active_is_desired and displaced_is_before:
+            _verify_stable_symlink(path, expected=target, label=label)
+            temporary.unlink()
+            _fsync_directory(path.parent)
+            return action
+        if active_is_before and displaced_is_desired:
+            temporary.unlink()
+            _fsync_directory(path.parent)
+        else:
+            raise ConfigurationError(
+                f"{label} exchange recovery found unproven path states: {path}, {temporary}"
+            )
+    try:
+        before = path.lstat()
+        raw_target = os.readlink(path)
+        if raw_target != str(target):
+            raise ConfigurationError(f"{label} does not use its canonical target")
+        _verify_stable_symlink(path, expected=target, label=label)
+        if _stat_identity(path.lstat()) != _stat_identity(before):
+            raise ConfigurationError(f"{label} changed during inspection")
+    except (ConfigurationError, OSError, RuntimeError, ValueError):
+        pass
+    else:
+        return "reused"
+    try:
+        observed = _activation_path_identity(snapshot)
+    except ConfigurationError:
+        if snapshot.before is not None:
+            raise ConfigurationError(f"{label} changed after bootstrap inspection") from None
+        try:
+            path.lstat()
+        except FileNotFoundError:
+            observed = None
+        except OSError as exc:
+            raise ConfigurationError(f"{label} could not be classified") from exc
+        else:
+            raise ConfigurationError(f"{label} appeared after bootstrap inspection") from None
+    else:
+        if snapshot.before is None or observed != snapshot.before:
+            raise ConfigurationError(f"{label} changed after bootstrap inspection")
+    if snapshot.before is None:
+        try:
+            path.symlink_to(target, target_is_directory=target.is_dir())
+            _fsync_directory(path.parent)
+        except FileExistsError as exc:
+            raise ConfigurationError(f"{label} appeared before activation") from exc
+        _verify_stable_symlink(path, expected=target, label=label)
+        if os.readlink(path) != str(target):  # pragma: no cover - written above
+            raise ConfigurationError(f"{label} did not use its canonical target")
+        return action
+    exchanged = False
+    try:
+        temporary.symlink_to(target, target_is_directory=target.is_dir())
+        desired = _capture_activation_object(
+            temporary,
+            kind="symlink",
+            maximum=4096,
+        )
+        if _activation_path_identity(snapshot) != snapshot.before:
+            raise ConfigurationError(f"{label} changed before activation")
+        exchanged = True
+        _atomic_exchange_paths(temporary, path)
+        try:
+            displaced = _capture_activation_object(
+                temporary,
+                kind=snapshot.kind,
+                maximum=4 * 1024 * 1024,
+            )
+        except ConfigurationError:
+            displaced = None
+        if displaced is None or not _activation_identity_matches_after_rename(
+            snapshot.before, displaced
+        ):
+            try:
+                active = _capture_activation_object(
+                    path,
+                    kind="symlink",
+                    maximum=4096,
+                )
+            except ConfigurationError as exc:
+                raise ConfigurationError(
+                    f"{label} changed during atomic activation; "
+                    f"displaced state retained at {temporary}"
+                ) from exc
+            if not _activation_identity_matches_after_rename(desired, active):
+                raise ConfigurationError(
+                    f"{label} changed during atomic activation; "
+                    f"displaced state retained at {temporary}"
+                )
+            _atomic_exchange_paths(temporary, path)
+            exchanged = False
+            _fsync_directory(path.parent)
+            raise ConfigurationError(f"{label} changed before atomic activation")
+        try:
+            active = _capture_activation_object(
+                path,
+                kind="symlink",
+                maximum=4096,
+            )
+        except ConfigurationError as exc:
+            temporary.unlink()
+            exchanged = False
+            _fsync_directory(path.parent)
+            raise ConfigurationError(f"{label} changed after atomic activation") from exc
+        if not _activation_identity_matches_after_rename(desired, active):
+            temporary.unlink()
+            exchanged = False
+            _fsync_directory(path.parent)
+            raise ConfigurationError(f"{label} changed after atomic activation")
+        temporary.unlink()
+        exchanged = False
+        _fsync_directory(path.parent)
+    except BaseException:
+        if not exchanged:
+            with suppress(OSError):
+                temporary.unlink(missing_ok=True)
+        raise
+    _verify_stable_symlink(path, expected=target, label=label)
+    if os.readlink(path) != str(target):  # pragma: no cover - written above
+        raise ConfigurationError(f"{label} did not use its canonical target")
+    return action
+
+
+def reconcile_staged_activation_links(
+    plan: BootstrapReconcilePlan,
+    *,
+    generation: Path,
+    home: Path | None = None,
+) -> dict[str, object]:
+    """Idempotently finish one fenced generation activation after any crash boundary."""
+    if plan.mode not in {"relay-only", "component-upgrade"}:
+        raise ConfigurationError("staged activation requires a replacement reconcile plan")
+    expected_names = {
+        "current",
+        "install_receipt",
+        "relay_launcher",
+        "jarvis_launcher",
+        "managed_repo",
+    }
+    if set(plan.activation_paths) != expected_names:
+        raise ConfigurationError("staged activation plan omitted its path identities")
+    lexical_home = Path(os.path.abspath((home or Path.home()).expanduser()))
+    expected_generation = (
+        lexical_home / ".local/share/clio-relay/generations" / plan.desired_fingerprint
+    )
+    if generation != expected_generation or generation.is_symlink() or not generation.is_dir():
+        raise ConfigurationError("staged activation generation path is invalid")
+    targets = {
+        "current": generation,
+        "install_receipt": lexical_home / ".local/share/clio-relay/current/install-receipt.json",
+        "relay_launcher": lexical_home / ".local/share/clio-relay/current/bin/clio-relay",
+        "jarvis_launcher": lexical_home / ".local/share/clio-relay/current/bin/jarvis",
+        "managed_repo": lexical_home
+        / ".local/share/clio-relay/current/source/jarvis-packages/clio_relay",
+    }
+    for name, target_path in {
+        "current": lexical_home / ".local/share/clio-relay/current",
+        "install_receipt": lexical_home / ".local/share/clio-relay/install-receipt.json",
+        "relay_launcher": lexical_home / ".local/bin/clio-relay",
+        "jarvis_launcher": lexical_home / ".local/bin/jarvis",
+        "managed_repo": lexical_home / ".local/share/clio-relay/managed-jarvis-repo",
+    }.items():
+        if Path(plan.activation_paths[name].path) != target_path:
+            raise ConfigurationError(f"staged activation path destination changed: {name}")
+    actions: dict[str, str] = {}
+    for name in (
+        "current",
+        "install_receipt",
+        "relay_launcher",
+        "jarvis_launcher",
+        "managed_repo",
+    ):
+        actions[name] = _reconcile_activation_symlink(
+            plan.activation_paths[name],
+            expected_target=targets[name],
+            label=f"bootstrap stable activation path {name}",
+            exchange_identity=plan.desired_fingerprint,
+        )
+    return {
+        "schema_version": "clio-relay.bootstrap-activation.v1",
+        "generation": plan.desired_fingerprint,
+        "actions": actions,
+    }
 
 
 def _queue_readiness_verified(evidence: dict[str, object] | None) -> bool:
@@ -2246,6 +3032,162 @@ def _cross_handle_stat_identity(value: os.stat_result) -> tuple[int, ...]:
             value.st_mtime_ns,
         )
     return _stat_identity(value)
+
+
+def _atomic_exchange_paths(left: Path, right: Path) -> None:
+    """Atomically exchange two existing pathnames without dropping either object."""
+    if sys.platform == "linux":
+        library = ctypes.CDLL(None, use_errno=True)
+        renameat2 = library.renameat2
+        renameat2.argtypes = (
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_uint,
+        )
+        renameat2.restype = ctypes.c_int
+        result = renameat2(
+            _AT_FDCWD,
+            os.fsencode(left),
+            _AT_FDCWD,
+            os.fsencode(right),
+            _RENAME_EXCHANGE,
+        )
+        if result != 0:
+            error = ctypes.get_errno()
+            raise OSError(error, os.strerror(error), f"{left} <-> {right}")
+        return
+    if os.name != "nt":
+        raise ConfigurationError("atomic bootstrap path exchange requires Linux")
+    # The staged bootstrap runs on Linux. This fallback keeps the path contract
+    # testable on Windows without weakening the supported cluster operation.
+    holding = right.with_name(f".{right.name}.{os.getpid()}.exchange")
+    if holding.exists() or holding.is_symlink():
+        raise ConfigurationError(f"atomic exchange holding path already exists: {holding}")
+    os.replace(right, holding)
+    try:
+        os.replace(left, right)
+    except BaseException:
+        os.replace(holding, right)
+        raise
+    os.replace(holding, left)
+
+
+def _identity_matches_after_rename(
+    before: tuple[int, int, int, int, int, int],
+    after: tuple[int, int, int, int, int, int],
+) -> bool:
+    """Compare file identity while excluding ctime, which rename changes on Linux."""
+    return before[:5] == after[:5]
+
+
+def _activation_identity_matches_after_rename(
+    before: BootstrapActivationPathIdentity,
+    after: BootstrapActivationPathIdentity,
+) -> bool:
+    """Compare a captured activation object after an atomic pathname exchange."""
+    return bool(
+        before.device == after.device
+        and before.inode == after.inode
+        and before.mode == after.mode
+        and before.size == after.size
+        and before.modified_ns == after.modified_ns
+        and before.file_type == after.file_type
+        and before.sha256 == after.sha256
+        and before.symlink_target == after.symlink_target
+    )
+
+
+def verify_atomic_exchange_support(
+    directories: tuple[Path, ...],
+    *,
+    identity: str,
+) -> dict[str, object]:
+    """Exercise and restore atomic exchange on every staged-mutation filesystem."""
+    try:
+        _require_sha256(identity, field="exchange_preflight_identity")
+    except ValueError as exc:
+        raise ConfigurationError(str(exc)) from exc
+    verified: list[str] = []
+    seen: set[Path] = set()
+    for raw_directory in directories:
+        directory = Path(os.path.abspath(raw_directory.expanduser()))
+        try:
+            details = directory.lstat()
+            resolved = directory.resolve(strict=True)
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise ConfigurationError(
+                f"atomic exchange preflight directory is unavailable: {directory}"
+            ) from exc
+        if directory.is_symlink() or not stat.S_ISDIR(details.st_mode):
+            raise ConfigurationError(
+                f"atomic exchange preflight path is not one directory: {directory}"
+            )
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        left = directory / f".clio-relay-exchange-{identity}.left"
+        right = directory / f".clio-relay-exchange-{identity}.right"
+        left_payload = f"left:{identity}\n".encode("ascii")
+        right_payload = f"right:{identity}\n".encode("ascii")
+        if left.exists() or left.is_symlink() or right.exists() or right.is_symlink():
+            try:
+                observed = {
+                    _read_regular_bounded(left, maximum=256),
+                    _read_regular_bounded(right, maximum=256),
+                }
+            except ConfigurationError as exc:
+                raise ConfigurationError(
+                    f"atomic exchange preflight recovery is unproven: {directory}"
+                ) from exc
+            if observed != {left_payload, right_payload}:
+                raise ConfigurationError(
+                    f"atomic exchange preflight recovery is unproven: {directory}"
+                )
+            left.unlink()
+            right.unlink()
+            _fsync_directory(directory)
+        try:
+            for path, payload in ((left, left_payload), (right, right_payload)):
+                with path.open("xb") as stream:
+                    os.chmod(path, 0o600)
+                    stream.write(payload)
+                    stream.flush()
+                    os.fsync(stream.fileno())
+            _fsync_directory(directory)
+            _atomic_exchange_paths(left, right)
+            if (
+                _read_regular_bounded(left, maximum=256) != right_payload
+                or _read_regular_bounded(right, maximum=256) != left_payload
+            ):
+                raise ConfigurationError(
+                    f"atomic exchange preflight produced invalid state: {directory}"
+                )
+            _atomic_exchange_paths(left, right)
+            if (
+                _read_regular_bounded(left, maximum=256) != left_payload
+                or _read_regular_bounded(right, maximum=256) != right_payload
+            ):
+                raise ConfigurationError(
+                    f"atomic exchange preflight did not restore state: {directory}"
+                )
+            left.unlink()
+            right.unlink()
+            _fsync_directory(directory)
+        except BaseException:
+            with suppress(OSError):
+                left.unlink(missing_ok=True)
+            with suppress(OSError):
+                right.unlink(missing_ok=True)
+            _fsync_directory(directory)
+            raise
+        verified.append(str(directory))
+    return {
+        "schema_version": "clio-relay.atomic-exchange-preflight.v1",
+        "identity": identity,
+        "directories": verified,
+    }
 
 
 def _atomic_json(path: Path, value: object) -> None:

--- a/src/clio_relay/bootstrap_reconcile.py
+++ b/src/clio_relay/bootstrap_reconcile.py
@@ -2107,8 +2107,44 @@ def _verify_uv(path: Path, *, desired: BootstrapDesiredState, reasons: list[str]
     except (OSError, BoundedProcessError) as exc:
         reasons.append(f"uv version probe failed: {exc}")
         return
-    if completed.returncode != 0 or completed.stdout.strip() != f"uv {desired.uv_version}":
+    if completed.returncode != 0 or not _uv_version_output_matches(
+        completed.stdout,
+        expected_version=desired.uv_version,
+    ):
         reasons.append("uv version changed")
+
+
+def _uv_version_output_matches(value: str, *, expected_version: str) -> bool:
+    """Match uv's pinned version with its optional bounded build target."""
+    observed = value
+    if observed.endswith("\r\n"):
+        observed = observed[:-2]
+    elif observed.endswith("\n"):
+        observed = observed[:-1]
+    if (
+        not observed
+        or observed != observed.strip()
+        or any(ord(character) < 32 or ord(character) == 127 for character in observed)
+    ):
+        return False
+    exact = f"uv {expected_version}"
+    if observed == exact:
+        return True
+    prefix = exact + " ("
+    if (
+        len(observed) > len(prefix) + 128
+        or not observed.startswith(prefix)
+        or not observed.endswith(")")
+    ):
+        return False
+    target = observed[len(prefix) : -1]
+    return bool(
+        target
+        and all(
+            character.isascii() and (character.isalnum() or character in {"-", "_", "."})
+            for character in target
+        )
+    )
 
 
 def _expand_home(value: str, home: Path) -> Path:

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -391,6 +391,11 @@ class _CleanupEvidenceLock:
     windows_parent: _WindowsPinnedDirectory | None = None
 
 
+def _optional_runtime_descriptor(descriptor: int | None) -> int | None:
+    """Preserve an OS-selected descriptor as optional across nested helpers."""
+    return descriptor
+
+
 def _windows_parent_guard_names(
     guard: tuple[Path, ctypes.c_void_p] | None,
 ) -> frozenset[str]:
@@ -471,6 +476,8 @@ def _open_windows_pinned_directory(
 
 def _verify_windows_pinned_directory(anchor: _WindowsPinnedDirectory) -> None:
     """Revalidate the named directory while its no-delete-share handle remains open."""
+    if os.name != "nt":  # pragma: no cover - platform contract
+        raise RelayError("Windows directory verification is unavailable")
     storage_path = internal_filesystem_path(anchor.path, force_extended=True)
     observed = os.stat(storage_path, follow_symlinks=False)
     if not os.path.samestat(anchor.status, observed):
@@ -487,6 +494,8 @@ def _close_windows_pinned_directory(anchor: _WindowsPinnedDirectory | None) -> N
     """Close one Windows directory anchor."""
     if anchor is None:
         return
+    if os.name != "nt":  # pragma: no cover - platform contract
+        raise RelayError("Windows directory handles cannot be closed on this platform")
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
     close_handle = kernel32.CloseHandle
     close_handle.argtypes = [ctypes.c_void_p]
@@ -504,6 +513,8 @@ def _windows_cleanup_file_information(
     *,
     path: Path,
 ) -> _WindowsCleanupFileInformation:
+    if os.name != "nt":  # pragma: no cover - platform contract
+        raise RelayError("Windows cleanup handles cannot be inspected on this platform")
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
     get_information = kernel32.GetFileInformationByHandle
     get_information.argtypes = [
@@ -716,6 +727,8 @@ def _release_cleanup_evidence_lock(lock: _CleanupEvidenceLock | None) -> None:
         except BaseException as exc:  # pragma: no cover - OS release failure
             release_error = release_error or exc
     if lock.windows_handle is not None:
+        if os.name != "nt":  # pragma: no cover - corrupt cross-platform state
+            raise RelayError("Windows cleanup evidence handle exists on a non-Windows platform")
         close_handle = ctypes.WinDLL("kernel32", use_last_error=True).CloseHandle
         close_handle.argtypes = [ctypes.c_void_p]
         close_handle.restype = ctypes.c_int
@@ -4279,6 +4292,8 @@ def _persist_local_cleanup_report_artifact(
                     release_private_configuration_windows_parent_guard(directory_windows_guard)
             raise
 
+    parent_fd = _optional_runtime_descriptor(parent_fd)
+    directory_fd = _optional_runtime_descriptor(directory_fd)
     ignored_internal_names = _windows_parent_guard_names(directory_windows_guard)
 
     def verify_directory() -> None:

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -8,6 +8,7 @@ import ctypes
 import hashlib
 import hmac
 import json
+import math
 import os
 import re
 import shlex
@@ -77,7 +78,12 @@ from clio_relay.deployment import (
 )
 from clio_relay.doctor import run_cluster_doctor, run_doctor
 from clio_relay.endpoint import EndpointWorker
-from clio_relay.errors import ConfigurationError, NotFoundError, RelayError
+from clio_relay.errors import (
+    ConfigurationError,
+    NotFoundError,
+    ObservationTimeoutError,
+    RelayError,
+)
 from clio_relay.filesystem_paths import internal_filesystem_path
 from clio_relay.frp_check import run_frpc_connection_check
 from clio_relay.identifiers import validate_durable_record_id
@@ -125,6 +131,7 @@ from clio_relay.models import (
     JarvisRunSpec,
     JobKind,
     JobState,
+    JobWaitResult,
     McpAdmissionClass,
     McpCallSpec,
     McpControlQueryEvidence,
@@ -184,7 +191,9 @@ from clio_relay.relay_ops import (
 )
 from clio_relay.relay_ops import (
     evaluate_monitor_rules,
+    job_wait_result,
     monitor_job,
+    observe_until_terminal,
     read_artifact_bytes,
     read_job_log,
     wait_for_terminal,
@@ -232,7 +241,10 @@ from clio_relay.scheduler_providers import (
 )
 from clio_relay.scheduler_validation import run_scheduler_lifecycle_validation
 from clio_relay.service_runtime import ServiceRuntimeSupervisor
-from clio_relay.session_api import submit_owned_session_job
+from clio_relay.session_api import (
+    OWNED_SESSION_WAIT_RESPONSE_GRACE_SECONDS,
+    submit_owned_session_job,
+)
 from clio_relay.session_lifecycle import (
     MAX_OWNED_SESSION_CLEANUP_FINALIZE_BYTES,
     MAX_OWNED_SESSION_CLEANUP_REPORT_BYTES,
@@ -306,6 +318,7 @@ DEFAULT_RELAY_CANCEL_POLL_SECONDS = 0.25
 MAX_RELAY_CANCEL_TIMEOUT_SECONDS = 3_600.0
 REMOTE_CLEANUP_COMMAND_TIMEOUT_SECONDS = 120.0
 REMOTE_CLEANUP_WORKER_INFO_TIMEOUT_SECONDS = 20.0
+REMOTE_JOB_WAIT_STATUS_TIMEOUT_SECONDS = 30.0
 MAX_FINALIZED_CLEANUP_RETRY_OUTPUT_BYTES = 1024 * 1024
 MAX_CLEANUP_VALIDATION_REPORT_BYTES = 8 * 1024 * 1024
 MAX_LOCAL_CLEANUP_REPORT_CHUNK_BYTES = 8 * 1024 * 1024
@@ -7470,26 +7483,24 @@ def job_wait(
     ] = None,
     timeout_seconds: Annotated[
         float,
-        typer.Option(help="Maximum seconds to wait for terminal state."),
+        typer.Option(help="Maximum seconds for this terminal-state observation."),
     ] = 600,
     poll_seconds: Annotated[float, typer.Option(help="Polling interval.")] = 2,
 ) -> None:
-    """Wait until a job reaches terminal state."""
-    if _try_remote_cluster_passthrough(
+    """Observe until terminal, returning current durable state when the bound expires."""
+    if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+        raise typer.BadParameter("timeout-seconds must be positive and finite")
+    if not math.isfinite(poll_seconds) or poll_seconds <= 0:
+        raise typer.BadParameter("poll-seconds must be positive and finite")
+    if _try_remote_job_wait_passthrough(
         cluster,
-        [
-            "job",
-            "wait",
-            job_id,
-            "--timeout-seconds",
-            str(timeout_seconds),
-            "--poll-seconds",
-            str(poll_seconds),
-        ],
+        job_id=job_id,
+        timeout_seconds=timeout_seconds,
+        poll_seconds=poll_seconds,
     ):
         return
     queue = ClioCoreQueue(RelaySettings.from_env().core_dir)
-    job = wait_for_terminal(
+    job = observe_until_terminal(
         queue,
         job_id,
         timeout_seconds=timeout_seconds,
@@ -15997,6 +16008,79 @@ def _try_remote_cluster_passthrough(cluster: str | None, args: list[str]) -> boo
     if not should_execute_on_cluster(definition):
         return False
     _run_remote_or_exit(definition, args)
+    return True
+
+
+def _try_remote_job_wait_passthrough(
+    cluster: str | None,
+    *,
+    job_id: str,
+    timeout_seconds: float,
+    poll_seconds: float,
+) -> bool:
+    """Run one bounded remote wait and preserve its durable receipt on observation expiry."""
+    if cluster is None:
+        return False
+    if os.getenv("CLIO_RELAY_CLI_MODE", "auto").strip().lower() == "local":
+        return False
+    definition = _require_cluster(cluster)
+    if not should_execute_on_cluster(definition):
+        return False
+    if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+        raise typer.BadParameter("timeout-seconds must be positive and finite")
+    if not math.isfinite(poll_seconds) or poll_seconds <= 0:
+        raise typer.BadParameter("poll-seconds must be positive and finite")
+
+    def action() -> None:
+        try:
+            with remote_command_timeout(
+                timeout_seconds + OWNED_SESSION_WAIT_RESPONSE_GRACE_SECONDS
+            ):
+                payload = run_remote_clio(
+                    definition,
+                    [
+                        "job",
+                        "wait",
+                        job_id,
+                        "--timeout-seconds",
+                        str(timeout_seconds),
+                        "--poll-seconds",
+                        str(poll_seconds),
+                    ],
+                )
+            document = _json_output(payload, "remote job wait")
+            if "observation" in document:
+                try:
+                    result = JobWaitResult.model_validate(document)
+                except ValidationError as exc:
+                    raise RelayError("remote job wait returned an invalid result") from exc
+            else:
+                result = job_wait_result(
+                    RelayJob.model_validate(document),
+                    timeout_seconds=timeout_seconds,
+                )
+        except ObservationTimeoutError as observation_error:
+            with remote_command_timeout(REMOTE_JOB_WAIT_STATUS_TIMEOUT_SECONDS):
+                status = _json_output(
+                    run_remote_clio(definition, ["job", "status", job_id]),
+                    "remote job status after bounded wait",
+                )
+            job = RelayJob.model_validate(status.get("job"))
+            terminal = job.state in {JobState.SUCCEEDED, JobState.FAILED, JobState.CANCELED}
+            if status.get("terminal") is not terminal:
+                raise RelayError(
+                    "remote job status disagrees with its durable job state"
+                ) from observation_error
+            result = job_wait_result(
+                job,
+                timeout_seconds=timeout_seconds,
+            )
+
+        if result.job_id != job_id or result.cluster != cluster:
+            raise RelayError("remote job wait returned a different durable receipt")
+        typer.echo(result.model_dump_json(indent=2))
+
+    _run_or_exit(action)
     return True
 
 

--- a/src/clio_relay/errors.py
+++ b/src/clio_relay/errors.py
@@ -5,6 +5,10 @@ class RelayError(RuntimeError):
     """Base class for relay errors."""
 
 
+class ObservationTimeoutError(RelayError):
+    """A bounded observation transport expired without changing durable work."""
+
+
 class ConfigurationError(RelayError):
     """Raised when required external configuration is absent."""
 

--- a/src/clio_relay/http_api.py
+++ b/src/clio_relay/http_api.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import math
 import os
 import secrets
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
@@ -67,6 +68,7 @@ from clio_relay.models import (
     JarvisRunSpec,
     JobKind,
     JobState,
+    JobWaitResult,
     McpAdmissionAuthority,
     McpAdmissionClass,
     McpCallSpec,
@@ -105,9 +107,9 @@ from clio_relay.relay_ops import (
 from clio_relay.relay_ops import (
     evaluate_monitor_rules,
     monitor_job,
+    observe_until_terminal,
     read_artifact_bytes,
     read_job_log,
-    wait_for_terminal,
 )
 from clio_relay.relay_ops import (
     job_status as get_job_status_operation,
@@ -1431,16 +1433,30 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
         except WebSocketDisconnect:
             return
 
-    @app.post("/jobs/{job_id}/wait", response_model=RelayJob, dependencies=[auth_dependency])
+    @app.post(
+        "/jobs/{job_id}/wait",
+        response_model=JobWaitResult,
+        dependencies=[auth_dependency],
+    )
     def wait(
         job_id: DurableRecordId,
         timeout_seconds: float = 600,
         poll_seconds: float = 2,
-    ) -> RelayJob:
+    ) -> JobWaitResult:
+        if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+            raise HTTPException(
+                status_code=422,
+                detail="timeout_seconds must be positive and finite",
+            )
+        if not math.isfinite(poll_seconds) or poll_seconds <= 0:
+            raise HTTPException(
+                status_code=422,
+                detail="poll_seconds must be positive and finite",
+            )
         try:
             require_owned_job(job_id)
             return _public_record(
-                wait_for_terminal(
+                observe_until_terminal(
                     queue,
                     job_id,
                     timeout_seconds=timeout_seconds,
@@ -1449,8 +1465,6 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
             )
         except NotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
-        except TimeoutError as exc:
-            raise HTTPException(status_code=408, detail=str(exc)) from exc
 
     @app.get("/jobs/{job_id}/logs/{stream_name}", dependencies=[auth_dependency])
     def get_log(

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -3673,7 +3673,11 @@ def _submit_jarvis_job(
         ),
         settings=settings,
     )
-    return _submission_result(job, arguments, queue=queue, definition=definition)
+    wait_arguments = {
+        **arguments,
+        "wait_timeout_seconds": arguments.get("timeout_seconds", 600),
+    }
+    return _submission_result(job, wait_arguments, queue=queue, definition=definition)
 
 
 def _submit_remote_agent(

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -11,6 +11,7 @@ import math
 import os
 import re
 import sys
+from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from json import JSONDecodeError
@@ -28,7 +29,11 @@ from clio_relay.cluster_config import (
 )
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
-from clio_relay.errors import ConfigurationError, NotFoundError
+from clio_relay.errors import (
+    ConfigurationError,
+    NotFoundError,
+    ObservationTimeoutError,
+)
 from clio_relay.filesystem_paths import logical_filesystem_text
 from clio_relay.identifiers import (
     durable_record_id_json_schema,
@@ -55,6 +60,7 @@ from clio_relay.jarvis_service_runtime import (
 )
 from clio_relay.models import (
     MCP_ADMISSION_AUTHORITY_METADATA_KEY,
+    TERMINAL_STATES,
     ArtifactRef,
     ArtifactUse,
     Cursor,
@@ -63,6 +69,7 @@ from clio_relay.models import (
     JarvisRunSpec,
     JobKind,
     JobState,
+    JobWaitResult,
     McpAdmissionClass,
     McpCallSpec,
     McpControlQueryEvidence,
@@ -102,6 +109,7 @@ from clio_relay.relay_ops import (
     wait_for_terminal,
 )
 from clio_relay.remote_cli import (
+    remote_command_timeout,
     remove_remote_file,
     run_remote_clio,
     should_execute_on_cluster,
@@ -151,13 +159,14 @@ MCP_RESULT_INLINE_LIMIT_MESSAGE = (
 JARVIS_WAIT_FOR_TERMINAL_DESCRIPTION = (
     "Observe this submission until it becomes terminal within the current call. "
     "The observation bound never becomes a relay, JARVIS, or scheduler execution "
-    "deadline and never fails, cancels, or resubmits the underlying job."
+    "deadline and never fails, cancels, or resubmits the underlying job. Expiry returns "
+    "the same receipt with observation.outcome=observation_unknown."
 )
 JARVIS_WAIT_TIMEOUT_DESCRIPTION = (
     "Maximum seconds to observe this submission in the current call when "
     "wait_for_terminal is true. Observation expiry never fails, cancels, or "
-    "resubmits the underlying relay, JARVIS, or scheduler job; preserve the job "
-    "receipt and observe it again later."
+    "resubmits the underlying relay, JARVIS, or scheduler job; expiry returns the same "
+    "receipt with observation.outcome=observation_unknown so it can be observed again later."
 )
 JARVIS_LEGACY_WAIT_TIMEOUT_DESCRIPTION = (
     "Deprecated observation-only alias for wait_timeout_seconds. It is not an "
@@ -167,6 +176,7 @@ JARVIS_LEGACY_WAIT_TIMEOUT_DESCRIPTION = (
 )
 MAX_OBSERVE_MATCHES = 100
 MAX_OBSERVE_MATCH_TEXT_CHARS = 1_024
+REMOTE_WAIT_STATUS_TIMEOUT_SECONDS = 30.0
 USER_MCP_TOOL_NAMES = {
     "relay_remote_mcp_context",
     "relay_submit_agent",
@@ -602,7 +612,9 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                 "Observe a relay job for a bounded period and return final status, verified "
                 "MCP result evidence, and optional logs if it finishes. Observation expiry "
                 "never fails, cancels, or resubmits the underlying relay, JARVIS, or scheduler "
-                "job. Preserve the receipt and call relay_wait again later. For a remote job, "
+                "job; it returns current durable status with "
+                "observation.outcome=observation_unknown. Preserve the receipt and call "
+                "relay_wait again later. For a remote job, "
                 "copy cluster, job_id, and "
                 "route_revision unchanged from its submission receipt on every follow-up "
                 "call, including on the same MCP connection. job_id alone is only for a "
@@ -3391,26 +3403,31 @@ def _observe_job(arguments: JSON, *, queue: ClioCoreQueue, settings: RelaySettin
 def _wait_job(arguments: JSON, *, queue: ClioCoreQueue, settings: RelaySettings) -> JSON:
     job_id = _required_durable_record_id(arguments, "job_id")
     target = _job_target(arguments)
+    timeout_seconds = _observation_timeout_seconds(arguments, "timeout_seconds")
+    poll_seconds = _observation_timeout_seconds(arguments, "poll_seconds", default=2.0)
     logs: JSON | None = None
     if target is not None and should_execute_on_cluster(target):
         if settings.owner_session_id is not None:
+            try:
+                with OwnedSessionApiClient(definition=target, settings=settings) as client:
+                    waited = _owned_json(
+                        client,
+                        method="POST",
+                        path=f"/jobs/{job_id}/wait",
+                        query={
+                            "timeout_seconds": timeout_seconds,
+                            "poll_seconds": poll_seconds,
+                        },
+                        label="owned remote job wait",
+                        response_timeout_seconds=(
+                            timeout_seconds + OWNED_SESSION_WAIT_RESPONSE_GRACE_SECONDS
+                        ),
+                    )
+                    if waited.get("job_id") != job_id or waited.get("cluster") != target.name:
+                        raise ValueError("owned remote wait returned a different job")
+            except ObservationTimeoutError:
+                pass
             with OwnedSessionApiClient(definition=target, settings=settings) as client:
-                waited = _owned_json(
-                    client,
-                    method="POST",
-                    path=f"/jobs/{job_id}/wait",
-                    query={
-                        "timeout_seconds": float(arguments.get("timeout_seconds", 600)),
-                        "poll_seconds": float(arguments.get("poll_seconds", 2)),
-                    },
-                    label="owned remote job wait",
-                    response_timeout_seconds=(
-                        float(arguments.get("timeout_seconds", 600))
-                        + OWNED_SESSION_WAIT_RESPONSE_GRACE_SECONDS
-                    ),
-                )
-                if waited.get("job_id") != job_id or waited.get("cluster") != target.name:
-                    raise ValueError("owned remote wait returned a different job")
                 result = _owned_json(
                     client,
                     method="GET",
@@ -3418,11 +3435,20 @@ def _wait_job(arguments: JSON, *, queue: ClioCoreQueue, settings: RelaySettings)
                     label="owned remote job status",
                 )
                 _validate_owned_job_status(result, job_id=job_id, cluster=target.name)
-                source_job = _terminal_remote_wait_job(
+                source_job, observation_unknown = _observed_remote_wait_job(
                     result,
                     job_id=job_id,
                     cluster=target.name,
                 )
+                if observation_unknown:
+                    _attach_wait_observation(
+                        result,
+                        observation_unknown=True,
+                        timeout_seconds=timeout_seconds,
+                    )
+                    result["cluster"] = target.name
+                    result["route_revision"] = _route_revision(target)
+                    return result
                 if arguments.get("include_logs", False) is True:
                     logs = _owned_job_logs(
                         client,
@@ -3437,24 +3463,40 @@ def _wait_job(arguments: JSON, *, queue: ClioCoreQueue, settings: RelaySettings)
                 )
                 parsed_result = _verified_owned_mcp_result(client, job_id, artifact_records)
         else:
-            run_remote_clio(
-                target,
-                [
-                    "job",
-                    "wait",
-                    job_id,
-                    "--timeout-seconds",
-                    str(float(arguments.get("timeout_seconds", 600))),
-                    "--poll-seconds",
-                    str(float(arguments.get("poll_seconds", 2))),
-                ],
-            )
-            result = _remote_json(target, ["job", "status", job_id], "remote job status")
-            source_job = _terminal_remote_wait_job(
+            try:
+                with remote_command_timeout(
+                    timeout_seconds + OWNED_SESSION_WAIT_RESPONSE_GRACE_SECONDS
+                ):
+                    run_remote_clio(
+                        target,
+                        [
+                            "job",
+                            "wait",
+                            job_id,
+                            "--timeout-seconds",
+                            str(timeout_seconds),
+                            "--poll-seconds",
+                            str(poll_seconds),
+                        ],
+                    )
+            except ObservationTimeoutError:
+                pass
+            with remote_command_timeout(REMOTE_WAIT_STATUS_TIMEOUT_SECONDS):
+                result = _remote_json(target, ["job", "status", job_id], "remote job status")
+            source_job, observation_unknown = _observed_remote_wait_job(
                 result,
                 job_id=job_id,
                 cluster=target.name,
             )
+            if observation_unknown:
+                _attach_wait_observation(
+                    result,
+                    observation_unknown=True,
+                    timeout_seconds=timeout_seconds,
+                )
+                result["cluster"] = target.name
+                result["route_revision"] = _route_revision(target)
+                return result
             if arguments.get("include_logs", False) is True:
                 logs = _remote_job_logs(
                     target,
@@ -3470,13 +3512,24 @@ def _wait_job(arguments: JSON, *, queue: ClioCoreQueue, settings: RelaySettings)
             parsed_result = _verified_mcp_result(target, job_id, artifact_records)
     else:
         _require_local_job_cluster(queue, job_id, target)
-        source_job = wait_for_terminal(
-            queue,
-            job_id,
-            timeout_seconds=float(arguments.get("timeout_seconds", 600)),
-            poll_seconds=float(arguments.get("poll_seconds", 2)),
-        )
-        result = job_status(queue, source_job.job_id)
+        with suppress(TimeoutError):
+            wait_for_terminal(
+                queue,
+                job_id,
+                timeout_seconds=timeout_seconds,
+                poll_seconds=poll_seconds,
+            )
+        result = job_status(queue, job_id)
+        source_job = RelayJob.model_validate(_object(result.get("job")))
+        if source_job.job_id != job_id:
+            raise ValueError("local wait status returned a different job")
+        if source_job.state not in TERMINAL_STATES:
+            _attach_wait_observation(
+                result,
+                observation_unknown=True,
+                timeout_seconds=timeout_seconds,
+            )
+            return result
         if arguments.get("include_logs", False) is True:
             logs = _job_logs(
                 queue,
@@ -3494,6 +3547,11 @@ def _wait_job(arguments: JSON, *, queue: ClioCoreQueue, settings: RelaySettings)
     if target is not None:
         result["cluster"] = target.name
         result["route_revision"] = _route_revision(target)
+    _attach_wait_observation(
+        result,
+        observation_unknown=False,
+        timeout_seconds=timeout_seconds,
+    )
     if parsed_result is not None:
         _attach_terminal_mcp_evidence(
             result,
@@ -3508,23 +3566,33 @@ def _wait_job(arguments: JSON, *, queue: ClioCoreQueue, settings: RelaySettings)
     return result
 
 
-def _terminal_remote_wait_job(
+def _observed_remote_wait_job(
     result: JSON,
     *,
     job_id: str,
     cluster: str,
-) -> RelayJob:
-    """Validate the exact terminal remote job backing a generic wait result."""
+) -> tuple[RelayJob, bool]:
+    """Validate an exact remote job after one bounded terminal observation."""
 
     source_job = RelayJob.model_validate(_object(result.get("job")))
     if source_job.job_id != job_id or source_job.cluster != cluster:
         raise ValueError("remote wait returned a different job")
-    if (
-        source_job.state not in {JobState.SUCCEEDED, JobState.FAILED, JobState.CANCELED}
-        or result.get("terminal") is not True
-    ):
-        raise ValueError("remote wait did not return one terminal job")
-    return source_job
+    terminal = source_job.state in TERMINAL_STATES
+    if result.get("terminal") is not terminal:
+        raise ValueError("remote wait status disagrees with its durable job state")
+    return source_job, not terminal
+
+
+def _relay_job_from_wait_document(document: JSON) -> RelayJob:
+    """Validate current and legacy HTTP wait documents without discarding the outcome."""
+    if "observation" not in document:
+        return RelayJob.model_validate(document)
+    result = JobWaitResult.model_validate(document)
+    terminal = result.state in TERMINAL_STATES
+    expected_outcome = "terminal" if terminal else "observation_unknown"
+    if result.observation.outcome != expected_outcome:
+        raise ValueError("remote wait observation disagrees with its durable job state")
+    return result
 
 
 def _job_logs(
@@ -3656,19 +3724,12 @@ def _submit_jarvis_pipeline(
         ),
         settings=settings,
     )
-    if bool(arguments.get("wait_for_terminal", False)):
-        job = wait_for_terminal(
-            queue,
-            job.job_id,
-            timeout_seconds=wait_timeout_seconds,
-            poll_seconds=float(arguments.get("poll_seconds", 2)),
-        )
-    return {
-        "job_id": job.job_id,
-        "state": job.state.value,
-        "kind": job.kind.value,
-        "terminal": job.state.value in {"succeeded", "failed", "canceled"},
-    }
+    return _submission_result(
+        job,
+        {**arguments, "wait_timeout_seconds": wait_timeout_seconds},
+        queue=queue,
+        definition=definition,
+    )
 
 
 def _submit_jarvis_job(
@@ -4162,25 +4223,52 @@ def _remote_mcp_submission_result(
     if not bool(arguments.get("wait_for_terminal", False)):
         return result
     job_id = _required_durable_record_id(result, "job_id")
-    run_remote_clio(
-        definition,
-        [
-            "job",
-            "wait",
-            job_id,
-            "--timeout-seconds",
-            str(float(arguments.get("wait_timeout_seconds", 600))),
-            "--poll-seconds",
-            str(float(arguments.get("poll_seconds", 2))),
-        ],
+    wait_timeout_seconds = _observation_timeout_seconds(
+        arguments,
+        "wait_timeout_seconds",
     )
-    status = _remote_json(definition, ["job", "status", job_id], "remote job status")
+    try:
+        with remote_command_timeout(
+            wait_timeout_seconds + OWNED_SESSION_WAIT_RESPONSE_GRACE_SECONDS
+        ):
+            run_remote_clio(
+                definition,
+                [
+                    "job",
+                    "wait",
+                    job_id,
+                    "--timeout-seconds",
+                    str(wait_timeout_seconds),
+                    "--poll-seconds",
+                    str(
+                        _observation_timeout_seconds(
+                            arguments,
+                            "poll_seconds",
+                            default=2.0,
+                        )
+                    ),
+                ],
+            )
+    except ObservationTimeoutError:
+        pass
+    with remote_command_timeout(REMOTE_WAIT_STATUS_TIMEOUT_SECONDS):
+        status = _remote_json(definition, ["job", "status", job_id], "remote job status")
     job = _object(status.get("job"))
     if job.get("job_id") != job_id or job.get("cluster") != definition.name:
         raise ValueError("remote MCP wait returned a different job")
-    state = job.get("state")
-    if state not in {"succeeded", "failed", "canceled"} or status.get("terminal") is not True:
-        raise ValueError("remote MCP wait did not return one terminal job")
+    source_job = RelayJob.model_validate(job)
+    state = source_job.state.value
+    terminal = source_job.state in TERMINAL_STATES
+    if status.get("terminal") is not terminal:
+        raise ValueError("remote MCP wait status disagrees with its durable job state")
+    result.update({"state": state, "terminal": terminal})
+    _attach_wait_observation(
+        result,
+        observation_unknown=not terminal,
+        timeout_seconds=wait_timeout_seconds,
+    )
+    if not terminal:
+        return result
     artifacts = _complete_remote_collection(
         definition,
         ["job", "list-artifacts", job_id],
@@ -4188,7 +4276,6 @@ def _remote_mcp_submission_result(
         label=f"remote artifacts for {job_id}",
     )
     parsed_result = _verified_mcp_result(definition, job_id, artifacts)
-    result.update({"state": state, "terminal": True})
     logs: JSON | None = None
     if arguments.get("include_logs", False) is True:
         logs = _remote_job_logs(
@@ -4199,7 +4286,6 @@ def _remote_mcp_submission_result(
     last_error = job.get("last_error")
     if last_error is not None and not isinstance(last_error, str):
         raise ValueError("remote MCP job returned an invalid last_error")
-    source_job = RelayJob.model_validate(job)
     _attach_terminal_mcp_evidence(
         result,
         source_job=source_job,
@@ -4228,36 +4314,38 @@ def _owned_session_submission_result(
     artifacts: list[JSON] = []
     parsed_result: _VerifiedMcpResult | None = None
     logs: JSON | None = None
+    observation_unknown = False
     if wait_for_terminal_result:
-        with OwnedSessionApiClient(definition=definition, settings=settings) as client:
-            document = _owned_json(
-                client,
-                method="POST",
-                path=f"/jobs/{job.job_id}/wait",
-                query={
-                    "timeout_seconds": wait_timeout_seconds,
-                    "poll_seconds": poll_seconds,
-                },
-                label="owned remote submitted job wait",
-                response_timeout_seconds=(
-                    wait_timeout_seconds + OWNED_SESSION_WAIT_RESPONSE_GRACE_SECONDS
-                ),
-            )
-            waited = RelayJob.model_validate(document)
-            if include_terminal_mcp_result:
-                artifacts = _complete_owned_collection(
+        try:
+            with OwnedSessionApiClient(definition=definition, settings=settings) as client:
+                document = _owned_json(
                     client,
-                    path=f"/jobs/{job.job_id}/artifacts",
-                    record_key="artifacts",
-                    label=f"owned remote artifacts for {job.job_id}",
+                    method="POST",
+                    path=f"/jobs/{job.job_id}/wait",
+                    query={
+                        "timeout_seconds": wait_timeout_seconds,
+                        "poll_seconds": poll_seconds,
+                    },
+                    label="owned remote submitted job wait",
+                    response_timeout_seconds=(
+                        wait_timeout_seconds + OWNED_SESSION_WAIT_RESPONSE_GRACE_SECONDS
+                    ),
                 )
-                parsed_result = _verified_owned_mcp_result(client, job.job_id, artifacts)
-            if include_terminal_logs:
-                logs = _owned_job_logs(
+                waited = _relay_job_from_wait_document(document)
+        except ObservationTimeoutError:
+            with OwnedSessionApiClient(definition=definition, settings=settings) as client:
+                status = _owned_json(
                     client,
-                    job.job_id,
-                    limit=terminal_log_limit,
+                    method="GET",
+                    path=f"/jobs/{job.job_id}/status",
+                    label="owned remote submitted job status after bounded wait",
                 )
+                _validate_owned_job_status(
+                    status,
+                    job_id=job.job_id,
+                    cluster=definition.name,
+                )
+                waited = RelayJob.model_validate(_object(status.get("job")))
         if (
             waited.job_id != job.job_id
             or waited.cluster != definition.name
@@ -4266,7 +4354,24 @@ def _owned_session_submission_result(
             != settings.owner_session_generation_id
         ):
             raise ValueError("owned remote wait returned a different submission receipt")
+        observation_unknown = waited.state not in TERMINAL_STATES
         job = waited
+        if not observation_unknown and (include_terminal_mcp_result or include_terminal_logs):
+            with OwnedSessionApiClient(definition=definition, settings=settings) as client:
+                if include_terminal_mcp_result:
+                    artifacts = _complete_owned_collection(
+                        client,
+                        path=f"/jobs/{job.job_id}/artifacts",
+                        record_key="artifacts",
+                        label=f"owned remote artifacts for {job.job_id}",
+                    )
+                    parsed_result = _verified_owned_mcp_result(client, job.job_id, artifacts)
+                if include_terminal_logs:
+                    logs = _owned_job_logs(
+                        client,
+                        job.job_id,
+                        limit=terminal_log_limit,
+                    )
     result: JSON = {
         "cluster": definition.name,
         "job_id": job.job_id,
@@ -4276,7 +4381,13 @@ def _owned_session_submission_result(
         "remote": True,
         "route_revision": _route_revision(definition),
     }
-    if wait_for_terminal_result and include_terminal_mcp_result:
+    if wait_for_terminal_result:
+        _attach_wait_observation(
+            result,
+            observation_unknown=observation_unknown,
+            timeout_seconds=wait_timeout_seconds,
+        )
+    if wait_for_terminal_result and not observation_unknown and include_terminal_mcp_result:
         _attach_terminal_mcp_evidence(
             result,
             source_job=job,
@@ -4284,7 +4395,7 @@ def _owned_session_submission_result(
             artifacts=artifacts,
             parsed_result=parsed_result,
         )
-    if wait_for_terminal_result and logs is not None:
+    if wait_for_terminal_result and not observation_unknown and logs is not None:
         result["logs"] = logs
     return result
 
@@ -4508,13 +4619,26 @@ def _submission_result(
     include_terminal_mcp_result: bool = False,
 ) -> JSON:
     waited = bool(arguments.get("wait_for_terminal", False))
+    observation_unknown = False
+    wait_timeout_seconds = _observation_timeout_seconds(
+        arguments,
+        "wait_timeout_seconds",
+    )
     if waited:
-        job = wait_for_terminal(
-            queue,
-            job.job_id,
-            timeout_seconds=float(arguments.get("wait_timeout_seconds", 600)),
-            poll_seconds=float(arguments.get("poll_seconds", 2)),
-        )
+        try:
+            job = wait_for_terminal(
+                queue,
+                job.job_id,
+                timeout_seconds=wait_timeout_seconds,
+                poll_seconds=_observation_timeout_seconds(
+                    arguments,
+                    "poll_seconds",
+                    default=2.0,
+                ),
+            )
+        except TimeoutError:
+            job = queue.get_job(job.job_id)
+        observation_unknown = job.state not in TERMINAL_STATES
     result: JSON = {
         "cluster": job.cluster,
         "job_id": job.job_id,
@@ -4524,7 +4648,13 @@ def _submission_result(
     }
     if definition is not None:
         result["route_revision"] = _route_revision(definition)
-    if waited and include_terminal_mcp_result:
+    if waited:
+        _attach_wait_observation(
+            result,
+            observation_unknown=observation_unknown,
+            timeout_seconds=wait_timeout_seconds,
+        )
+    if waited and not observation_unknown and include_terminal_mcp_result:
         artifacts = _complete_local_artifacts(queue, job.job_id)
         _attach_terminal_mcp_evidence(
             result,
@@ -4533,7 +4663,7 @@ def _submission_result(
             artifacts=artifacts,
             parsed_result=_verified_local_mcp_result(queue, job.job_id),
         )
-    if waited and arguments.get("include_logs", False) is True:
+    if waited and not observation_unknown and arguments.get("include_logs", False) is True:
         if settings is None:
             raise ValueError("local waited log retrieval requires relay settings")
         result["logs"] = _job_logs(
@@ -5002,6 +5132,37 @@ def _positive_float_argument(
     if value <= 0 or value > maximum:
         raise ValueError(f"{field_name} must be greater than 0 and at most {maximum:g}")
     return value
+
+
+def _observation_timeout_seconds(
+    arguments: JSON,
+    field_name: str,
+    *,
+    default: float = 600.0,
+) -> float:
+    """Read one finite positive observation bound without creating an execution deadline."""
+    raw = arguments.get(field_name, default)
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        raise ValueError(f"{field_name} must be a number")
+    value = float(raw)
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError(f"{field_name} must be a finite number greater than 0")
+    return value
+
+
+def _attach_wait_observation(
+    result: JSON,
+    *,
+    observation_unknown: bool,
+    timeout_seconds: float,
+) -> None:
+    """Attach a machine-readable outcome for one bounded wait without mutating its job."""
+    result["observation"] = {
+        "outcome": "observation_unknown" if observation_unknown else "terminal",
+        "timeout_seconds": timeout_seconds,
+        "scheduler_action": "none",
+        "relay_action": "none",
+    }
 
 
 def _jarvis_submission_wait_timeout_seconds(arguments: JSON) -> float:

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -7,6 +7,7 @@ import copy
 import hashlib
 import hmac
 import json
+import math
 import os
 import re
 import sys
@@ -146,6 +147,23 @@ MCP_RESULT_INLINE_LIMIT_MESSAGE = (
     "inline response limit and is unavailable to the agent. Immutable private evidence was "
     "preserved for operator diagnosis. Remote side effects may have occurred; inspect the "
     "job before retrying."
+)
+JARVIS_WAIT_FOR_TERMINAL_DESCRIPTION = (
+    "Observe this submission until it becomes terminal within the current call. "
+    "The observation bound never becomes a relay, JARVIS, or scheduler execution "
+    "deadline and never fails, cancels, or resubmits the underlying job."
+)
+JARVIS_WAIT_TIMEOUT_DESCRIPTION = (
+    "Maximum seconds to observe this submission in the current call when "
+    "wait_for_terminal is true. Observation expiry never fails, cancels, or "
+    "resubmits the underlying relay, JARVIS, or scheduler job; preserve the job "
+    "receipt and observe it again later."
+)
+JARVIS_LEGACY_WAIT_TIMEOUT_DESCRIPTION = (
+    "Deprecated observation-only alias for wait_timeout_seconds. It is not an "
+    "execution deadline and never fails, cancels, or resubmits the underlying "
+    "relay, JARVIS, or scheduler job. If both aliases are supplied, their values "
+    "must be equal."
 )
 MAX_OBSERVE_MATCHES = 100
 MAX_OBSERVE_MATCH_TEXT_CHARS = 1_024
@@ -581,8 +599,11 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
         {
             "name": "relay_wait",
             "description": (
-                "Wait for a relay job to finish and return final status, verified MCP result "
-                "evidence, and optional logs. For a remote job, copy cluster, job_id, and "
+                "Observe a relay job for a bounded period and return final status, verified "
+                "MCP result evidence, and optional logs if it finishes. Observation expiry "
+                "never fails, cancels, or resubmits the underlying relay, JARVIS, or scheduler "
+                "job. Preserve the receipt and call relay_wait again later. For a remote job, "
+                "copy cluster, job_id, and "
                 "route_revision unchanged from its submission receipt on every follow-up "
                 "call, including on the same MCP connection. job_id alone is only for a "
                 "local relay job. Treat mcp_result.structured_result as the authoritative "
@@ -598,7 +619,16 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                     "job_id": durable_record_id_json_schema(),
                     "cluster": {"type": "string"},
                     "route_revision": cluster_route_revision_json_schema(),
-                    "timeout_seconds": {"type": "number", "default": 600},
+                    "timeout_seconds": {
+                        "type": "number",
+                        "exclusiveMinimum": 0,
+                        "default": 600,
+                        "description": (
+                            "Maximum seconds for this observation call. Expiry never changes "
+                            "the underlying relay, JARVIS, or scheduler job state and never "
+                            "fails, cancels, or resubmits that work."
+                        ),
+                    },
                     "poll_seconds": {"type": "number", "default": 2},
                     "include_logs": {"type": "boolean", "default": False},
                     "log_limit": {
@@ -618,7 +648,12 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
         },
         {
             "name": "relay_submit_jarvis_pipeline",
-            "description": "Submit a JARVIS pipeline YAML document to a configured relay cluster.",
+            "description": (
+                "Submit a JARVIS pipeline YAML document to a configured relay cluster. "
+                "Submission is asynchronous by default. Any requested wait bounds only the "
+                "current observation; it never limits, fails, cancels, or resubmits the "
+                "underlying relay, JARVIS, or scheduler job."
+            ),
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -626,8 +661,23 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                     "pipeline_yaml": {"type": "string"},
                     "idempotency_key": {"type": "string"},
                     "used_artifact_refs": _artifact_use_refs_json_schema(),
-                    "wait_for_terminal": {"type": "boolean", "default": False},
-                    "timeout_seconds": {"type": "number", "default": 600},
+                    "wait_for_terminal": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": JARVIS_WAIT_FOR_TERMINAL_DESCRIPTION,
+                    },
+                    "wait_timeout_seconds": {
+                        "type": "number",
+                        "exclusiveMinimum": 0,
+                        "default": 600,
+                        "description": JARVIS_WAIT_TIMEOUT_DESCRIPTION,
+                    },
+                    "timeout_seconds": {
+                        "type": "number",
+                        "exclusiveMinimum": 0,
+                        "deprecated": True,
+                        "description": JARVIS_LEGACY_WAIT_TIMEOUT_DESCRIPTION,
+                    },
                     "poll_seconds": {"type": "number", "default": 2},
                 },
                 "required": ["cluster", "pipeline_yaml"],
@@ -637,7 +687,10 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
         {
             "name": "relay_submit_jarvis_job",
             "description": (
-                "Submit an existing JARVIS pipeline by name on a configured relay cluster."
+                "Submit an existing JARVIS pipeline by name on a configured relay cluster. "
+                "Submission is asynchronous by default. Any requested wait bounds only the "
+                "current observation; it never limits, fails, cancels, or resubmits the "
+                "underlying relay, JARVIS, or scheduler job."
             ),
             "inputSchema": {
                 "type": "object",
@@ -646,8 +699,23 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                     "pipeline_name": {"type": "string"},
                     "idempotency_key": {"type": "string"},
                     "used_artifact_refs": _artifact_use_refs_json_schema(),
-                    "wait_for_terminal": {"type": "boolean", "default": False},
-                    "timeout_seconds": {"type": "number", "default": 600},
+                    "wait_for_terminal": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": JARVIS_WAIT_FOR_TERMINAL_DESCRIPTION,
+                    },
+                    "wait_timeout_seconds": {
+                        "type": "number",
+                        "exclusiveMinimum": 0,
+                        "default": 600,
+                        "description": JARVIS_WAIT_TIMEOUT_DESCRIPTION,
+                    },
+                    "timeout_seconds": {
+                        "type": "number",
+                        "exclusiveMinimum": 0,
+                        "deprecated": True,
+                        "description": JARVIS_LEGACY_WAIT_TIMEOUT_DESCRIPTION,
+                    },
                     "poll_seconds": {"type": "number", "default": 2},
                 },
                 "required": ["cluster", "pipeline_name"],
@@ -3542,6 +3610,7 @@ def _submit_jarvis_pipeline(
 ) -> JSON:
     cluster = _required_str(arguments, "cluster")
     pipeline_yaml = _required_str(arguments, "pipeline_yaml")
+    wait_timeout_seconds = _jarvis_submission_wait_timeout_seconds(arguments)
     used_artifact_refs = _artifact_use_refs(arguments)
     digest = hashlib.sha256(pipeline_yaml.encode("utf-8")).hexdigest()
     dependency_digest = _stable_digest(
@@ -3573,7 +3642,7 @@ def _submit_jarvis_pipeline(
             definition=definition,
             settings=settings,
             wait_for_terminal_result=bool(arguments.get("wait_for_terminal", False)),
-            wait_timeout_seconds=float(arguments.get("timeout_seconds", 600)),
+            wait_timeout_seconds=wait_timeout_seconds,
             poll_seconds=float(arguments.get("poll_seconds", 2)),
         )
     job = _submit_local_job(
@@ -3591,7 +3660,7 @@ def _submit_jarvis_pipeline(
         job = wait_for_terminal(
             queue,
             job.job_id,
-            timeout_seconds=float(arguments.get("timeout_seconds", 600)),
+            timeout_seconds=wait_timeout_seconds,
             poll_seconds=float(arguments.get("poll_seconds", 2)),
         )
     return {
@@ -3609,6 +3678,7 @@ def _submit_jarvis_job(
     settings: RelaySettings,
 ) -> JSON:
     cluster = _required_str(arguments, "cluster")
+    wait_timeout_seconds = _jarvis_submission_wait_timeout_seconds(arguments)
     used_artifact_refs = _artifact_use_refs(arguments)
     dependency_digest = _stable_digest(
         {"used_artifact_refs": [item.model_dump(mode="json") for item in used_artifact_refs]}
@@ -3640,8 +3710,15 @@ def _submit_jarvis_job(
                 definition=definition,
                 settings=settings,
                 wait_for_terminal_result=bool(arguments.get("wait_for_terminal", False)),
-                wait_timeout_seconds=float(arguments.get("timeout_seconds", 600)),
+                wait_timeout_seconds=wait_timeout_seconds,
                 poll_seconds=float(arguments.get("poll_seconds", 2)),
+            )
+        if bool(arguments.get("wait_for_terminal", False)):
+            raise ValueError(
+                "wait_for_terminal is unavailable for a direct remote JARVIS pipeline "
+                "submission without an owned relay session; submit asynchronously, preserve "
+                "the remote receipt, and call relay_wait with its cluster, job_id, and "
+                "route_revision"
             )
         remote_args = [
             "job",
@@ -3675,7 +3752,7 @@ def _submit_jarvis_job(
     )
     wait_arguments = {
         **arguments,
-        "wait_timeout_seconds": arguments.get("timeout_seconds", 600),
+        "wait_timeout_seconds": wait_timeout_seconds,
     }
     return _submission_result(job, wait_arguments, queue=queue, definition=definition)
 
@@ -4925,6 +5002,33 @@ def _positive_float_argument(
     if value <= 0 or value > maximum:
         raise ValueError(f"{field_name} must be greater than 0 and at most {maximum:g}")
     return value
+
+
+def _jarvis_submission_wait_timeout_seconds(arguments: JSON) -> float:
+    """Resolve canonical and legacy JARVIS submission observation bounds."""
+    resolved: dict[str, float] = {}
+    for field_name in ("wait_timeout_seconds", "timeout_seconds"):
+        if field_name not in arguments:
+            continue
+        raw = arguments[field_name]
+        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+            raise ValueError(f"{field_name} must be a number")
+        value = float(raw)
+        if not math.isfinite(value) or value <= 0:
+            raise ValueError(f"{field_name} must be a finite number greater than 0")
+        resolved[field_name] = value
+    canonical = resolved.get("wait_timeout_seconds")
+    legacy = resolved.get("timeout_seconds")
+    if canonical is not None and legacy is not None and canonical != legacy:
+        raise ValueError(
+            "wait_timeout_seconds and legacy timeout_seconds must be equal when both are "
+            "provided; both fields bound observation only"
+        )
+    if canonical is not None:
+        return canonical
+    if legacy is not None:
+        return legacy
+    return 600.0
 
 
 def _required_environment_secret(name: str, label: str) -> str:

--- a/src/clio_relay/models.py
+++ b/src/clio_relay/models.py
@@ -8,7 +8,7 @@ import re
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from pathlib import Path
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Self
 from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -686,6 +686,31 @@ class RelayJob(BaseModel):
         if len(artifact_ids) != len(set(artifact_ids)):
             raise ValueError("used_artifact_refs must contain unique artifact_id values")
         return sorted(value, key=lambda item: item.artifact_id)
+
+
+class WaitObservation(BaseModel):
+    """Machine-readable outcome of one bounded terminal-state observation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    outcome: Literal["terminal", "observation_unknown"]
+    timeout_seconds: float = Field(gt=0, allow_inf_nan=False)
+    scheduler_action: Literal["none"] = "none"
+    relay_action: Literal["none"] = "none"
+
+
+class JobWaitResult(RelayJob):
+    """A durable job snapshot plus the outcome of one bounded observation."""
+
+    observation: WaitObservation
+
+    @model_validator(mode="after")
+    def observation_must_match_durable_state(self) -> Self:
+        """Reject contradictory terminal claims from local or remote wait surfaces."""
+        expected = "terminal" if self.state in TERMINAL_STATES else "observation_unknown"
+        if self.observation.outcome != expected:
+            raise ValueError("wait observation outcome disagrees with durable job state")
+        return self
 
 
 def prepare_owned_jarvis_run_submission(job: RelayJob) -> RelayJob:

--- a/src/clio_relay/relay_ops.py
+++ b/src/clio_relay/relay_ops.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import hmac
+import math
 import os
 import re
 import time
@@ -20,12 +21,14 @@ from clio_relay.models import (
     Cursor,
     JobKind,
     JobState,
+    JobWaitResult,
     MonitorRule,
     MonitorRuleAction,
     ProgressRecord,
     RelayEvent,
     RelayJob,
     RemoteAgentTaskSpec,
+    WaitObservation,
     utc_now,
 )
 from clio_relay.pagination import validate_response_page_limit
@@ -50,10 +53,10 @@ def wait_for_terminal(
     poll_seconds: float = 2.0,
 ) -> RelayJob:
     """Poll a job until it reaches a terminal state or timeout expires."""
-    if timeout_seconds <= 0:
-        raise ConfigurationError("timeout_seconds must be positive")
-    if poll_seconds <= 0:
-        raise ConfigurationError("poll_seconds must be positive")
+    if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+        raise ConfigurationError("timeout_seconds must be positive and finite")
+    if not math.isfinite(poll_seconds) or poll_seconds <= 0:
+        raise ConfigurationError("poll_seconds must be positive and finite")
     deadline = time.monotonic() + timeout_seconds
     while True:
         job = queue.get_job(job_id)
@@ -62,6 +65,39 @@ def wait_for_terminal(
         if time.monotonic() >= deadline:
             raise TimeoutError(f"job did not reach terminal state before timeout: {job_id}")
         time.sleep(min(poll_seconds, max(0.0, deadline - time.monotonic())))
+
+
+def observe_until_terminal(
+    queue: ClioCoreQueue,
+    job_id: str,
+    *,
+    timeout_seconds: float,
+    poll_seconds: float = 2.0,
+) -> JobWaitResult:
+    """Return a terminal job or its current durable state when this observation expires."""
+    try:
+        job = wait_for_terminal(
+            queue,
+            job_id,
+            timeout_seconds=timeout_seconds,
+            poll_seconds=poll_seconds,
+        )
+    except TimeoutError:
+        job = queue.get_job(job_id)
+    return job_wait_result(job, timeout_seconds=timeout_seconds)
+
+
+def job_wait_result(job: RelayJob, *, timeout_seconds: float) -> JobWaitResult:
+    """Attach a no-side-effect observation outcome to one exact durable job snapshot."""
+    return JobWaitResult.model_validate(
+        {
+            **job.model_dump(mode="python"),
+            "observation": WaitObservation(
+                outcome=("terminal" if job.state in TERMINAL_STATES else "observation_unknown"),
+                timeout_seconds=timeout_seconds,
+            ).model_dump(mode="python"),
+        }
+    )
 
 
 def monitor_job(

--- a/src/clio_relay/remote_cli.py
+++ b/src/clio_relay/remote_cli.py
@@ -19,7 +19,7 @@ from typing import cast
 import yaml
 
 from clio_relay.cluster_config import ClusterDefinition
-from clio_relay.errors import ConfigurationError, RelayError
+from clio_relay.errors import ConfigurationError, ObservationTimeoutError, RelayError
 from clio_relay.jarvis_mcp import JARVIS_MCP_SPACK_COMMAND_ENV
 from clio_relay.remote_values import render_remote_shell_path, render_remote_shell_value
 
@@ -205,7 +205,7 @@ def run_remote_shell(definition: ClusterDefinition, script: str) -> str:
                 timeout=timeout_seconds,
             )
     except subprocess.TimeoutExpired as exc:
-        raise RelayError(
+        raise ObservationTimeoutError(
             f"remote command timed out after {timeout_seconds:g} seconds: {definition.ssh_host}"
         ) from exc
     except OSError as exc:

--- a/src/clio_relay/remote_mcp.py
+++ b/src/clio_relay/remote_mcp.py
@@ -324,6 +324,29 @@ VIRTUAL_REMOTE_MCP_JOB_OUTPUT_SCHEMA: JSON = {
             ),
         },
         "last_error": {"type": ["string", "null"]},
+        "observation": {
+            "type": "object",
+            "properties": {
+                "outcome": {
+                    "type": "string",
+                    "enum": ["terminal", "observation_unknown"],
+                },
+                "timeout_seconds": {"type": "number", "exclusiveMinimum": 0},
+                "scheduler_action": {"type": "string", "const": "none"},
+                "relay_action": {"type": "string", "const": "none"},
+            },
+            "required": [
+                "outcome",
+                "timeout_seconds",
+                "scheduler_action",
+                "relay_action",
+            ],
+            "additionalProperties": False,
+            "description": (
+                "Result of the bounded observation requested by this call. "
+                "observation_unknown preserves the durable job for later observation."
+            ),
+        },
         "mcp_result": {"type": "object"},
         "mcp_result_artifact": {"type": "object"},
         "logs": {"type": "object"},

--- a/src/clio_relay/session_api.py
+++ b/src/clio_relay/session_api.py
@@ -21,7 +21,7 @@ from pydantic import ValidationError
 
 from clio_relay.cluster_config import ClusterDefinition
 from clio_relay.config import RelaySettings
-from clio_relay.errors import ConfigurationError, RelayError
+from clio_relay.errors import ConfigurationError, ObservationTimeoutError, RelayError
 from clio_relay.jarvis_mcp import is_virtual_jarvis_control_query
 from clio_relay.models import (
     MCP_ADMISSION_AUTHORITY_METADATA_KEY,
@@ -657,6 +657,10 @@ def _request_json_on_connection(
             )
         return document
     except (OSError, http.client.HTTPException) as exc:
+        if response_timeout_applied and isinstance(exc, TimeoutError):
+            raise ObservationTimeoutError(
+                f"owned session API response observation timed out for {method} {path}"
+            ) from exc
         raise RelayError(
             f"owned session API identity-bound request failed for {method} {path}: {exc}"
         ) from exc

--- a/src/clio_relay/validation_report.py
+++ b/src/clio_relay/validation_report.py
@@ -4410,6 +4410,8 @@ def _windows_validation_directory_identity(
     *,
     path: Path,
 ) -> tuple[int, int, int]:
+    if os.name != "nt":  # pragma: no cover - platform contract
+        raise OSError("Windows validation handles cannot be inspected on this platform")
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
     get_information = kernel32.GetFileInformationByHandle
     get_information.argtypes = [
@@ -4439,6 +4441,8 @@ def _close_windows_validation_directory(
 
 
 def _close_windows_validation_handle(handle: ctypes.c_void_p, *, path: Path) -> None:
+    if os.name != "nt":  # pragma: no cover - platform contract
+        raise OSError("Windows validation handles cannot be closed on this platform")
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
     close_handle = kernel32.CloseHandle
     close_handle.argtypes = [ctypes.c_void_p]
@@ -4454,6 +4458,8 @@ def _open_windows_validation_handle(
     allow_delete_share: bool,
     acl_write: bool,
 ) -> ctypes.c_void_p:
+    if os.name != "nt":  # pragma: no cover - platform contract
+        raise OSError("Windows validation handles cannot be opened on this platform")
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
     create_file = kernel32.CreateFileW
     create_file.argtypes = [
@@ -4825,6 +4831,8 @@ def _create_windows_validation_directory_child(
     child_name: str,
 ) -> _WindowsValidationDirectoryAnchor:
     """Create, durably name, and pin one private child below a pinned parent."""
+    if os.name != "nt":  # pragma: no cover - platform contract
+        raise OSError("Windows validation directories cannot be created on this platform")
     if Path(child_name).name != child_name or child_name in {".", ".."}:
         raise OSError(f"unsafe validation report directory component: {child_name}")
     _verify_windows_validation_directory(parent)

--- a/src/clio_relay/worker_lifetime_lock.py
+++ b/src/clio_relay/worker_lifetime_lock.py
@@ -186,6 +186,7 @@ def _pin_locked_core_directory(
         return None, None
     flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
     flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    directory_fd: int | None = None
     try:
         directory_fd = os.open(root, flags)
         os.set_inheritable(directory_fd, False)
@@ -221,7 +222,7 @@ def _pin_locked_core_directory(
                 return directory_fd, candidate
         raise ConfigurationError("POSIX migration requires a descriptor filesystem alias")
     except BaseException:
-        if "directory_fd" in locals():
+        if directory_fd is not None:
             with suppress(OSError):
                 os.close(directory_fd)
         raise

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -34,7 +34,8 @@ from clio_relay.bootstrap import (
     JARVIS_CD_WHEEL_SHA256,
     JARVIS_CD_WHEEL_URL,
     JARVIS_UTIL_COMMIT,
-    UV_LINUX_AMD64_SHA256,
+    UV_LINUX_AMD64_ARCHIVE_SHA256,
+    UV_LINUX_AMD64_EXECUTABLE_SHA256,
     UV_VERSION,
     assert_clean_git_checkout,
     create_bootstrap_archive,
@@ -161,7 +162,9 @@ def test_linux_user_bootstrap_script_installs_required_components() -> None:
     assert f'FRPS_SHA256="{FRPS_LINUX_AMD64_SHA256}"' in script
     assert "sha256sum --check --strict -" in script
     assert f'UV_VERSION="{UV_VERSION}"' in script
-    assert f'UV_SHA256="{UV_LINUX_AMD64_SHA256}"' in script
+    assert f'UV_ARCHIVE_SHA256="{UV_LINUX_AMD64_ARCHIVE_SHA256}"' in script
+    assert f'UV_EXECUTABLE_SHA256="{UV_LINUX_AMD64_EXECUTABLE_SHA256}"' in script
+    assert "UV_EXECUTABLE_SHA256 *$HOME/.local/bin/uv" in script
     assert "https://astral.sh/uv/install.sh" not in script
     assert "uv python install 3.12" in script
     assert 'export UV_TOOL_DIR="$HOME/.local/share/clio-relay/uv-tools"' in script
@@ -309,6 +312,9 @@ def test_fresh_bootstrap_loads_packaged_graph_before_explicit_build_fallback() -
     assert 'requested_source=os.environ["CLIO_RELAY_BOOTSTRAP_JARVIS_MCP_SOURCE"]' in script
     assert "relay_artifact_sha256=" in script
     assert "reconcile_managed_jarvis_repository(" in script
+    assert 'echo "$BOOTSTRAP_JARVIS_REPOS_SHA256_BEFORE *$JARVIS_REPOS_FILE"' not in script
+    assert 'echo "$BOOTSTRAP_JARVIS_CONFIG_SHA256_BEFORE *$JARVIS_CONFIG_FILE"' in script
+    assert 'echo "$BOOTSTRAP_JARVIS_GRAPH_SHA256_BEFORE *$JARVIS_GRAPH_FILE"' in script
     assert '"$HOME/.local/share/clio-relay/jarvis-shared" || true' not in script
     assert "python -m pip install --upgrade pip setuptools wheel" not in script
     assert "spack install" not in script
@@ -400,8 +406,11 @@ def test_bootstrap_uv_pin_matches_release_policy() -> None:
     policy = yaml.safe_load(policy_path.read_text(encoding="utf-8"))
 
     assert policy["required_uv_version"] == UV_VERSION
-    assert UV_LINUX_AMD64_SHA256 == (
+    assert UV_LINUX_AMD64_ARCHIVE_SHA256 == (
         "e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224"
+    )
+    assert UV_LINUX_AMD64_EXECUTABLE_SHA256 == (
+        "1cb9cd0a1749debf6049d7d2bb933882cc52d81016326ee6d99a786d6c988b03"
     )
 
 

--- a/tests/test_bootstrap_cluster_paths.py
+++ b/tests/test_bootstrap_cluster_paths.py
@@ -874,6 +874,12 @@ def test_bootstrap_over_ssh_forwards_configured_data_directories(
             stdout = ""
         return subprocess.CompletedProcess(command, 0, stdout, "")
 
+    def validate_receipt(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    def verify_persistent_receipt(**_kwargs: object) -> None:
+        return None
+
     monkeypatch.setattr(bootstrap, "create_bootstrap_archive", fake_create_bootstrap_archive)
     monkeypatch.setattr(
         bootstrap,
@@ -881,11 +887,11 @@ def test_bootstrap_over_ssh_forwards_configured_data_directories(
         fake_render_linux_user_bootstrap_script,
     )
     monkeypatch.setattr(bootstrap, "_run", fake_run)
-    monkeypatch.setattr(bootstrap, "_validate_bootstrap_receipt", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(bootstrap, "_validate_bootstrap_receipt", validate_receipt)
     monkeypatch.setattr(
         bootstrap,
         "_verify_persistent_bootstrap_receipt",
-        lambda **_kwargs: None,
+        verify_persistent_receipt,
     )
     monkeypatch.setattr(bootstrap, "uuid4", lambda: SimpleNamespace(hex="paths"))
 

--- a/tests/test_bootstrap_fast_path.py
+++ b/tests/test_bootstrap_fast_path.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import base64
 import copy
+import hashlib
+import json
+import os
+import shutil
 import subprocess
+import sys
 import tarfile
 from contextlib import nullcontext
 from datetime import UTC, datetime
@@ -38,6 +43,147 @@ def _which(executable: str) -> str:
     """Return a deterministic executable resolution for bootstrap tests."""
 
     return executable
+
+
+def test_staged_provider_exec_is_hash_bound_sealed_and_venv_aware(tmp_path: Path) -> None:
+    """The staged provider is executed from sealed bytes with lexical venv semantics."""
+    if sys.platform != "linux":
+        result = subprocess.run(
+            [
+                "wsl.exe",
+                "-e",
+                "bash",
+                "-lc",
+                (
+                    "export UV_PROJECT_ENVIRONMENT="
+                    "/tmp/clio-relay-staged-provider-test-venv; "
+                    "uv run pytest -q "
+                    "tests/test_bootstrap_fast_path.py::"
+                    "test_staged_provider_exec_is_hash_bound_sealed_and_venv_aware"
+                ),
+            ],
+            cwd=Path(__file__).parents[1],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        return
+    generation = tmp_path / "generation"
+    provider_root = generation / "tools/clio-relay"
+    subprocess.run(
+        [sys.executable, "-m", "venv", str(provider_root)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    provider = provider_root / "bin/python"
+    relay = generation / "bin/clio-relay"
+    relay.parent.mkdir(parents=True)
+    relay_payload = f"#!{provider}\n# staged relay launcher\n".encode()
+    relay.write_bytes(relay_payload)
+    relay.chmod(0o755)
+    provider_sha256 = hashlib.sha256(provider.resolve(strict=True).read_bytes()).hexdigest()
+    receipt = {
+        "component_artifacts": {
+            "clio-relay": {
+                "runtime_interpreters": {"provider": str(provider)},
+                "runtime_executables": {"clio-relay": str(relay)},
+                "persistent_tool": {
+                    "provider_interpreter": str(provider),
+                    "provider_interpreter_sha256": provider_sha256,
+                    "tool_executable": str(relay),
+                    "tool_executable_sha256": hashlib.sha256(relay_payload).hexdigest(),
+                },
+            }
+        }
+    }
+    receipt_path = generation / "install-receipt.json"
+    receipt_payload = json.dumps(receipt, sort_keys=True).encode()
+    receipt_path.write_bytes(receipt_payload)
+    manifest = {
+        "install_receipt": str(receipt_path),
+        "install_receipt_sha256": hashlib.sha256(receipt_payload).hexdigest(),
+    }
+    manifest_payload = json.dumps(manifest, sort_keys=True).encode()
+    (generation / "manifest.json").write_bytes(manifest_payload)
+    expected_manifest_sha256 = hashlib.sha256(manifest_payload).hexdigest()
+    poisoned_python_path = tmp_path / "poisoned-python-path"
+    poisoned_python_path.mkdir()
+    (poisoned_python_path / "sitecustomize.py").write_text(
+        "raise SystemExit('poisoned PYTHONPATH was imported')\n",
+        encoding="utf-8",
+    )
+    compiler = shutil.which("cc")
+    assert compiler is not None, "the sealed-provider test requires a C compiler"
+    preload_library = tmp_path / "preload-sentinel.so"
+    subprocess.run(
+        [compiler, "-shared", "-fPIC", "-x", "c", "-o", str(preload_library), "-"],
+        input=(
+            "#include <fcntl.h>\n"
+            "#include <stdlib.h>\n"
+            "#include <unistd.h>\n"
+            "__attribute__((constructor)) static void mark_loaded(void) {\n"
+            '  const char *marker = getenv("CLIO_PRELOAD_MARKER");\n'
+            "  if (marker == NULL) return;\n"
+            "  int descriptor = open(marker, O_WRONLY | O_CREAT | O_APPEND, 0600);\n"
+            "  if (descriptor < 0) return;\n"
+            '  (void)write(descriptor, "loaded\\n", 7);\n'
+            "  (void)close(descriptor);\n"
+            "}\n"
+        ),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    preload_marker = tmp_path / "preload-sentinel.marker"
+    provider_environment = os.environ.copy()
+    provider_environment.update(
+        {
+            "CLIO_PRELOAD_MARKER": str(preload_marker),
+            "LD_PRELOAD": str(preload_library),
+            "LD_LIBRARY_PATH": "/clio-relay/poisoned-library-path",
+            "PYTHONHOME": "/clio-relay/poisoned-python-home",
+            "PYTHONPATH": str(poisoned_python_path),
+        }
+    )
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            (
+                "set -euo pipefail\n"
+                ': > "$CLIO_PRELOAD_MARKER"\n'
+                f"{bootstrap._STAGED_PROVIDER_ENVIRONMENT_SANITIZER}\n"  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+                'exec "$@"\n'
+            ),
+            "bootstrap-provider-test",
+            sys.executable,
+            "-I",
+            "-c",
+            bootstrap._STAGED_PROVIDER_EXEC_PROGRAM,  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            str(generation),
+            expected_manifest_sha256,
+            "-c",
+            (
+                "import os, sys; "
+                f"assert sys.prefix == {str(provider_root)!r}; "
+                f"assert sys.executable == {str(provider)!r}; "
+                "assert sys.flags.isolated == 1; "
+                "assert not any(name.startswith('LD_') for name in os.environ); "
+                "assert not any(name.startswith('PYTHON') for name in os.environ); "
+                "print('sealed-provider-ok')"
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=provider_environment,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "sealed-provider-ok"
+    assert preload_marker.read_bytes() == b""
 
 
 def test_exact_remote_bootstrap_never_reads_or_builds_payload(
@@ -527,7 +673,7 @@ def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration(
     }
     managed_repo = "/home/operator/.local/share/clio-relay/managed-jarvis-repo"
     repository_update: dict[str, object] = {
-        "link_action": "reused",
+        "link_action": "created",
         "link": managed_repo,
         "target": (
             "/home/operator/.local/share/clio-relay/current/source/jarvis-packages/clio_relay"
@@ -570,6 +716,41 @@ def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration(
         expected_worker_service=desired.worker_service,
     )
 
+    relay_only = copy.deepcopy(receipt)
+    relay_transaction = cast(dict[str, object], relay_only["transaction"])
+    relay_transaction["mode"] = "relay-only"
+    relay_components = cast(dict[str, object], relay_only["components"])
+    for name, action in {
+        "clio-relay": "prepared",
+        "clio-kit": "reused",
+        "jarvis-cd": "reused",
+    }.items():
+        evidence = cast(dict[str, object], relay_components[name])
+        evidence["action"] = action
+    bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        relay_only,
+        bootstrap_profile="linux-user",
+        relay_install_spec=desired.relay_install_spec,
+        desired_fingerprint=desired.fingerprint,
+        expected_jarvis_resource_graph_profile="ares",
+        expected_allow_jarvis_resource_graph_build=False,
+        expected_worker_service=desired.worker_service,
+    )
+    invalid_relay_binding = copy.deepcopy(relay_only)
+    relay_preservation = cast(dict[str, object], invalid_relay_binding["jarvis_preservation"])
+    relay_binding = cast(dict[str, object], relay_preservation["repositories"])
+    relay_binding["target"] = "/operator/unrelated-repository"
+    with pytest.raises(RelayError, match="repository binding is invalid"):
+        bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            invalid_relay_binding,
+            bootstrap_profile="linux-user",
+            relay_install_spec=desired.relay_install_spec,
+            desired_fingerprint=desired.fingerprint,
+            expected_jarvis_resource_graph_profile="ares",
+            expected_allow_jarvis_resource_graph_build=False,
+            expected_worker_service=desired.worker_service,
+        )
+
     tampered = copy.deepcopy(receipt)
     preservation = cast(dict[str, object], tampered["jarvis_preservation"])
     binding = cast(dict[str, object], preservation["repositories"])
@@ -606,9 +787,22 @@ def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration(
     preservation = cast(dict[str, object], replaced_link["jarvis_preservation"])
     binding = cast(dict[str, object], preservation["repositories"])
     binding["link_action"] = "retargeted"
+    bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        replaced_link,
+        bootstrap_profile="linux-user",
+        relay_install_spec=desired.relay_install_spec,
+        desired_fingerprint=desired.fingerprint,
+        expected_jarvis_resource_graph_profile="ares",
+        expected_allow_jarvis_resource_graph_build=False,
+        expected_worker_service=desired.worker_service,
+    )
+
+    unproven_retarget = copy.deepcopy(replaced_link)
+    generation = cast(dict[str, object], unproven_retarget["generation"])
+    generation["previous"] = "unproven"
     with pytest.raises(RelayError, match="did not preserve existing JARVIS state"):
         bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
-            replaced_link,
+            unproven_retarget,
             bootstrap_profile="linux-user",
             relay_install_spec=desired.relay_install_spec,
             desired_fingerprint=desired.fingerprint,
@@ -885,6 +1079,42 @@ def test_payload_script_uses_digest_bound_safe_extractor() -> None:
     assert "from clio_relay.safe_archive import safe_extract_tar" in script
     assert "candidate_safe_archive" not in script
     assert "BOOTSTRAP_CANDIDATE_PACKAGE/safe_archive.py" in script
+
+
+def test_staged_upgrade_uses_journal_bound_idempotent_forward_activation() -> None:
+    """Legacy adoption and recovery share one staged-provider activation path."""
+    script = bootstrap.render_linux_user_bootstrap_script(cluster="cluster-a")
+    provider_start = script.index("bootstrap_provider_exec() (")
+    provider_end = script.index("\n)\n\nbootstrap_candidate_action", provider_start)
+    provider_function = script[provider_start:provider_end]
+    activation = script.index("  bootstrap_candidate_action journal-advance activating")
+    finish = script.index("bootstrap_candidate_action finish-activation", activation)
+    verify = script.index("  bootstrap_verify_stable_activation_links", finish)
+    activated = script.index(
+        "  bootstrap_candidate_action journal-advance activated",
+        verify,
+    )
+    migration = script.index(
+        "  bootstrap_candidate_action journal-advance migration_started",
+        activated,
+    )
+    recovery = script[script.index("bootstrap_recover_previous_transaction()") : activation]
+
+    assert "bootstrap_use_staged_provider()" in script
+    assert "journal-phase prepared_manifest" in script
+    assert provider_function.index("compgen -e") < provider_function.index("exec python3 -I -c")
+    assert 'LD_*|PYTHON*) unset "$bootstrap_environment_name"' in provider_function
+    assert activation < finish < verify < activated < migration
+    assert "bootstrap_candidate_action finish-activation" in recovery
+    assert "phase_identities" in recovery
+    assert "sha256sum --check --strict -" in recovery
+    assert 'mv -Tf "$HOME/.local/share/clio-relay/.current.' not in script
+    assert 'readlink "$HOME/.local/share/clio-relay/current"' not in script
+    assert (
+        'MANAGED_JARVIS_REPO_TARGET="$HOME/.local/share/clio-relay/current/'
+        'source/jarvis-packages/clio_relay"'
+    ) in script
+    assert "scancel" not in script
 
 
 def test_fresh_jarvis_hardware_graph_commands_are_exact_and_ordered() -> None:

--- a/tests/test_bootstrap_fast_path.py
+++ b/tests/test_bootstrap_fast_path.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import base64
+import copy
 import subprocess
 import tarfile
 from contextlib import nullcontext
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import NoReturn
+from typing import NoReturn, cast
 
 import pytest
 from typer.testing import CliRunner
@@ -20,11 +21,13 @@ from clio_relay.bootstrap_reconcile import (
     BootstrapDesiredState,
     BootstrapInspection,
     BootstrapReadinessEvidence,
+    BootstrapTransactionJournal,
+    BootstrapTransactionState,
     JarvisStateEvidence,
     make_bootstrap_receipt,
 )
 from clio_relay.cluster_config import ClusterDefinition, ClusterRegistry
-from clio_relay.errors import ConfigurationError
+from clio_relay.errors import ConfigurationError, RelayError
 
 
 def _verify_persistent_receipt(**_kwargs: object) -> None:
@@ -436,6 +439,183 @@ def test_bootstrap_inspection_deadlines_match_acceptance_contract() -> None:
     assert (
         cli.BOOTSTRAP_EXACT_INSPECTION_DEADLINE_SECONDS < cli.BOOTSTRAP_REPAIR_DEADLINE_SECONDS < 60
     )
+
+
+def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration() -> None:
+    """A fenced upgrade may register relay's exact repository without changing other state."""
+    desired = bootstrap._bootstrap_desired_state(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        identity=bootstrap.BootstrapRelayIdentity(
+            install_spec=f"clio-relay=={__version__}",
+            transport_install_spec=f"clio-relay=={__version__}",
+            source_identity=f"release:clio-relay=={__version__}:sha256:{'a' * 64}",
+            deployment_artifact_sha256="a" * 64,
+        ),
+        cluster="ares",
+        core_dir=bootstrap.DEFAULT_REMOTE_CORE_DIR,
+        spool_dir=bootstrap.DEFAULT_REMOTE_SPOOL_DIR,
+        frp_version=bootstrap.FRP_VERSION,
+        clio_kit_install_spec=bootstrap.CLIO_KIT_JARVIS_MCP_WHEEL_URL,
+        clio_kit_artifact_sha256=bootstrap.CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
+        agent_adapter="exec",
+        agent_npm_package=None,
+        agent_npm_bin=None,
+        agent_args=[],
+        jarvis_resource_graph_profile="ares",
+    )
+    before = JarvisStateEvidence(
+        initialized=True,
+        root="/home/operator/.ppi-jarvis",
+        roots={
+            "config_dir": "/operator/jarvis/config",
+            "private_dir": "/operator/jarvis/private",
+            "shared_dir": "/operator/jarvis/shared",
+        },
+        config_sha256="b" * 64,
+        repos_sha256="c" * 64,
+        resource_graph_sha256="d" * 64,
+        managed_repo_registered=False,
+    )
+    after = before.model_copy(update={"repos_sha256": "e" * 64, "managed_repo_registered": True})
+    inspection = BootstrapInspection(
+        exact_match=True,
+        desired_fingerprint=desired.fingerprint,
+        install_receipt_sha256="f" * 64,
+        active_generation=desired.fingerprint,
+        current_generation_target=f"/home/operator/generations/{desired.fingerprint}",
+        jarvis_state=after,
+        readiness=BootstrapReadinessEvidence(
+            service_name=desired.worker_service,
+            service_was_active=True,
+            service_was_enabled=True,
+            queue_ready=True,
+            queue={
+                "schema_version": "clio-relay.queue-readiness.v1",
+                "complete": True,
+                "sealed": True,
+                "repair_required": False,
+            },
+            worker_ready=True,
+        ),
+    )
+    transaction = BootstrapTransactionJournal(
+        invocation_id="bootstrap_component_upgrade",
+        desired_fingerprint=desired.fingerprint,
+        mode="component-upgrade",
+        state=BootstrapTransactionState.COMMITTED,
+        previous_generation="legacy",
+        prepared_generation=desired.fingerprint,
+        service_name=desired.worker_service,
+        service_was_active=True,
+        service_was_enabled=True,
+        irreversible_boundary=True,
+    )
+    actions = {
+        "clio-relay": "replaced",
+        "clio-kit": "replaced",
+        "jarvis-cd": "replaced",
+        "jarvis-util": "reused",
+        "frp": "reused",
+        "uv": "reused",
+    }
+    components: dict[str, dict[str, object]] = {
+        name: {
+            "action": action,
+            "observed_identity": {},
+            "duration_seconds": 1.0,
+        }
+        for name, action in actions.items()
+    }
+    managed_repo = "/home/operator/.local/share/clio-relay/managed-jarvis-repo"
+    repository_update: dict[str, object] = {
+        "link_action": "reused",
+        "link": managed_repo,
+        "target": (
+            "/home/operator/.local/share/clio-relay/current/source/jarvis-packages/clio_relay"
+        ),
+        "repositories": {
+            "action": "updated",
+            "managed_repo": managed_repo,
+            "added_managed_repos": [managed_repo],
+            "removed_previous_managed_repos": [
+                "/home/operator/.local/src/clio-relay/jarvis-packages/clio_relay"
+            ],
+            "before_sha256": before.repos_sha256,
+            "after_sha256": after.repos_sha256,
+        },
+    }
+    receipt = make_bootstrap_receipt(
+        invocation_id=transaction.invocation_id,
+        desired=desired,
+        outcome="reconciled",
+        inspection=inspection,
+        started_at=datetime.now(UTC),
+        transaction=transaction,
+        previous_generation="legacy",
+        active_generation=desired.fingerprint,
+        components=components,
+        duration_seconds=1.0,
+        jarvis_state_before=before,
+        jarvis_repo_reconciliation=repository_update,
+        payload_transfer_count=2,
+        payload_transfer_bytes=1,
+    )
+
+    bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        receipt,
+        bootstrap_profile="linux-user",
+        relay_install_spec=desired.relay_install_spec,
+        desired_fingerprint=desired.fingerprint,
+        expected_jarvis_resource_graph_profile="ares",
+        expected_allow_jarvis_resource_graph_build=False,
+        expected_worker_service=desired.worker_service,
+    )
+
+    tampered = copy.deepcopy(receipt)
+    preservation = cast(dict[str, object], tampered["jarvis_preservation"])
+    binding = cast(dict[str, object], preservation["repositories"])
+    update = cast(dict[str, object], binding["repositories"])
+    update["after_sha256"] = "0" * 64
+    with pytest.raises(RelayError, match="hashes do not bind"):
+        bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            tampered,
+            bootstrap_profile="linux-user",
+            relay_install_spec=desired.relay_install_spec,
+            desired_fingerprint=desired.fingerprint,
+            expected_jarvis_resource_graph_profile="ares",
+            expected_allow_jarvis_resource_graph_build=False,
+            expected_worker_service=desired.worker_service,
+        )
+
+    unauthorized_removal = copy.deepcopy(receipt)
+    preservation = cast(dict[str, object], unauthorized_removal["jarvis_preservation"])
+    binding = cast(dict[str, object], preservation["repositories"])
+    update = cast(dict[str, object], binding["repositories"])
+    update["removed_previous_managed_repos"] = ["/operator/unrelated-repository"]
+    with pytest.raises(RelayError, match="repository migration is invalid"):
+        bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            unauthorized_removal,
+            bootstrap_profile="linux-user",
+            relay_install_spec=desired.relay_install_spec,
+            desired_fingerprint=desired.fingerprint,
+            expected_jarvis_resource_graph_profile="ares",
+            expected_allow_jarvis_resource_graph_build=False,
+            expected_worker_service=desired.worker_service,
+        )
+
+    replaced_link = copy.deepcopy(receipt)
+    preservation = cast(dict[str, object], replaced_link["jarvis_preservation"])
+    binding = cast(dict[str, object], preservation["repositories"])
+    binding["link_action"] = "retargeted"
+    with pytest.raises(RelayError, match="did not preserve existing JARVIS state"):
+        bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            replaced_link,
+            bootstrap_profile="linux-user",
+            relay_install_spec=desired.relay_install_spec,
+            desired_fingerprint=desired.fingerprint,
+            expected_jarvis_resource_graph_profile="ares",
+            expected_allow_jarvis_resource_graph_build=False,
+            expected_worker_service=desired.worker_service,
+        )
 
 
 def test_fresh_bootstrap_receipt_allows_explicit_pending_service_install(

--- a/tests/test_bootstrap_fast_path.py
+++ b/tests/test_bootstrap_fast_path.py
@@ -836,7 +836,7 @@ def test_future_release_identity_does_not_require_network_or_a_digest(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(bootstrap, "__version__", "1.4.17")
+    monkeypatch.setattr(bootstrap, "__version__", "1.4.18")
 
     identity = bootstrap.bootstrap_relay_identity(
         source_root=tmp_path / "not-a-checkout",
@@ -844,8 +844,8 @@ def test_future_release_identity_does_not_require_network_or_a_digest(
         relay_artifact_sha256="1" * 64,
     )
 
-    assert identity.install_spec == "clio-relay==1.4.17"
-    assert identity.source_identity == f"release:clio-relay==1.4.17:sha256:{'1' * 64}"
+    assert identity.install_spec == "clio-relay==1.4.18"
+    assert identity.source_identity == f"release:clio-relay==1.4.18:sha256:{'1' * 64}"
     assert identity.deployment_artifact_sha256 == "1" * 64
 
 

--- a/tests/test_bootstrap_fast_path.py
+++ b/tests/test_bootstrap_fast_path.py
@@ -27,6 +27,16 @@ from clio_relay.cluster_config import ClusterDefinition, ClusterRegistry
 from clio_relay.errors import ConfigurationError
 
 
+def _verify_persistent_receipt(**_kwargs: object) -> None:
+    """Model a successfully re-read persistent receipt."""
+
+
+def _which(executable: str) -> str:
+    """Return a deterministic executable resolution for bootstrap tests."""
+
+    return executable
+
+
 def test_exact_remote_bootstrap_never_reads_or_builds_payload(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -115,10 +125,14 @@ def test_exact_remote_bootstrap_never_reads_or_builds_payload(
         raise AssertionError("the exact no-op touched bootstrap payload code")
 
     monkeypatch.setattr(bootstrap, "_bootstrap_preflight_over_ssh", preflight)
-    monkeypatch.setattr(bootstrap, "_verify_persistent_bootstrap_receipt", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        bootstrap,
+        "_verify_persistent_bootstrap_receipt",
+        _verify_persistent_receipt,
+    )
     monkeypatch.setattr(bootstrap, "create_bootstrap_archive", poison)
     monkeypatch.setattr(bootstrap, "_validate_relay_bootstrap_wheel", poison)
-    monkeypatch.setattr(bootstrap.shutil, "which", lambda executable: executable)
+    monkeypatch.setattr(bootstrap.shutil, "which", _which)
     monkeypatch.setattr(bootstrap, "uuid4", lambda: type("Uuid", (), {"hex": "test"})())
 
     lines = bootstrap.bootstrap_cluster_over_ssh(
@@ -217,17 +231,21 @@ def test_public_cluster_bootstrap_noop_never_touches_nonexistent_wheel(
         raise AssertionError("the public exact no-op touched bootstrap payload code")
 
     monkeypatch.setattr(bootstrap, "_bootstrap_preflight_over_ssh", preflight)
-    monkeypatch.setattr(bootstrap, "_verify_persistent_bootstrap_receipt", lambda **_: None)
+    monkeypatch.setattr(
+        bootstrap,
+        "_verify_persistent_bootstrap_receipt",
+        _verify_persistent_receipt,
+    )
     monkeypatch.setattr(bootstrap, "create_bootstrap_archive", poison)
     monkeypatch.setattr(bootstrap, "_validate_relay_bootstrap_wheel", poison)
-    monkeypatch.setattr(bootstrap.shutil, "which", lambda executable: executable)
+    monkeypatch.setattr(bootstrap.shutil, "which", _which)
     monkeypatch.setattr(bootstrap, "uuid4", lambda: type("Uuid", (), {"hex": "cli_test"})())
     monkeypatch.setattr(cli, "package_source_root", lambda: tmp_path / "missing-source")
-    monkeypatch.setattr(
-        cli,
-        "_remote_target_identity",
-        lambda _definition: {"verified": True},
-    )
+
+    def remote_target_identity(_definition: ClusterDefinition) -> dict[str, object]:
+        return {"verified": True}
+
+    monkeypatch.setattr(cli, "_remote_target_identity", remote_target_identity)
 
     result = CliRunner().invoke(
         cli.app,
@@ -252,16 +270,16 @@ def test_payload_reconcile_requires_profile_before_building_archive(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Only exact reuse may omit a profile; fresh state needs operator graph policy."""
-    monkeypatch.setattr(
-        bootstrap,
-        "_bootstrap_preflight_over_ssh",
-        lambda **_kwargs: bootstrap.BootstrapPreflightResult(
+
+    def preflight(**_kwargs: object) -> bootstrap.BootstrapPreflightResult:
+        return bootstrap.BootstrapPreflightResult(
             action="payload_required",
             receipt=None,
             lines=["bootstrap_preflight_json={}"],
-        ),
-    )
-    monkeypatch.setattr(bootstrap.shutil, "which", lambda executable: executable)
+        )
+
+    monkeypatch.setattr(bootstrap, "_bootstrap_preflight_over_ssh", preflight)
+    monkeypatch.setattr(bootstrap.shutil, "which", _which)
 
     def poison(*_args: object, **_kwargs: object) -> NoReturn:
         raise AssertionError("missing profile reached payload construction")
@@ -293,7 +311,7 @@ def test_public_release_bootstrap_requires_artifact_digest(
         }
     ).save(tmp_path / ".clio-relay/clusters.json")
     monkeypatch.setattr(cli, "package_source_root", lambda: tmp_path / "installed-package")
-    monkeypatch.setattr(bootstrap.shutil, "which", lambda executable: executable)
+    monkeypatch.setattr(bootstrap.shutil, "which", _which)
 
     result = CliRunner().invoke(
         cli.app,
@@ -384,20 +402,24 @@ def test_payload_free_inspector_fails_closed_after_repair_does_not_converge(
         stdout = "loaded\n" if "show" in command else ""
         return subprocess.CompletedProcess(command, 0, stdout, "")
 
-    monkeypatch.setattr(cli, "installation_info", lambda: {})
+    def installation_info() -> dict[str, object]:
+        return {}
+
+    def inspect(*_args: object, **_kwargs: object) -> BootstrapInspection:
+        return next(inspections)
+
+    def worker_info(**_kwargs: object) -> dict[str, object]:
+        return {"running": True}
+
+    def invocation_lock(**_kwargs: object) -> nullcontext[Path]:
+        return nullcontext(tmp_path / "bootstrap.lock")
+
+    monkeypatch.setattr(cli, "installation_info", installation_info)
     monkeypatch.setattr(cli, "ClioCoreQueue", ReadyQueue)
-    monkeypatch.setattr(
-        cli,
-        "inspect_exact_bootstrap_noop",
-        lambda *_args, **_kwargs: next(inspections),
-    )
+    monkeypatch.setattr(cli, "inspect_exact_bootstrap_noop", inspect)
     monkeypatch.setattr(cli, "run_bounded_process", systemctl)
-    monkeypatch.setattr(cli, "worker_runtime_info", lambda **_kwargs: {"running": True})
-    monkeypatch.setattr(
-        cli,
-        "bootstrap_invocation_lock",
-        lambda **_kwargs: nullcontext(tmp_path / "bootstrap.lock"),
-    )
+    monkeypatch.setattr(cli, "worker_runtime_info", worker_info)
+    monkeypatch.setattr(cli, "bootstrap_invocation_lock", invocation_lock)
 
     result = CliRunner().invoke(
         cli.app,
@@ -472,7 +494,7 @@ def test_fresh_bootstrap_receipt_allows_explicit_pending_service_install(
             worker_ready=False,
         ),
     )
-    components = {
+    components: dict[str, dict[str, object]] = {
         name: {
             "action": "prepared",
             "observed_identity": {},
@@ -553,7 +575,7 @@ def test_fresh_bootstrap_receipt_allows_explicit_pending_service_install(
             },
         )
 
-    unavailable = {
+    unavailable: dict[str, object] = {
         "schema_version": "jarvis.resource-graph-builtin.v1",
         "profile": "ares",
         "action": "unavailable",

--- a/tests/test_bootstrap_journal.py
+++ b/tests/test_bootstrap_journal.py
@@ -241,7 +241,7 @@ def test_journal_parent_swap_during_create_fails_closed(
     relocated = parent.with_name("clio-relay-relocated")
     outside = tmp_path / "outside"
     outside.mkdir()
-    original = journal_module._atomic_json_at
+    original = journal_module._atomic_json_at  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
 
     def swapped_atomic(
         parent_descriptor: int | None,
@@ -318,7 +318,7 @@ def test_parent_swap_after_journal_open_never_reaches_replacement_tree(
     replacement_target.mkdir(parents=True)
     sentinel = replacement_target / "operator.txt"
     sentinel.write_text("operator\n", encoding="utf-8")
-    original = journal_module._require_current_owner
+    original = journal_module._require_current_owner  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
     swapped = False
 
     def swap_after_home_open(descriptor: int, description: str) -> None:
@@ -353,7 +353,7 @@ def test_target_swap_to_symlink_is_rejected_without_following(
     outside.mkdir()
     sentinel = outside / "operator.txt"
     sentinel.write_text("operator\n", encoding="utf-8")
-    original = journal_module._discard_owned_entry_at
+    original = journal_module._discard_owned_entry_at  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
 
     def swap_target(
         parent_descriptor: int,
@@ -451,7 +451,7 @@ def test_interrupted_discard_is_idempotently_resumed(
     (target / "one").write_text("one", encoding="utf-8")
     (target / "two").write_text("two", encoding="utf-8")
     record_owned_path(journal_path, "target")
-    original = journal_module._unlink_entry_at
+    original = journal_module._unlink_entry_at  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
     interrupted = False
 
     def interrupt_after_unlink(
@@ -492,7 +492,7 @@ def test_owned_publication_never_claims_a_racing_replacement(
     source = tmp_path / "source"
     source.write_text("relay\n", encoding="utf-8")
     displaced = target.with_name("relay-created-displaced")
-    original = journal_module._owned_identity_at
+    original = journal_module._owned_identity_at  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
     swapped = False
 
     def swap_before_claim(

--- a/tests/test_bootstrap_reconcile.py
+++ b/tests/test_bootstrap_reconcile.py
@@ -578,6 +578,32 @@ def test_existing_jarvis_144_plans_staged_component_upgrade_to_148(
     ]
 
 
+def test_uv_version_output_accepts_only_pinned_bounded_target_triple() -> None:
+    """Accept uv's real target suffix without weakening the pinned version boundary."""
+    matches = bootstrap_reconcile_module._uv_version_output_matches  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    for accepted in (
+        "uv 0.11.28",
+        "uv 0.11.28\n",
+        "uv 0.11.28\r\n",
+        "uv 0.11.28 (x86_64-unknown-linux-gnu)",
+        "uv 0.11.28 (x86_64-unknown-linux-gnu)\n",
+    ):
+        assert matches(accepted, expected_version="0.11.28")
+
+    for rejected in (
+        "uv 0.11.27",
+        "uv 0.11.28 ()",
+        "uv 0.11.28 (x86_64 unknown linux gnu)",
+        "uv 0.11.28 (x86_64-unknown-linux-gnu) extra",
+        "uv 0.11.28 (x86_64-unknown-linux-gnu)(extra)",
+        "uv 0.11.28\n\n",
+        " uv 0.11.28",
+        "uv 0.11.28\x00",
+        "uv 0.11.28 (" + "a" * 129 + ")",
+    ):
+        assert not matches(rejected, expected_version="0.11.28")
+
+
 def test_existing_operator_jarvis_roots_are_adopted_without_mutation(tmp_path: Path) -> None:
     desired = _desired(uv_sha256="a" * 64, frpc_sha256="b" * 64, frps_sha256="c" * 64)
     root, config_before, graph_before = _write_jarvis_state(tmp_path, desired)

--- a/tests/test_bootstrap_reconcile.py
+++ b/tests/test_bootstrap_reconcile.py
@@ -776,7 +776,7 @@ def test_managed_repo_atomic_exchange_preserves_or_recovers_racing_state(
     repos_file.write_text("repos:\n  - /operator/original\n", encoding="utf-8")
     operator_update = b"repos:\n  - /operator/concurrent\n"
     managed = tmp_path / "managed-jarvis-repo"
-    original_exchange = bootstrap_reconcile_module._atomic_exchange_paths  # noqa: SLF001
+    original_exchange = bootstrap_reconcile_module._atomic_exchange_paths  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
     exchanged = False
 
     def raced_exchange(left: Path, right: Path) -> None:
@@ -852,7 +852,7 @@ def test_stable_link_atomic_exchange_preserves_or_recovers_racing_state(
     target.write_bytes(b"new")
     target.chmod(0o755)
     operator_update = b"operator-concurrent"
-    original_exchange = bootstrap_reconcile_module._atomic_exchange_paths  # noqa: SLF001
+    original_exchange = bootstrap_reconcile_module._atomic_exchange_paths  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
     simulated_links: dict[Path, Path] = {}
     if os.name == "nt":
         real_is_symlink = Path.is_symlink
@@ -877,7 +877,7 @@ def test_stable_link_atomic_exchange_preserves_or_recovers_racing_state(
             candidate = Path(path)
             if candidate in simulated_links:
                 return str(simulated_links[candidate])
-            return cast(str, real_readlink(path))
+            return real_readlink(path)
 
         def simulated_resolve(path: Path, strict: bool = False) -> Path:
             candidate = path
@@ -1058,7 +1058,7 @@ def test_staged_activation_adopts_legacy_paths_idempotently(
             candidate = Path(path)
             if candidate in simulated_links:
                 return str(simulated_links[candidate])
-            return cast(str, original_readlink(path))
+            return original_readlink(path)
 
         def simulated_replace(source: Path | str, destination: Path | str) -> None:
             source_path = Path(source)
@@ -1349,7 +1349,7 @@ def test_staged_activation_resumes_across_repository_crash_boundaries(
     def simulated_readlink(path: Path | str) -> str:
         if Path(path) == managed_repo:
             return str(managed_target)
-        return cast(str, original_readlink(path))
+        return original_readlink(path)
 
     monkeypatch.setattr(
         bootstrap_reconcile_module.os,
@@ -1459,7 +1459,7 @@ def test_managed_repo_repair_refuses_unproven_broken_link(
     def simulated_readlink(path: Path | str) -> str:
         if Path(path) == managed:
             return str(tmp_path / "attacker-controlled/missing")
-        return cast(str, original_readlink(path))
+        return original_readlink(path)
 
     monkeypatch.setattr(Path, "lstat", simulated_lstat)
     monkeypatch.setattr(Path, "resolve", simulated_resolve)

--- a/tests/test_bootstrap_reconcile.py
+++ b/tests/test_bootstrap_reconcile.py
@@ -392,13 +392,15 @@ def test_existing_jarvis_144_plans_staged_component_upgrade_to_148(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A released runtime upgrade preserves state instead of falling into fresh bootstrap."""
+    """The exact legacy Ares layout enters the fenced staged-upgrade path."""
     bin_dir = tmp_path / ".local/bin"
     bin_dir.mkdir(parents=True)
     for name, content in (("uv", b"uv"), ("frpc", b"frpc"), ("frps", b"frps")):
         path = bin_dir / name
         path.write_bytes(content)
         path.chmod(0o755)
+    clio_kit_wheel = tmp_path / "clio_kit-2.5.23-py3-none-any.whl"
+    clio_kit_wheel.write_bytes(b"clio-kit-2.5.23")
     desired = _desired(
         uv_sha256=_digest(b"uv"),
         frpc_sha256=_digest(b"frpc"),
@@ -414,9 +416,15 @@ def test_existing_jarvis_144_plans_staged_component_upgrade_to_148(
             "jarvis_cd_wheel_sha256": (
                 "ebf5e5f375b921f20c79075d461926431a5a017ca8b45e598878a89b229b3935"
             ),
+            "clio_kit_version": "2.5.23",
+            "clio_kit_artifact_sha256": _digest(b"clio-kit-2.5.23"),
         }
     )
-    _write_jarvis_state(tmp_path, desired)
+    jarvis_root, _config_before, _graph_before = _write_jarvis_state(tmp_path, desired)
+    (jarvis_root / "repos.yaml").write_text(
+        yaml.safe_dump({"repos": ["/operator/clio_relay"]}, sort_keys=False),
+        encoding="utf-8",
+    )
     legacy_python = (
         tmp_path
         / ".local/share/clio-relay/jarvis-venv"
@@ -425,9 +433,26 @@ def test_existing_jarvis_144_plans_staged_component_upgrade_to_148(
     legacy_python.parent.mkdir(parents=True)
     legacy_python.write_bytes(b"python")
     legacy_python.chmod(0o755)
-    legacy_jarvis = legacy_python.parent / ("jarvis.exe" if os.name == "nt" else "jarvis")
-    legacy_jarvis.write_bytes(b"jarvis")
+    base_python = tmp_path / "uv-python" / legacy_python.name
+    base_python.parent.mkdir()
+    base_python.write_bytes(b"base-python")
+    base_python.chmod(0o755)
+    legacy_jarvis_target = legacy_python.parent / ("jarvis.exe" if os.name == "nt" else "jarvis")
+    legacy_jarvis_target.write_bytes(b"jarvis")
+    legacy_jarvis_target.chmod(0o755)
+    legacy_jarvis = bin_dir / legacy_jarvis_target.name
+    legacy_jarvis.write_bytes(b"stable-wrapper-link")
     legacy_jarvis.chmod(0o755)
+    resolve_path = Path.resolve
+
+    def resolve_stable_wrapper(path: Path, strict: bool = False) -> Path:
+        if path == legacy_python:
+            return resolve_path(base_python, strict=strict)
+        if path == legacy_jarvis:
+            return resolve_path(legacy_jarvis_target, strict=strict)
+        return resolve_path(path, strict=strict)
+
+    monkeypatch.setattr(Path, "resolve", resolve_stable_wrapper)
     jarvis_util_checkout = tmp_path / ".local/src/jarvis-util"
     (jarvis_util_checkout / ".git").mkdir(parents=True)
     receipt_path = tmp_path / ".local/share/clio-relay/install-receipt.json"
@@ -437,7 +462,13 @@ def test_existing_jarvis_144_plans_staged_component_upgrade_to_148(
     components = cast(dict[str, object], receipt["components"])
     components["jarvis-cd"] = "1.4.4"
     components["clio-kit"] = "2.5.22"
-    receipt["component_artifacts"] = {
+    component_runtime = info["component_runtime"]
+    assert isinstance(component_runtime, dict)
+    component_runtime["clio-kit"] = {
+        "error": "uv tool directory is unavailable",
+        "persistent_tool_verified": False,
+    }
+    component_artifacts: dict[str, object] = {
         "clio-kit": {
             "runtime_interpreters": {"provider": "/old/clio-kit/python"},
             "runtime_executables": {"clio-kit": "/old/clio-kit/clio-kit"},
@@ -447,6 +478,7 @@ def test_existing_jarvis_144_plans_staged_component_upgrade_to_148(
             "runtime_executables": {"jarvis": str(legacy_jarvis)},
         },
     }
+    receipt["component_artifacts"] = component_artifacts
 
     def read_installation(_path: Path | None = None) -> dict[str, object]:
         return info
@@ -489,7 +521,61 @@ def test_existing_jarvis_144_plans_staged_component_upgrade_to_148(
         "frp": "reuse",
         "uv": "reuse",
     }
-    assert plan.reusable_paths["jarvis_execution_python"] == str(legacy_python.resolve())
+    assert plan.reusable_paths["jarvis_execution_python"] == str(legacy_python)
+    assert plan.reusable_paths["jarvis_execution_executable"] == str(legacy_jarvis_target.resolve())
+    assert plan.reasons == [
+        "clio-kit version requires a staged upgrade",
+        "jarvis-cd version requires a staged upgrade",
+    ]
+
+    read_regular = bootstrap_reconcile_module._read_regular_bounded_with_identity  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    swapped = False
+
+    def swap_launcher_after_read(
+        path: Path,
+        *,
+        maximum: int,
+    ) -> tuple[bytes, tuple[int, int, int, int, int, int]]:
+        nonlocal swapped
+        payload, identity = read_regular(path, maximum=maximum)
+        if path == legacy_jarvis_target.resolve() and not swapped:
+            swapped = True
+            path.unlink()
+            path.write_bytes(b"replacement-jarvis")
+            path.chmod(0o755)
+        return payload, identity
+
+    monkeypatch.setattr(
+        bootstrap_reconcile_module,
+        "_read_regular_bounded_with_identity",
+        swap_launcher_after_read,
+    )
+    raced = plan_bootstrap_reconcile(desired, home=tmp_path)
+    monkeypatch.setattr(
+        bootstrap_reconcile_module,
+        "_read_regular_bounded_with_identity",
+        read_regular,
+    )
+
+    assert raced.mode == "full"
+    assert "legacy JARVIS execution environment is not reusable" in raced.reasons
+
+    components["clio-kit"] = desired.clio_kit_version
+    artifacts = cast(dict[str, object], receipt["component_artifacts"])
+    artifacts["clio-kit"] = {
+        "artifact_sha256": desired.clio_kit_artifact_sha256,
+        "runtime_artifact_path": str(clio_kit_wheel),
+        "runtime_interpreters": {"provider": "/old/clio-kit/python"},
+        "runtime_executables": {"clio-kit": "/old/clio-kit/clio-kit"},
+    }
+
+    unsafe_reuse = plan_bootstrap_reconcile(desired, home=tmp_path)
+
+    assert unsafe_reuse.mode == "full"
+    assert unsafe_reuse.reasons == [
+        "jarvis-cd version requires a staged upgrade",
+        "clio-kit live runtime is not reusable",
+    ]
 
 
 def test_existing_operator_jarvis_roots_are_adopted_without_mutation(tmp_path: Path) -> None:

--- a/tests/test_bootstrap_reconcile.py
+++ b/tests/test_bootstrap_reconcile.py
@@ -561,7 +561,7 @@ def test_existing_jarvis_144_plans_staged_component_upgrade_to_148(
     assert "legacy JARVIS execution environment is not reusable" in raced.reasons
 
     components["clio-kit"] = desired.clio_kit_version
-    artifacts = cast(dict[str, object], receipt["component_artifacts"])
+    artifacts = receipt["component_artifacts"]
     artifacts["clio-kit"] = {
         "artifact_sha256": desired.clio_kit_artifact_sha256,
         "runtime_artifact_path": str(clio_kit_wheel),

--- a/tests/test_bootstrap_reconcile.py
+++ b/tests/test_bootstrap_reconcile.py
@@ -11,7 +11,7 @@ import sys
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 import yaml
@@ -151,9 +151,16 @@ def test_exact_noop_is_read_only_and_preserves_operator_jarvis_bytes(
     root, config_before, graph_before = _write_jarvis_state(tmp_path, desired)
     generation = tmp_path / ".local/share/clio-relay/generations" / desired.fingerprint
     generation.mkdir(parents=True)
+
+    def inspect_active_generation(
+        *_args: object,
+        **_kwargs: object,
+    ) -> tuple[str, str]:
+        return desired.fingerprint, str(generation.resolve())
+
     monkeypatch.setattr(
         "clio_relay.bootstrap_reconcile._inspect_active_generation",
-        lambda *_args, **_kwargs: (desired.fingerprint, str(generation.resolve())),
+        inspect_active_generation,
     )
     receipt_path = tmp_path / ".local/share/clio-relay/install-receipt.json"
     receipt_path.write_text("{}\n", encoding="utf-8")
@@ -166,16 +173,21 @@ def test_exact_noop_is_read_only_and_preserves_operator_jarvis_bytes(
             root / "resource_graph.yaml",
         )
     }
-    monkeypatch.setattr(
-        "clio_relay.bootstrap_reconcile.installation_info",
-        lambda _path: _installation_info(desired),
-    )
+
+    def read_installation(_path: Path | None = None) -> dict[str, object]:
+        return _installation_info(desired)
+
+    def run_identity(
+        *_args: object,
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["uv", "--version"], 0, "uv 0.11.28\n", "")
+
+    monkeypatch.setattr("clio_relay.bootstrap_reconcile.installation_info", read_installation)
     monkeypatch.setattr(
         bootstrap_reconcile_module,
         "run_bounded_process",
-        lambda *_args, **_kwargs: subprocess.CompletedProcess(
-            ["uv", "--version"], 0, "uv 0.11.28\n", ""
-        ),
+        run_identity,
     )
 
     inspection = inspect_exact_bootstrap_noop(
@@ -230,13 +242,21 @@ def test_matching_receipt_with_tampered_runtime_is_not_a_noop(
     runtime = info["component_runtime"]
     assert isinstance(runtime, dict)
     runtime["clio-relay"] = {"persistent_tool_verified": False}
-    monkeypatch.setattr("clio_relay.bootstrap_reconcile.installation_info", lambda _path: info)
+
+    def read_installation(_path: Path | None = None) -> dict[str, object]:
+        return info
+
+    def run_identity(
+        *_args: object,
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["uv", "--version"], 0, "uv 0.11.28\n", "")
+
+    monkeypatch.setattr("clio_relay.bootstrap_reconcile.installation_info", read_installation)
     monkeypatch.setattr(
         subprocess,
         "run",
-        lambda *_args, **_kwargs: subprocess.CompletedProcess(
-            ["uv", "--version"], 0, "uv 0.11.28\n", ""
-        ),
+        run_identity,
     )
 
     inspection = inspect_exact_bootstrap_noop(
@@ -300,8 +320,7 @@ def test_first_legacy_upgrade_plans_relay_only_and_reuses_verified_components(
         }
     )
     info = _installation_info(desired)
-    receipt = info["receipt"]
-    assert isinstance(receipt, dict)
+    receipt = cast(dict[str, object], info["receipt"])
     receipt.pop("deployment_fingerprint")
     receipt.pop("deployment_manifest")
     receipt["component_artifacts"] = {
@@ -318,7 +337,11 @@ def test_first_legacy_upgrade_plans_relay_only_and_reuses_verified_components(
             "runtime_executables": {"jarvis": str(legacy_jarvis)},
         },
     }
-    monkeypatch.setattr("clio_relay.bootstrap_reconcile.installation_info", lambda _path: info)
+
+    def read_installation(_path: Path | None = None) -> dict[str, object]:
+        return info
+
+    monkeypatch.setattr("clio_relay.bootstrap_reconcile.installation_info", read_installation)
 
     def identity_command(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
         if command[:2] != [str(bin_dir / "uv"), "--version"]:
@@ -410,10 +433,8 @@ def test_existing_jarvis_144_plans_staged_component_upgrade_to_148(
     receipt_path = tmp_path / ".local/share/clio-relay/install-receipt.json"
     receipt_path.write_text("{}\n", encoding="utf-8")
     info = _installation_info(desired)
-    receipt = info["receipt"]
-    assert isinstance(receipt, dict)
-    components = receipt["components"]
-    assert isinstance(components, dict)
+    receipt = cast(dict[str, object], info["receipt"])
+    components = cast(dict[str, object], receipt["components"])
     components["jarvis-cd"] = "1.4.4"
     components["clio-kit"] = "2.5.22"
     receipt["component_artifacts"] = {
@@ -426,7 +447,11 @@ def test_existing_jarvis_144_plans_staged_component_upgrade_to_148(
             "runtime_executables": {"jarvis": str(legacy_jarvis)},
         },
     }
-    monkeypatch.setattr("clio_relay.bootstrap_reconcile.installation_info", lambda _path: info)
+
+    def read_installation(_path: Path | None = None) -> dict[str, object]:
+        return info
+
+    monkeypatch.setattr("clio_relay.bootstrap_reconcile.installation_info", read_installation)
 
     def identity_command(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
         assert command[:2] == [str(bin_dir / "uv"), "--version"]
@@ -529,7 +554,7 @@ def test_managed_repo_reconcile_refuses_concurrent_operator_edit(
     repos_file = tmp_path / "repos.yaml"
     repos_file.write_text("repos:\n  - /operator/original\n", encoding="utf-8")
     operator_update = b"repos:\n  - /operator/concurrent\n"
-    original_read = bootstrap_reconcile_module._read_regular_bounded_with_identity  # noqa: SLF001
+    original_read = bootstrap_reconcile_module._read_regular_bounded_with_identity  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
     call_count = 0
 
     def mutate_before_compare(
@@ -580,11 +605,14 @@ def test_managed_repo_repair_refuses_unproven_broken_link(
             return SimpleNamespace(st_mode=stat.S_IFLNK)
         return original_lstat(path)
 
+    def redirected_readlink(_path: os.PathLike[str] | str) -> str:
+        return str(tmp_path / "attacker-controlled/missing")
+
     monkeypatch.setattr(Path, "lstat", simulated_lstat)
     monkeypatch.setattr(
         bootstrap_reconcile_module.os,
         "readlink",
-        lambda path: str(tmp_path / "attacker-controlled/missing"),
+        redirected_readlink,
     )
 
     with pytest.raises(ConfigurationError, match="not proven by an earlier receipt"):
@@ -809,10 +837,11 @@ def test_prepared_generation_refuses_a_tampered_relay_owned_jarvis_wrapper(
     )
     with (generation / ".prepared").open("w", encoding="ascii", newline="\n") as stream:
         stream.write(desired.fingerprint + "\n")
-    monkeypatch.setattr(
-        "clio_relay.bootstrap_reconcile.installation_info",
-        lambda _path: _installation_info(desired),
-    )
+
+    def read_installation(_path: Path | None = None) -> dict[str, object]:
+        return _installation_info(desired)
+
+    monkeypatch.setattr("clio_relay.bootstrap_reconcile.installation_info", read_installation)
 
     evidence = inspect_prepared_generation(
         desired,
@@ -820,7 +849,8 @@ def test_prepared_generation_refuses_a_tampered_relay_owned_jarvis_wrapper(
         legacy_execution_identity=execution_identity,
     )
 
-    assert evidence["launcher_targets"]["jarvis"] == str(wrapper)
+    launcher_targets = cast(dict[str, object], evidence["launcher_targets"])
+    assert launcher_targets["jarvis"] == str(wrapper)
     assert wrapper.read_bytes() == jarvis_wrapper_payload(execution_python)
 
     wrapper.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")

--- a/tests/test_bootstrap_reconcile.py
+++ b/tests/test_bootstrap_reconcile.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shlex
 import stat
 import subprocess
 import sys
@@ -18,11 +19,14 @@ import yaml
 
 import clio_relay.bootstrap_reconcile as bootstrap_reconcile_module
 from clio_relay.bootstrap_reconcile import (
+    BootstrapActivationPath,
     BootstrapDesiredState,
+    BootstrapReconcilePlan,
     BootstrapTransactionJournal,
     BootstrapTransactionState,
     bootstrap_invocation_lock,
     execution_environment_identity,
+    finish_staged_activation,
     inspect_exact_bootstrap_noop,
     inspect_jarvis_state,
     inspect_prepared_generation,
@@ -30,6 +34,7 @@ from clio_relay.bootstrap_reconcile import (
     make_bootstrap_receipt,
     plan_bootstrap_reconcile,
     reconcile_managed_jarvis_repository,
+    reconcile_staged_activation_links,
     repair_managed_jarvis_binding,
     validate_jarvis_builtin_result,
     write_jarvis_wrapper,
@@ -284,7 +289,12 @@ def test_first_legacy_upgrade_plans_relay_only_and_reuses_verified_components(
 ) -> None:
     bin_dir = tmp_path / ".local/bin"
     bin_dir.mkdir(parents=True)
-    for name, content in (("uv", b"uv"), ("frpc", b"frpc"), ("frps", b"frps")):
+    for name, content in (
+        ("uv", b"uv"),
+        ("frpc", b"frpc"),
+        ("frps", b"frps"),
+        ("clio-relay", b"relay"),
+    ):
         path = bin_dir / name
         path.write_bytes(content)
         path.chmod(0o755)
@@ -294,6 +304,7 @@ def test_first_legacy_upgrade_plans_relay_only_and_reuses_verified_components(
         frps_sha256=_digest(b"frps"),
     )
     _write_jarvis_state(tmp_path, desired)
+    (tmp_path / ".local/share/clio-relay/managed-jarvis-repo").rmdir()
     legacy_python = (
         tmp_path
         / ".local/share/clio-relay/jarvis-venv"
@@ -305,6 +316,9 @@ def test_first_legacy_upgrade_plans_relay_only_and_reuses_verified_components(
     legacy_jarvis = legacy_python.parent / ("jarvis.exe" if os.name == "nt" else "jarvis")
     legacy_jarvis.write_bytes(b"jarvis")
     legacy_jarvis.chmod(0o755)
+    stable_jarvis = bin_dir / "jarvis"
+    stable_jarvis.write_bytes(b"stable-jarvis")
+    stable_jarvis.chmod(0o755)
     jarvis_util_checkout = tmp_path / ".local/src/jarvis-util"
     (jarvis_util_checkout / ".git").mkdir(parents=True)
     receipt_path = tmp_path / ".local/share/clio-relay/install-receipt.json"
@@ -324,6 +338,9 @@ def test_first_legacy_upgrade_plans_relay_only_and_reuses_verified_components(
     receipt.pop("deployment_fingerprint")
     receipt.pop("deployment_manifest")
     receipt["component_artifacts"] = {
+        "clio-relay": {
+            "runtime_executables": {"clio-relay": str(bin_dir / "clio-relay")},
+        },
         "clio-kit": {
             "artifact_sha256": desired.clio_kit_artifact_sha256,
             "runtime_artifact_path": str(clio_kit_wheel),
@@ -386,6 +403,9 @@ def test_first_legacy_upgrade_plans_relay_only_and_reuses_verified_components(
     assert plan.reusable_paths["jarvis_execution_environment"] == str(
         (tmp_path / ".local/share/clio-relay/jarvis-venv").resolve()
     )
+    assert plan.activation_paths["current"].before is None
+    assert plan.activation_paths["managed_repo"].before is None
+    assert plan.activation_paths["install_receipt"].before is not None
 
 
 def test_existing_jarvis_144_plans_staged_component_upgrade_to_148(
@@ -395,7 +415,12 @@ def test_existing_jarvis_144_plans_staged_component_upgrade_to_148(
     """The exact legacy Ares layout enters the fenced staged-upgrade path."""
     bin_dir = tmp_path / ".local/bin"
     bin_dir.mkdir(parents=True)
-    for name, content in (("uv", b"uv"), ("frpc", b"frpc"), ("frps", b"frps")):
+    for name, content in (
+        ("uv", b"uv"),
+        ("frpc", b"frpc"),
+        ("frps", b"frps"),
+        ("clio-relay", b"relay"),
+    ):
         path = bin_dir / name
         path.write_bytes(content)
         path.chmod(0o755)
@@ -421,6 +446,7 @@ def test_existing_jarvis_144_plans_staged_component_upgrade_to_148(
         }
     )
     jarvis_root, _config_before, _graph_before = _write_jarvis_state(tmp_path, desired)
+    (tmp_path / ".local/share/clio-relay/managed-jarvis-repo").rmdir()
     (jarvis_root / "repos.yaml").write_text(
         yaml.safe_dump({"repos": ["/operator/clio_relay"]}, sort_keys=False),
         encoding="utf-8",
@@ -440,7 +466,7 @@ def test_existing_jarvis_144_plans_staged_component_upgrade_to_148(
     legacy_jarvis_target = legacy_python.parent / ("jarvis.exe" if os.name == "nt" else "jarvis")
     legacy_jarvis_target.write_bytes(b"jarvis")
     legacy_jarvis_target.chmod(0o755)
-    legacy_jarvis = bin_dir / legacy_jarvis_target.name
+    legacy_jarvis = bin_dir / "jarvis"
     legacy_jarvis.write_bytes(b"stable-wrapper-link")
     legacy_jarvis.chmod(0o755)
     resolve_path = Path.resolve
@@ -469,6 +495,9 @@ def test_existing_jarvis_144_plans_staged_component_upgrade_to_148(
         "persistent_tool_verified": False,
     }
     component_artifacts: dict[str, object] = {
+        "clio-relay": {
+            "runtime_executables": {"clio-relay": str(bin_dir / "clio-relay")},
+        },
         "clio-kit": {
             "runtime_interpreters": {"provider": "/old/clio-kit/python"},
             "runtime_executables": {"clio-kit": "/old/clio-kit/clio-kit"},
@@ -527,6 +556,10 @@ def test_existing_jarvis_144_plans_staged_component_upgrade_to_148(
         "clio-kit version requires a staged upgrade",
         "jarvis-cd version requires a staged upgrade",
     ]
+    assert plan.activation_paths["current"].before is None
+    assert plan.activation_paths["managed_repo"].before is None
+    assert plan.activation_paths["relay_launcher"].before is not None
+    assert plan.activation_paths["jarvis_launcher"].before is not None
 
     read_regular = bootstrap_reconcile_module._read_regular_bounded_with_identity  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
     swapped = False
@@ -686,7 +719,7 @@ def test_managed_repo_reconcile_refuses_concurrent_operator_edit(
         mutate_before_compare,
     )
 
-    with pytest.raises(ConfigurationError, match="changed during reconciliation"):
+    with pytest.raises(ConfigurationError, match="changed .*reconciliation"):
         reconcile_managed_jarvis_repository(
             repos_file,
             tmp_path / "relay/managed-jarvis-repo",
@@ -696,35 +729,749 @@ def test_managed_repo_reconcile_refuses_concurrent_operator_edit(
     assert not list(tmp_path.glob(".repos.yaml.*.tmp"))
 
 
+def test_managed_repo_reconcile_cleans_a_proven_previous_registration(tmp_path: Path) -> None:
+    """An existing managed alias does not prevent exact legacy-path cleanup."""
+    repos_file = tmp_path / "repos.yaml"
+    managed = tmp_path / "managed-jarvis-repo"
+    previous = tmp_path / "legacy/clio_relay"
+    operator = tmp_path / "operator/clio_relay"
+    repos_file.write_text(
+        yaml.safe_dump(
+            {
+                "repos": [
+                    str(managed.absolute()),
+                    str(previous.absolute()),
+                    str(operator.absolute()),
+                ]
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    evidence = reconcile_managed_jarvis_repository(
+        repos_file,
+        managed,
+        previous_managed_repos=(previous,),
+        exchange_identity="a" * 64,
+    )
+
+    assert evidence["action"] == "updated"
+    assert evidence["added_managed_repos"] == []
+    assert evidence["removed_previous_managed_repos"] == [str(previous.absolute())]
+    assert yaml.safe_load(repos_file.read_text(encoding="utf-8"))["repos"] == [
+        str(managed.absolute()),
+        str(operator.absolute()),
+    ]
+
+
+@pytest.mark.parametrize("race_boundary", ["before_exchange", "after_exchange", "crash"])
+def test_managed_repo_atomic_exchange_preserves_or_recovers_racing_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    race_boundary: str,
+) -> None:
+    """The exact exchange boundary never silently overwrites an operator edit."""
+    repos_file = tmp_path / "repos.yaml"
+    repos_file.write_text("repos:\n  - /operator/original\n", encoding="utf-8")
+    operator_update = b"repos:\n  - /operator/concurrent\n"
+    managed = tmp_path / "managed-jarvis-repo"
+    original_exchange = bootstrap_reconcile_module._atomic_exchange_paths  # noqa: SLF001
+    exchanged = False
+
+    def raced_exchange(left: Path, right: Path) -> None:
+        nonlocal exchanged
+        if exchanged:
+            original_exchange(left, right)
+            return
+        exchanged = True
+        if race_boundary == "before_exchange":
+            repos_file.write_bytes(operator_update)
+        original_exchange(left, right)
+        if race_boundary == "after_exchange":
+            repos_file.write_bytes(operator_update)
+        if race_boundary == "crash":
+            raise RuntimeError("crash after atomic exchange")
+
+    monkeypatch.setattr(
+        bootstrap_reconcile_module,
+        "_atomic_exchange_paths",
+        raced_exchange,
+    )
+
+    if race_boundary == "crash":
+        with pytest.raises(RuntimeError, match="crash after atomic exchange"):
+            reconcile_managed_jarvis_repository(
+                repos_file,
+                managed,
+                exchange_identity="b" * 64,
+            )
+        monkeypatch.setattr(
+            bootstrap_reconcile_module,
+            "_atomic_exchange_paths",
+            original_exchange,
+        )
+        recovered = reconcile_managed_jarvis_repository(
+            repos_file,
+            managed,
+            exchange_identity="b" * 64,
+        )
+        assert recovered["action"] == "updated"
+        assert yaml.safe_load(repos_file.read_text(encoding="utf-8"))["repos"] == [
+            str(managed.absolute()),
+            "/operator/original",
+        ]
+    else:
+        with pytest.raises(ConfigurationError, match="changed .*reconciliation"):
+            reconcile_managed_jarvis_repository(
+                repos_file,
+                managed,
+                exchange_identity="b" * 64,
+            )
+        assert repos_file.read_bytes() == operator_update
+    assert not list(tmp_path.glob(".repos.yaml.*.exchange"))
+
+
+@pytest.mark.parametrize("race_boundary", ["before_exchange", "after_exchange", "crash"])
+def test_stable_link_atomic_exchange_preserves_or_recovers_racing_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    race_boundary: str,
+) -> None:
+    """Stable launcher exchange restores a raced object or resumes after a crash."""
+    destination = tmp_path / "launcher"
+    destination.write_bytes(b"legacy")
+    destination.chmod(0o755)
+    snapshot = bootstrap_reconcile_module._capture_activation_path(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        destination,
+        kind="file_or_symlink",
+        maximum=1024,
+        allow_absent=False,
+    )
+    target = tmp_path / "new-launcher"
+    target.write_bytes(b"new")
+    target.chmod(0o755)
+    operator_update = b"operator-concurrent"
+    original_exchange = bootstrap_reconcile_module._atomic_exchange_paths  # noqa: SLF001
+    simulated_links: dict[Path, Path] = {}
+    if os.name == "nt":
+        real_is_symlink = Path.is_symlink
+        real_resolve = Path.resolve
+        real_readlink = os.readlink
+
+        def simulated_symlink_to(
+            path: Path,
+            link_target: Path | str,
+            target_is_directory: bool = False,
+        ) -> None:
+            del target_is_directory
+            if path.exists() or path in simulated_links:
+                raise FileExistsError(path)
+            path.write_bytes(b"simulated-symlink")
+            simulated_links[path] = Path(link_target)
+
+        def simulated_is_symlink(path: Path) -> bool:
+            return path in simulated_links or real_is_symlink(path)
+
+        def simulated_readlink(path: Path | str) -> str:
+            candidate = Path(path)
+            if candidate in simulated_links:
+                return str(simulated_links[candidate])
+            return cast(str, real_readlink(path))
+
+        def simulated_resolve(path: Path, strict: bool = False) -> Path:
+            candidate = path
+            for _ in range(4):
+                if candidate not in simulated_links:
+                    return real_resolve(candidate, strict=strict)
+                candidate = simulated_links[candidate]
+            raise AssertionError("simulated symlink chain did not terminate")
+
+        real_exchange = original_exchange
+
+        def simulated_exchange(left: Path, right: Path) -> None:
+            left_target = simulated_links.pop(left, None)
+            right_target = simulated_links.pop(right, None)
+            real_exchange(left, right)
+            if left_target is not None:
+                simulated_links[right] = left_target
+            if right_target is not None:
+                simulated_links[left] = right_target
+
+        original_exchange = simulated_exchange
+        monkeypatch.setattr(Path, "symlink_to", simulated_symlink_to)
+        monkeypatch.setattr(Path, "is_symlink", simulated_is_symlink)
+        monkeypatch.setattr(Path, "resolve", simulated_resolve)
+        monkeypatch.setattr(bootstrap_reconcile_module.os, "readlink", simulated_readlink)
+    exchanged = False
+
+    def raced_exchange(left: Path, right: Path) -> None:
+        nonlocal exchanged
+        if exchanged:
+            original_exchange(left, right)
+            return
+        exchanged = True
+        if race_boundary == "before_exchange":
+            destination.write_bytes(operator_update)
+        original_exchange(left, right)
+        if race_boundary == "after_exchange":
+            destination.unlink()
+            simulated_links.pop(destination, None)
+            destination.write_bytes(operator_update)
+        if race_boundary == "crash":
+            raise RuntimeError("crash after atomic exchange")
+
+    monkeypatch.setattr(
+        bootstrap_reconcile_module,
+        "_atomic_exchange_paths",
+        raced_exchange,
+    )
+    reconcile = bootstrap_reconcile_module._reconcile_activation_symlink  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+
+    if race_boundary == "crash":
+        with pytest.raises(RuntimeError, match="crash after atomic exchange"):
+            reconcile(
+                snapshot,
+                expected_target=target,
+                label="stable launcher",
+                exchange_identity="c" * 64,
+            )
+        monkeypatch.setattr(
+            bootstrap_reconcile_module,
+            "_atomic_exchange_paths",
+            original_exchange,
+        )
+        assert (
+            reconcile(
+                snapshot,
+                expected_target=target,
+                label="stable launcher",
+                exchange_identity="c" * 64,
+            )
+            == "retargeted"
+        )
+        assert os.readlink(destination) == str(target)
+    else:
+        with pytest.raises(ConfigurationError, match="changed .*atomic activation"):
+            reconcile(
+                snapshot,
+                expected_target=target,
+                label="stable launcher",
+                exchange_identity="c" * 64,
+            )
+        assert destination.read_bytes() == operator_update
+    assert not list(tmp_path.glob(".launcher.*.exchange"))
+
+
+def test_atomic_exchange_preflight_restores_and_cleans_every_directory(
+    tmp_path: Path,
+) -> None:
+    """The exact exchange primitive is exercised without retaining probe state."""
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+
+    evidence = bootstrap_reconcile_module.verify_atomic_exchange_support(
+        (first, second, first),
+        identity="d" * 64,
+    )
+
+    assert evidence["directories"] == [str(first), str(second)]
+    assert list(first.iterdir()) == []
+    assert list(second.iterdir()) == []
+
+
+def test_staged_activation_adopts_legacy_paths_idempotently(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pre-generation install converges every stable path to canonical links."""
+    desired = _desired(uv_sha256="a" * 64, frpc_sha256="b" * 64, frps_sha256="c" * 64)
+    share = tmp_path / ".local/share/clio-relay"
+    bin_dir = tmp_path / ".local/bin"
+    generation = share / "generations" / desired.fingerprint
+    (generation / "bin").mkdir(parents=True)
+    (generation / "source/jarvis-packages/clio_relay").mkdir(parents=True)
+    bin_dir.mkdir(parents=True)
+    for path, payload in (
+        (share / "install-receipt.json", b"legacy-receipt"),
+        (bin_dir / "clio-relay", b"legacy-relay"),
+        (bin_dir / "jarvis", b"legacy-jarvis"),
+        (generation / "install-receipt.json", b"new-receipt"),
+        (generation / "bin/clio-relay", b"new-relay"),
+        (generation / "bin/jarvis", b"new-jarvis"),
+    ):
+        path.write_bytes(payload)
+        path.chmod(0o755)
+    activation_paths = bootstrap_reconcile_module._capture_reconcile_activation_paths(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        home=tmp_path,
+    )
+    plan = BootstrapReconcilePlan(
+        mode="component-upgrade",
+        desired_fingerprint=desired.fingerprint,
+        component_actions={"clio-relay": "replace"},
+        activation_paths=activation_paths,
+    )
+
+    simulated_links: dict[Path, Path] = {}
+    if os.name == "nt":
+        original_is_symlink = Path.is_symlink
+        original_resolve = Path.resolve
+        original_readlink = os.readlink
+        original_replace = os.replace
+
+        def simulated_target(path: Path) -> Path:
+            candidate = path
+            for _ in range(10):
+                matches: list[tuple[int, Path, Path]] = []
+                for link, target in simulated_links.items():
+                    try:
+                        relative = candidate.relative_to(link)
+                    except ValueError:
+                        continue
+                    matches.append((len(link.parts), target, relative))
+                if not matches:
+                    return candidate
+                _length, target, relative = max(matches, key=lambda item: item[0])
+                candidate = target / relative
+            raise AssertionError("simulated symlink chain did not terminate")
+
+        def simulated_symlink_to(
+            path: Path,
+            target: Path | str,
+            target_is_directory: bool = False,
+        ) -> None:
+            del target_is_directory
+            if path.exists() or path in simulated_links:
+                raise FileExistsError(path)
+            path.write_bytes(b"simulated-symlink")
+            simulated_links[path] = Path(target)
+
+        def simulated_is_symlink(path: Path) -> bool:
+            return path in simulated_links or original_is_symlink(path)
+
+        def simulated_resolve(path: Path, strict: bool = False) -> Path:
+            return original_resolve(simulated_target(path), strict=strict)
+
+        def simulated_readlink(path: Path | str) -> str:
+            candidate = Path(path)
+            if candidate in simulated_links:
+                return str(simulated_links[candidate])
+            return cast(str, original_readlink(path))
+
+        def simulated_replace(source: Path | str, destination: Path | str) -> None:
+            source_path = Path(source)
+            destination_path = Path(destination)
+            original_replace(source_path, destination_path)
+            if source_path in simulated_links:
+                simulated_links[destination_path] = simulated_links.pop(source_path)
+
+        monkeypatch.setattr(Path, "symlink_to", simulated_symlink_to)
+        monkeypatch.setattr(Path, "is_symlink", simulated_is_symlink)
+        monkeypatch.setattr(Path, "resolve", simulated_resolve)
+        monkeypatch.setattr(bootstrap_reconcile_module.os, "readlink", simulated_readlink)
+        monkeypatch.setattr(bootstrap_reconcile_module.os, "replace", simulated_replace)
+
+    first = reconcile_staged_activation_links(plan, generation=generation, home=tmp_path)
+    second = reconcile_staged_activation_links(plan, generation=generation, home=tmp_path)
+    first_actions = cast(dict[str, str], first["actions"])
+    second_actions = cast(dict[str, str], second["actions"])
+
+    assert first_actions == {
+        "current": "created",
+        "install_receipt": "retargeted",
+        "relay_launcher": "retargeted",
+        "jarvis_launcher": "retargeted",
+        "managed_repo": "created",
+    }
+    assert set(second_actions.values()) == {"reused"}
+    expected_targets = {
+        share / "current": generation,
+        share / "install-receipt.json": share / "current/install-receipt.json",
+        bin_dir / "clio-relay": share / "current/bin/clio-relay",
+        bin_dir / "jarvis": share / "current/bin/jarvis",
+        share / "managed-jarvis-repo": share / "current/source/jarvis-packages/clio_relay",
+    }
+    assert {path: bootstrap_reconcile_module.os.readlink(path) for path in expected_targets} == {
+        path: str(target) for path, target in expected_targets.items()
+    }
+
+
+def test_staged_activation_rejects_manifest_path_substitution_before_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A signed plan cannot redirect any stable activation destination."""
+    desired = _desired(uv_sha256="a" * 64, frpc_sha256="b" * 64, frps_sha256="c" * 64)
+    share = tmp_path / ".local/share/clio-relay"
+    generation = share / "generations" / desired.fingerprint
+    generation.mkdir(parents=True)
+    activation_paths = {
+        "current": BootstrapActivationPath(
+            path=str(tmp_path / "attacker/current"),
+            kind="symlink",
+        ),
+        "install_receipt": BootstrapActivationPath(
+            path=str(share / "install-receipt.json"),
+            kind="file_or_symlink",
+        ),
+        "relay_launcher": BootstrapActivationPath(
+            path=str(tmp_path / ".local/bin/clio-relay"),
+            kind="file_or_symlink",
+        ),
+        "jarvis_launcher": BootstrapActivationPath(
+            path=str(tmp_path / ".local/bin/jarvis"),
+            kind="file_or_symlink",
+        ),
+        "managed_repo": BootstrapActivationPath(
+            path=str(share / "managed-jarvis-repo"),
+            kind="symlink",
+        ),
+    }
+    plan = BootstrapReconcilePlan(
+        mode="component-upgrade",
+        desired_fingerprint=desired.fingerprint,
+        component_actions={"clio-relay": "replace"},
+        activation_paths=activation_paths,
+    )
+
+    def unexpected_symlink(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("activation wrote before validating destinations")
+
+    monkeypatch.setattr(Path, "symlink_to", unexpected_symlink)
+
+    with pytest.raises(ConfigurationError, match="destination changed: current"):
+        reconcile_staged_activation_links(plan, generation=generation, home=tmp_path)
+
+    assert not (tmp_path / "attacker/current").exists()
+
+
+def test_finish_staged_activation_rejects_manifest_tamper_before_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Recovery uses the journaled manifest digest instead of trusting disk state."""
+    desired = _desired(uv_sha256="a" * 64, frpc_sha256="b" * 64, frps_sha256="c" * 64)
+    generation = tmp_path / "generation"
+    generation.mkdir()
+    (generation / "manifest.json").write_bytes(b'{"tampered":true}\n')
+
+    def unexpected_mutation(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("tampered manifest reached activation")
+
+    monkeypatch.setattr(
+        bootstrap_reconcile_module,
+        "reconcile_staged_activation_links",
+        unexpected_mutation,
+    )
+    monkeypatch.setattr(
+        bootstrap_reconcile_module,
+        "reconcile_managed_jarvis_repository",
+        unexpected_mutation,
+    )
+
+    with pytest.raises(ConfigurationError, match="manifest changed before activation"):
+        finish_staged_activation(
+            desired,
+            generation=generation,
+            expected_manifest_sha256="f" * 64,
+            home=tmp_path,
+        )
+
+
+def test_staged_activation_preserves_a_raced_absent_destination(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exclusive link creation fails closed without clobbering a racing writer."""
+    destination = tmp_path / "stable-link"
+    target = tmp_path / "target"
+    target.mkdir()
+    snapshot = BootstrapActivationPath(path=str(destination), kind="symlink")
+
+    def race_symlink(
+        path: Path,
+        _target: Path,
+        target_is_directory: bool = False,
+    ) -> None:
+        del target_is_directory
+        assert path == destination
+        path.write_bytes(b"operator-owned")
+        raise FileExistsError(path)
+
+    monkeypatch.setattr(Path, "symlink_to", race_symlink)
+
+    with pytest.raises(ConfigurationError, match="appeared before activation"):
+        bootstrap_reconcile_module._reconcile_activation_symlink(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            snapshot,
+            expected_target=target,
+            label="stable test link",
+        )
+
+    assert destination.read_bytes() == b"operator-owned"
+
+
+def test_staged_activation_refuses_a_changed_legacy_launcher(tmp_path: Path) -> None:
+    """The activation fence cannot replace a launcher changed after planning."""
+    destination = tmp_path / "legacy-launcher"
+    destination.write_bytes(b"original")
+    destination.chmod(0o755)
+    snapshot = bootstrap_reconcile_module._capture_activation_path(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        destination,
+        kind="file_or_symlink",
+        maximum=1024,
+        allow_absent=False,
+    )
+    destination.write_bytes(b"operator-replacement")
+    target = tmp_path / "new-launcher"
+    target.write_bytes(b"new")
+
+    with pytest.raises(ConfigurationError, match="changed after bootstrap inspection"):
+        bootstrap_reconcile_module._reconcile_activation_symlink(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            snapshot,
+            expected_target=target,
+            label="stable relay launcher",
+        )
+
+    assert destination.read_bytes() == b"operator-replacement"
+
+
+@pytest.mark.parametrize("crash_boundary", ["before_repository", "after_replace", "completed"])
+def test_staged_activation_resumes_across_repository_crash_boundaries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    crash_boundary: str,
+) -> None:
+    """Forward recovery completes exact repository migration after every boundary."""
+    desired = _desired(uv_sha256="a" * 64, frpc_sha256="b" * 64, frps_sha256="c" * 64)
+    execution_root = tmp_path / ".local/share/clio-relay/jarvis-venv"
+    execution_bin = execution_root / ("Scripts" if os.name == "nt" else "bin")
+    execution_bin.mkdir(parents=True)
+    execution_python = execution_bin / ("python.exe" if os.name == "nt" else "python")
+    execution_jarvis = execution_bin / ("jarvis.exe" if os.name == "nt" else "jarvis")
+    for path in (execution_python, execution_jarvis):
+        path.write_bytes(path.name.encode())
+        path.chmod(0o755)
+    legacy_identity = execution_environment_identity(
+        execution_root,
+        executables={"python": execution_python, "jarvis": execution_jarvis},
+    )
+    generation = tmp_path / ".local/share/clio-relay/generations" / desired.fingerprint
+    generation.mkdir(parents=True)
+    generation_receipt = generation / "install-receipt.json"
+    generation_receipt.write_text("{}\n", encoding="utf-8")
+    plan = BootstrapReconcilePlan(
+        mode="component-upgrade",
+        desired_fingerprint=desired.fingerprint,
+        component_actions={"clio-relay": "replace"},
+        reusable_paths={
+            "jarvis_execution_environment": str(execution_root),
+            "jarvis_execution_python": str(execution_python),
+            "jarvis_execution_executable": str(execution_jarvis),
+        },
+    )
+    manifest = {
+        "schema_version": "clio-relay.bootstrap-generation.v1",
+        "fingerprint": desired.fingerprint,
+        "plan": plan.model_dump(mode="json"),
+        "legacy_execution_identity": legacy_identity,
+        "active_execution_identity": legacy_identity,
+        "jarvis_wrapper_sha256": "1" * 64,
+        "install_receipt": str(generation_receipt),
+        "install_receipt_sha256": _digest(generation_receipt.read_bytes()),
+    }
+    manifest_bytes = (json.dumps(manifest, sort_keys=True) + "\n").encode()
+    (generation / "manifest.json").write_bytes(manifest_bytes)
+    manifest_sha256 = _digest(manifest_bytes)
+    jarvis_root = tmp_path / ".ppi-jarvis"
+    jarvis_root.mkdir()
+    repos_file = jarvis_root / "repos.yaml"
+    previous_repo = tmp_path / ".local/src/clio-relay/jarvis-packages/clio_relay"
+    operator_repo = tmp_path / "operator/clio_relay"
+    repos_file.write_text(
+        yaml.safe_dump(
+            {"repos": [str(operator_repo.absolute()), str(previous_repo.absolute())]},
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    link_calls = 0
+
+    def simulated_links(
+        _plan: BootstrapReconcilePlan,
+        *,
+        generation: Path,
+        home: Path | None = None,
+    ) -> dict[str, object]:
+        nonlocal link_calls
+        del generation, home
+        link_calls += 1
+        action = "created" if link_calls == 1 else "reused"
+        return {
+            "schema_version": "clio-relay.bootstrap-activation.v1",
+            "generation": desired.fingerprint,
+            "actions": {"managed_repo": action},
+        }
+
+    def simulated_inspection(
+        _desired: BootstrapDesiredState,
+        *,
+        generation: Path,
+        legacy_execution_identity: dict[str, object],
+    ) -> dict[str, object]:
+        del generation, legacy_execution_identity
+        return {"manifest_sha256": manifest_sha256}
+
+    def simulated_stable_link(path: Path, *, expected: Path, label: str) -> Path:
+        del path, label
+        return expected
+
+    monkeypatch.setattr(
+        bootstrap_reconcile_module,
+        "inspect_prepared_generation",
+        simulated_inspection,
+    )
+    monkeypatch.setattr(
+        bootstrap_reconcile_module,
+        "reconcile_staged_activation_links",
+        simulated_links,
+    )
+    monkeypatch.setattr(
+        bootstrap_reconcile_module,
+        "_verify_stable_symlink",
+        simulated_stable_link,
+    )
+    original_readlink = os.readlink
+    managed_repo = tmp_path / ".local/share/clio-relay/managed-jarvis-repo"
+    managed_target = tmp_path / ".local/share/clio-relay/current/source/jarvis-packages/clio_relay"
+
+    def simulated_readlink(path: Path | str) -> str:
+        if Path(path) == managed_repo:
+            return str(managed_target)
+        return cast(str, original_readlink(path))
+
+    monkeypatch.setattr(
+        bootstrap_reconcile_module.os,
+        "readlink",
+        simulated_readlink,
+    )
+    original_reconcile = reconcile_managed_jarvis_repository
+    repository_calls = 0
+
+    def crashable_reconcile(
+        path: Path,
+        managed: Path,
+        *,
+        previous_managed_repos: tuple[Path, ...] = (),
+        exchange_identity: str | None = None,
+    ) -> dict[str, object]:
+        nonlocal repository_calls
+        repository_calls += 1
+        if repository_calls == 1 and crash_boundary == "before_repository":
+            raise RuntimeError("crash before repository migration")
+        evidence = original_reconcile(
+            path,
+            managed,
+            previous_managed_repos=previous_managed_repos,
+            exchange_identity=exchange_identity,
+        )
+        if repository_calls == 1 and crash_boundary == "after_replace":
+            raise RuntimeError("crash after repository replacement")
+        return evidence
+
+    monkeypatch.setattr(
+        bootstrap_reconcile_module,
+        "reconcile_managed_jarvis_repository",
+        crashable_reconcile,
+    )
+
+    if crash_boundary != "completed":
+        with pytest.raises(RuntimeError, match="crash"):
+            finish_staged_activation(
+                desired,
+                generation=generation,
+                expected_manifest_sha256=manifest_sha256,
+                home=tmp_path,
+            )
+    first_completed = finish_staged_activation(
+        desired,
+        generation=generation,
+        expected_manifest_sha256=manifest_sha256,
+        home=tmp_path,
+    )
+    second_completed = finish_staged_activation(
+        desired,
+        generation=generation,
+        expected_manifest_sha256=manifest_sha256,
+        home=tmp_path,
+    )
+
+    repositories = yaml.safe_load(repos_file.read_text(encoding="utf-8"))["repos"]
+    assert repositories == [str(managed_repo.absolute()), str(operator_repo.absolute())]
+    first_repository = cast(dict[str, object], first_completed["jarvis_repository"])
+    second_repository = cast(dict[str, object], second_completed["jarvis_repository"])
+    second_update = cast(dict[str, object], second_repository["repositories"])
+    assert second_update["action"] == "reused"
+    assert first_repository["target"] == str(managed_target)
+    assert link_calls >= 2
+
+
 def test_managed_repo_repair_refuses_unproven_broken_link(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A broken link is existing untrusted state, not an absent managed path."""
     desired = _desired(uv_sha256="a" * 64, frpc_sha256="b" * 64, frps_sha256="c" * 64)
-    expected = (
-        tmp_path
-        / ".local/share/clio-relay/generations"
-        / desired.fingerprint
-        / "source/jarvis-packages/clio_relay"
-    )
+    generation = tmp_path / ".local/share/clio-relay/generations" / desired.fingerprint
+    expected = generation / "source/jarvis-packages/clio_relay"
     expected.mkdir(parents=True)
+    current = tmp_path / ".local/share/clio-relay/current"
     managed = tmp_path / ".local/share/clio-relay/managed-jarvis-repo"
     original_lstat = Path.lstat
+    original_readlink = os.readlink
+    original_resolve = Path.resolve
+    original_verify = bootstrap_reconcile_module._verify_stable_symlink  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    managed_identity = original_lstat(expected)
+
+    def simulated_resolve(path: Path, strict: bool = False) -> Path:
+        if path == current / "source/jarvis-packages/clio_relay":
+            return original_resolve(expected, strict=strict)
+        return original_resolve(path, strict=strict)
+
+    def simulated_verify(path: Path, *, expected: Path, label: str) -> Path:
+        if path == current:
+            return generation
+        return original_verify(path, expected=expected, label=label)
 
     def simulated_lstat(path: Path) -> os.stat_result | SimpleNamespace:
         if path == managed:
-            return SimpleNamespace(st_mode=stat.S_IFLNK)
+            return SimpleNamespace(
+                st_dev=managed_identity.st_dev,
+                st_ino=managed_identity.st_ino,
+                st_mode=stat.S_IFLNK,
+                st_size=1,
+                st_mtime_ns=managed_identity.st_mtime_ns,
+                st_ctime_ns=managed_identity.st_ctime_ns,
+            )
         return original_lstat(path)
 
-    def redirected_readlink(_path: os.PathLike[str] | str) -> str:
-        return str(tmp_path / "attacker-controlled/missing")
+    def simulated_readlink(path: Path | str) -> str:
+        if Path(path) == managed:
+            return str(tmp_path / "attacker-controlled/missing")
+        return cast(str, original_readlink(path))
 
     monkeypatch.setattr(Path, "lstat", simulated_lstat)
+    monkeypatch.setattr(Path, "resolve", simulated_resolve)
+    monkeypatch.setattr(
+        bootstrap_reconcile_module,
+        "_verify_stable_symlink",
+        simulated_verify,
+    )
     monkeypatch.setattr(
         bootstrap_reconcile_module.os,
         "readlink",
-        redirected_readlink,
+        simulated_readlink,
     )
 
     with pytest.raises(ConfigurationError, match="not proven by an earlier receipt"):
@@ -894,7 +1641,7 @@ def test_prepared_generation_refuses_a_tampered_relay_owned_jarvis_wrapper(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     desired = _desired(uv_sha256="a" * 64, frpc_sha256="b" * 64, frps_sha256="c" * 64)
-    execution_root = tmp_path / "jarvis-venv"
+    execution_root = tmp_path / "legacy-jarvis-venv"
     execution_bin = execution_root / ("Scripts" if os.name == "nt" else "bin")
     execution_bin.mkdir(parents=True)
     execution_python = execution_bin / ("python.exe" if os.name == "nt" else "python")
@@ -909,11 +1656,26 @@ def test_prepared_generation_refuses_a_tampered_relay_owned_jarvis_wrapper(
         execution_root,
         executables={"python": execution_python, "jarvis": legacy_jarvis},
     )
+    active_root = tmp_path / "active-jarvis-venv"
+    active_bin = active_root / ("Scripts" if os.name == "nt" else "bin")
+    active_bin.mkdir(parents=True)
+    active_python = active_bin / ("python.exe" if os.name == "nt" else "python")
+    active_jarvis = active_bin / ("jarvis.exe" if os.name == "nt" else "jarvis")
+    for path, payload in (
+        (active_python, b"active-python-runtime"),
+        (active_jarvis, b"active-jarvis-launcher"),
+    ):
+        path.write_bytes(payload)
+        path.chmod(0o755)
+    active_identity = execution_environment_identity(
+        active_root,
+        executables={"python": active_python, "jarvis": active_jarvis},
+    )
     generation = tmp_path / "generation"
     generation_bin = generation / "bin"
     generation_bin.mkdir(parents=True)
     wrapper = generation_bin / "jarvis"
-    wrapper_evidence = write_jarvis_wrapper(wrapper, execution_python)
+    wrapper_evidence = write_jarvis_wrapper(wrapper, active_python)
     simulated_launchers: set[Path] = set()
     for name in ("clio-relay", "clio-kit"):
         target = tmp_path / f"{name}-target"
@@ -931,7 +1693,7 @@ def test_prepared_generation_refuses_a_tampered_relay_owned_jarvis_wrapper(
     receipt_path = generation / "install-receipt.json"
     receipt_path.write_text("{}\n", encoding="utf-8")
     plan = {
-        "mode": "relay-only",
+        "mode": "component-upgrade",
         "desired_fingerprint": desired.fingerprint,
         "component_actions": {"clio-relay": "replace"},
     }
@@ -940,8 +1702,10 @@ def test_prepared_generation_refuses_a_tampered_relay_owned_jarvis_wrapper(
         "fingerprint": desired.fingerprint,
         "plan": plan,
         "legacy_execution_identity": execution_identity,
+        "active_execution_identity": active_identity,
         "jarvis_wrapper_sha256": wrapper_evidence["sha256"],
         "install_receipt": str(receipt_path),
+        "install_receipt_sha256": _digest(receipt_path.read_bytes()),
     }
     (generation / "manifest.json").write_text(
         json.dumps(manifest, indent=2, sort_keys=True) + "\n",
@@ -949,11 +1713,19 @@ def test_prepared_generation_refuses_a_tampered_relay_owned_jarvis_wrapper(
     )
     with (generation / ".prepared").open("w", encoding="ascii", newline="\n") as stream:
         stream.write(desired.fingerprint + "\n")
+    installation = _installation_info(desired)
+    receipt = cast(dict[str, object], installation["receipt"])
+    receipt["component_artifacts"] = {
+        "jarvis-cd": {"runtime_interpreters": {"execution": str(active_python)}}
+    }
 
     def read_installation(_path: Path | None = None) -> dict[str, object]:
-        return _installation_info(desired)
+        return installation
 
-    monkeypatch.setattr("clio_relay.bootstrap_reconcile.installation_info", read_installation)
+    monkeypatch.setattr(
+        "clio_relay.bootstrap_reconcile.installation_info",
+        read_installation,
+    )
 
     evidence = inspect_prepared_generation(
         desired,
@@ -963,7 +1735,29 @@ def test_prepared_generation_refuses_a_tampered_relay_owned_jarvis_wrapper(
 
     launcher_targets = cast(dict[str, object], evidence["launcher_targets"])
     assert launcher_targets["jarvis"] == str(wrapper)
-    assert wrapper.read_bytes() == jarvis_wrapper_payload(execution_python)
+    assert wrapper.read_bytes() == jarvis_wrapper_payload(active_python)
+
+    artifacts = cast(dict[str, object], receipt["component_artifacts"])
+    jarvis_artifact = cast(dict[str, object], artifacts["jarvis-cd"])
+    interpreters = cast(dict[str, object], jarvis_artifact["runtime_interpreters"])
+    interpreters["execution"] = str(execution_python)
+    with pytest.raises(ConfigurationError, match="not bound to its install receipt"):
+        inspect_prepared_generation(
+            desired,
+            generation=generation,
+            legacy_execution_identity=execution_identity,
+        )
+    interpreters["execution"] = str(active_python)
+
+    receipt_before = receipt_path.read_bytes()
+    receipt_path.write_text('{"changed":true}\n', encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="manifest identity changed"):
+        inspect_prepared_generation(
+            desired,
+            generation=generation,
+            legacy_execution_identity=execution_identity,
+        )
+    receipt_path.write_bytes(receipt_before)
 
     wrapper.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     wrapper.chmod(0o755)
@@ -973,6 +1767,33 @@ def test_prepared_generation_refuses_a_tampered_relay_owned_jarvis_wrapper(
             generation=generation,
             legacy_execution_identity=execution_identity,
         )
+
+
+def test_jarvis_wrapper_executes_the_lexical_venv_python(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resolving a venv Python must not bypass its installed site-packages."""
+    lexical_python = tmp_path / "venv/bin/python"
+    resolved_python = tmp_path / "base/bin/python3"
+    lexical_python.parent.mkdir(parents=True)
+    resolved_python.parent.mkdir(parents=True)
+    for path in (lexical_python, resolved_python):
+        path.write_bytes(b"python")
+        path.chmod(0o755)
+    original_resolve = Path.resolve
+
+    def simulated_venv_resolve(path: Path, strict: bool = False) -> Path:
+        if path == lexical_python:
+            return original_resolve(resolved_python, strict=strict)
+        return original_resolve(path, strict=strict)
+
+    monkeypatch.setattr(Path, "resolve", simulated_venv_resolve)
+
+    payload = jarvis_wrapper_payload(lexical_python).decode("utf-8")
+
+    assert f"exec {shlex.quote(str(lexical_python))}" in payload
+    assert f"exec {shlex.quote(str(resolved_python))}" not in payload
 
 
 def test_active_generation_rejects_coordinated_manifest_and_wrapper_tamper(
@@ -1015,8 +1836,10 @@ def test_active_generation_rejects_coordinated_manifest_and_wrapper_tamper(
             "component_actions": {"clio-relay": "replace"},
         },
         "legacy_execution_identity": original_identity,
+        "active_execution_identity": original_identity,
         "jarvis_wrapper_sha256": wrapper_evidence["sha256"],
         "install_receipt": str(receipt_path),
+        "install_receipt_sha256": _digest(receipt_path.read_bytes()),
     }
     manifest_path = generation / "manifest.json"
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
@@ -1038,7 +1861,7 @@ def test_active_generation_rejects_coordinated_manifest_and_wrapper_tamper(
     )
     wrapper.unlink()
     replacement_wrapper = write_jarvis_wrapper(wrapper, replacement_python)
-    manifest["legacy_execution_identity"] = replacement_identity
+    manifest["active_execution_identity"] = replacement_identity
     manifest["jarvis_wrapper_sha256"] = replacement_wrapper["sha256"]
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,6 +51,7 @@ from clio_relay.models import (
     JarvisRunSpec,
     JobKind,
     JobState,
+    JobWaitResult,
     McpAdmissionClass,
     McpCallSpec,
     McpOperation,
@@ -971,6 +972,81 @@ def test_cli_job_status_includes_relay_queue(tmp_path: Path, monkeypatch: Monkey
     status = json.loads(result.output)
     assert status["job"]["job_id"] == job.job_id
     assert status["relay_queue"] == {"state": "queued", "jobs_ahead": 0, "position": 1}
+
+
+def test_cli_job_wait_returns_current_state_when_observation_expires(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    core_dir = tmp_path / "core"
+    queue = ClioCoreQueue(core_dir)
+    job = queue.submit_job(
+        RelayJob(
+            cluster="test-cluster",
+            kind=JobKind.JARVIS,
+            spec=JarvisRunSpec(pipeline_name="long-cli-run"),
+            idempotency_key="long-cli-run",
+        )
+    )
+    monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(core_dir))
+    observations: list[tuple[str, float, float]] = []
+
+    def observe(
+        selected_queue: ClioCoreQueue,
+        job_id: str,
+        *,
+        timeout_seconds: float,
+        poll_seconds: float,
+    ) -> JobWaitResult:
+        observations.append((job_id, timeout_seconds, poll_seconds))
+        return cli.job_wait_result(
+            selected_queue.get_job(job_id),
+            timeout_seconds=timeout_seconds,
+        )
+
+    monkeypatch.setattr(cli, "observe_until_terminal", observe)
+    result = CliRunner().invoke(
+        app,
+        [
+            "job",
+            "wait",
+            job.job_id,
+            "--timeout-seconds",
+            "0.25",
+            "--poll-seconds",
+            "0.05",
+        ],
+    )
+
+    assert result.exit_code == 0
+    observed = json.loads(result.output)
+    assert observed["job_id"] == job.job_id
+    assert observed["state"] == "queued"
+    assert observed["observation"] == {
+        "outcome": "observation_unknown",
+        "timeout_seconds": 0.25,
+        "scheduler_action": "none",
+        "relay_action": "none",
+    }
+    assert observations == [(job.job_id, 0.25, 0.05)]
+    assert queue.get_job(job.job_id).state is JobState.QUEUED
+
+
+@pytest.mark.parametrize(
+    ("option", "value"),
+    [("--timeout-seconds", "inf"), ("--poll-seconds", "inf")],
+)
+def test_cli_job_wait_rejects_nonfinite_observation_bounds(
+    option: str,
+    value: str,
+) -> None:
+    result = CliRunner().invoke(
+        app,
+        ["job", "wait", "job_00000000000000000000000000000001", option, value],
+    )
+
+    assert result.exit_code != 0
+    assert "positive and finite" in result.output
 
 
 def test_cli_queue_management_commands(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
@@ -9272,17 +9348,33 @@ def test_cli_remote_wait_passthrough_uses_cluster_core(
     monkeypatch.setenv("CLIO_RELAY_CLI_MODE", "ssh")
     _write_test_cluster(tmp_path)
     commands: list[list[str]] = []
+    remote_job = RelayJob(
+        job_id="job_00000000000000000000000000000001",
+        cluster="ares",
+        kind=JobKind.JARVIS,
+        state=JobState.QUEUED,
+        spec=JarvisRunSpec(pipeline_name="long-remote-run"),
+        idempotency_key="long-remote-run",
+    )
+    wait_result = cli.job_wait_result(remote_job, timeout_seconds=1.0)
 
     def fake_run(
         command: list[str],
         *,
         capture_output: bool,
         check: bool,
+        timeout: float | None = None,
     ) -> subprocess.CompletedProcess[bytes]:
         commands.append(command)
         assert capture_output is True
         assert check is False
-        return subprocess.CompletedProcess(command, 0, b'{"job_id":"job_remote"}\n', b"")
+        assert timeout == 11.0
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            wait_result.model_dump_json().encode("utf-8"),
+            b"",
+        )
 
     monkeypatch.setattr("clio_relay.remote_cli.subprocess.run", fake_run)
 
@@ -9291,7 +9383,7 @@ def test_cli_remote_wait_passthrough_uses_cluster_core(
         [
             "job",
             "wait",
-            "job_remote",
+            remote_job.job_id,
             "--cluster",
             "ares",
             "--timeout-seconds",
@@ -9302,9 +9394,144 @@ def test_cli_remote_wait_passthrough_uses_cluster_core(
     )
 
     assert result.exit_code == 0
-    assert json.loads(result.output)["job_id"] == "job_remote"
+    observed = json.loads(result.output)
+    assert observed["job_id"] == remote_job.job_id
+    assert observed["observation"]["outcome"] == "observation_unknown"
     assert len(commands) == 1
-    assert "clio-relay job wait job_remote" in commands[0][2]
+    assert f"clio-relay job wait {remote_job.job_id}" in commands[0][2]
+
+
+def test_cli_remote_wait_transport_expiry_reobserves_exact_status(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_CLI_MODE", "ssh")
+    _write_test_cluster(tmp_path)
+    remote_job = RelayJob(
+        job_id="job_00000000000000000000000000000002",
+        cluster="ares",
+        kind=JobKind.JARVIS,
+        state=JobState.QUEUED,
+        spec=JarvisRunSpec(pipeline_name="long-remote-run"),
+        idempotency_key="long-remote-run-timeout",
+    )
+    commands: list[list[str]] = []
+    timeouts: list[float | None] = []
+
+    def fake_run(
+        command: list[str],
+        *,
+        capture_output: bool,
+        check: bool,
+        timeout: float | None = None,
+    ) -> subprocess.CompletedProcess[bytes]:
+        commands.append(command)
+        timeouts.append(timeout)
+        assert capture_output is True
+        assert check is False
+        if "clio-relay job wait" in command[2]:
+            raise subprocess.TimeoutExpired(command, timeout or 0)
+        if "clio-relay job status" in command[2]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps(
+                    {
+                        "job": remote_job.model_dump(mode="json"),
+                        "relay_queue": {"state": "queued"},
+                        "scheduler": [{"scheduler_job_id": "42", "raw_state": "PENDING"}],
+                        "terminal": False,
+                    }
+                ).encode("utf-8"),
+                b"",
+            )
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr("clio_relay.remote_cli.subprocess.run", fake_run)
+    result = CliRunner().invoke(
+        app,
+        [
+            "job",
+            "wait",
+            remote_job.job_id,
+            "--cluster",
+            "ares",
+            "--timeout-seconds",
+            "1",
+            "--poll-seconds",
+            "0.1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    observed = json.loads(result.output)
+    assert observed["job_id"] == remote_job.job_id
+    assert observed["state"] == "queued"
+    assert observed["observation"]["outcome"] == "observation_unknown"
+    assert observed["observation"]["scheduler_action"] == "none"
+    assert len(commands) == 2
+    assert timeouts == [11.0, 30.0]
+
+
+def test_cli_remote_wait_rejects_contradictory_terminal_claim(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_CLI_MODE", "ssh")
+    _write_test_cluster(tmp_path)
+    remote_job = RelayJob(
+        job_id="job_00000000000000000000000000000003",
+        cluster="ares",
+        kind=JobKind.JARVIS,
+        state=JobState.QUEUED,
+        spec=JarvisRunSpec(pipeline_name="hostile-remote-run"),
+        idempotency_key="hostile-remote-run",
+    )
+
+    def fake_run(
+        command: list[str],
+        *,
+        capture_output: bool,
+        check: bool,
+        timeout: float | None = None,
+    ) -> subprocess.CompletedProcess[bytes]:
+        assert capture_output is True
+        assert check is False
+        assert timeout == 11.0
+        contradictory = {
+            **remote_job.model_dump(mode="json"),
+            "observation": {
+                "outcome": "terminal",
+                "timeout_seconds": 1,
+                "scheduler_action": "none",
+                "relay_action": "none",
+            },
+        }
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            json.dumps(contradictory).encode("utf-8"),
+            b"",
+        )
+
+    monkeypatch.setattr("clio_relay.remote_cli.subprocess.run", fake_run)
+    result = CliRunner().invoke(
+        app,
+        [
+            "job",
+            "wait",
+            remote_job.job_id,
+            "--cluster",
+            "ares",
+            "--timeout-seconds",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "remote job wait returned an invalid result" in result.output
 
 
 def test_cli_cluster_bootstrap_uses_package_source_root(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from threading import Thread
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
@@ -85,6 +85,18 @@ from tests.queue_validation_fixtures import (
 _REAL_PERSIST_VERIFIED_CLEANUP_REPORT = (
     cli._persist_verified_cleanup_report_before_closure  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
 )
+
+
+def _fake_no_worker_observation(
+    _definition: ClusterDefinition,
+) -> tuple[None, None]:
+    """Return the typed no-worker observation used by teardown tests."""
+
+    return None, None
+
+
+def _fake_no_completed_cleanup(**_kwargs: object) -> None:
+    """Model an absent completed cleanup receipt without untyped lambdas."""
 
 
 def _owner_session_closure_payload(
@@ -1882,14 +1894,20 @@ def test_session_start_finalizes_completed_teardown_receipt_before_reconnect(
             }
         )
 
+    def read_report(**_kwargs: object) -> SessionLifecycleReport:
+        return report
+
+    def execute_on_cluster(_definition: ClusterDefinition) -> bool:
+        return True
+
     monkeypatch.setattr(cli, "status_remote_session", fake_status)
     monkeypatch.setattr(
         cli,
         "read_remote_session_cleanup_report",
-        lambda **_kwargs: report,
+        read_report,
     )
     monkeypatch.setattr(cli, "run_remote_clio", fake_remote)
-    monkeypatch.setattr(cli, "should_execute_on_cluster", lambda _definition: True)
+    monkeypatch.setattr(cli, "should_execute_on_cluster", execute_on_cluster)
     real_set_closed = ClioCoreQueue.set_owner_session_closed
     local_mutations = 0
 
@@ -2143,7 +2161,7 @@ def test_session_teardown_never_closes_before_finalized_sidecar_reread(
     monkeypatch.setattr(cli, "status_remote_session", _fake_owned_session_status)
     monkeypatch.setattr(cli, "teardown_remote_session", _fake_verified_teardown)
     monkeypatch.setattr(cli, "_cleanup_owned_runtime_sessions", _fake_empty_runtime_cleanup)
-    monkeypatch.setattr(cli, "_observe_worker_before_cleanup", lambda _definition: (None, None))
+    monkeypatch.setattr(cli, "_observe_worker_before_cleanup", _fake_no_worker_observation)
     monkeypatch.setattr(
         cli,
         "_persist_verified_cleanup_report_before_closure",
@@ -2672,8 +2690,12 @@ def test_normal_session_teardown_uses_compact_projection_for_large_report(
     report = _verified_teardown_report()
     report.resources[0].detail = "large-normal-report:" + ("x" * (9 * 1024 * 1024))
     monkeypatch.setattr(cli, "status_remote_session", _fake_owned_session_status)
-    monkeypatch.setattr(cli, "teardown_remote_session", lambda **_kwargs: report)
-    monkeypatch.setattr(cli, "_observe_worker_before_cleanup", lambda _definition: (None, None))
+
+    def teardown(**_kwargs: object) -> SessionLifecycleReport:
+        return report
+
+    monkeypatch.setattr(cli, "teardown_remote_session", teardown)
+    monkeypatch.setattr(cli, "_observe_worker_before_cleanup", _fake_no_worker_observation)
     validation_path = tmp_path / "large-normal.json"
 
     result = CliRunner().invoke(
@@ -2877,6 +2899,9 @@ def test_session_teardown_reuses_finalized_report_before_rediscovery(
     ) -> tuple[dict[str, object] | None, Exception | None]:
         return None, None
 
+    def read_authoritative_admission(**_kwargs: object) -> dict[str, object]:
+        return authoritative_admission()
+
     monkeypatch.setattr(cli, "should_execute_on_cluster", remote_execution)
     monkeypatch.setattr(
         cli,
@@ -2887,7 +2912,7 @@ def test_session_teardown_reuses_finalized_report_before_rediscovery(
     monkeypatch.setattr(
         cli,
         "_owner_session_admission_status",
-        lambda **_kwargs: authoritative_admission(),
+        read_authoritative_admission,
     )
     monkeypatch.setattr(cli, "_observe_worker_before_cleanup", no_worker_observation)
     report_reads: list[OwnedSessionRecoveryStatus] = []
@@ -3094,7 +3119,11 @@ def test_session_start_never_closes_from_remote_only_cleanup_receipt(
             },
         },
     ).model_dump(mode="json")
-    monkeypatch.setattr(cli, "status_remote_session", lambda **_kwargs: status)
+
+    def read_status(**_kwargs: object) -> dict[str, object]:
+        return status
+
+    monkeypatch.setattr(cli, "status_remote_session", read_status)
 
     def forbidden_remote(*_args: object, **_kwargs: object) -> str:
         raise AssertionError("remote-only cleanup evidence must not close admission")
@@ -3160,7 +3189,9 @@ def test_local_owner_session_closure_replay_is_read_only_after_split_failure(
         report
     )
 
-    def recovery(process_state: str) -> OwnedSessionRecoveryStatus:
+    def recovery(
+        process_state: Literal["cleanup_pending", "already_closed"],
+    ) -> OwnedSessionRecoveryStatus:
         return OwnedSessionRecoveryStatus(
             cluster="ares",
             session_id=session_id,
@@ -3202,23 +3233,23 @@ def test_local_owner_session_closure_replay_is_read_only_after_split_failure(
         return real_set_closed(self, owner_session_id, **kwargs)  # pyright: ignore[reportArgumentType]
 
     monkeypatch.setattr(ClioCoreQueue, "set_owner_session_closed", fail_first_mirror_close)
-    arguments = {
-        "queue": queue,
-        "definition": ClusterDefinition(name="ares", ssh_host="ares"),
-        "cluster": "ares",
-        "remote_execution": False,
-        "session_id": session_id,
-        "local_admission_session_id": local_session_id,
-        "session_generation_id": generation_id,
-        "legacy_unversioned_job_ids": [],
-        "finalized_report": report,
-    }
+
+    def mark_closed(finalized_recovery: OwnedSessionRecoveryStatus) -> None:
+        cli._mark_owner_session_closed(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            queue=queue,
+            definition=ClusterDefinition(name="ares", ssh_host="ares"),
+            cluster="ares",
+            remote_execution=False,
+            session_id=session_id,
+            local_admission_session_id=local_session_id,
+            session_generation_id=generation_id,
+            legacy_unversioned_job_ids=[],
+            finalized_recovery=finalized_recovery,
+            finalized_report=report,
+        )
 
     with pytest.raises(RelayError, match="simulated local mirror crash"):
-        cli._mark_owner_session_closed(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
-            **arguments,
-            finalized_recovery=recovery("cleanup_pending"),
-        )
+        mark_closed(recovery("cleanup_pending"))
     assert (
         queue.owner_session_generation_status(
             session_id,
@@ -3235,14 +3266,8 @@ def test_local_owner_session_closure_replay_is_read_only_after_split_failure(
     )
 
     closed_recovery = recovery("already_closed")
-    cli._mark_owner_session_closed(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
-        **arguments,
-        finalized_recovery=closed_recovery,
-    )
-    cli._mark_owner_session_closed(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
-        **arguments,
-        finalized_recovery=closed_recovery,
-    )
+    mark_closed(closed_recovery)
+    mark_closed(closed_recovery)
 
     assert setter_calls[session_id] == 1
     assert setter_calls[local_session_id] == 2
@@ -3556,11 +3581,17 @@ def test_session_start_rejects_invalid_finalized_cleanup_before_closure(
         },
     ).model_dump(mode="json")
 
-    monkeypatch.setattr(cli, "status_remote_session", lambda **_kwargs: status)
+    def read_status(**_kwargs: object) -> dict[str, object]:
+        return status
+
+    def read_report(**_kwargs: object) -> SessionLifecycleReport:
+        return report
+
+    monkeypatch.setattr(cli, "status_remote_session", read_status)
     monkeypatch.setattr(
         cli,
         "read_remote_session_cleanup_report",
-        lambda **_kwargs: report,
+        read_report,
     )
 
     def forbidden_remote(*_args: object, **_kwargs: object) -> str:
@@ -3912,7 +3943,7 @@ def test_cli_session_start_verifies_exact_worker_inside_lock_before_mutation(
     monkeypatch.setattr(
         cli,
         "_finalize_completed_cleanup_receipt_before_start",
-        lambda **_kwargs: None,
+        _fake_no_completed_cleanup,
     )
 
     result = CliRunner().invoke(
@@ -3950,16 +3981,21 @@ def test_cli_session_start_json_returns_self_contained_current_selector(
             f"remote_api_port={kwargs['remote_api_port']}",
         ]
 
+    def verify_worker_compatibility(
+        _definition: ClusterDefinition,
+    ) -> SessionApiReleaseIdentity:
+        return release
+
     monkeypatch.setattr(cli, "start_remote_session", start)
     monkeypatch.setattr(
         cli,
         "_verify_session_start_worker_compatibility",
-        lambda _definition: release,
+        verify_worker_compatibility,
     )
     monkeypatch.setattr(
         cli,
         "_finalize_completed_cleanup_receipt_before_start",
-        lambda **_kwargs: None,
+        _fake_no_completed_cleanup,
     )
 
     result = CliRunner().invoke(
@@ -4024,10 +4060,15 @@ def test_cli_session_start_rejects_stale_plan_before_cleanup_mutation(
         starts += 1
         return []
 
+    def verify_worker_compatibility(
+        _definition: ClusterDefinition,
+    ) -> SessionApiReleaseIdentity:
+        return release
+
     monkeypatch.setattr(
         cli,
         "_verify_session_start_worker_compatibility",
-        lambda _definition: release,
+        verify_worker_compatibility,
     )
     monkeypatch.setattr(cli, "_finalize_completed_cleanup_receipt_before_start", finalize)
     monkeypatch.setattr(cli, "start_remote_session", start)

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -11,6 +11,7 @@ import pytest
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
+from clio_relay import http_api as http_api_module
 from clio_relay.cluster_config import (
     CLUSTER_REGISTRY_ENV,
     ClusterDefinition,
@@ -34,6 +35,7 @@ from clio_relay.models import (
     JarvisRunSpec,
     JobKind,
     JobState,
+    JobWaitResult,
     McpAdmissionAuthority,
     McpAdmissionClass,
     McpCallSpec,
@@ -46,6 +48,7 @@ from clio_relay.models import (
     TaskTimelineEvent,
     utc_now,
 )
+from clio_relay.relay_ops import job_wait_result
 from clio_relay.remote_mcp import (
     cache_entry_from_discovery_artifact,
     remote_mcp_registration_revision,
@@ -122,6 +125,73 @@ def test_http_monitor_logs_and_artifact_content(tmp_path: Path) -> None:
     assert artifact_response.status_code == 200
     assert artifact_response.json()["artifact"]["artifact_id"] == artifact.artifact_id
     assert [response.status_code for response in invalid_log_responses] == [422, 422, 422]
+
+
+def test_http_wait_returns_nonterminal_durable_state_when_observation_expires(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    job = queue.submit_job(
+        RelayJob(
+            cluster="test-cluster",
+            kind=JobKind.JARVIS,
+            spec=JarvisRunSpec(pipeline_name="long-http-run"),
+            idempotency_key="long-http-run",
+        )
+    )
+    observed_arguments: list[tuple[str, float, float]] = []
+
+    def observe(
+        selected_queue: ClioCoreQueue,
+        job_id: str,
+        *,
+        timeout_seconds: float,
+        poll_seconds: float,
+    ) -> JobWaitResult:
+        observed_arguments.append((job_id, timeout_seconds, poll_seconds))
+        return job_wait_result(
+            selected_queue.get_job(job_id),
+            timeout_seconds=timeout_seconds,
+        )
+
+    monkeypatch.setattr(http_api_module, "observe_until_terminal", observe)
+    response = cast(Any, TestClient(create_app(settings))).post(
+        f"/jobs/{job.job_id}/wait",
+        params={"timeout_seconds": 0.25, "poll_seconds": 0.05},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["job_id"] == job.job_id
+    assert response.json()["state"] == "queued"
+    assert response.json()["observation"] == {
+        "outcome": "observation_unknown",
+        "timeout_seconds": 0.25,
+        "scheduler_action": "none",
+        "relay_action": "none",
+    }
+    assert observed_arguments == [(job.job_id, 0.25, 0.05)]
+    assert queue.get_job(job.job_id).state is JobState.QUEUED
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("timeout_seconds", "inf"), ("poll_seconds", "inf")],
+)
+def test_http_wait_rejects_nonfinite_observation_bounds(
+    tmp_path: Path,
+    field: str,
+    value: str,
+) -> None:
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    response = cast(Any, TestClient(create_app(settings))).post(
+        "/jobs/job_00000000000000000000000000000001/wait",
+        params={field: value},
+    )
+
+    assert response.status_code == 422
+    assert "positive and finite" in response.json()["detail"]
 
 
 def test_http_monitor_sse_streams_monitor_and_terminal_events(tmp_path: Path) -> None:

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -245,17 +245,27 @@ def test_native_jarvis_runtime_accepts_canonical_source_aliases(
     ) -> bool:
         return bool(runtime_command)
 
+    def probe_record_closure(
+        _python: str | None,
+        _distribution_name: str,
+        _expected_artifact: Path | None,
+        *,
+        environment: dict[str, str] | None = None,
+    ) -> dict[str, object]:
+        del environment
+        return {
+            "schema_version": "clio-relay.python-record-closure.v1",
+            "verified": True,
+            "tree_scanned": False,
+            "tree_copied": False,
+        }
+
     monkeypatch.setattr(installation_module.metadata, "distribution", find_distribution)
     monkeypatch.setattr(installation_module, "_probe_python_distribution", probe_execution)
     monkeypatch.setattr(
         installation_module,
         "_probe_python_distribution_record_closure",
-        lambda *_args: {
-            "schema_version": "clio-relay.python-record-closure.v1",
-            "verified": True,
-            "tree_scanned": False,
-            "tree_copied": False,
-        },
+        probe_record_closure,
     )
     monkeypatch.setattr(
         installation_module,
@@ -340,7 +350,7 @@ def test_native_jarvis_record_closure_rejects_a_tampered_installed_member(
         ),
     }
     record_name = "fixture_jarvis-1.0.dist-info/RECORD"
-    record_lines = []
+    record_lines: list[str] = []
     for relative, payload in sorted(members.items()):
         encoded = urlsafe_b64encode(hashlib.sha256(payload).digest()).rstrip(b"=").decode()
         record_lines.append(f"{relative},sha256={encoded},{len(payload)}")
@@ -901,7 +911,11 @@ def test_worker_runtime_info_reads_only_the_sealed_fresh_endpoint_index(
     )
     monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(root))
     monkeypatch.setattr(installation_module, "installation_info", lambda: identity)
-    monkeypatch.setattr(installation_module, "_worker_process_matches", lambda _pid: True)
+
+    def worker_process_matches(_pid: int) -> bool:
+        return True
+
+    monkeypatch.setattr(installation_module, "_worker_process_matches", worker_process_matches)
 
     def reject_history(*_args: object, **_kwargs: object) -> object:
         raise AssertionError("worker readiness must not scan endpoint history")

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -894,7 +894,15 @@ def test_worker_runtime_info_reads_only_the_sealed_fresh_endpoint_index(
     from clio_relay.models import EndpointRegistration, EndpointRole
 
     root = tmp_path / "core"
-    identity: dict[str, object] = {"distribution_version": "test"}
+    wheel = tmp_path / "clio_relay-1.0.0-py3-none-any.whl"
+    wheel.write_bytes(b"worker-index-candidate-wheel")
+    receipt_path = tmp_path / "worker-index-receipt.json"
+    write_install_receipt(
+        install_spec=str(wheel),
+        artifact_path=wheel,
+        path=receipt_path,
+    )
+    identity = installation_info(receipt_path)
     queue = ClioCoreQueue(root)
     endpoint = queue.register_endpoint(
         EndpointRegistration(
@@ -910,7 +918,11 @@ def test_worker_runtime_info_reads_only_the_sealed_fresh_endpoint_index(
         )
     )
     monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(root))
-    monkeypatch.setattr(installation_module, "installation_info", lambda: identity)
+
+    def current_installation() -> dict[str, object]:
+        return identity
+
+    monkeypatch.setattr(installation_module, "installation_info", current_installation)
 
     def worker_process_matches(_pid: int) -> bool:
         return True

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -22,6 +22,7 @@ from clio_relay.cluster_config import (
 )
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
+from clio_relay.errors import ObservationTimeoutError, RelayError
 from clio_relay.filesystem_paths import internal_filesystem_path
 from clio_relay.identifiers import durable_record_id_json_schema
 from clio_relay.mcp_server import (
@@ -832,7 +833,16 @@ def test_mcp_jarvis_wait_timeout_never_becomes_an_execution_deadline(
         queue=queue,
     )
 
-    assert response is not None and "error" in response
+    assert response is not None and "error" not in response
+    receipt = response["result"]["structuredContent"]
+    assert receipt["state"] == "queued"
+    assert receipt["terminal"] is False
+    assert receipt["observation"] == {
+        "outcome": "observation_unknown",
+        "timeout_seconds": 1.0,
+        "scheduler_action": "none",
+        "relay_action": "none",
+    }
     assert observations == [(1.0, 0.25)]
     jobs = queue.list_jobs()
     assert len(jobs) == 1
@@ -994,6 +1004,111 @@ def test_owned_mcp_jarvis_wait_uses_only_the_canonical_observation_bound(
     assert result["poll_seconds"] == 0.25
     assert isinstance(job.spec, JarvisRunSpec)
     assert job.spec.timeout_seconds is None
+
+
+def test_owned_mcp_jarvis_wait_deadline_reobserves_the_same_remote_job(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An owned-session response deadline must become a resumable observation result."""
+    definition = ClusterDefinition(name="cluster-a", ssh_host="cluster-login")
+    registry_path = tmp_path / "clusters.json"
+    ClusterRegistry(clusters={"cluster-a": definition}).save(registry_path)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        api_token="session-api-token",
+        owner_session_id="desktop-session-1",
+        owner_session_generation_id="generation-1",
+    )
+    remote_job = RelayJob(
+        cluster="cluster-a",
+        kind=JobKind.JARVIS,
+        spec=JarvisRunSpec(pipeline_name="long-owned-run"),
+        idempotency_key="long-owned-run",
+        metadata={
+            "owner": "clio-relay",
+            "owner_session_id": settings.owner_session_id,
+            "owner_session_generation_id": settings.owner_session_generation_id,
+        },
+    )
+
+    def submit_owned(**_kwargs: object) -> RelayJob:
+        return remote_job
+
+    monkeypatch.setattr(mcp_server_module, "submit_owned_session_job", submit_owned)
+    requests: list[tuple[str, str]] = []
+
+    class FakeOwnedSessionApiClient:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        def __enter__(self) -> FakeOwnedSessionApiClient:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def request_json(
+            self,
+            *,
+            method: str,
+            path: str,
+            query: dict[str, object] | None = None,
+            body: dict[str, object] | None = None,
+            response_timeout_seconds: float | None = None,
+        ) -> object:
+            del query, body, response_timeout_seconds
+            requests.append((method, path))
+            if method == "POST" and path == f"/jobs/{remote_job.job_id}/wait":
+                raise ObservationTimeoutError("owned wait response deadline expired")
+            if method == "GET" and path == f"/jobs/{remote_job.job_id}/status":
+                return {
+                    "job": remote_job.model_dump(mode="json"),
+                    "relay_queue": {},
+                    "scheduler": [],
+                    "terminal": False,
+                }
+            raise AssertionError(f"unexpected request: {method} {path}")
+
+    monkeypatch.setattr(
+        mcp_server_module,
+        "OwnedSessionApiClient",
+        FakeOwnedSessionApiClient,
+    )
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 125,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_submit_jarvis_job",
+                "arguments": {
+                    "cluster": "cluster-a",
+                    "pipeline_name": "long-owned-run",
+                    "wait_for_terminal": True,
+                    "wait_timeout_seconds": 0.25,
+                    "poll_seconds": 0.05,
+                },
+            },
+        },
+        queue=ClioCoreQueue(settings.core_dir),
+        settings=settings,
+        profile="admin",
+    )
+
+    assert response is not None and "error" not in response
+    receipt = response["result"]["structuredContent"]
+    assert receipt["job_id"] == remote_job.job_id
+    assert receipt["state"] == "queued"
+    assert receipt["terminal"] is False
+    assert receipt["observation"]["outcome"] == "observation_unknown"
+    assert receipt["observation"]["scheduler_action"] == "none"
+    assert requests == [
+        ("POST", f"/jobs/{remote_job.job_id}/wait"),
+        ("GET", f"/jobs/{remote_job.job_id}/status"),
+    ]
 
 
 def test_direct_remote_named_jarvis_wait_is_rejected_before_submission(
@@ -1209,6 +1324,7 @@ def test_mcp_compact_status_observe_wait_and_cancel(tmp_path: Path) -> None:
     assert wait_response is not None
     waited = wait_response["result"]["structuredContent"]
     assert waited["terminal"] is True
+    assert waited["observation"]["outcome"] == "terminal"
     assert "finished" in waited["logs"]["stdout"]["text"]
     assert cancel_response is not None
     assert cancel_response["result"]["structuredContent"]["job_id"] == job.job_id
@@ -1253,7 +1369,235 @@ def test_mcp_wait_omits_logs_unless_explicitly_requested(
     assert response is not None and "error" not in response
     waited = response["result"]["structuredContent"]
     assert waited["terminal"] is True
+    assert waited["observation"]["outcome"] == "terminal"
     assert "logs" not in waited
+
+
+def test_mcp_wait_timeout_returns_the_same_durable_job_without_actions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bounded observation ending must return a resumable receipt, not fail the job."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    job = queue.submit_job(
+        RelayJob(
+            cluster="test-cluster",
+            kind=JobKind.JARVIS,
+            spec=JarvisRunSpec(pipeline_name="long-queued-run"),
+            idempotency_key="durable-wait-observation",
+        )
+    )
+
+    def bounded_wait(
+        _queue: ClioCoreQueue,
+        _job_id: str,
+        *,
+        timeout_seconds: float,
+        poll_seconds: float,
+    ) -> RelayJob:
+        assert timeout_seconds == 0.25
+        assert poll_seconds == 0.05
+        raise TimeoutError("bounded observation ended")
+
+    monkeypatch.setattr(mcp_server_module, "wait_for_terminal", bounded_wait)
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 33,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_wait",
+                "arguments": {
+                    "job_id": job.job_id,
+                    "timeout_seconds": 0.25,
+                    "poll_seconds": 0.05,
+                },
+            },
+        },
+        queue=queue,
+        settings=settings,
+    )
+
+    assert response is not None and "error" not in response
+    observed = response["result"]["structuredContent"]
+    assert observed["job"]["job_id"] == job.job_id
+    assert observed["job"]["state"] == "queued"
+    assert observed["terminal"] is False
+    assert observed["observation"] == {
+        "outcome": "observation_unknown",
+        "timeout_seconds": 0.25,
+        "scheduler_action": "none",
+        "relay_action": "none",
+    }
+    preserved = queue.get_job(job.job_id)
+    assert preserved.state is JobState.QUEUED
+    assert "cancellation_request" not in preserved.metadata
+
+
+def test_mcp_wait_classifies_the_exact_status_snapshot_after_timeout_race(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A job completing at the observation boundary must not be reported as unknown."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    job = queue.submit_job(
+        RelayJob(
+            cluster="test-cluster",
+            kind=JobKind.JARVIS,
+            spec=JarvisRunSpec(pipeline_name="boundary-completion"),
+            idempotency_key="boundary-completion",
+        )
+    )
+
+    def complete_at_boundary(
+        selected_queue: ClioCoreQueue,
+        job_id: str,
+        *,
+        timeout_seconds: float,
+        poll_seconds: float,
+    ) -> RelayJob:
+        del timeout_seconds, poll_seconds
+        selected_queue.update_job_state(job_id, JobState.SUCCEEDED)
+        raise TimeoutError("observation boundary raced with completion")
+
+    monkeypatch.setattr(mcp_server_module, "wait_for_terminal", complete_at_boundary)
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 331,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_wait",
+                "arguments": {
+                    "job_id": job.job_id,
+                    "timeout_seconds": 0.25,
+                    "poll_seconds": 0.05,
+                },
+            },
+        },
+        queue=queue,
+        settings=settings,
+    )
+
+    assert response is not None and "error" not in response
+    observed = response["result"]["structuredContent"]
+    assert observed["job"]["state"] == "succeeded"
+    assert observed["terminal"] is True
+    assert observed["observation"]["outcome"] == "terminal"
+
+
+def test_direct_remote_wait_timeout_reobserves_exact_receipt_without_actions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SSH wait expiry must fall through to an exact status read, never a resubmission."""
+    definition = ClusterDefinition(name="cluster-a", ssh_host="cluster-login")
+    registry_path = tmp_path / "clusters.json"
+    ClusterRegistry(clusters={"cluster-a": definition}).save(registry_path)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+    monkeypatch.setenv("CLIO_RELAY_CLI_MODE", "ssh")
+    remote_job = RelayJob(
+        cluster="cluster-a",
+        kind=JobKind.JARVIS,
+        spec=JarvisRunSpec(pipeline_name="long-remote-run"),
+        idempotency_key="long-remote-run",
+    )
+    commands: list[list[str]] = []
+
+    def run_remote(_definition: ClusterDefinition, arguments: list[str]) -> str:
+        commands.append(arguments)
+        if arguments[:2] == ["job", "wait"]:
+            raise ObservationTimeoutError("remote observation deadline expired")
+        if arguments[:2] == ["job", "status"]:
+            return json.dumps(
+                {
+                    "job": remote_job.model_dump(mode="json"),
+                    "relay_queue": {},
+                    "scheduler": [{"state": "PENDING", "job_id": "slurm-42"}],
+                    "terminal": False,
+                }
+            )
+        raise AssertionError(f"unexpected remote command: {arguments}")
+
+    monkeypatch.setattr(mcp_server_module, "run_remote_clio", run_remote)
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 34,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_wait",
+                "arguments": {
+                    "cluster": definition.name,
+                    "job_id": remote_job.job_id,
+                    "route_revision": cluster_route_revision(definition),
+                    "timeout_seconds": 0.25,
+                    "poll_seconds": 0.05,
+                },
+            },
+        },
+        queue=ClioCoreQueue(tmp_path / "core"),
+        settings=RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool"),
+        profile="admin",
+    )
+
+    assert response is not None and "error" not in response
+    observed = response["result"]["structuredContent"]
+    assert observed["job"]["job_id"] == remote_job.job_id
+    assert observed["job"]["state"] == "queued"
+    assert observed["scheduler"] == [{"state": "PENDING", "job_id": "slurm-42"}]
+    assert observed["terminal"] is False
+    assert observed["observation"]["outcome"] == "observation_unknown"
+    assert commands == [
+        [
+            "job",
+            "wait",
+            remote_job.job_id,
+            "--timeout-seconds",
+            "0.25",
+            "--poll-seconds",
+            "0.05",
+        ],
+        ["job", "status", remote_job.job_id],
+    ]
+
+    rejected_commands: list[list[str]] = []
+
+    def reject_wait(_definition: ClusterDefinition, arguments: list[str]) -> str:
+        rejected_commands.append(arguments)
+        raise RelayError("remote authentication rejected the wait")
+
+    monkeypatch.setattr(mcp_server_module, "run_remote_clio", reject_wait)
+    rejected = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 35,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_wait",
+                "arguments": {
+                    "cluster": definition.name,
+                    "job_id": remote_job.job_id,
+                    "route_revision": cluster_route_revision(definition),
+                    "timeout_seconds": 0.25,
+                    "poll_seconds": 0.05,
+                },
+            },
+        },
+        queue=ClioCoreQueue(tmp_path / "rejected-core"),
+        settings=RelaySettings(
+            core_dir=tmp_path / "rejected-core",
+            spool_dir=tmp_path / "rejected-spool",
+        ),
+        profile="admin",
+    )
+
+    assert rejected is not None and "error" in rejected
+    assert "authentication rejected" in rejected["error"]["message"]
+    assert len(rejected_commands) == 1
+    assert rejected_commands[0][:2] == ["job", "wait"]
 
 
 def test_mcp_compact_log_limit_is_enforced_before_log_access(tmp_path: Path) -> None:
@@ -2477,7 +2821,15 @@ def test_waited_owned_jarvis_call_returns_bounded_artifact_bound_failure(
             del query, body
             requests.append((method, path, response_timeout_seconds))
             if path == f"/jobs/{queued.job_id}/wait":
-                return terminal.model_dump(mode="json")
+                return {
+                    **terminal.model_dump(mode="json"),
+                    "observation": {
+                        "outcome": "terminal",
+                        "timeout_seconds": 600,
+                        "scheduler_action": "none",
+                        "relay_action": "none",
+                    },
+                }
             if path == f"/jobs/{queued.job_id}/artifacts":
                 return {
                     "artifacts": [artifact],
@@ -3714,12 +4066,12 @@ def test_owned_remote_followups_use_session_api_and_never_direct_ssh(
     assert not any("/logs/" in cast(str, item["path"]) for item in requests)
     wait_paths = [item["path"] for item in requests if item["instance"] == max(client_instances)]
     assert wait_paths == [
-        f"/jobs/{running.job_id}/wait",
         f"/jobs/{running.job_id}/status",
         f"/jobs/{running.job_id}/artifacts",
     ]
     wait_request = next(item for item in requests if item["path"] == f"/jobs/{running.job_id}/wait")
     assert wait_request["response_timeout_seconds"] == 610
+    assert wait_request["instance"] != max(client_instances)
 
 
 def test_mcp_virtual_jarvis_edit_routes_remove_operation(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -735,6 +735,71 @@ def test_mcp_submit_jarvis_job_creates_named_pipeline_job(tmp_path: Path) -> Non
     assert job.spec.pipeline_name == "site_simulation_4node"
 
 
+@pytest.mark.parametrize(
+    ("tool_name", "source_arguments"),
+    [
+        (
+            "relay_submit_jarvis_pipeline",
+            {"pipeline_yaml": "name: observation-only\npkgs: []\n"},
+        ),
+        (
+            "relay_submit_jarvis_job",
+            {"pipeline_name": "observation-only"},
+        ),
+    ],
+)
+def test_mcp_jarvis_wait_timeout_never_becomes_an_execution_deadline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tool_name: str,
+    source_arguments: dict[str, object],
+) -> None:
+    """Agent wait bounds must not become JARVIS or scheduler runtime limits."""
+    queue = ClioCoreQueue(tmp_path / "core")
+    observations: list[tuple[float, float]] = []
+
+    def bounded_wait(
+        _queue: ClioCoreQueue,
+        _job_id: str,
+        *,
+        timeout_seconds: float,
+        poll_seconds: float,
+    ) -> RelayJob:
+        observations.append((timeout_seconds, poll_seconds))
+        raise TimeoutError("bounded observation ended")
+
+    monkeypatch.setattr(mcp_server_module, "wait_for_terminal", bounded_wait)
+
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 120,
+            "method": "tools/call",
+            "params": {
+                "name": tool_name,
+                "arguments": {
+                    "cluster": "test-cluster",
+                    **source_arguments,
+                    "wait_for_terminal": True,
+                    "timeout_seconds": 1,
+                    "poll_seconds": 0.25,
+                },
+            },
+        },
+        queue=queue,
+    )
+
+    assert response is not None and "error" in response
+    assert observations == [(1.0, 0.25)]
+    jobs = queue.list_jobs()
+    assert len(jobs) == 1
+    job = jobs[0]
+    assert isinstance(job.spec, JarvisRunSpec)
+    assert job.spec.timeout_seconds is None
+    assert job.state is JobState.QUEUED
+    assert "cancellation_request" not in job.metadata
+
+
 def test_mcp_submit_remote_agent_creates_real_job(tmp_path: Path) -> None:
     queue = ClioCoreQueue(tmp_path / "core")
     prompt_path = tmp_path / "prompt.md"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -548,6 +548,40 @@ def test_mcp_admin_profile_lists_operational_tools(tmp_path: Path) -> None:
     assert "scheduler_job_id" not in update_gateway_tool["inputSchema"]["properties"]
 
 
+def test_mcp_jarvis_wait_schemas_are_explicitly_observation_only(tmp_path: Path) -> None:
+    """Agent schemas must not imply that bounded observation limits scheduler work."""
+    response = handle_request(
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        queue=ClioCoreQueue(tmp_path / "core"),
+        profile="admin",
+    )
+
+    assert response is not None
+    tools = {tool["name"]: tool for tool in response["result"]["tools"]}
+    relay_wait = tools["relay_wait"]
+    assert "never fails, cancels, or resubmits" in relay_wait["description"]
+    assert (
+        "underlying relay, JARVIS, or scheduler job state"
+        in (relay_wait["inputSchema"]["properties"]["timeout_seconds"]["description"])
+    )
+    for name in ("relay_submit_jarvis_pipeline", "relay_submit_jarvis_job"):
+        tool = tools[name]
+        properties = tool["inputSchema"]["properties"]
+        canonical = properties["wait_timeout_seconds"]
+        legacy = properties["timeout_seconds"]
+        assert canonical["default"] == 600
+        assert canonical["exclusiveMinimum"] == 0
+        assert "Observation expiry never fails, cancels, or resubmits" in (canonical["description"])
+        assert legacy["deprecated"] is True
+        assert "default" not in legacy
+        assert "observation-only alias" in legacy["description"]
+        assert "execution deadline" in legacy["description"]
+        assert (
+            "never becomes a relay, JARVIS, or scheduler execution deadline"
+            in (properties["wait_for_terminal"]["description"])
+        )
+
+
 def test_mcp_event_monitor_and_log_schemas_publish_strict_maximums(tmp_path: Path) -> None:
     queue = ClioCoreQueue(tmp_path / "core")
 
@@ -748,11 +782,20 @@ def test_mcp_submit_jarvis_job_creates_named_pipeline_job(tmp_path: Path) -> Non
         ),
     ],
 )
+@pytest.mark.parametrize(
+    "wait_arguments",
+    [
+        {"wait_timeout_seconds": 1},
+        {"timeout_seconds": 1},
+        {"wait_timeout_seconds": 1, "timeout_seconds": 1.0},
+    ],
+)
 def test_mcp_jarvis_wait_timeout_never_becomes_an_execution_deadline(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     tool_name: str,
     source_arguments: dict[str, object],
+    wait_arguments: dict[str, object],
 ) -> None:
     """Agent wait bounds must not become JARVIS or scheduler runtime limits."""
     queue = ClioCoreQueue(tmp_path / "core")
@@ -781,7 +824,7 @@ def test_mcp_jarvis_wait_timeout_never_becomes_an_execution_deadline(
                     "cluster": "test-cluster",
                     **source_arguments,
                     "wait_for_terminal": True,
-                    "timeout_seconds": 1,
+                    **wait_arguments,
                     "poll_seconds": 0.25,
                 },
             },
@@ -798,6 +841,224 @@ def test_mcp_jarvis_wait_timeout_never_becomes_an_execution_deadline(
     assert job.spec.timeout_seconds is None
     assert job.state is JobState.QUEUED
     assert "cancellation_request" not in job.metadata
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "source_arguments"),
+    [
+        (
+            "relay_submit_jarvis_pipeline",
+            {"pipeline_yaml": "name: conflicting-observation\npkgs: []\n"},
+        ),
+        (
+            "relay_submit_jarvis_job",
+            {"pipeline_name": "conflicting-observation"},
+        ),
+    ],
+)
+def test_mcp_jarvis_wait_timeout_alias_conflict_fails_before_submission(
+    tmp_path: Path,
+    tool_name: str,
+    source_arguments: dict[str, object],
+) -> None:
+    queue = ClioCoreQueue(tmp_path / "core")
+
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 121,
+            "method": "tools/call",
+            "params": {
+                "name": tool_name,
+                "arguments": {
+                    "cluster": "test-cluster",
+                    **source_arguments,
+                    "wait_for_terminal": True,
+                    "wait_timeout_seconds": 1,
+                    "timeout_seconds": 2,
+                },
+            },
+        },
+        queue=queue,
+    )
+
+    assert response is not None and "error" in response
+    assert response["error"]["message"] == (
+        "wait_timeout_seconds and legacy timeout_seconds must be equal when both are "
+        "provided; both fields bound observation only"
+    )
+    assert queue.list_jobs() == []
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "source_arguments", "path", "source_key"),
+    [
+        (
+            "relay_submit_jarvis_pipeline",
+            {"pipeline_yaml": "name: owned-observation\npkgs: []\n"},
+            "/jobs/jarvis",
+            "pipeline_yaml",
+        ),
+        (
+            "relay_submit_jarvis_job",
+            {"pipeline_name": "owned-observation"},
+            "/jobs/jarvis-pipeline",
+            "pipeline_name",
+        ),
+    ],
+)
+def test_owned_mcp_jarvis_wait_uses_only_the_canonical_observation_bound(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tool_name: str,
+    source_arguments: dict[str, object],
+    path: str,
+    source_key: str,
+) -> None:
+    definition = ClusterDefinition(name="cluster-a", ssh_host="cluster-login")
+    registry_path = tmp_path / "clusters.json"
+    ClusterRegistry(clusters={"cluster-a": definition}).save(registry_path)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+    captured: dict[str, object] = {}
+
+    def submit_owned(**kwargs: object) -> RelayJob:
+        captured["submission"] = kwargs
+        payload = cast(dict[str, object], kwargs["payload"])
+        source_value = cast(str, payload[source_key])
+        spec = (
+            JarvisRunSpec(pipeline_yaml=source_value)
+            if source_key == "pipeline_yaml"
+            else JarvisRunSpec(pipeline_name=source_value)
+        )
+        return RelayJob(
+            cluster="cluster-a",
+            kind=JobKind.JARVIS,
+            spec=spec,
+            idempotency_key=cast(str, payload["idempotency_key"]),
+            metadata={
+                "owner_session_id": "desktop-session-1",
+                "owner_session_generation_id": "generation-1",
+            },
+        )
+
+    def submission_result(job: RelayJob, **kwargs: object) -> dict[str, object]:
+        captured["result"] = kwargs
+        captured["job"] = job
+        return {"job_id": job.job_id, "state": job.state.value}
+
+    monkeypatch.setattr(mcp_server_module, "submit_owned_session_job", submit_owned)
+    monkeypatch.setattr(
+        mcp_server_module,
+        "_owned_session_submission_result",
+        submission_result,
+    )
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        api_token="session-api-token",
+        owner_session_id="desktop-session-1",
+        owner_session_generation_id="generation-1",
+    )
+
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 122,
+            "method": "tools/call",
+            "params": {
+                "name": tool_name,
+                "arguments": {
+                    "cluster": "cluster-a",
+                    **source_arguments,
+                    "wait_for_terminal": True,
+                    "wait_timeout_seconds": 1,
+                    "timeout_seconds": 1.0,
+                    "poll_seconds": 0.25,
+                },
+            },
+        },
+        queue=ClioCoreQueue(settings.core_dir),
+        settings=settings,
+        profile="admin",
+    )
+
+    assert response is not None and "error" not in response, response
+    submission = cast(dict[str, object], captured["submission"])
+    payload = cast(dict[str, object], submission["payload"])
+    result = cast(dict[str, object], captured["result"])
+    job = cast(RelayJob, captured["job"])
+    assert submission["path"] == path
+    assert "timeout_seconds" not in payload
+    assert "wait_timeout_seconds" not in payload
+    assert result["wait_timeout_seconds"] == 1.0
+    assert result["poll_seconds"] == 0.25
+    assert isinstance(job.spec, JarvisRunSpec)
+    assert job.spec.timeout_seconds is None
+
+
+def test_direct_remote_named_jarvis_wait_is_rejected_before_submission(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    definition = ClusterDefinition(name="cluster-a", ssh_host="cluster-login")
+    registry_path = tmp_path / "clusters.json"
+    ClusterRegistry(clusters={"cluster-a": definition}).save(registry_path)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+    commands: list[list[str]] = []
+
+    def run_remote(_definition: ClusterDefinition, arguments: list[str]) -> str:
+        commands.append(arguments)
+        return "job_1234567890abcdef1234567890abcdef\n"
+
+    monkeypatch.setattr(mcp_server_module, "run_remote_clio", run_remote)
+    queue = ClioCoreQueue(tmp_path / "core")
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 123,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_submit_jarvis_job",
+                "arguments": {
+                    "cluster": "cluster-a",
+                    "pipeline_name": "durable-pipeline",
+                    "wait_for_terminal": True,
+                    "wait_timeout_seconds": 1,
+                },
+            },
+        },
+        queue=queue,
+        profile="admin",
+    )
+
+    assert response is not None and "error" in response
+    assert "submit asynchronously" in response["error"]["message"]
+    assert "call relay_wait" in response["error"]["message"]
+    assert commands == []
+    assert queue.list_jobs() == []
+
+    asynchronous = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 124,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_submit_jarvis_job",
+                "arguments": {
+                    "cluster": "cluster-a",
+                    "pipeline_name": "durable-pipeline",
+                    "wait_for_terminal": False,
+                },
+            },
+        },
+        queue=queue,
+        profile="admin",
+    )
+    assert asynchronous is not None and "error" not in asynchronous
+    receipt = asynchronous["result"]["structuredContent"]
+    assert receipt["job_id"] == "job_1234567890abcdef1234567890abcdef"
+    assert receipt["terminal"] is False
+    assert commands[0][:2] == ["job", "submit-pipeline"]
 
 
 def test_mcp_submit_remote_agent_creates_real_job(tmp_path: Path) -> None:

--- a/tests/test_process_containment.py
+++ b/tests/test_process_containment.py
@@ -422,32 +422,44 @@ def test_deferred_credentials_are_built_after_persistent_scope_is_registered(
     invocation = "1" * 32
     events: list[str] = []
 
-    monkeypatch.setattr(
-        process_containment,
-        "containment_capability",
-        lambda **_kwargs: {
+    def capability(**_kwargs: object) -> dict[str, object]:
+        return {
             "mode": "linux_systemd_scope",
             "enforceable": True,
             "reason": "test",
-        },
-    )
-    monkeypatch.setattr(process_containment.sys, "platform", "linux")
-    monkeypatch.setattr(
-        process_containment,
-        "_validate_broker_credential_payload",
-        lambda _payload: None,
-    )
-    monkeypatch.setattr(
-        process_containment,
-        "_spawn_linux_systemd_scope",
-        lambda *_args, **_kwargs: (
+        }
+
+    def validate_credential_payload(_payload: str | None) -> None:
+        return None
+
+    def spawn_scope(
+        *_args: object,
+        **_kwargs: object,
+    ) -> tuple[SimpleNamespace, str, Path, str, str, SimpleNamespace]:
+        return (
             process,
             unit,
             scope,
             invocation,
             description,
             readiness,
-        ),
+        )
+
+    monkeypatch.setattr(
+        process_containment,
+        "containment_capability",
+        capability,
+    )
+    monkeypatch.setattr(process_containment.sys, "platform", "linux")
+    monkeypatch.setattr(
+        process_containment,
+        "_validate_broker_credential_payload",
+        validate_credential_payload,
+    )
+    monkeypatch.setattr(
+        process_containment,
+        "_spawn_linux_systemd_scope",
+        spawn_scope,
     )
 
     def on_ready(process_id: int, metadata: dict[str, object]) -> None:
@@ -485,10 +497,14 @@ def test_recorded_scope_rejects_invocation_reuse_before_reading_processes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     process_reads: list[Path] = []
-    monkeypatch.setattr(
-        process_containment,
-        "_systemctl_user",
-        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+
+    def systemctl_user(
+        _arguments: list[str],
+        *,
+        timeout_seconds: float,
+    ) -> subprocess.CompletedProcess[str]:
+        assert timeout_seconds > 0
+        return subprocess.CompletedProcess(
             [],
             0,
             "ControlGroup=/user.slice/test.scope\n"
@@ -496,12 +512,21 @@ def test_recorded_scope_rejects_invocation_reuse_before_reading_processes(
             "Description=expected\n"
             "LoadState=loaded\n",
             "",
-        ),
+        )
+
+    def cgroup_process_ids(path: Path) -> list[int]:
+        process_reads.append(path)
+        return [4321]
+
+    monkeypatch.setattr(
+        process_containment,
+        "_systemctl_user",
+        systemctl_user,
     )
     monkeypatch.setattr(
         process_containment,
         "_linux_cgroup_process_ids",
-        lambda path: process_reads.append(path) or [4321],
+        cgroup_process_ids,
     )
 
     with pytest.raises(RuntimeError, match="drifted or was reused"):
@@ -524,10 +549,14 @@ def test_recorded_scope_returns_only_exact_cgroup_members(
     scope.mkdir()
     invocation = "1" * 32
     description = "expected"
-    monkeypatch.setattr(
-        process_containment,
-        "_systemctl_user",
-        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+
+    def systemctl_user(
+        _arguments: list[str],
+        *,
+        timeout_seconds: float,
+    ) -> subprocess.CompletedProcess[str]:
+        assert timeout_seconds > 0
+        return subprocess.CompletedProcess(
             [],
             0,
             f"ControlGroup=/user.slice/{unit}\n"
@@ -535,17 +564,35 @@ def test_recorded_scope_returns_only_exact_cgroup_members(
             f"Description={description}\n"
             "LoadState=loaded\n",
             "",
-        ),
+        )
+
+    def validated_cgroup_path(
+        _control_group: str,
+        *,
+        unit: str,
+        cgroup_root: Path = Path("/sys/fs/cgroup"),
+    ) -> Path:
+        del cgroup_root
+        assert unit == "clio-relay-session-generation.scope"
+        return scope.resolve()
+
+    def cgroup_process_ids(path: Path) -> list[int]:
+        return [4321, 4322] if path == scope.resolve() else []
+
+    monkeypatch.setattr(
+        process_containment,
+        "_systemctl_user",
+        systemctl_user,
     )
     monkeypatch.setattr(
         process_containment,
         "_validated_systemd_cgroup_path",
-        lambda *_args, **_kwargs: scope.resolve(),
+        validated_cgroup_path,
     )
     monkeypatch.setattr(
         process_containment,
         "_linux_cgroup_process_ids",
-        lambda path: [4321, 4322] if path == scope.resolve() else [],
+        cgroup_process_ids,
     )
 
     assert process_containment.recorded_linux_systemd_scope_process_ids(

--- a/tests/test_queue_readiness.py
+++ b/tests/test_queue_readiness.py
@@ -94,7 +94,7 @@ def test_read_only_fresh_endpoint_lookup_never_scans_history_or_writes(
         )
     )
     before = _tree_identity(root)
-    original_scan = ClioCoreQueue._scan_json_record_paths  # noqa: SLF001
+    original_scan = ClioCoreQueue._scan_json_record_paths  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
 
     def reject_historical_scan(
         directory: Path,

--- a/tests/test_relay_ops.py
+++ b/tests/test_relay_ops.py
@@ -11,9 +11,13 @@ import pytest
 import clio_relay.relay_ops as relay_ops_module
 import clio_relay.spool as spool_module
 from clio_relay.core_queue import ClioCoreQueue
-from clio_relay.errors import RelayError
-from clio_relay.models import ArtifactRef, JarvisRunSpec, JobKind, RelayJob
-from clio_relay.relay_ops import MAX_ARTIFACT_CONTENT_BYTES, read_artifact_bytes
+from clio_relay.errors import ConfigurationError, RelayError
+from clio_relay.models import ArtifactRef, JarvisRunSpec, JobKind, JobState, RelayJob
+from clio_relay.relay_ops import (
+    MAX_ARTIFACT_CONTENT_BYTES,
+    observe_until_terminal,
+    read_artifact_bytes,
+)
 from clio_relay.spool import ARTIFACT_OWNERSHIP_SCHEMA, MAX_LOG_READ_BYTES, JobSpool
 
 
@@ -22,6 +26,66 @@ def _owned_artifact_metadata(root: Path) -> dict[str, str]:
         "ownership_schema": ARTIFACT_OWNERSHIP_SCHEMA,
         "owned_root_uri": root.absolute().as_uri(),
     }
+
+
+def test_observe_until_terminal_returns_current_durable_job_on_expiry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue = ClioCoreQueue(tmp_path / "core")
+    job = queue.submit_job(
+        RelayJob(
+            cluster="ares",
+            kind=JobKind.JARVIS,
+            spec=JarvisRunSpec(pipeline_name="long-queued-run"),
+            idempotency_key="long-queued-run",
+        )
+    )
+
+    def expire(
+        _queue: ClioCoreQueue,
+        _job_id: str,
+        *,
+        timeout_seconds: float,
+        poll_seconds: float,
+    ) -> RelayJob:
+        assert timeout_seconds == 1
+        assert poll_seconds == 0.1
+        raise TimeoutError("observation expired")
+
+    monkeypatch.setattr(relay_ops_module, "wait_for_terminal", expire)
+    observed = observe_until_terminal(
+        queue,
+        job.job_id,
+        timeout_seconds=1,
+        poll_seconds=0.1,
+    )
+
+    assert observed.job_id == job.job_id
+    assert observed.state is JobState.QUEUED
+    assert observed.observation.outcome == "observation_unknown"
+    assert observed.observation.scheduler_action == "none"
+    assert queue.get_job(job.job_id).state is JobState.QUEUED
+
+
+@pytest.mark.parametrize(
+    ("timeout_seconds", "poll_seconds"),
+    [(float("inf"), 0.1), (1.0, float("inf"))],
+)
+def test_observe_until_terminal_rejects_nonfinite_bounds(
+    tmp_path: Path,
+    timeout_seconds: float,
+    poll_seconds: float,
+) -> None:
+    queue = ClioCoreQueue(tmp_path / "core")
+
+    with pytest.raises(ConfigurationError, match="positive and finite"):
+        observe_until_terminal(
+            queue,
+            "job_00000000000000000000000000000001",
+            timeout_seconds=timeout_seconds,
+            poll_seconds=poll_seconds,
+        )
 
 
 def test_read_artifact_rejects_tampered_backing_file(tmp_path: Path) -> None:

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.17"
+    assert version == "1.4.18"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -75,6 +75,10 @@ def test_tag_push_uploads_exact_release_distributions_asynchronously() -> None:
     assert "releases/tags/$TAG_NAME" in text
     assert "for attempt in $(seq 1 20)" in text
     assert "sleep 3" in text
+    assert 'source_commit="$(gh api "repos/$REPOSITORY/commits/$TAG_NAME" --jq .sha)"' in text
+    assert 'test "$source_commit" = "$SOURCE_COMMIT"' in text
+    assert 'test "$source_commit" = "$(git rev-parse HEAD)"' in text
+    assert 'test "$(jq -r .target_commitish' not in text
     assert "releases/assets/$asset_id" in text
     assert "sha256sum --check --strict SHA256SUMS" in text
     assert "distribution-archives" in text

--- a/tests/test_remote_cli.py
+++ b/tests/test_remote_cli.py
@@ -5,7 +5,7 @@ import subprocess
 from pytest import MonkeyPatch, raises
 
 from clio_relay.cluster_config import ClusterDefinition
-from clio_relay.errors import RelayError
+from clio_relay.errors import ObservationTimeoutError, RelayError
 from clio_relay.remote_cli import (
     remote_command_timeout,
     remote_env,
@@ -132,5 +132,8 @@ def test_bounded_remote_command_timeout_is_translated(monkeypatch: MonkeyPatch) 
 
     monkeypatch.setattr("clio_relay.remote_cli.subprocess.run", timed_out)
 
-    with raises(RelayError, match="timed out after 12 seconds"), remote_command_timeout(12):
+    with (
+        raises(ObservationTimeoutError, match="timed out after 12 seconds"),
+        remote_command_timeout(12),
+    ):
         run_remote_shell(definition, "true")

--- a/tests/test_session_api.py
+++ b/tests/test_session_api.py
@@ -11,7 +11,7 @@ import pytest
 
 from clio_relay.cluster_config import ClusterDefinition
 from clio_relay.config import RelaySettings
-from clio_relay.errors import RelayError
+from clio_relay.errors import ObservationTimeoutError, RelayError
 from clio_relay.models import (
     MCP_ADMISSION_AUTHORITY_METADATA_KEY,
     JobKind,
@@ -45,6 +45,11 @@ class _Response:
 
     def read(self, _amount: int) -> bytes:
         return self._payload
+
+
+class _TimeoutResponse(_Response):
+    def read(self, _amount: int) -> bytes:
+        raise TimeoutError("bounded response observation expired")
 
 
 class _Socket:
@@ -518,6 +523,38 @@ def test_owned_session_client_scopes_long_response_timeout_to_one_request(
 
     assert len(connections) == 1
     assert connections[0].socket.timeout_changes == [610, 30]
+
+
+def test_owned_session_client_types_only_a_bounded_response_deadline_as_observation_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = session_identity_document(
+        owner_token="owner-token",
+        cluster="ares",
+        session_id="desktop-session-1",
+        generation_id="generation-1",
+        nonce="1" * 64,
+    )
+    _captured, connections = _install_transport(
+        monkeypatch,
+        responses=[_Response(identity), _TimeoutResponse({})],
+    )
+
+    with (
+        OwnedSessionApiClient(
+            definition=ClusterDefinition(name="ares", ssh_host="ares-login"),
+            settings=_settings(tmp_path),
+        ) as client,
+        pytest.raises(ObservationTimeoutError, match="response observation timed out"),
+    ):
+        client.request_json(
+            method="POST",
+            path="/jobs/job_1/wait",
+            response_timeout_seconds=0.25,
+        )
+
+    assert connections[0].socket.timeout_changes == [0.25, 30]
 
 
 def test_owned_session_client_never_reconnects_after_identity_proof(

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -185,8 +185,57 @@ class _FakeSessionTransaction:
         return True
 
 
+def _fake_transaction_opener(
+    transaction: _FakeSessionTransaction,
+) -> Callable[..., _FakeSessionTransaction]:
+    """Return a fully typed replacement for the owned-session transaction factory."""
+
+    def open_transaction(
+        *,
+        session_id: str,
+        create: bool,
+        timeout_seconds: float,
+        home: Path | None = None,
+    ) -> _FakeSessionTransaction:
+        del session_id, create, timeout_seconds, home
+        return transaction
+
+    return open_transaction
+
+
+def _ignore_remote_port(_port: int) -> None:
+    """Represent an available port without introducing an unknown lambda parameter."""
+
+
+def _fixed_process_start_identity(_pid: int) -> str:
+    """Return the process identity used by replacement-session tests."""
+
+    return "linux-proc:7000"
+
+
+def _successful_process_wait(**_kwargs: object) -> int:
+    """Represent a test process that exits successfully when waited on."""
+
+    return 0
+
+
+def _fixed_api_readiness(elapsed_seconds: float) -> Callable[..., float]:
+    """Return a typed API-readiness replacement with a fixed elapsed time."""
+
+    def ready(
+        *,
+        process: subprocess.Popen[bytes],
+        port: int,
+        require_token: bool,
+    ) -> float:
+        del process, port, require_token
+        return elapsed_seconds
+
+    return ready
+
+
 @pytest.fixture(autouse=True)
-def _use_fake_recorded_scope(monkeypatch: MonkeyPatch) -> None:
+def use_fake_recorded_scope(monkeypatch: MonkeyPatch) -> None:
     """Represent exact cgroup membership without consulting the host's systemd."""
 
     def recorded_scope_processes(
@@ -208,7 +257,7 @@ def _use_fake_recorded_scope(monkeypatch: MonkeyPatch) -> None:
             if membership.exists()
             else []
         )
-        processes = []
+        processes: list[object] = []
         for process_id in process_ids:
             try:
                 processes.append(
@@ -600,10 +649,12 @@ def test_start_persists_candidate_before_core_admission(
         "_current_session_api_release_identity",
         _api_release_identity,
     )
-    monkeypatch.setattr(session_lifecycle, "_assert_remote_port_available", lambda _port: None)
-    monkeypatch.setattr(
-        os, "geteuid", lambda: os.getuid() if hasattr(os, "getuid") else 0, raising=False
-    )
+    monkeypatch.setattr(session_lifecycle, "_assert_remote_port_available", _ignore_remote_port)
+
+    def effective_user_id() -> int:
+        return tmp_path.stat().st_uid
+
+    monkeypatch.setattr(os, "geteuid", effective_user_id, raising=False)
     transaction = _FakeSessionTransaction(
         tmp_path / "home" / ".local" / "share" / "clio-relay" / "sessions" / request.session_id,
         session_id=request.session_id,
@@ -611,7 +662,7 @@ def test_start_persists_candidate_before_core_admission(
     monkeypatch.setattr(
         session_lifecycle,
         "open_owned_session_transaction",
-        lambda **_kwargs: transaction,
+        _fake_transaction_opener(transaction),
     )
 
     def crash_before_admission(*_args: object, **_kwargs: object) -> str:
@@ -704,13 +755,13 @@ def test_start_attempt_accepts_every_durable_crash_boundary(
             "containment_broker_start_identity": broker_start,
         }
         session_lifecycle._write_session_attempt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
-            transaction,
+            cast(session_lifecycle._OwnedSessionTransaction, transaction),  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
             operation="start",
             identity=identity,
         )
 
         recovered = session_lifecycle._validated_resumable_start_attempt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
-            transaction,
+            cast(session_lifecycle._OwnedSessionTransaction, transaction),  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
             request=request,
             release_identity_sha256="b" * 64,
         )
@@ -767,7 +818,7 @@ def test_distinct_operation_cannot_overwrite_nonterminal_start_transition(
     monkeypatch.setattr(
         session_lifecycle,
         "open_owned_session_transaction",
-        lambda **_kwargs: transaction,
+        _fake_transaction_opener(transaction),
     )
     monkeypatch.setattr(
         session_lifecycle,
@@ -843,7 +894,7 @@ def test_same_completed_operation_cannot_create_a_second_generation(
     monkeypatch.setattr(
         session_lifecycle,
         "open_owned_session_transaction",
-        lambda **_kwargs: transaction,
+        _fake_transaction_opener(transaction),
     )
     monkeypatch.setattr(
         session_lifecycle,
@@ -851,10 +902,9 @@ def test_same_completed_operation_cannot_create_a_second_generation(
         _api_release_identity,
     )
     monkeypatch.setattr(os, "geteuid", lambda: 0, raising=False)
-    monkeypatch.setattr(
-        session_lifecycle,
-        "inspect_owned_session_recovery_status",
-        lambda **_kwargs: OwnedSessionRecoveryStatus(
+
+    def completed_status(**_kwargs: object) -> OwnedSessionRecoveryStatus:
+        return OwnedSessionRecoveryStatus(
             cluster=request.cluster,
             session_id=request.session_id,
             session_generation_id=generation,
@@ -868,7 +918,12 @@ def test_same_completed_operation_cannot_create_a_second_generation(
             start_phase="contained",
             start_attempt_verified=True,
             api_release_identity=_api_release_identity(),
-        ),
+        )
+
+    monkeypatch.setattr(
+        session_lifecycle,
+        "inspect_owned_session_recovery_status",
+        completed_status,
     )
     mutation_attempted = False
 
@@ -1028,7 +1083,7 @@ def test_executor_replaces_exact_legacy_old_release_session(
     monkeypatch.setattr(
         session_lifecycle,
         "open_owned_session_transaction",
-        lambda **_kwargs: transaction,
+        _fake_transaction_opener(transaction),
     )
     monkeypatch.setattr(
         session_lifecycle,
@@ -1077,12 +1132,12 @@ def test_executor_replaces_exact_legacy_old_release_session(
         )
 
     monkeypatch.setattr(session_lifecycle, "inspect_owned_session_recovery_status", inspect)
-    monkeypatch.setattr(session_lifecycle, "_assert_remote_port_available", lambda _port: None)
+    monkeypatch.setattr(session_lifecycle, "_assert_remote_port_available", _ignore_remote_port)
     containment_module = importlib.import_module("clio_relay.process_containment")
     monkeypatch.setattr(
         containment_module,
         "process_start_identity",
-        lambda _pid: "linux-proc:7000",
+        _fixed_process_start_identity,
     )
 
     def spawn(*_args: object, **kwargs: object) -> object:
@@ -1106,7 +1161,7 @@ def test_executor_replaces_exact_legacy_old_release_session(
             pid=7000,
             poll=lambda: None,
             terminate=lambda: None,
-            wait=lambda **_kwargs: 0,
+            wait=_successful_process_wait,
         )
 
     monkeypatch.setattr(containment_module, "spawn_owned_process", spawn)
@@ -1120,7 +1175,7 @@ def test_executor_replaces_exact_legacy_old_release_session(
         )
 
     monkeypatch.setattr(session_lifecycle, "_wait_for_api_startup_receipt", receipt)
-    monkeypatch.setattr(session_lifecycle, "_wait_for_api_ready", lambda **_kwargs: 0.125)
+    monkeypatch.setattr(session_lifecycle, "_wait_for_api_ready", _fixed_api_readiness(0.125))
 
     lines = execute_owned_session_start(
         request,
@@ -1163,7 +1218,7 @@ def test_executor_refuses_mismatched_legacy_journal_without_mutation(
     monkeypatch.setattr(
         session_lifecycle,
         "open_owned_session_transaction",
-        lambda **_kwargs: transaction,
+        _fake_transaction_opener(transaction),
     )
     monkeypatch.setattr(
         session_lifecycle,
@@ -1171,15 +1226,19 @@ def test_executor_refuses_mismatched_legacy_journal_without_mutation(
         _api_release_identity,
     )
     monkeypatch.setattr(os, "geteuid", lambda: 0, raising=False)
-    monkeypatch.setattr(
-        session_lifecycle,
-        "inspect_owned_session_recovery_status",
-        lambda **_kwargs: _legacy_existing_status(
+
+    def legacy_status(**_kwargs: object) -> OwnedSessionRecoveryStatus:
+        return _legacy_existing_status(
             request=request,
             metadata=metadata,
             old_release=old_release,
             journal_bound=False,
-        ),
+        )
+
+    monkeypatch.setattr(
+        session_lifecycle,
+        "inspect_owned_session_recovery_status",
+        legacy_status,
     )
     mutation_attempted = False
 
@@ -1216,8 +1275,12 @@ def test_old_release_migration_crash_retries_same_replacement_with_real_inspecti
     )
     current_release = _api_release_identity()
     old_release = current_release.model_copy(update={"artifact_sha256": "f" * 64})
-    metadata = json.loads((session_dir / "metadata.json").read_text(encoding="utf-8"))
-    assert isinstance(metadata, dict)
+    raw_metadata = cast(
+        object,
+        json.loads((session_dir / "metadata.json").read_text(encoding="utf-8")),
+    )
+    assert isinstance(raw_metadata, dict)
+    metadata = cast(dict[str, object], raw_metadata)
     owner_token = cast(str, metadata["owner_token"])
     registry_path = Path(cast(str, metadata["cluster_registry_path"]))
     registry_document = json.loads(registry_path.read_bytes())
@@ -1230,8 +1293,9 @@ def test_old_release_migration_crash_retries_same_replacement_with_real_inspecti
     registry_path.write_bytes(registry_payload)
     registry_sha256 = session_lifecycle.hashlib.sha256(registry_payload).hexdigest()
     receipt_path = Path(cast(str, metadata["api_startup_receipt_path"]))
-    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
-    assert isinstance(receipt, dict)
+    raw_receipt = cast(object, json.loads(receipt_path.read_text(encoding="utf-8")))
+    assert isinstance(raw_receipt, dict)
+    receipt = cast(dict[str, object], raw_receipt)
     receipt["api_release_identity_sha256"] = old_release.sha256()
     receipt["cluster_registry_sha256"] = registry_sha256
     receipt["hmac_sha256"] = session_lifecycle._startup_receipt_signature(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
@@ -1259,7 +1323,7 @@ def test_old_release_migration_crash_retries_same_replacement_with_real_inspecti
         cluster_registry_sha256=registry_sha256,
         cluster_route_revision=cast(str, metadata["cluster_route_revision"]),
     )
-    legacy = {
+    legacy: dict[str, object] = {
         "schema_version": "clio-relay.owner-session-attempt.v1",
         "operation": "start",
         "cluster": request.cluster,
@@ -1290,7 +1354,7 @@ def test_old_release_migration_crash_retries_same_replacement_with_real_inspecti
     monkeypatch.setattr(
         session_lifecycle,
         "open_owned_session_transaction",
-        lambda **_kwargs: transaction,
+        _fake_transaction_opener(transaction),
     )
     monkeypatch.setattr(
         session_lifecycle,
@@ -1303,8 +1367,19 @@ def test_old_release_migration_crash_retries_same_replacement_with_real_inspecti
     class MigrationCrash(RuntimeError):
         """Simulated process loss immediately after the durable v2 write."""
 
-    def migrate_then_crash(*args: object, **kwargs: object) -> object:
-        migrated = migrate(*args, **kwargs)
+    def migrate_then_crash(
+        selected_transaction: session_lifecycle._OwnedSessionTransaction,  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        *,
+        request: OwnedSessionStartRequest,
+        release_identity_sha256: str,
+        replacement_identity_verified: bool = False,
+    ) -> dict[str, object] | None:
+        migrated = migrate(
+            selected_transaction,
+            request=request,
+            release_identity_sha256=release_identity_sha256,
+            replacement_identity_verified=replacement_identity_verified,
+        )
         assert migrated is not None
         raise MigrationCrash
 
@@ -1343,7 +1418,7 @@ def test_old_release_migration_crash_retries_same_replacement_with_real_inspecti
     assert status.start_retryable is True
 
     monkeypatch.setattr(session_lifecycle, "_migrate_legacy_start_attempt", migrate)
-    monkeypatch.setattr(session_lifecycle, "_assert_remote_port_available", lambda _port: None)
+    monkeypatch.setattr(session_lifecycle, "_assert_remote_port_available", _ignore_remote_port)
 
     class ReplacementResumed(RuntimeError):
         """The retry reached replacement admission instead of terminal refusal."""
@@ -1381,10 +1456,13 @@ def test_durable_start_deadline_observes_late_ready_transition(
             "start transport deadline"
         )
 
+    def ready_status(**_kwargs: object) -> OwnedSessionRecoveryStatus:
+        return _durable_start_status(plan, state="ready")
+
     monkeypatch.setattr(
         session_lifecycle,
         "status_remote_session_start",
-        lambda **_kwargs: _durable_start_status(plan, state="ready"),
+        ready_status,
     )
 
     result = session_lifecycle.start_remote_session_durable(
@@ -1536,14 +1614,26 @@ def test_exact_start_rejection_during_lock_contention_is_not_terminal(
 def test_unstructured_ssh_nonzero_is_ambiguous_not_terminal(
     monkeypatch: MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(
-        session_lifecycle,
-        "_run_bounded_command",
-        lambda *_args, **_kwargs: session_lifecycle._BoundedCommandResult(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    def connection_reset(
+        _command: list[str],
+        *,
+        input_bytes: bytes = b"",
+        timeout_seconds: float,
+        stdout_limit: int,
+        stderr_limit: int,
+        environment: dict[str, str] | None = None,
+    ) -> session_lifecycle._BoundedCommandResult:  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        del input_bytes, timeout_seconds, stdout_limit, stderr_limit, environment
+        return session_lifecycle._BoundedCommandResult(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
             returncode=255,
             stdout=b"",
             stderr=b"connection reset after remote acceptance",
-        ),
+        )
+
+    monkeypatch.setattr(
+        session_lifecycle,
+        "_run_bounded_command",
+        connection_reset,
     )
 
     with pytest.raises(
@@ -1566,10 +1656,13 @@ def test_durable_start_projects_terminal_failure_and_stops_retrying(
             "start transport deadline"
         )
 
+    def failed_status(**_kwargs: object) -> OwnedSessionRecoveryStatus:
+        return _durable_start_status(plan, state="failed")
+
     monkeypatch.setattr(
         session_lifecycle,
         "status_remote_session_start",
-        lambda **_kwargs: _durable_start_status(plan, state="failed"),
+        failed_status,
     )
 
     result = session_lifecycle.start_remote_session_durable(
@@ -1675,12 +1768,29 @@ def test_api_readiness_rejects_wrong_auth_policy(monkeypatch: MonkeyPatch) -> No
             return b'{"ok":true,"auth":false}'
 
     moments = iter((0.0, 0.0, 61.0))
+
+    def ignore_sleep(_seconds: float) -> None:
+        return None
+
+    def open_response(
+        _url: str,
+        data: bytes | None = None,
+        timeout: float | None = None,
+        *,
+        cafile: str | None = None,
+        capath: str | None = None,
+        cadefault: bool = False,
+        context: object | None = None,
+    ) -> Response:
+        del data, timeout, cafile, capath, cadefault, context
+        return Response()
+
     monkeypatch.setattr(session_lifecycle.time, "monotonic", lambda: next(moments))
-    monkeypatch.setattr(session_lifecycle.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(session_lifecycle.time, "sleep", ignore_sleep)
     monkeypatch.setattr(
         session_lifecycle.urllib.request,
         "urlopen",
-        lambda *_args, **_kwargs: Response(),
+        open_response,
     )
     process = cast(subprocess.Popen[bytes], SimpleNamespace(poll=lambda: None))
 
@@ -1787,7 +1897,7 @@ def test_contained_start_crash_is_promoted_only_after_full_identity_recheck(
         return process_identity
 
     monkeypatch.setattr(session_lifecycle, "_wait_for_api_startup_receipt", verify_receipt)
-    monkeypatch.setattr(session_lifecycle, "_wait_for_api_ready", lambda **_kwargs: 0.25)
+    monkeypatch.setattr(session_lifecycle, "_wait_for_api_ready", _fixed_api_readiness(0.25))
 
     lines = session_lifecycle._promote_resumable_contained_start(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
         transaction=cast(session_lifecycle._OwnedSessionTransaction, transaction),  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
@@ -2184,7 +2294,7 @@ def test_cleanup_deletes_oversized_api_log_by_pinned_inode(tmp_path: Path) -> No
 
     with _FakeSessionTransaction(session_dir, session_id="session-1") as transaction:
         target = session_lifecycle._capture_cleanup_target(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
-            transaction,
+            cast(session_lifecycle._OwnedSessionTransaction, transaction),  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
             name="api.log",
             maximum_bytes=None,
         )
@@ -2192,7 +2302,7 @@ def test_cleanup_deletes_oversized_api_log_by_pinned_inode(tmp_path: Path) -> No
         assert target.sha256 is None
         assert target.size == 20 * 1024 * 1024
         session_lifecycle._delete_cleanup_targets(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
-            transaction,
+            cast(session_lifecycle._OwnedSessionTransaction, transaction),  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
             [target],
         )
 
@@ -2239,11 +2349,40 @@ def test_owned_session_read_revalidates_descriptor_and_path_after_read(
     fstats = iter([initial_opened, final_opened])
     stats = iter([initial_linked, final_linked])
     reads = iter([payload, b""])
-    monkeypatch.setattr(os, "open", lambda *_args, **_kwargs: 41)
-    monkeypatch.setattr(os, "fstat", lambda _descriptor: next(fstats))
-    monkeypatch.setattr(os, "stat", lambda *_args, **_kwargs: next(stats))
-    monkeypatch.setattr(os, "read", lambda _descriptor, _size: next(reads))
-    monkeypatch.setattr(os, "close", lambda _descriptor: None)
+
+    def open_file(
+        _path: str,
+        _flags: int,
+        _mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        del dir_fd
+        return 41
+
+    def fstat_file(_descriptor: int) -> SimpleNamespace:
+        return next(fstats)
+
+    def stat_file(
+        _path: str,
+        *,
+        dir_fd: int | None = None,
+        follow_symlinks: bool = True,
+    ) -> SimpleNamespace:
+        del dir_fd, follow_symlinks
+        return next(stats)
+
+    def read_file(_descriptor: int, _size: int) -> bytes:
+        return next(reads)
+
+    def close_file(_descriptor: int) -> None:
+        return None
+
+    monkeypatch.setattr(os, "open", open_file)
+    monkeypatch.setattr(os, "fstat", fstat_file)
+    monkeypatch.setattr(os, "stat", stat_file)
+    monkeypatch.setattr(os, "read", read_file)
+    monkeypatch.setattr(os, "close", close_file)
     transaction = session_lifecycle._OwnedSessionTransaction(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
         session_id="session-1",
         path=tmp_path,
@@ -2398,10 +2537,20 @@ def test_cleanup_report_finalization_is_immutable_and_idempotent(
             recovery_verified=True,
         )
 
+    def open_transaction(
+        *,
+        session_id: str,
+        create: bool,
+        timeout_seconds: float,
+        home: Path | None = None,
+    ) -> FakeTransaction:
+        del session_id, create, timeout_seconds, home
+        return transaction
+
     monkeypatch.setattr(
         session_lifecycle,
         "open_owned_session_transaction",
-        lambda **_kwargs: transaction,
+        open_transaction,
     )
     monkeypatch.setattr(session_lifecycle, "inspect_owned_session_recovery_status", inspect)
     monkeypatch.setattr(os, "geteuid", lambda: 1000, raising=False)
@@ -3043,7 +3192,10 @@ def test_cleanup_report_candidate_scan_is_bounded_and_strict(
         def __exit__(self, *_args: object) -> None:
             return None
 
-    monkeypatch.setattr(os, "scandir", lambda _path: FakeScan())
+    def scan_directory(_path: int) -> FakeScan:
+        return FakeScan()
+
+    monkeypatch.setattr(os, "scandir", scan_directory)
     transaction = session_lifecycle._OwnedSessionTransaction(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
         session_id="session-1",
         path=tmp_path,

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2340,13 +2340,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.17-py3-none-any.whl",
+            resource_id="clio-relay-1.4.18-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.17.tar.gz",
+            resource_id="clio_relay-1.4.18.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2485,7 +2485,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.17"
+    assert policy.release_version == "1.4.18"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/tests/test_worker_lifetime_lock.py
+++ b/tests/test_worker_lifetime_lock.py
@@ -711,7 +711,7 @@ def test_queue_seal_handoff_bounds_exclusive_wait_and_restores_shared(
     try:
         started = time.monotonic()
         with pytest.raises(WorkerLifetimeLockUnavailable, match="timed out acquiring"):
-            storage_runtime_module._initialize_queue_with_shared_writer_fencing(  # noqa: SLF001
+            storage_runtime_module._initialize_queue_with_shared_writer_fencing(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
                 candidate
             )
         assert time.monotonic() - started < 1
@@ -759,7 +759,7 @@ def test_queue_seal_handoff_bounds_shared_reacquire(
             WorkerLifetimeLockUnavailable,
             match="restoring shared writer ownership",
         ):
-            storage_runtime_module._initialize_queue_with_shared_writer_fencing(  # noqa: SLF001
+            storage_runtime_module._initialize_queue_with_shared_writer_fencing(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
                 candidate
             )
         assert time.monotonic() - started < 1
@@ -783,7 +783,7 @@ def test_locked_initialization_never_writes_replacement_root_after_path_swap(
     core_dir = tmp_path / "core"
     displaced_core = tmp_path / "displaced-core"
     core_dir.mkdir()
-    original_audit = ClioCoreQueue._audit_legacy_state_before_initialization  # noqa: SLF001
+    original_audit = ClioCoreQueue._audit_legacy_state_before_initialization  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
     swapped = False
 
     def swap_during_audit(queue: ClioCoreQueue) -> object:

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.17"
+version = "1.4.18"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- make bounded waits observation windows rather than scheduler execution deadlines, preserving exact relay, JARVIS, and scheduler identities without cancellation or resubmission
- make legacy bootstrap upgrades crash-recoverable through journaled, preflighted atomic activation and verified component reuse
- pin staged provider execution to verified and sealed runtime bytes, including uv standalone Python origin dependencies, before worker fencing
- bind release validation to the exact tag commit and keep strict Linux/Windows typing platform-stable
- prepare version 1.4.18 policy, matrix, and release documentation

## Focused validation

- 15 focused bootstrap, durable-observation, release-workflow, and release-policy tests passed
- real WSL sealed-provider and poisoned-loader tests passed
- Ruff passed on the changed bootstrap surface
- strict Pyright passed with zero errors for Linux and Windows
- rendered bootstrap script passed `bash -n`
- hostile boundary review: CLEAR

Live released-artifact validation on Ares follows publication and is not claimed by this PR.
