### PR TITLE
fix: upgrade legacy bootstrap safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.18` uses a release-first patch process. A maintainer builds the
+> Version `1.4.19` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.18"
+$Version = "1.4.19"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.18"
+release_version: "1.4.19"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 40dfa7ad56a9137be1a705e54621109c3ef535c1c084394597553514710f784c
+acceptance_matrix_sha256: 43eac4c693ed3bb2303975eb0f70df7beefad44638abb002299d621ded342faf
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.18"
+$Tag = "v1.4.19"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.18" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.19" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.18",
-  "matrix_sha256": "40dfa7ad56a9137be1a705e54621109c3ef535c1c084394597553514710f784c",
+  "release_version": "1.4.19",
+  "matrix_sha256": "43eac4c693ed3bb2303975eb0f70df7beefad44638abb002299d621ded342faf",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.18"
+version = "1.4.19"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.18"
+__version__ = "1.4.19"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -81,7 +81,7 @@ DEFAULT_REMOTE_SPOOL_DIR = "$HOME/.local/share/clio-relay/spool"
 _STAGED_PROVIDER_ENVIRONMENT_SANITIZER = r"""
 while IFS= read -r bootstrap_environment_name; do
   case "$bootstrap_environment_name" in
-    LD_*|PYTHON*) unset "$bootstrap_environment_name" ;;
+    LD_*|PYTHON*|BASH_ENV|ENV) unset "$bootstrap_environment_name" ;;
   esac
 done < <(compgen -e)
 """.strip()
@@ -481,6 +481,962 @@ finally:
     os.close(generation_descriptor)
 """
 MAX_RELAY_WHEEL_METADATA_BYTES = 1024 * 1024
+_BOOTSTRAP_RECEIPT_CLASSIFIER_SOURCE = r"""import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+
+def identity(details):
+    return (
+        details.st_dev,
+        details.st_ino,
+        details.st_mode,
+        details.st_size,
+        details.st_mtime_ns,
+        details.st_ctime_ns,
+    )
+
+
+path = Path(sys.argv[1])
+home = Path.home()
+stable_details = path.lstat()
+stable_target = None
+current = None
+current_details = None
+current_target_text = None
+if stat.S_ISLNK(stable_details.st_mode):
+    stable_target = os.readlink(path)
+    expected_target = str(home / ".local/share/clio-relay/current/install-receipt.json")
+    if stable_target != expected_target:
+        raise SystemExit("bootstrap install receipt link has an unsupported target")
+    current = home / ".local/share/clio-relay/current"
+    current_details = current.lstat()
+    if not stat.S_ISLNK(current_details.st_mode):
+        raise SystemExit("bootstrap current generation pointer is not a symbolic link")
+    current_target_text = os.readlink(current)
+    if not current_target_text or any(character in current_target_text for character in "\x00\r\n"):
+        raise SystemExit("bootstrap current generation target is invalid")
+    current_target = Path(current_target_text)
+    if not current_target.is_absolute():
+        current_target = current.parent / current_target
+    if ".." in current_target.parts:
+        raise SystemExit("bootstrap current generation target is not normalized")
+    generations = (home / ".local/share/clio-relay/generations").resolve(strict=True)
+    resolved_generation = current_target.resolve(strict=True)
+    try:
+        relative_generation = resolved_generation.relative_to(generations)
+    except ValueError as exc:
+        raise SystemExit("bootstrap current pointer escaped managed generations") from exc
+    if (
+        len(relative_generation.parts) != 1
+        or len(relative_generation.name) != 64
+        or any(character not in "0123456789abcdef" for character in relative_generation.name)
+    ):
+        raise SystemExit("bootstrap current pointer has an invalid generation identity")
+    generation_details = current_target.lstat()
+    if current_target.is_symlink() or not stat.S_ISDIR(generation_details.st_mode):
+        raise SystemExit("bootstrap current pointer target is not one real generation")
+    read_path = resolved_generation / "install-receipt.json"
+    details = read_path.lstat()
+elif stat.S_ISREG(stable_details.st_mode):
+    read_path = path
+    details = stable_details
+else:
+    raise SystemExit("bootstrap install receipt has an unsupported file type")
+if read_path.is_symlink() or not stat.S_ISREG(details.st_mode):
+    raise SystemExit("bootstrap install receipt target is not one regular file")
+if not 1 <= details.st_size <= 4 * 1024 * 1024:
+    raise SystemExit("bootstrap install receipt size is invalid")
+flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+descriptor = os.open(read_path, flags)
+try:
+    opened = os.fstat(descriptor)
+    if identity(opened) != identity(details):
+        raise SystemExit("bootstrap install receipt changed before reading")
+    with os.fdopen(descriptor, "rb", closefd=False) as stream:
+        payload = stream.read(4 * 1024 * 1024 + 1)
+    after = os.fstat(descriptor)
+finally:
+    os.close(descriptor)
+if (
+    len(payload) > 4 * 1024 * 1024
+    or identity(after) != identity(opened)
+    or identity(read_path.lstat()) != identity(details)
+    or identity(path.lstat()) != identity(stable_details)
+):
+    raise SystemExit("bootstrap install receipt changed while reading")
+if stable_target is not None:
+    assert current is not None
+    assert current_details is not None
+    assert current_target_text is not None
+    if (
+        os.readlink(path) != stable_target
+        or identity(current.lstat()) != identity(current_details)
+        or os.readlink(current) != current_target_text
+    ):
+        raise SystemExit("bootstrap generation links changed while reading the receipt")
+value = json.loads(payload)
+if not isinstance(value, dict):
+    raise SystemExit("bootstrap install receipt is not an object")
+artifacts = value.get("component_artifacts")
+relay = artifacts.get("clio-relay") if isinstance(artifacts, dict) else None
+print(
+    "current"
+    if isinstance(relay, dict) and relay.get("persistent_tool") is not None
+    else "legacy"
+)"""
+_BOOTSTRAP_PREPARING_ROOT_SOURCE = r"""import os
+import stat
+import sys
+from pathlib import Path
+
+
+def identity(details):
+    return (
+        details.st_dev,
+        details.st_ino,
+        details.st_mode,
+        details.st_size,
+        details.st_mtime_ns,
+        details.st_ctime_ns,
+    )
+
+
+def object_identity(details):
+    return (details.st_dev, details.st_ino, details.st_mode, details.st_uid)
+
+
+def owned_private_directory(details, label):
+    if not stat.S_ISDIR(details.st_mode):
+        raise SystemExit(f"{label} is not one real directory")
+    if hasattr(os, "getuid") and details.st_uid != os.getuid():
+        raise SystemExit(f"{label} is not owned by the current user")
+    if stat.S_IMODE(details.st_mode) & 0o077:
+        raise SystemExit(f"{label} is not owner-private")
+
+
+def entry_details(parent_descriptor, name):
+    try:
+        return os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+    except FileNotFoundError:
+        return None
+
+
+def remove_entry(parent_descriptor, name):
+    details = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+    if not stat.S_ISDIR(details.st_mode):
+        if not (stat.S_ISREG(details.st_mode) or stat.S_ISLNK(details.st_mode)):
+            raise SystemExit("bootstrap scratch contains an unsupported entry")
+        os.unlink(name, dir_fd=parent_descriptor)
+        os.fsync(parent_descriptor)
+        return
+    flags = os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(name, flags, dir_fd=parent_descriptor)
+    try:
+        opened = os.fstat(descriptor)
+        if identity(opened) != identity(details):
+            raise SystemExit("bootstrap scratch entry changed before pinned cleanup")
+        for child in os.listdir(descriptor):
+            if child in {"", ".", ".."} or "/" in child or "\x00" in child:
+                raise SystemExit("bootstrap scratch contains an invalid child name")
+            remove_entry(descriptor, child)
+        if object_identity(os.fstat(descriptor)) != object_identity(opened):
+            raise SystemExit("bootstrap scratch directory changed during pinned cleanup")
+    finally:
+        os.close(descriptor)
+    os.rmdir(name, dir_fd=parent_descriptor)
+    os.fsync(parent_descriptor)
+
+
+def remove_owned_root(parent_descriptor, name):
+    details = entry_details(parent_descriptor, name)
+    if details is None:
+        return
+    owned_private_directory(details, "bootstrap scratch quarantine")
+    remove_entry(parent_descriptor, name)
+
+
+parent = Path(sys.argv[1])
+root = Path(sys.argv[2])
+action = sys.argv[3]
+if action not in {"prepare", "cleanup"}:
+    raise SystemExit("bootstrap scratch action is invalid")
+if not parent.is_absolute() or root.parent != parent or root.name != "active":
+    raise SystemExit("bootstrap scratch path escaped its fixed private parent")
+parent_before = parent.lstat()
+owned_private_directory(parent_before, "bootstrap preparing parent")
+flags = os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_CLOEXEC", 0)
+flags |= getattr(os, "O_NOFOLLOW", 0)
+parent_descriptor = os.open(parent, flags)
+try:
+    parent_opened = os.fstat(parent_descriptor)
+    if identity(parent_opened) != identity(parent_before):
+        raise SystemExit("bootstrap preparing parent changed before it was pinned")
+    quarantine = ".active.quarantine"
+    remove_owned_root(parent_descriptor, quarantine)
+    active = entry_details(parent_descriptor, root.name)
+    if active is not None:
+        owned_private_directory(active, "bootstrap preparing root")
+        os.rename(
+            root.name,
+            quarantine,
+            src_dir_fd=parent_descriptor,
+            dst_dir_fd=parent_descriptor,
+        )
+        os.fsync(parent_descriptor)
+        moved = os.stat(quarantine, dir_fd=parent_descriptor, follow_symlinks=False)
+        if object_identity(moved) != object_identity(active):
+            raise SystemExit("bootstrap preparing root changed during quarantine")
+        remove_owned_root(parent_descriptor, quarantine)
+    if action == "prepare":
+        os.mkdir(root.name, mode=0o700, dir_fd=parent_descriptor)
+        os.fsync(parent_descriptor)
+        created = os.stat(root.name, dir_fd=parent_descriptor, follow_symlinks=False)
+        owned_private_directory(created, "bootstrap preparing root")
+    parent_after = parent.lstat()
+    if object_identity(parent_after) != object_identity(parent_opened):
+        raise SystemExit("bootstrap preparing parent changed while it was pinned")
+finally:
+    os.close(parent_descriptor)"""
+_BOOTSTRAP_PINNED_UV_COPY_SOURCE = r"""import hashlib
+import os
+import stat
+import sys
+from pathlib import Path
+
+
+def identity(details):
+    return (
+        details.st_dev,
+        details.st_ino,
+        details.st_mode,
+        details.st_size,
+        details.st_mtime_ns,
+        details.st_ctime_ns,
+    )
+
+
+def object_identity(details):
+    return (details.st_dev, details.st_ino, details.st_mode, details.st_uid)
+
+
+source = Path(sys.argv[1])
+root = Path(sys.argv[2])
+expected_sha256 = sys.argv[3]
+if (
+    not source.is_absolute()
+    or not root.is_absolute()
+    or len(expected_sha256) != 64
+    or any(character not in "0123456789abcdef" for character in expected_sha256)
+):
+    raise SystemExit("candidate uv copy arguments are invalid")
+source_before = source.lstat()
+root_before = root.lstat()
+if (
+    not stat.S_ISREG(source_before.st_mode)
+    or source_before.st_nlink != 1
+    or source_before.st_mode & 0o111 == 0
+    or not 1 <= source_before.st_size <= 256 * 1024 * 1024
+    or (hasattr(os, "getuid") and source_before.st_uid != os.getuid())
+    or stat.S_IMODE(source_before.st_mode) & 0o022
+):
+    raise SystemExit("candidate uv source is not one private bounded executable")
+flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+source_descriptor = os.open(source, flags)
+directory_flags = flags | os.O_DIRECTORY
+root_descriptor = os.open(root, directory_flags)
+destination_descriptor = None
+destination_created = False
+try:
+    source_opened = os.fstat(source_descriptor)
+    root_opened = os.fstat(root_descriptor)
+    if identity(source_opened) != identity(source_before):
+        raise SystemExit("candidate uv source changed before its pinned copy")
+    if object_identity(root_opened) != object_identity(root_before) or (
+        not stat.S_ISDIR(root_opened.st_mode)
+        or (hasattr(os, "getuid") and root_opened.st_uid != os.getuid())
+        or stat.S_IMODE(root_opened.st_mode) & 0o077
+    ):
+        raise SystemExit("candidate uv destination root is not owner-private")
+    destination_flags = (
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    destination_descriptor = os.open(
+        "pinned-uv",
+        destination_flags,
+        0o500,
+        dir_fd=root_descriptor,
+    )
+    destination_created = True
+    digest = hashlib.sha256()
+    copied = 0
+    while chunk := os.read(source_descriptor, 1024 * 1024):
+        copied += len(chunk)
+        if copied > 256 * 1024 * 1024:
+            raise SystemExit("candidate uv source exceeded its copy bound")
+        digest.update(chunk)
+        view = memoryview(chunk)
+        while view:
+            written = os.write(destination_descriptor, view)
+            if written < 1:
+                raise SystemExit("candidate uv copy made no progress")
+            view = view[written:]
+    os.fchmod(destination_descriptor, 0o500)
+    os.fsync(destination_descriptor)
+    destination_written = os.fstat(destination_descriptor)
+    source_after = os.fstat(source_descriptor)
+    source_linked_after = source.lstat()
+    if (
+        copied != source_opened.st_size
+        or digest.hexdigest() != expected_sha256
+        or identity(source_after) != identity(source_opened)
+        or identity(source_linked_after) != identity(source_opened)
+        or destination_written.st_size != copied
+        or destination_written.st_nlink != 1
+        or stat.S_IMODE(destination_written.st_mode) != 0o500
+        or (destination_written.st_dev, destination_written.st_ino)
+        == (source_opened.st_dev, source_opened.st_ino)
+    ):
+        raise SystemExit("candidate uv source changed or did not match its release pin")
+    os.close(destination_descriptor)
+    destination_descriptor = None
+    verification_descriptor = os.open("pinned-uv", flags, dir_fd=root_descriptor)
+    try:
+        verification_opened = os.fstat(verification_descriptor)
+        if identity(verification_opened) != identity(destination_written):
+            raise SystemExit("candidate uv private copy changed before verification")
+        verified_digest = hashlib.sha256()
+        verified_size = 0
+        while chunk := os.read(verification_descriptor, 1024 * 1024):
+            verified_size += len(chunk)
+            verified_digest.update(chunk)
+        verification_after = os.fstat(verification_descriptor)
+    finally:
+        os.close(verification_descriptor)
+    linked_copy = os.stat("pinned-uv", dir_fd=root_descriptor, follow_symlinks=False)
+    if (
+        verified_size != copied
+        or verified_digest.hexdigest() != expected_sha256
+        or identity(verification_after) != identity(verification_opened)
+        or identity(linked_copy) != identity(verification_opened)
+    ):
+        raise SystemExit("candidate uv private copy did not retain its pinned identity")
+    os.fsync(root_descriptor)
+    if object_identity(root.lstat()) != object_identity(root_opened):
+        raise SystemExit("candidate uv destination root changed while it was pinned")
+except BaseException:
+    if destination_descriptor is not None:
+        os.close(destination_descriptor)
+    if destination_created:
+        try:
+            os.unlink("pinned-uv", dir_fd=root_descriptor)
+            os.fsync(root_descriptor)
+        except FileNotFoundError:
+            pass
+    raise
+finally:
+    os.close(root_descriptor)
+    os.close(source_descriptor)
+print(root / "pinned-uv")"""
+_BOOTSTRAP_CANDIDATE_UV_INSTALL_SOURCE = r"""import base64
+import ctypes
+import csv
+import fcntl
+import hashlib
+import os
+import signal
+import stat
+import struct
+import subprocess
+import sys
+import zipfile
+from pathlib import Path, PurePosixPath
+
+
+MAX_PROVIDER = 256 * 1024 * 1024
+MAX_RUNTIME_LIBRARY = 512 * 1024 * 1024
+
+
+def create_memfd(name, flags):
+    creator = getattr(os, "memfd_create", None)
+    if creator is not None:
+        return creator(name, flags)
+    library = ctypes.CDLL(None, use_errno=True)
+    creator = library.memfd_create
+    creator.argtypes = (ctypes.c_char_p, ctypes.c_uint)
+    creator.restype = ctypes.c_int
+    descriptor = creator(name.encode(), flags)
+    if descriptor < 0:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+    return descriptor
+
+
+def origin_dependency_relocations(payload):
+    if payload[:4] != b"\x7fELF":
+        return []
+    if len(payload) < 64 or payload[4:6] != b"\x02\x01":
+        raise SystemExit("candidate provider is not a supported ELF64 executable")
+    program_offset = struct.unpack_from("<Q", payload, 32)[0]
+    program_entry_size = struct.unpack_from("<H", payload, 54)[0]
+    program_count = struct.unpack_from("<H", payload, 56)[0]
+    if (
+        program_entry_size < 56
+        or program_count < 1
+        or program_offset + program_entry_size * program_count > len(payload)
+    ):
+        raise SystemExit("candidate provider ELF program table is invalid")
+    load_segments = []
+    dynamic_segment = None
+    for index in range(program_count):
+        offset = program_offset + index * program_entry_size
+        (
+            program_type,
+            _flags,
+            file_offset,
+            virtual_address,
+            _physical_address,
+            file_size,
+            _memory_size,
+            _alignment,
+        ) = struct.unpack_from("<IIQQQQQQ", payload, offset)
+        if file_offset + file_size > len(payload):
+            raise SystemExit("candidate provider ELF segment is out of bounds")
+        if program_type == 1:
+            load_segments.append((file_offset, virtual_address, file_size))
+        elif program_type == 2:
+            if dynamic_segment is not None:
+                raise SystemExit("candidate provider has multiple ELF dynamic segments")
+            dynamic_segment = (file_offset, file_size)
+    if dynamic_segment is None:
+        return []
+    dynamic_offset, dynamic_size = dynamic_segment
+    if dynamic_size % 16:
+        raise SystemExit("candidate provider ELF dynamic segment is invalid")
+    string_address = None
+    string_size = None
+    needed_offsets = []
+    for offset in range(dynamic_offset, dynamic_offset + dynamic_size, 16):
+        tag, value = struct.unpack_from("<qQ", payload, offset)
+        if tag == 0:
+            break
+        if tag == 1:
+            needed_offsets.append(value)
+        elif tag == 5:
+            string_address = value
+        elif tag == 10:
+            string_size = value
+    if not needed_offsets:
+        return []
+    if string_address is None or string_size is None or string_size < 1:
+        raise SystemExit("candidate provider ELF string table is missing")
+    string_candidates = [
+        file_offset + string_address - virtual_address
+        for file_offset, virtual_address, file_size in load_segments
+        if virtual_address <= string_address
+        and string_address + string_size <= virtual_address + file_size
+    ]
+    if len(string_candidates) != 1:
+        raise SystemExit("candidate provider ELF string table is ambiguous")
+    string_offset = string_candidates[0]
+    string_end = string_offset + string_size
+    origin_prefix = b"$ORIGIN/../lib/"
+    relocations = []
+    for needed_offset in needed_offsets:
+        start = string_offset + needed_offset
+        if start < string_offset or start >= string_end:
+            raise SystemExit("candidate provider ELF dependency is out of bounds")
+        end = payload.find(b"\0", start, string_end)
+        if end < 0:
+            raise SystemExit("candidate provider ELF dependency is unterminated")
+        dependency = payload[start:end]
+        if not dependency.startswith(origin_prefix):
+            continue
+        library_name_bytes = dependency[len(origin_prefix) :]
+        try:
+            library_name = library_name_bytes.decode("ascii")
+        except UnicodeDecodeError as error:
+            raise SystemExit("candidate provider ELF origin dependency is invalid") from error
+        if (
+            not library_name
+            or library_name != os.path.basename(library_name)
+            or any(
+                character
+                not in (
+                    "abcdefghijklmnopqrstuvwxyz"
+                    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                    "0123456789._+-"
+                )
+                for character in library_name
+            )
+        ):
+            raise SystemExit("candidate provider ELF origin dependency is unsafe")
+        relocations.append((start, len(dependency), library_name))
+    return relocations
+
+
+def sealed_memfd(name, payload, *, inheritable):
+    flags = getattr(os, "MFD_ALLOW_SEALING", 2) | getattr(os, "MFD_EXEC", 0)
+    if not inheritable:
+        flags |= getattr(os, "MFD_CLOEXEC", 1)
+    descriptor = create_memfd(name, flags)
+    try:
+        view = memoryview(payload)
+        while view:
+            written = os.write(descriptor, view)
+            if written < 1:
+                raise SystemExit(f"could not copy {name} into sealed memory")
+            view = view[written:]
+        os.fchmod(descriptor, 0o500)
+        seals = (
+            getattr(fcntl, "F_SEAL_WRITE", 0x0008)
+            | getattr(fcntl, "F_SEAL_GROW", 0x0004)
+            | getattr(fcntl, "F_SEAL_SHRINK", 0x0002)
+            | getattr(fcntl, "F_SEAL_SEAL", 0x0001)
+        )
+        add_seals = getattr(fcntl, "F_ADD_SEALS", 1033)
+        get_seals = getattr(fcntl, "F_GET_SEALS", 1034)
+        fcntl.fcntl(descriptor, add_seals, seals)
+        if fcntl.fcntl(descriptor, get_seals) & seals != seals:
+            raise SystemExit(f"{name} memfd did not seal")
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        os.set_inheritable(descriptor, inheritable)
+        return descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def exec_candidate_provider(
+    provider,
+    source_provider,
+    provider_payload,
+    provider_arguments,
+    environment,
+):
+    relocations = origin_dependency_relocations(provider_payload)
+    relocated_provider = bytearray(provider_payload)
+    runtime_library_memfds = []
+    library_memfds_by_name = {}
+    try:
+        if relocations:
+            provider_library = os.path.normpath(
+                os.path.join(os.path.dirname(source_provider), "..", "lib")
+            )
+            library_directory_descriptor = os.open(
+                provider_library,
+                os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_NOFOLLOW", 0),
+            )
+            try:
+                for _start, _size, library_name in relocations:
+                    if library_name in library_memfds_by_name:
+                        continue
+                    library_descriptor = os.open(
+                        library_name,
+                        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+                        dir_fd=library_directory_descriptor,
+                    )
+                    try:
+                        library_payload, _details = read_descriptor(
+                            library_descriptor,
+                            MAX_RUNTIME_LIBRARY,
+                            f"candidate provider origin dependency {library_name}",
+                        )
+                    finally:
+                        os.close(library_descriptor)
+                    library_memfd = sealed_memfd(
+                        f"clio-relay-{library_name}",
+                        library_payload,
+                        inheritable=True,
+                    )
+                    runtime_library_memfds.append(library_memfd)
+                    library_memfds_by_name[library_name] = library_memfd
+            finally:
+                os.close(library_directory_descriptor)
+            for start, size, library_name in relocations:
+                replacement = f"/proc/self/fd/{library_memfds_by_name[library_name]}".encode()
+                if len(replacement) > size:
+                    raise SystemExit("candidate provider origin dependency fd path is too long")
+                relocated_provider[start : start + size] = replacement + b"\0" * (
+                    size - len(replacement)
+                )
+        provider_memfd = sealed_memfd(
+            "clio-relay-candidate-provider",
+            relocated_provider,
+            inheritable=False,
+        )
+        try:
+            if os.execve not in os.supports_fd:
+                raise SystemExit("candidate provider fd execution is unavailable")
+            environment["BOOTSTRAP_PLAN_PROVIDER_EXEC_SHA256"] = hashlib.sha256(
+                relocated_provider
+            ).hexdigest()
+            os.execve(provider_memfd, [str(provider), *provider_arguments], environment)
+        finally:
+            os.close(provider_memfd)
+    finally:
+        for runtime_library_memfd in runtime_library_memfds:
+            os.close(runtime_library_memfd)
+
+
+def identity(details):
+    return (
+        details.st_dev,
+        details.st_ino,
+        details.st_mode,
+        details.st_size,
+        details.st_mtime_ns,
+        details.st_ctime_ns,
+    )
+
+
+def read_descriptor(descriptor, maximum, label):
+    before = os.fstat(descriptor)
+    if not stat.S_ISREG(before.st_mode) or not 1 <= before.st_size <= maximum:
+        raise SystemExit(f"{label} is not one bounded regular file")
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    chunks = []
+    remaining = maximum + 1
+    while remaining:
+        chunk = os.read(descriptor, min(1024 * 1024, remaining))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    payload = b"".join(chunks)
+    after = os.fstat(descriptor)
+    if (
+        len(payload) != before.st_size
+        or len(payload) > maximum
+        or identity(after) != identity(before)
+    ):
+        raise SystemExit(f"{label} changed while it was pinned")
+    return payload, before
+
+
+def read_path(path, maximum, label):
+    before = path.lstat()
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        payload, opened = read_descriptor(descriptor, maximum, label)
+    finally:
+        os.close(descriptor)
+    if identity(opened) != identity(before) or identity(path.lstat()) != identity(opened):
+        raise SystemExit(f"{label} path changed while it was pinned")
+    return payload
+
+
+action, *values = sys.argv[1:]
+if action not in {
+    "install-and-verify",
+    "install-verify-and-exec",
+    "verify-installed",
+    "verify-installed-and-exec",
+}:
+    raise SystemExit("candidate uv installation action is invalid")
+if len(values) < 8:
+    raise SystemExit("candidate uv installation arguments are incomplete")
+identity_values = values[:8]
+remaining_values = values[8:]
+expected_provider_sha256 = None
+if action == "verify-installed-and-exec":
+    if not remaining_values:
+        raise SystemExit("candidate provider execution omitted its expected digest")
+    expected_provider_sha256, *provider_arguments = remaining_values
+    if len(expected_provider_sha256) != 64 or any(
+        character not in "0123456789abcdef" for character in expected_provider_sha256
+    ):
+        raise SystemExit("candidate provider expected digest is invalid")
+else:
+    provider_arguments = remaining_values
+if action.endswith("-and-exec"):
+    if not provider_arguments or provider_arguments[0] != "-I":
+        raise SystemExit("candidate provider execution must be isolated")
+elif provider_arguments:
+    raise SystemExit("candidate uv verification received unexpected arguments")
+(
+    uv_value,
+    expected_uv_sha256,
+    wheel_value,
+    expected_wheel_sha256,
+    tool_directory_value,
+    tool_bin_directory_value,
+    cache_directory_value,
+    python_install_directory_value,
+) = identity_values
+if os.name != "posix" or os.execve not in os.supports_fd:
+    raise SystemExit("candidate uv installation requires POSIX fd execution")
+for digest, label in (
+    (expected_uv_sha256, "uv"),
+    (expected_wheel_sha256, "wheel"),
+):
+    if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
+        raise SystemExit(f"candidate {label} digest is invalid")
+uv_path = Path(uv_value)
+wheel_path = Path(wheel_value)
+tool_directory = Path(tool_directory_value)
+tool_bin_directory = Path(tool_bin_directory_value)
+cache_directory = Path(cache_directory_value)
+python_install_directory = Path(python_install_directory_value)
+if any(
+    not path.is_absolute()
+    for path in (
+        uv_path,
+        wheel_path,
+        tool_directory,
+        tool_bin_directory,
+        cache_directory,
+        python_install_directory,
+    )
+):
+    raise SystemExit("candidate uv installation paths must be absolute")
+flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+uv_before = uv_path.lstat()
+wheel_before = wheel_path.lstat()
+uv_descriptor = os.open(uv_path, flags)
+wheel_descriptor = os.open(wheel_path, flags)
+provider_descriptor = None
+try:
+    uv_payload, uv_opened = read_descriptor(
+        uv_descriptor,
+        256 * 1024 * 1024,
+        "candidate uv executable",
+    )
+    wheel_payload, wheel_opened = read_descriptor(
+        wheel_descriptor,
+        256 * 1024 * 1024,
+        "candidate relay wheel",
+    )
+    if (
+        identity(uv_before) != identity(uv_opened)
+        or identity(wheel_before) != identity(wheel_opened)
+        or hashlib.sha256(uv_payload).hexdigest() != expected_uv_sha256
+        or hashlib.sha256(wheel_payload).hexdigest() != expected_wheel_sha256
+    ):
+        raise SystemExit("candidate uv or wheel changed before fd-bound installation")
+    environment = {
+        name: value
+        for name, value in os.environ.items()
+        if not name.startswith(("LD_", "PYTHON", "UV_", "PIP_"))
+        and name not in {"BASH_ENV", "ENV", "VIRTUAL_ENV", "CONDA_PREFIX"}
+    }
+    environment.update(
+        {
+            "UV_TOOL_DIR": str(tool_directory),
+            "UV_TOOL_BIN_DIR": str(tool_bin_directory),
+            "UV_CACHE_DIR": str(cache_directory),
+            "UV_PYTHON_INSTALL_DIR": str(python_install_directory),
+            "UV_PYTHON_DOWNLOADS": "never",
+        }
+    )
+    if action in {"install-and-verify", "install-verify-and-exec"}:
+        command = [
+            str(uv_path),
+            "tool",
+            "install",
+            "--force",
+            "--python",
+            "3.12",
+            "--no-config",
+            "--default-index",
+            "https://pypi.org/simple",
+            str(wheel_path),
+        ]
+        process = subprocess.Popen(
+            command,
+            executable=f"/proc/self/fd/{uv_descriptor}",
+            pass_fds=(uv_descriptor,),
+            env=environment,
+            start_new_session=True,
+            stdout=sys.stderr,
+            stderr=sys.stderr,
+        )
+        try:
+            returncode = process.wait(timeout=300)
+        except subprocess.TimeoutExpired:
+            os.killpg(process.pid, signal.SIGTERM)
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=5)
+            raise SystemExit("candidate fd-bound uv installation timed out") from None
+        if returncode != 0:
+            raise SystemExit(f"candidate fd-bound uv installation failed: {returncode}")
+
+    provider_location = tool_directory / "clio-relay/bin/python"
+    try:
+        provider_target = provider_location.resolve(strict=True)
+        provider_before = provider_target.lstat()
+        provider_descriptor = os.open(
+            provider_target,
+            os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
+    except (OSError, RuntimeError) as error:
+        raise SystemExit("candidate provider target is unavailable") from error
+
+    stream = os.fdopen(os.dup(wheel_descriptor), "rb")
+    with stream, zipfile.ZipFile(stream) as archive:
+        infos = archive.infolist()
+        names = [item.filename for item in infos if not item.is_dir()]
+        if not names or len(names) > 100_000 or len(names) != len(set(names)):
+            raise SystemExit("candidate wheel has an invalid bounded member set")
+        for item in infos:
+            path = PurePosixPath(item.filename)
+            mode = item.external_attr >> 16
+            if (
+                path.is_absolute()
+                or ".." in path.parts
+                or any(part in {"", "."} for part in path.parts)
+                or (mode and stat.S_IFMT(mode) not in {0, stat.S_IFREG})
+                or item.file_size > 256 * 1024 * 1024
+            ):
+                raise SystemExit("candidate wheel contains an unsafe member")
+        record_names = [name for name in names if name.endswith(".dist-info/RECORD")]
+        if len(record_names) != 1:
+            raise SystemExit("candidate wheel RECORD ownership is ambiguous")
+        record_name = record_names[0]
+        record_bytes = archive.read(record_name)
+        if len(record_bytes) > 8 * 1024 * 1024:
+            raise SystemExit("candidate wheel RECORD exceeds its byte bound")
+        try:
+            rows = list(csv.reader(record_bytes.decode("utf-8").splitlines(), strict=True))
+        except (UnicodeDecodeError, csv.Error) as error:
+            raise SystemExit("candidate wheel RECORD is malformed") from error
+        wheel_rows = {row[0]: row for row in rows if len(row) == 3}
+        if set(wheel_rows) != set(names) or len(wheel_rows) != len(rows):
+            raise SystemExit("candidate wheel RECORD does not close over its members")
+
+        environment_prefix = tool_directory / "clio-relay"
+        site_package_matches = list(environment_prefix.glob("lib/python*/site-packages"))
+        if len(site_package_matches) != 1:
+            raise SystemExit("candidate uv environment has no exact site-packages root")
+        site_packages = site_package_matches[0].resolve(strict=True)
+        dist_info = PurePosixPath(record_name).parent
+        installed_record = site_packages.joinpath(*PurePosixPath(record_name).parts)
+        if installed_record.is_symlink() or not installed_record.resolve(
+            strict=True
+        ).is_relative_to(site_packages):
+            raise SystemExit("installed candidate RECORD escaped site-packages")
+        installed_record_bytes = read_path(
+            installed_record,
+            8 * 1024 * 1024,
+            "installed candidate RECORD",
+        )
+        try:
+            installed_rows = list(
+                csv.reader(installed_record_bytes.decode("utf-8").splitlines(), strict=True)
+            )
+        except (UnicodeDecodeError, csv.Error) as error:
+            raise SystemExit("installed candidate RECORD is malformed") from error
+        installed_names = {row[0] for row in installed_rows if len(row) == 3}
+        generated = {
+            os.path.relpath(environment_prefix / "bin/clio-relay", site_packages).replace(
+                os.sep, "/"
+            ),
+            *(str(dist_info / name) for name in (
+                "INSTALLER",
+                "REQUESTED",
+                "direct_url.json",
+                "uv_cache.json",
+            )),
+        }
+        if len(installed_names) != len(installed_rows) or installed_names != set(names) | generated:
+            raise SystemExit("installed candidate distribution contains unpinned members")
+
+        total = 0
+        for name in names:
+            row = wheel_rows[name]
+            installed_path = site_packages.joinpath(*PurePosixPath(name).parts)
+            if name == record_name:
+                continue
+            if installed_path.is_symlink() or not installed_path.resolve(
+                strict=True
+            ).is_relative_to(site_packages):
+                raise SystemExit("installed candidate member escaped site-packages")
+            expected_hash, expected_size_text = row[1:]
+            if not expected_hash.startswith("sha256=") or not expected_size_text.isdigit():
+                raise SystemExit("candidate wheel RECORD member omitted its identity")
+            expected_size = int(expected_size_text)
+            total += expected_size
+            if total > 2 * 1024 * 1024 * 1024:
+                raise SystemExit("candidate wheel expanded closure exceeds its byte bound")
+            wheel_member = archive.read(name)
+            installed_member = read_path(
+                installed_path,
+                256 * 1024 * 1024,
+                "installed candidate member",
+            )
+            digest = hashlib.sha256(wheel_member).digest()
+            encoded = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+            if (
+                len(wheel_member) != expected_size
+                or expected_hash != "sha256=" + encoded
+                or installed_member != wheel_member
+            ):
+                raise SystemExit("installed candidate differs from the pinned wheel fd")
+    if (
+        identity(os.fstat(uv_descriptor)) != identity(uv_opened)
+        or identity(os.fstat(wheel_descriptor)) != identity(wheel_opened)
+    ):
+        raise SystemExit("candidate uv or wheel descriptor changed during installation")
+    assert provider_descriptor is not None
+    try:
+        provider_payload, provider_opened = read_descriptor(
+            provider_descriptor,
+            256 * 1024 * 1024,
+            "candidate provider",
+        )
+        source_provider = os.path.realpath(f"/proc/self/fd/{provider_descriptor}")
+        source_details = os.stat(source_provider, follow_symlinks=False)
+        if (
+            identity(provider_before) != identity(provider_opened)
+            or provider_location.resolve(strict=True) != provider_target
+            or identity(provider_target.lstat()) != identity(provider_opened)
+            or (source_details.st_dev, source_details.st_ino)
+            != (provider_opened.st_dev, provider_opened.st_ino)
+            or provider_opened.st_mode & 0o111 == 0
+        ):
+            raise SystemExit("candidate provider path changed while it was pinned")
+        provider_sha256 = hashlib.sha256(provider_payload).hexdigest()
+        if (
+            expected_provider_sha256 is not None
+            and provider_sha256 != expected_provider_sha256
+        ):
+            raise SystemExit("candidate provider changed after its planning pin")
+    finally:
+        os.close(provider_descriptor)
+        provider_descriptor = None
+finally:
+    if provider_descriptor is not None:
+        os.close(provider_descriptor)
+    os.close(wheel_descriptor)
+    os.close(uv_descriptor)
+if action.endswith("-and-exec"):
+    provider_environment = {
+        name: value
+        for name, value in os.environ.items()
+        if not name.startswith(("LD_", "PYTHON")) and name not in {"BASH_ENV", "ENV"}
+    }
+    provider_environment["BOOTSTRAP_PLAN_PROVIDER"] = str(provider_location)
+    provider_environment["BOOTSTRAP_PLAN_PROVIDER_SHA256"] = provider_sha256
+    exec_candidate_provider(
+        provider_location,
+        source_provider,
+        provider_payload,
+        provider_arguments,
+        provider_environment,
+    )
+print("bootstrap_candidate_provider_sha256=" + provider_sha256)
+print("bootstrap_candidate_install=fd-bound-wheel-verified:" + action)"""
 BOOTSTRAP_REMOTE_SCRIPT_TIMEOUT_SECONDS = 1800.0
 BOOTSTRAP_PUBLIC_EXACT_DEADLINE_SECONDS = 29.0
 BOOTSTRAP_PUBLIC_REPAIR_DEADLINE_SECONDS = 58.0
@@ -1261,11 +2217,30 @@ def _bootstrap_preflight_over_ssh(
     command = "\n".join(
         [
             "set -u",
+            *_STAGED_PROVIDER_ENVIRONMENT_SANITIZER.splitlines(),
             f"export CLIO_RELAY_CORE_DIR={render_remote_shell_path(core_dir, field='core_dir')}",
             f"export CLIO_RELAY_SPOOL_DIR={render_remote_shell_path(spool_dir, field='spool_dir')}",
             ("export CLIO_RELAY_BOOTSTRAP_DESIRED_STATE_BASE64=" + shlex.quote(encoded)),
             'if [ ! -x "$HOME/.local/bin/clio-relay" ]; then '
             "echo bootstrap_preflight_unsupported=not_installed; exit 0; fi",
+            'BOOTSTRAP_INSTALL_RECEIPT="$HOME/.local/share/clio-relay/install-receipt.json"',
+            'if [ -e "$BOOTSTRAP_INSTALL_RECEIPT" ] || [ -L "$BOOTSTRAP_INSTALL_RECEIPT" ]; then',
+            '  if ! BOOTSTRAP_RELAY_RECEIPT_CLASS="$(python3 -I - '
+            "\"$BOOTSTRAP_INSTALL_RECEIPT\" <<'__CLIO_RELAY_PREFLIGHT_RECEIPT__'",
+            *_BOOTSTRAP_RECEIPT_CLASSIFIER_SOURCE.splitlines(),
+            "__CLIO_RELAY_PREFLIGHT_RECEIPT__",
+            '  )"; then',
+            "    echo bootstrap_preflight_unsupported=legacy_relay_provider",
+            "    exit 0",
+            "  fi",
+            '  if [ "$BOOTSTRAP_RELAY_RECEIPT_CLASS" != "current" ]; then',
+            "    echo bootstrap_preflight_unsupported=legacy_relay_provider",
+            "    exit 0",
+            "  fi",
+            "else",
+            "  echo bootstrap_preflight_unsupported=legacy_relay_provider",
+            "  exit 0",
+            "fi",
             "if ! command -v timeout >/dev/null 2>&1; then",
             '  echo "timeout is required" >&2',
             "  exit 1",
@@ -1312,6 +2287,7 @@ def _bootstrap_preflight_over_ssh(
             in {
                 "bootstrap_preflight_unsupported=not_installed",
                 "bootstrap_preflight_unsupported=missing_command",
+                "bootstrap_preflight_unsupported=legacy_relay_provider",
             }
         ]
         if len(unsupported) != 1:
@@ -2364,6 +3340,9 @@ def _worker_upgrade_fence_script(
             "    fi",
             "  fi",
             "  bootstrap_release_worker_lifetime_guard || true",
+            "  if declare -F bootstrap_cleanup_preparing_root >/dev/null; then",
+            "    bootstrap_cleanup_preparing_root || true",
+            "  fi",
             '  exit "$status"',
             "}",
             "trap bootstrap_worker_fence_exit EXIT",
@@ -2472,6 +3451,7 @@ def _relay_only_reconcile_script(
     rendered_source_archive: str,
     rendered_source_archive_sha256: str,
     invocation_id: str,
+    candidate_uv_install_program: str,
 ) -> str:
     """Render the staged relay-only generation transaction."""
     staged_provider_exec_program = shlex.quote(_STAGED_PROVIDER_EXEC_PROGRAM)
@@ -2499,8 +3479,17 @@ bootstrap_provider_exec() (
     exec python3 -I -c {staged_provider_exec_program} \
       "$BOOTSTRAP_STAGED_GENERATION" \
       "$BOOTSTRAP_STAGED_MANIFEST_SHA256" "$@"
+  elif [ "${{BOOTSTRAP_CANDIDATE_PROVIDER_READY:-0}}" = "1" ]; then
+    exec python3 -I -c {candidate_uv_install_program} \
+      verify-installed-and-exec \
+      "$BOOTSTRAP_PINNED_UV" {UV_LINUX_AMD64_EXECUTABLE_SHA256} \
+      "$BOOTSTRAP_CANDIDATE_ARTIFACT" "$BOOTSTRAP_CANDIDATE_ARTIFACT_SHA256" \
+      "$BOOTSTRAP_CANDIDATE_TOOL_DIR" "$BOOTSTRAP_CANDIDATE_BIN_DIR" \
+      "$BOOTSTRAP_CANDIDATE_CACHE_DIR" \
+      "$BOOTSTRAP_CANDIDATE_PYTHON_INSTALL_DIR" \
+      "$BOOTSTRAP_CANDIDATE_PROVIDER_SHA256" -I "$@"
   else
-    exec "$BOOTSTRAP_PLAN_PROVIDER" "$@"
+    exec "$BOOTSTRAP_RECOVERY_PROVIDER" -I "$@"
   fi
 )
 
@@ -2719,6 +3708,7 @@ bootstrap_reconcile_transaction_exit() {{
     esac
   fi
   bootstrap_release_worker_lifetime_guard 2>/dev/null || true
+  bootstrap_cleanup_preparing_root || true
   exit "$status"
 }}
 
@@ -3741,6 +4731,7 @@ print("bootstrap_receipt_json=" + json.dumps(receipt, sort_keys=True, separators
 __CLIO_RELAY_RECONCILE_RECEIPT__
   trap - EXIT
   bootstrap_release_worker_lifetime_guard || true
+  bootstrap_cleanup_preparing_root
 }}
 
 bootstrap_repair_transaction_exit() {{
@@ -3750,6 +4741,7 @@ bootstrap_repair_transaction_exit() {{
     echo "bootstrap readiness repair did not complete; queue migration state is retained" >&2
   fi
   bootstrap_release_worker_lifetime_guard 2>/dev/null || true
+  bootstrap_cleanup_preparing_root || true
   exit "$status"
 }}
 
@@ -3957,6 +4949,7 @@ print("bootstrap_receipt_json=" + json.dumps(receipt, sort_keys=True, separators
 __CLIO_RELAY_REPAIR_RECEIPT__
   trap - EXIT
   bootstrap_release_worker_lifetime_guard || true
+  bootstrap_cleanup_preparing_root
 }}
 """
 
@@ -3997,6 +4990,7 @@ def render_linux_user_bootstrap_script(
     rendered_jarvis_resource_graph_profile = shlex.quote(jarvis_resource_graph_profile or "")
     rendered_allow_jarvis_resource_graph_build = "1" if allow_jarvis_resource_graph_build else "0"
     rendered_relay_install_spec = _render_relay_install_spec(relay_install_spec)
+    rendered_candidate_relay_install_spec = shlex.quote(relay_install_spec)
     resolved_relay_deployment_install_spec = relay_deployment_install_spec or relay_install_spec
     source_archive_path = PurePosixPath(source_archive)
     if (
@@ -4094,6 +5088,9 @@ def render_linux_user_bootstrap_script(
         sort_keys=True,
         separators=(",", ":"),
     )
+    preparing_root_program = shlex.quote(_BOOTSTRAP_PREPARING_ROOT_SOURCE)
+    pinned_uv_copy_program = shlex.quote(_BOOTSTRAP_PINNED_UV_COPY_SOURCE)
+    candidate_uv_install_program = shlex.quote(_BOOTSTRAP_CANDIDATE_UV_INSTALL_SOURCE)
     candidate_package_sha256 = {
         name: hashlib.sha256(payload).hexdigest()
         for name, payload in candidate_package_sources.items()
@@ -4124,10 +5121,16 @@ def render_linux_user_bootstrap_script(
         rendered_source_archive=rendered_source_archive,
         rendered_source_archive_sha256=rendered_source_archive_sha256,
         invocation_id=invocation_id,
+        candidate_uv_install_program=candidate_uv_install_program,
     )
     script = f"""set -euo pipefail
 umask 077
 export PATH="$HOME/.local/bin:$PATH"
+while IFS= read -r variable_name; do
+  case "$variable_name" in
+    LD_*|PYTHON*|BASH_ENV|ENV) unset "$variable_name" ;;
+  esac
+done < <(compgen -e)
 export UV_TOOL_DIR="$HOME/.local/share/clio-relay/uv-tools"
 export UV_TOOL_BIN_DIR="$HOME/.local/share/clio-relay/uv-bin"
 export UV_PYTHON_INSTALL_DIR="$HOME/.local/share/clio-relay/uv-python"
@@ -4437,10 +5440,27 @@ __CLIO_RELAY_EARLY_RECOVERY_FIELDS__
 fi
 BOOTSTRAP_CURRENT_RELAY="$HOME/.local/bin/clio-relay"
 BOOTSTRAP_CURRENT_PROVIDER=""
+BOOTSTRAP_LEGACY_RELAY_PROVIDER=1
+BOOTSTRAP_INSTALL_RECEIPT="$HOME/.local/share/clio-relay/install-receipt.json"
+if [ -e "$BOOTSTRAP_INSTALL_RECEIPT" ] || [ -L "$BOOTSTRAP_INSTALL_RECEIPT" ]; then
+  if BOOTSTRAP_RELAY_RECEIPT_CLASS="$(
+    env -u PYTHONPATH -u PYTHONHOME -u LD_PRELOAD -u LD_LIBRARY_PATH \
+      python3 -I - "$BOOTSTRAP_INSTALL_RECEIPT" <<'__CLIO_RELAY_RECEIPT_CLASSIFY__'
+{_BOOTSTRAP_RECEIPT_CLASSIFIER_SOURCE}
+__CLIO_RELAY_RECEIPT_CLASSIFY__
+  )"; then
+    if [ "$BOOTSTRAP_RELAY_RECEIPT_CLASS" = "current" ]; then
+      BOOTSTRAP_LEGACY_RELAY_PROVIDER=0
+    fi
+  else
+    echo "bootstrap receipt classification failed; candidate payload is required" >&2
+  fi
+fi
 if [ -x "$BOOTSTRAP_CURRENT_RELAY" ]; then
   BOOTSTRAP_CURRENT_PROVIDER="$(sed -n '1{{s/^#!//;p;}}' "$BOOTSTRAP_CURRENT_RELAY")"
 fi
 if [ "$BOOTSTRAP_RECOVERY_REQUIRED" = "0" ] && \
+   [ "$BOOTSTRAP_LEGACY_RELAY_PROVIDER" = "0" ] && \
    [ -x "$BOOTSTRAP_CURRENT_RELAY" ]; then
   if [ -x "$BOOTSTRAP_CURRENT_PROVIDER" ] && \
      "$BOOTSTRAP_CURRENT_PROVIDER" -c \
@@ -4604,6 +5624,10 @@ BOOTSTRAP_JARVIS_CONFIG_SHA256_BEFORE=""
 BOOTSTRAP_JARVIS_REPOS_SHA256_BEFORE=""
 BOOTSTRAP_JARVIS_GRAPH_SHA256_BEFORE=""
 if [ "$JARVIS_EXISTING_FILE_COUNT" -eq 3 ]; then
+  command -v timeout >/dev/null 2>&1 || {{
+    echo "timeout is required for bounded candidate staging" >&2
+    exit 1
+  }}
   BOOTSTRAP_JARVIS_CONFIG_SHA256_BEFORE="$(sha256sum "$JARVIS_CONFIG_FILE" | awk '{{print $1}}')"
   BOOTSTRAP_JARVIS_REPOS_SHA256_BEFORE="$(sha256sum "$JARVIS_REPOS_FILE" | awk '{{print $1}}')"
   BOOTSTRAP_JARVIS_GRAPH_SHA256_BEFORE="$(sha256sum "$JARVIS_GRAPH_FILE" | awk '{{print $1}}')"
@@ -4618,7 +5642,7 @@ if [ "$JARVIS_EXISTING_FILE_COUNT" -eq 3 ] && \
 fi
 if [ "$JARVIS_EXISTING_FILE_COUNT" -eq 3 ]; then
   export JARVIS_CONFIG_FILE
-  "$HOME/.local/share/clio-relay/jarvis-venv/bin/python" - <<'__CLIO_RELAY_JARVIS_ROOT_PROBE__'
+  "$HOME/.local/share/clio-relay/jarvis-venv/bin/python" -I - <<'__CLIO_RELAY_JARVIS_ROOT_PROBE__'
 import os
 from pathlib import Path
 
@@ -4639,8 +5663,19 @@ print("jarvis_existing_roots=verified")
 __CLIO_RELAY_JARVIS_ROOT_PROBE__
 fi
 {relay_only_reconcile}
-BOOTSTRAP_PREPARING_ROOT="$HOME/.local/share/clio-relay/preparing/{invocation_id}"
-mkdir -p "$BOOTSTRAP_PREPARING_ROOT"
+BOOTSTRAP_PREPARING_PARENT="$HOME/.local/share/clio-relay/preparing"
+BOOTSTRAP_PREPARING_ROOT="$BOOTSTRAP_PREPARING_PARENT/active"
+export BOOTSTRAP_PREPARING_PARENT BOOTSTRAP_PREPARING_ROOT
+mkdir -m 0700 -p "$BOOTSTRAP_PREPARING_PARENT"
+env -u PYTHONPATH -u PYTHONHOME -u LD_PRELOAD -u LD_LIBRARY_PATH \
+  python3 -I -c {preparing_root_program} \
+  "$BOOTSTRAP_PREPARING_PARENT" "$BOOTSTRAP_PREPARING_ROOT" prepare
+bootstrap_cleanup_preparing_root() {{
+  env -u PYTHONPATH -u PYTHONHOME -u LD_PRELOAD -u LD_LIBRARY_PATH \
+    python3 -I -c {preparing_root_program} \
+    "$BOOTSTRAP_PREPARING_PARENT" "$BOOTSTRAP_PREPARING_ROOT" cleanup
+}}
+trap bootstrap_cleanup_preparing_root EXIT
 BOOTSTRAP_CANDIDATE_PYTHON_ROOT="$BOOTSTRAP_PREPARING_ROOT/candidate-python"
 BOOTSTRAP_CANDIDATE_PACKAGE="$BOOTSTRAP_CANDIDATE_PYTHON_ROOT/clio_relay"
 if [ -L "$BOOTSTRAP_CANDIDATE_PYTHON_ROOT" ] || \
@@ -4649,7 +5684,7 @@ if [ -L "$BOOTSTRAP_CANDIDATE_PYTHON_ROOT" ] || \
   exit 1
 fi
 mkdir -m 0700 -p "$BOOTSTRAP_CANDIDATE_PACKAGE"
-python3 - "$BOOTSTRAP_CANDIDATE_PACKAGE" <<'__CLIO_RELAY_CANDIDATE_PACKAGE__'
+python3 -I - "$BOOTSTRAP_CANDIDATE_PACKAGE" <<'__CLIO_RELAY_CANDIDATE_PACKAGE__'
 import base64
 import hashlib
 import json
@@ -4702,16 +5737,26 @@ bootstrap_safe_extract() {{
   local provider="$1"
   local archive="$2"
   local destination="$3"
-  PYTHONPATH="$BOOTSTRAP_CANDIDATE_PYTHON_ROOT" \
-    "$provider" - "$archive" "$destination" \
+  bootstrap_safe_extract_provider() {{
+    if [ "${{BOOTSTRAP_CANDIDATE_PROVIDER_READY:-0}}" = "1" ] && \
+       [ "$provider" = "${{BOOTSTRAP_PLAN_PROVIDER:-}}" ]; then
+      bootstrap_provider_exec "$@"
+    else
+      "$provider" -I "$@"
+    fi
+  }}
+  bootstrap_safe_extract_provider - "$BOOTSTRAP_CANDIDATE_PYTHON_ROOT" \
+    "$archive" "$destination" \
       <<'__CLIO_RELAY_SAFE_EXTRACT__'
 import json
 import sys
 from pathlib import Path
 
+candidate_root, archive_value, destination_value = sys.argv[1:]
+sys.path.insert(0, candidate_root)
 from clio_relay.safe_archive import safe_extract_tar
 
-receipt = safe_extract_tar(Path(sys.argv[1]), Path(sys.argv[2]))
+receipt = safe_extract_tar(Path(archive_value), Path(destination_value))
 print(
     "bootstrap_archive_extraction="
     + json.dumps(
@@ -4731,56 +5776,238 @@ __CLIO_RELAY_SAFE_EXTRACT__
 }}
 BOOTSTRAP_PLAN_MODE="full"
 BOOTSTRAP_PLAN_JSON=""
-BOOTSTRAP_PLAN_PROVIDER=""
+BOOTSTRAP_RECOVERY_PROVIDER=""
+BOOTSTRAP_CANDIDATE_PROVIDER_READY=0
 if [ -x "$BOOTSTRAP_CURRENT_PROVIDER" ]; then
-  BOOTSTRAP_PLAN_PROVIDER="$BOOTSTRAP_CURRENT_PROVIDER"
+  BOOTSTRAP_RECOVERY_PROVIDER="$BOOTSTRAP_CURRENT_PROVIDER"
 elif [ -x "$HOME/.local/share/clio-relay/jarvis-venv/bin/python" ]; then
-  BOOTSTRAP_PLAN_PROVIDER="$HOME/.local/share/clio-relay/jarvis-venv/bin/python"
+  BOOTSTRAP_RECOVERY_PROVIDER="$HOME/.local/share/clio-relay/jarvis-venv/bin/python"
 fi
-export BOOTSTRAP_PLAN_PROVIDER BOOTSTRAP_CANDIDATE_RECONCILE
-if [ -n "$BOOTSTRAP_PLAN_PROVIDER" ]; then
-  "$BOOTSTRAP_PLAN_PROVIDER" -I "$BOOTSTRAP_CANDIDATE_PROVIDER_BUILD_INFO" \
-    "$BOOTSTRAP_CANDIDATE_PACKAGE"
-fi
+export BOOTSTRAP_RECOVERY_PROVIDER BOOTSTRAP_CANDIDATE_PROVIDER_READY
+export BOOTSTRAP_CANDIDATE_RECONCILE
 if [ "$BOOTSTRAP_RECOVERY_REQUIRED" = "1" ]; then
-  if [ -z "$BOOTSTRAP_PLAN_PROVIDER" ]; then
+  if [ -z "$BOOTSTRAP_RECOVERY_PROVIDER" ]; then
     echo "bootstrap recovery has no trusted installed Python provider" >&2
     exit 1
   fi
+  env -u PYTHONPATH -u PYTHONHOME -u LD_PRELOAD -u LD_LIBRARY_PATH \
+    "$BOOTSTRAP_RECOVERY_PROVIDER" -I "$BOOTSTRAP_CANDIDATE_PROVIDER_BUILD_INFO" \
+      "$BOOTSTRAP_CANDIDATE_PACKAGE"
   bootstrap_recover_previous_transaction
   exec 9>&-
   unset CLIO_RELAY_BOOTSTRAP_LOCK_FD
+  bootstrap_cleanup_preparing_root
+  trap - EXIT
   exec bash "$0"
 fi
-if [ -n "$BOOTSTRAP_PLAN_PROVIDER" ] && [ "$JARVIS_EXISTING_FILE_COUNT" -eq 3 ]; then
-  export BOOTSTRAP_CANDIDATE_RECONCILE
+if [ "$JARVIS_EXISTING_FILE_COUNT" -eq 3 ]; then
+  SOURCE_ARCHIVE={rendered_source_archive}
+  SOURCE_ARCHIVE_SHA256={rendered_source_archive_sha256}
+  if [ -z "$SOURCE_ARCHIVE_SHA256" ]; then
+    echo "retained-state reconcile requires a verified source archive digest" >&2
+    exit 1
+  fi
+  echo "$SOURCE_ARCHIVE_SHA256 *$SOURCE_ARCHIVE" | sha256sum --check --strict -
+  BOOTSTRAP_CANDIDATE_SOURCE_ROOT="$BOOTSTRAP_PREPARING_ROOT/source"
+  bootstrap_safe_extract python3 "$SOURCE_ARCHIVE" "$BOOTSTRAP_CANDIDATE_SOURCE_ROOT"
+
+  BOOTSTRAP_CANDIDATE_INSTALL_SPEC={rendered_candidate_relay_install_spec}
+  BOOTSTRAP_CANDIDATE_ARTIFACT_SHA256={rendered_relay_artifact_sha256}
+  if [ -z "$BOOTSTRAP_CANDIDATE_ARTIFACT_SHA256" ]; then
+    echo "retained-state reconcile requires an exact relay wheel SHA-256" >&2
+    exit 1
+  fi
+  BOOTSTRAP_CANDIDATE_ARTIFACT=""
+  case "$BOOTSTRAP_CANDIDATE_INSTALL_SPEC" in
+    '$DEST/'*)
+      BOOTSTRAP_CANDIDATE_ARTIFACT="$(
+        python3 -I - "$BOOTSTRAP_CANDIDATE_INSTALL_SPEC" \
+          "$BOOTSTRAP_CANDIDATE_SOURCE_ROOT" <<'__CLIO_RELAY_CANDIDATE_WHEEL_PATH__'
+import sys
+from pathlib import Path
+
+specification, source_value = sys.argv[1:]
+if not specification.startswith("$DEST/"):
+    raise SystemExit("transported relay wheel did not use the archive destination")
+source = Path(source_value).resolve(strict=True)
+lexical_candidate = source / specification.removeprefix("$DEST/")
+candidate_details = lexical_candidate.lstat()
+if lexical_candidate.is_symlink() or not lexical_candidate.is_file():
+    raise SystemExit("transported relay wheel is not one regular file")
+candidate = lexical_candidate.resolve(strict=True)
+if candidate == source or not candidate.is_relative_to(source):
+    raise SystemExit("transported relay wheel escaped the verified source archive")
+observed = lexical_candidate.lstat()
+identity = lambda value: (
+    value.st_dev,
+    value.st_ino,
+    value.st_mode,
+    value.st_size,
+    value.st_mtime_ns,
+    value.st_ctime_ns,
+)
+if identity(observed) != identity(candidate_details) or candidate.suffix != ".whl":
+    raise SystemExit("transported relay wheel is not one regular wheel file")
+print(candidate)
+__CLIO_RELAY_CANDIDATE_WHEEL_PATH__
+      )"
+      ;;
+    clio-relay==*)
+      BOOTSTRAP_CANDIDATE_ARTIFACT="$BOOTSTRAP_PREPARING_ROOT/candidate-relay.whl"
+      timeout --signal=TERM --kill-after=5s 180 \
+        python3 -I - "$BOOTSTRAP_CANDIDATE_INSTALL_SPEC" \
+        "$BOOTSTRAP_CANDIDATE_ARTIFACT_SHA256" \
+        "$BOOTSTRAP_CANDIDATE_ARTIFACT" <<'__CLIO_RELAY_CANDIDATE_PYPI_WHEEL__'
+import hashlib
+import json
+import sys
+from pathlib import Path
+from urllib.parse import quote, urlsplit
+from urllib.request import urlopen
+
+specification, expected_sha256, destination_value = sys.argv[1:]
+version = specification.removeprefix("clio-relay==")
+if not version or specification != f"clio-relay=={{version}}":
+    raise SystemExit("candidate PyPI install spec is not exact")
+with urlopen(
+    f"https://pypi.org/pypi/clio-relay/{{quote(version, safe='')}}/json",
+    timeout=30,
+) as response:
+    metadata = response.read(4 * 1024 * 1024 + 1)
+if len(metadata) > 4 * 1024 * 1024:
+    raise SystemExit("candidate PyPI metadata exceeds its bound")
+document = json.loads(metadata)
+expected_filename = f"clio_relay-{{version}}-py3-none-any.whl"
+matches = [
+    item
+    for item in document.get("urls", [])
+    if isinstance(item, dict)
+    and item.get("filename") == expected_filename
+    and item.get("packagetype") == "bdist_wheel"
+    and item.get("digests", {{}}).get("sha256") == expected_sha256
+]
+if len(matches) != 1:
+    raise SystemExit("PyPI did not return the exact digest-pinned relay wheel")
+url = matches[0].get("url")
+if not isinstance(url, str):
+    raise SystemExit("PyPI relay wheel URL is missing")
+parsed = urlsplit(url)
+if parsed.scheme != "https" or not parsed.hostname or not parsed.hostname.endswith(
+    ".pythonhosted.org"
+):
+    raise SystemExit("PyPI relay wheel URL has an unsupported origin")
+destination = Path(destination_value)
+digest = hashlib.sha256()
+size = 0
+with urlopen(url, timeout=60) as response, destination.open("xb") as stream:
+    while chunk := response.read(1024 * 1024):
+        size += len(chunk)
+        if size > 256 * 1024 * 1024:
+            raise SystemExit("candidate relay wheel exceeds its bound")
+        digest.update(chunk)
+        stream.write(chunk)
+if size < 1 or digest.hexdigest() != expected_sha256:
+    destination.unlink(missing_ok=True)
+    raise SystemExit("downloaded candidate relay wheel did not match its digest")
+__CLIO_RELAY_CANDIDATE_PYPI_WHEEL__
+      ;;
+    *)
+      echo "retained-state reconcile supports only an exact released relay wheel" >&2
+      exit 1
+      ;;
+  esac
+  echo "$BOOTSTRAP_CANDIDATE_ARTIFACT_SHA256 *$BOOTSTRAP_CANDIDATE_ARTIFACT" | \
+    sha256sum --check --strict -
+
+  BOOTSTRAP_PINNED_UV_SOURCE="$HOME/.local/bin/uv"
+  BOOTSTRAP_PINNED_UV="$(
+    env -u PYTHONPATH -u PYTHONHOME -u LD_PRELOAD -u LD_LIBRARY_PATH \
+      python3 -I -c {pinned_uv_copy_program} \
+      "$BOOTSTRAP_PINNED_UV_SOURCE" "$BOOTSTRAP_PREPARING_ROOT" \
+      {UV_LINUX_AMD64_EXECUTABLE_SHA256}
+  )"
+  BOOTSTRAP_CANDIDATE_TOOL_DIR="$BOOTSTRAP_PREPARING_ROOT/uv-tools"
+  BOOTSTRAP_CANDIDATE_BIN_DIR="$BOOTSTRAP_PREPARING_ROOT/uv-bin"
+  BOOTSTRAP_CANDIDATE_CACHE_DIR="$BOOTSTRAP_PREPARING_ROOT/uv-cache"
+  BOOTSTRAP_CANDIDATE_PYTHON_INSTALL_DIR="$HOME/.local/share/clio-relay/uv-python"
+  mkdir -m 0700 "$BOOTSTRAP_CANDIDATE_CACHE_DIR"
+  BOOTSTRAP_CANDIDATE_RELAY="$BOOTSTRAP_CANDIDATE_BIN_DIR/clio-relay"
+  BOOTSTRAP_PLAN_PROVIDER="$BOOTSTRAP_CANDIDATE_TOOL_DIR/clio-relay/bin/python"
+  export BOOTSTRAP_PLAN_PROVIDER BOOTSTRAP_CANDIDATE_RECONCILE
+  export BOOTSTRAP_CANDIDATE_SOURCE_ROOT BOOTSTRAP_CANDIDATE_ARTIFACT
+  export BOOTSTRAP_CANDIDATE_TOOL_DIR BOOTSTRAP_CANDIDATE_BIN_DIR
+  export BOOTSTRAP_CANDIDATE_CACHE_DIR BOOTSTRAP_CANDIDATE_PYTHON_INSTALL_DIR
+  export BOOTSTRAP_CANDIDATE_RELAY BOOTSTRAP_PINNED_UV SOURCE_ARCHIVE_SHA256
   BOOTSTRAP_PLAN_STARTED_NS="$(python3 -c 'import time; print(time.monotonic_ns())')"
-  BOOTSTRAP_PLAN_JSON="$(
-    "$BOOTSTRAP_PLAN_PROVIDER" - <<'__CLIO_RELAY_RECONCILE_PLAN__'
-import importlib.util
+  BOOTSTRAP_PLAN_CAPTURE="$(
+    python3 -I -c {candidate_uv_install_program} \
+      install-verify-and-exec \
+      "$BOOTSTRAP_PINNED_UV" {UV_LINUX_AMD64_EXECUTABLE_SHA256} \
+      "$BOOTSTRAP_CANDIDATE_ARTIFACT" "$BOOTSTRAP_CANDIDATE_ARTIFACT_SHA256" \
+      "$BOOTSTRAP_CANDIDATE_TOOL_DIR" "$BOOTSTRAP_CANDIDATE_BIN_DIR" \
+      "$BOOTSTRAP_CANDIDATE_CACHE_DIR" \
+      "$BOOTSTRAP_CANDIDATE_PYTHON_INSTALL_DIR" -I - \
+      <<'__CLIO_RELAY_RECONCILE_PLAN__'
 import json
 import os
-import sys
+from pathlib import Path
 
-path = os.environ["BOOTSTRAP_CANDIDATE_RECONCILE"]
-candidate_root = os.environ["BOOTSTRAP_CANDIDATE_PYTHON_ROOT"]
-if not sys.path or sys.path[0] != candidate_root:
-    sys.path.insert(0, candidate_root)
-name = "clio_relay.bootstrap_reconcile_candidate"
-spec = importlib.util.spec_from_file_location(name, path)
-if spec is None or spec.loader is None:
-    raise SystemExit("could not load candidate bootstrap reconciler")
-module = importlib.util.module_from_spec(spec)
-sys.modules[name] = module
-spec.loader.exec_module(module)
+from clio_relay.bootstrap_reconcile import (
+    BootstrapDesiredState,
+    plan_bootstrap_reconcile,
+    prove_bootstrap_replacement_provider,
+)
+
 desired_payload = json.loads(os.environ["BOOTSTRAP_DESIRED_STATE"])
 desired_payload["agent_npm_package"] = os.environ["AGENT_NPM_PACKAGE"] or None
 desired_payload["agent_npm_bin"] = os.environ["AGENT_NPM_BIN"] or None
-desired = module.BootstrapDesiredState.model_validate(desired_payload)
-plan = module.plan_bootstrap_reconcile(desired)
+desired = BootstrapDesiredState.model_validate(desired_payload)
+evidence = prove_bootstrap_replacement_provider(
+    desired,
+    uv_executable=Path(os.environ["BOOTSTRAP_PINNED_UV"]),
+    tool_executable=Path(os.environ["BOOTSTRAP_CANDIDATE_RELAY"]),
+    source_artifact=Path(os.environ["BOOTSTRAP_CANDIDATE_ARTIFACT"]),
+    tool_directory=Path(os.environ["BOOTSTRAP_CANDIDATE_TOOL_DIR"]),
+    tool_bin_directory=Path(os.environ["BOOTSTRAP_CANDIDATE_BIN_DIR"]),
+    preparing_root=Path(os.environ["BOOTSTRAP_PREPARING_ROOT"]),
+    extracted_source_root=Path(os.environ["BOOTSTRAP_CANDIDATE_SOURCE_ROOT"]),
+    source_archive_sha256=os.environ["SOURCE_ARCHIVE_SHA256"],
+    expected_provider_interpreter_sha256=os.environ["BOOTSTRAP_PLAN_PROVIDER_SHA256"],
+)
+plan = plan_bootstrap_reconcile(desired, replacement_provider=evidence)
+print("bootstrap_candidate_provider_sha256=" + os.environ["BOOTSTRAP_PLAN_PROVIDER_SHA256"])
 print(json.dumps(plan.model_dump(mode="json"), sort_keys=True, separators=(",", ":")))
 __CLIO_RELAY_RECONCILE_PLAN__
   )"
+  BOOTSTRAP_PLAN_JSON=""
+  BOOTSTRAP_CANDIDATE_PROVIDER_SHA256=""
+  while IFS= read -r bootstrap_plan_line; do
+    case "$bootstrap_plan_line" in
+      bootstrap_candidate_provider_sha256=*)
+        BOOTSTRAP_CANDIDATE_PROVIDER_SHA256="${{bootstrap_plan_line#*=}}"
+        ;;
+      '{{'*'}}')
+        if [ -n "$BOOTSTRAP_PLAN_JSON" ]; then
+          echo "candidate planner returned multiple plan objects" >&2
+          exit 1
+        fi
+        BOOTSTRAP_PLAN_JSON="$bootstrap_plan_line"
+        ;;
+      *)
+        echo "candidate planner returned unrecognized output" >&2
+        exit 1
+        ;;
+    esac
+  done <<< "$BOOTSTRAP_PLAN_CAPTURE"
+  if [ "${{#BOOTSTRAP_CANDIDATE_PROVIDER_SHA256}}" -ne 64 ]; then
+    echo "candidate planner omitted its pinned provider digest" >&2
+    exit 1
+  fi
+  case "$BOOTSTRAP_CANDIDATE_PROVIDER_SHA256" in
+    *[!0-9a-f]*) echo "candidate planner provider digest is invalid" >&2; exit 1 ;;
+  esac
+  BOOTSTRAP_CANDIDATE_PROVIDER_READY=1
+  export BOOTSTRAP_CANDIDATE_PROVIDER_READY BOOTSTRAP_CANDIDATE_PROVIDER_SHA256
   BOOTSTRAP_PLAN_COMPLETED_NS="$(python3 -c 'import time; print(time.monotonic_ns())')"
   export BOOTSTRAP_PLAN_JSON
   BOOTSTRAP_PLAN_MODE="$(
@@ -4801,6 +6028,7 @@ fi
 if [ "$BOOTSTRAP_PLAN_MODE" = "full" ] && \
    {{ [ "$JARVIS_EXISTING_FILE_COUNT" -eq 3 ] || \
       [ -e "$HOME/.local/share/clio-relay/jarvis-venv" ]; }}; then
+  printf '%s\\n' "bootstrap_reconcile_plan=$BOOTSTRAP_PLAN_JSON" >&2
   echo "full component reconcile requires a staged generation;" \
     "refusing to clear the retained legacy JARVIS execution environment" >&2
   exit 1

--- a/src/clio_relay/bootstrap_reconcile.py
+++ b/src/clio_relay/bootstrap_reconcile.py
@@ -53,6 +53,7 @@ _FCHMOD = cast(
     Callable[[int, int], None] | None,
     getattr(os, "fchmod", None),  # noqa: B009 - absent from Windows typing/runtime
 )
+_GETUID = cast(Callable[[], int] | None, getattr(os, "getuid", None))
 _AT_FDCWD = -100
 _RENAME_EXCHANGE = 2
 
@@ -271,7 +272,7 @@ class BootstrapActivationPath(BaseModel):
 
 
 class BootstrapReconcilePlan(BaseModel):
-    """Read-only component plan produced before preparation or fencing."""
+    """Read-only component plan produced before journaling, fencing, or activation."""
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -281,6 +282,59 @@ class BootstrapReconcilePlan(BaseModel):
     component_actions: dict[str, Literal["reuse", "replace"]]
     reusable_paths: dict[str, str] = Field(default_factory=dict)
     activation_paths: dict[str, BootstrapActivationPath] = Field(default_factory=dict)
+
+
+class BootstrapPersistentUvToolIdentity(BaseModel):
+    """Typed candidate uv-tool identity independent of the installed relay version."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal["clio-relay.persistent-uv-tool-identity.v2"]
+    manager: Literal["uv"]
+    uv_executable: str
+    uv_version: str
+    uv_executable_sha256: str
+    tool_directory: str
+    tool_bin_directory: str
+    environment_prefix: str
+    provider_interpreter: str
+    provider_interpreter_sha256: str
+    tool_executable: str
+    tool_executable_resolved: str
+    tool_executable_sha256: str
+    distribution_console_script_path: str
+    distribution_console_script_sha256: str
+    uv_receipt_path: str
+    uv_receipt_sha256: str
+    distribution: str
+    distribution_version: str
+    distribution_metadata_path: str
+    entry_point: str
+    source_artifact_path: str
+    source_artifact_sha256: str
+    record_path: str
+    record_sha256: str
+    runtime_closure_sha256: str
+    runtime_file_count: int = Field(gt=0)
+    runtime_bytes: int = Field(gt=0)
+    pyvenv_uv_version: str
+
+
+class BootstrapReplacementProviderEvidence(BaseModel):
+    """Attested candidate provider allowed to replace one legacy relay runtime."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal["clio-relay.bootstrap-replacement-provider.v1"] = (
+        "clio-relay.bootstrap-replacement-provider.v1"
+    )
+    desired_fingerprint: str
+    relay_install_spec: str
+    preparing_root: str
+    extracted_source_root: str
+    source_archive_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    coordinator_provider_sha256: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")
+    persistent_tool: BootstrapPersistentUvToolIdentity
 
 
 class BootstrapTransactionState(StrEnum):
@@ -1123,10 +1177,206 @@ def finish_staged_activation(
     }
 
 
+def prove_bootstrap_replacement_provider(
+    desired: BootstrapDesiredState,
+    *,
+    uv_executable: Path,
+    tool_executable: Path,
+    source_artifact: Path,
+    tool_directory: Path,
+    tool_bin_directory: Path,
+    preparing_root: Path,
+    extracted_source_root: Path,
+    source_archive_sha256: str,
+    expected_provider_interpreter_sha256: str | None = None,
+    home: Path | None = None,
+) -> BootstrapReplacementProviderEvidence:
+    """Attest the normally imported candidate wheel before legacy planning."""
+    from clio_relay.installation import probe_persistent_uv_tool_identity
+
+    if not _is_sha256(source_archive_sha256):
+        raise ConfigurationError("candidate source archive SHA-256 is invalid")
+    try:
+        distribution_version = desired.relay_install_spec.removeprefix("clio-relay==")
+    except AttributeError as exc:  # pragma: no cover - typed as str by pydantic
+        raise ConfigurationError("candidate relay install spec is invalid") from exc
+    if (
+        not distribution_version
+        or desired.relay_install_spec != f"clio-relay=={distribution_version}"
+        or desired.relay_artifact_sha256 is None
+    ):
+        raise ConfigurationError(
+            "retained-state replacement requires one exact released clio-relay wheel"
+        )
+    probed_identity = probe_persistent_uv_tool_identity(
+        uv_executable=str(uv_executable),
+        tool_executable=str(tool_executable),
+        provider_interpreter=str(Path(sys.executable).absolute()),
+        source_artifact=source_artifact,
+        distribution="clio-relay",
+        distribution_version=distribution_version,
+        entry_point="clio-relay",
+        tool_directory=str(tool_directory),
+        tool_bin_directory=str(tool_bin_directory),
+        expected_uv_executable_sha256=desired.uv_sha256,
+        expected_provider_interpreter_sha256=expected_provider_interpreter_sha256,
+    )
+    identity = BootstrapPersistentUvToolIdentity.model_validate(
+        probed_identity.model_dump(mode="json")
+    )
+    evidence = BootstrapReplacementProviderEvidence(
+        desired_fingerprint=desired.fingerprint,
+        relay_install_spec=desired.relay_install_spec,
+        preparing_root=str(Path(os.path.abspath(preparing_root.expanduser()))),
+        extracted_source_root=str(Path(os.path.abspath(extracted_source_root.expanduser()))),
+        source_archive_sha256=source_archive_sha256,
+        coordinator_provider_sha256=expected_provider_interpreter_sha256,
+        persistent_tool=identity,
+    )
+    _verify_bootstrap_replacement_provider(desired, evidence, home=home)
+    return evidence
+
+
+def _verify_bootstrap_replacement_provider(
+    desired: BootstrapDesiredState,
+    evidence: BootstrapReplacementProviderEvidence,
+    *,
+    home: Path | None = None,
+) -> None:
+    """Re-probe a staged candidate and bind it to this process and desired state."""
+    lexical_home = Path(os.path.abspath((home or Path.home()).expanduser()))
+    try:
+        parent_lexical = lexical_home / ".local/share/clio-relay/preparing"
+        parent_details = parent_lexical.lstat()
+        expected_parent = parent_lexical.resolve(strict=True)
+        root_lexical = Path(evidence.preparing_root)
+        root_details = root_lexical.lstat()
+        root = root_lexical.resolve(strict=True)
+        source_lexical = Path(evidence.extracted_source_root)
+        source_details = source_lexical.lstat()
+        source_root = source_lexical.resolve(strict=True)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ConfigurationError("candidate replacement root is unavailable") from exc
+    if (
+        parent_lexical.is_symlink()
+        or not stat.S_ISDIR(parent_details.st_mode)
+        or (os.name != "nt" and stat.S_IMODE(parent_details.st_mode) & 0o022)
+        or (_GETUID is not None and parent_details.st_uid != _GETUID())
+    ):
+        raise ConfigurationError("candidate replacement parent is not private")
+    if (
+        not root_lexical.is_absolute()
+        or ".." in root_lexical.parts
+        or root_lexical.is_symlink()
+        or not stat.S_ISDIR(root_details.st_mode)
+        or root_lexical.name != "active"
+        or root.parent != expected_parent
+        or (os.name != "nt" and stat.S_IMODE(root_details.st_mode) & 0o077)
+        or (_GETUID is not None and root_details.st_uid != _GETUID())
+    ):
+        raise ConfigurationError("candidate replacement root is not owner-private")
+    if (
+        source_lexical.is_symlink()
+        or not stat.S_ISDIR(source_details.st_mode)
+        or source_root == root
+        or not source_root.is_relative_to(root)
+        or not source_root.is_dir()
+    ):
+        raise ConfigurationError("candidate extracted source escaped its preparing root")
+
+    identity = evidence.persistent_tool
+    if (
+        evidence.desired_fingerprint != desired.fingerprint
+        or evidence.relay_install_spec != desired.relay_install_spec
+        or not _is_sha256(evidence.source_archive_sha256)
+        or desired.relay_artifact_sha256 is None
+        or identity.distribution.lower().replace("_", "-") != "clio-relay"
+        or desired.relay_install_spec != f"clio-relay=={identity.distribution_version}"
+        or identity.entry_point != "clio-relay"
+        or identity.source_artifact_sha256 != desired.relay_artifact_sha256
+        or identity.uv_version != desired.uv_version
+        or identity.uv_executable_sha256 != desired.uv_sha256
+        or (
+            evidence.coordinator_provider_sha256 is not None
+            and evidence.coordinator_provider_sha256 != identity.provider_interpreter_sha256
+        )
+    ):
+        raise ConfigurationError("candidate replacement identity does not match desired state")
+    current_provider = Path(sys.executable).absolute()
+    try:
+        if Path(identity.provider_interpreter).absolute() != current_provider or Path(
+            identity.provider_interpreter
+        ).resolve(strict=True) != current_provider.resolve(strict=True):
+            raise ConfigurationError("candidate planner is not running under its attested provider")
+        expected_uv = root_lexical / "pinned-uv"
+        if Path(identity.uv_executable).absolute() != expected_uv or expected_uv.resolve(
+            strict=True
+        ) != Path(identity.uv_executable).resolve(strict=True):
+            raise ConfigurationError("candidate replacement did not use the pinned uv executable")
+        environment = Path(identity.environment_prefix).resolve(strict=True)
+        imported_module = Path(__file__).resolve(strict=True)
+        provider_target = current_provider.resolve(strict=True)
+        base_prefix = Path(sys.base_prefix).resolve(strict=True)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ConfigurationError("candidate replacement runtime path is unavailable") from exc
+    if (
+        os.name != "nt"
+        and provider_target != base_prefix
+        and not provider_target.is_relative_to(base_prefix)
+    ):
+        raise ConfigurationError("candidate provider target escaped its Python base prefix")
+    staged_paths = (
+        identity.tool_directory,
+        identity.tool_bin_directory,
+        identity.environment_prefix,
+        identity.provider_interpreter,
+        identity.tool_executable,
+        identity.tool_executable_resolved,
+        identity.distribution_console_script_path,
+        identity.uv_receipt_path,
+        identity.distribution_metadata_path,
+        identity.source_artifact_path,
+        identity.record_path,
+    )
+    try:
+        if any(
+            (lexical := Path(os.path.abspath(Path(value).expanduser()))) == root
+            or not lexical.is_relative_to(root)
+            or not lexical.exists()
+            for value in staged_paths
+        ):
+            raise ConfigurationError("candidate replacement runtime escaped its preparing root")
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ConfigurationError("candidate replacement runtime path is unavailable") from exc
+    if imported_module == environment or not imported_module.is_relative_to(environment):
+        raise ConfigurationError("candidate planner module was not imported from its uv tool")
+    from clio_relay.installation import probe_persistent_uv_tool_identity
+
+    probed_observed = probe_persistent_uv_tool_identity(
+        uv_executable=identity.uv_executable,
+        tool_executable=identity.tool_executable,
+        provider_interpreter=identity.provider_interpreter,
+        source_artifact=Path(identity.source_artifact_path),
+        distribution="clio-relay",
+        distribution_version=identity.distribution_version,
+        entry_point="clio-relay",
+        tool_directory=identity.tool_directory,
+        tool_bin_directory=identity.tool_bin_directory,
+        expected_uv_executable_sha256=desired.uv_sha256,
+        expected_provider_interpreter_sha256=evidence.coordinator_provider_sha256,
+    )
+    observed = BootstrapPersistentUvToolIdentity.model_validate(
+        probed_observed.model_dump(mode="json")
+    )
+    if observed != identity:
+        raise ConfigurationError("candidate replacement runtime changed during attestation")
+
+
 def plan_bootstrap_reconcile(
     desired: BootstrapDesiredState,
     *,
     home: Path | None = None,
+    replacement_provider: BootstrapReplacementProviderEvidence | None = None,
 ) -> BootstrapReconcilePlan:
     """Plan a relay-only generation when every non-relay component verifies.
 
@@ -1141,11 +1391,22 @@ def plan_bootstrap_reconcile(
     upgrade_components: set[str] = set()
     reusable_paths: dict[str, str] = {}
     receipt_path = resolved_home / ".local/share/clio-relay/install-receipt.json"
+    replacement_verified = False
+    if replacement_provider is not None:
+        try:
+            _verify_bootstrap_replacement_provider(
+                desired,
+                replacement_provider,
+                home=lexical_home,
+            )
+        except (ConfigurationError, OSError, RuntimeError, ValueError) as exc:
+            return _full_plan(desired, f"candidate replacement provider did not verify: {exc}")
+        replacement_verified = True
     try:
         info = installation_info(receipt_path)
     except (ConfigurationError, OSError, ValueError) as exc:
         return _full_plan(desired, f"installation identity did not verify: {exc}")
-    if info.get("receipt_matches_install") is not True:
+    if info.get("receipt_matches_install") is not True and not replacement_verified:
         return _full_plan(desired, "install receipt does not match the running relay")
     raw_receipt = info.get("receipt")
     raw_runtime = info.get("component_runtime")
@@ -1154,11 +1415,19 @@ def plan_bootstrap_reconcile(
     receipt = cast(dict[str, object], raw_receipt)
     runtime = cast(dict[str, object], raw_runtime)
     relay_runtime = runtime.get("clio-relay")
-    if (
+    if not replacement_verified and (
         not isinstance(relay_runtime, dict)
         or cast(dict[str, object], relay_runtime).get("persistent_tool_verified") is not True
     ):
-        return _full_plan(desired, "clio-relay live provider is not reusable")
+        relay_runtime_error = (
+            cast(dict[str, object], relay_runtime).get("error")
+            if isinstance(relay_runtime, dict)
+            else None
+        )
+        reason = "clio-relay live provider is not reusable"
+        if isinstance(relay_runtime_error, str) and relay_runtime_error:
+            reason += ": " + relay_runtime_error[:512]
+        return _full_plan(desired, reason)
     raw_components = receipt.get("components")
     raw_artifacts = receipt.get("component_artifacts")
     if not isinstance(raw_components, dict) or not isinstance(raw_artifacts, dict):

--- a/src/clio_relay/installation.py
+++ b/src/clio_relay/installation.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import hashlib
+import io
 import json
 import math
 import os
 import re
 import sys
 import tomllib
+from contextlib import redirect_stdout
 from datetime import UTC, datetime
 from importlib import metadata
 from pathlib import Path
@@ -53,6 +55,88 @@ CLIO_KIT_NATIVE_OPERATIONS = (
     "jarvis_get_execution",
     "jarvis_run",
 )
+_UV_FD_EXEC_SOURCE = r"""import hashlib
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+
+def identity(details):
+    return (
+        details.st_dev,
+        details.st_ino,
+        details.st_mode,
+        details.st_size,
+        details.st_mtime_ns,
+        details.st_ctime_ns,
+    )
+
+
+def cross_identity(details):
+    if os.name == "nt":
+        return (
+            details.st_dev,
+            details.st_ino,
+            stat.S_IFMT(details.st_mode),
+            details.st_size,
+        )
+    return identity(details)
+
+
+path = Path(sys.argv[1])
+expected_sha256 = sys.argv[2]
+arguments = sys.argv[3:]
+before = path.lstat()
+if (
+    not stat.S_ISREG(before.st_mode)
+    or not 1 <= before.st_size <= 256 * 1024 * 1024
+    or len(expected_sha256) != 64
+    or any(character not in "0123456789abcdef" for character in expected_sha256)
+):
+    raise SystemExit("uv executable identity is invalid")
+flags = (
+    os.O_RDONLY
+    | getattr(os, "O_BINARY", 0)
+    | getattr(os, "O_CLOEXEC", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+)
+descriptor = os.open(path, flags)
+try:
+    opened = os.fstat(descriptor)
+    if cross_identity(opened) != cross_identity(before):
+        raise SystemExit("uv executable changed before its pinned read")
+    digest = hashlib.sha256()
+    size = 0
+    while chunk := os.read(descriptor, 1024 * 1024):
+        size += len(chunk)
+        if size > 256 * 1024 * 1024:
+            raise SystemExit("uv executable exceeded its byte bound")
+        digest.update(chunk)
+    after = os.fstat(descriptor)
+    linked_after = path.lstat()
+    if (
+        size != opened.st_size
+        or digest.hexdigest() != expected_sha256
+        or cross_identity(after) != cross_identity(opened)
+        or cross_identity(linked_after) != cross_identity(opened)
+    ):
+        raise SystemExit("uv executable changed or did not match its release pin")
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    environment = {
+        name: value
+        for name, value in os.environ.items()
+        if not name.startswith(("LD_", "PYTHON")) and name not in {"BASH_ENV", "ENV"}
+    }
+    if os.execve in os.supports_fd:
+        os.execve(descriptor, [str(path), *arguments], environment)
+    if os.name == "nt":
+        raise SystemExit(subprocess.run([str(path), *arguments], env=environment).returncode)
+    os.execve(str(path), [str(path), *arguments], environment)
+finally:
+    os.close(descriptor)
+"""
 OFFICIAL_COMPONENT_RELEASE_REPOSITORIES = {
     "clio-kit": ("iowarp", "clio-kit"),
     "jarvis-cd": ("grc-iit", "jarvis-cd"),
@@ -358,6 +442,8 @@ def probe_persistent_uv_tool_identity(
     entry_point: str,
     tool_directory: str | None = None,
     tool_bin_directory: str | None = None,
+    expected_uv_executable_sha256: str | None = None,
+    expected_provider_interpreter_sha256: str | None = None,
 ) -> PersistentUvToolIdentity:
     """Capture and verify an install-once uv tool environment and wheel closure."""
     if (tool_directory is None) is not (tool_bin_directory is None):
@@ -385,12 +471,43 @@ def probe_persistent_uv_tool_identity(
         provider_location,
         label="tool provider interpreter",
     )
+    provider_interpreter_sha256 = sha256_file(provider_path)
+    if (
+        expected_provider_interpreter_sha256 is not None
+        and provider_interpreter_sha256 != expected_provider_interpreter_sha256
+    ):
+        raise ConfigurationError(
+            "persistent tool provider interpreter did not match its coordinator pin"
+        )
     provider_environment_location = _resolved_parent_location(
         provider_location,
         label="tool provider interpreter",
     )
     source_path = _required_regular_file(source_artifact, label="tool source artifact")
-    uv_version_output = _bounded_identity_command([str(uv_path), "--version"])
+    uv_executable_sha256 = sha256_file(uv_path)
+    if (
+        expected_uv_executable_sha256 is not None
+        and uv_executable_sha256 != expected_uv_executable_sha256
+    ):
+        raise ConfigurationError("persistent tool uv executable did not match its release pin")
+
+    def uv_command(
+        *arguments: str,
+        environment: dict[str, str] | None = None,
+    ) -> str:
+        if expected_uv_executable_sha256 is not None:
+            return _bounded_uv_identity_command(
+                uv_path,
+                uv_executable_sha256,
+                list(arguments),
+                environment=environment,
+            )
+        return _bounded_identity_command(
+            [str(uv_path), *arguments],
+            environment=environment,
+        )
+
+    uv_version_output = uv_command("--version")
     version_match = re.fullmatch(
         r"uv ([0-9]+\.[0-9]+\.[0-9]+(?:[A-Za-z0-9.+-]*))(?: .*)?",
         uv_version_output,
@@ -399,17 +516,11 @@ def probe_persistent_uv_tool_identity(
         raise ConfigurationError("persistent tool uv executable returned no exact version")
     uv_version = version_match.group(1)
     observed_tool_directory = _required_directory_output(
-        _bounded_identity_command(
-            [str(uv_path), "tool", "dir", "--no-config"],
-            environment=uv_environment,
-        ),
+        uv_command("tool", "dir", "--no-config", environment=uv_environment),
         label="uv tool directory",
     )
     observed_tool_bin_directory = _required_directory_output(
-        _bounded_identity_command(
-            [str(uv_path), "tool", "dir", "--bin", "--no-config"],
-            environment=uv_environment,
-        ),
+        uv_command("tool", "dir", "--bin", "--no-config", environment=uv_environment),
         label="uv tool bin directory",
     )
     if executable_location.parent.resolve() != observed_tool_bin_directory:
@@ -526,19 +637,27 @@ print(json.dumps({
     "runtime_bytes": runtime_bytes,
 }, sort_keys=True))
 """
-    raw_probe = _bounded_identity_command(
-        [
-            str(provider_location),
-            "-I",
-            "-c",
-            probe_source,
-            distribution,
-            entry_point,
-            str(executable_location),
-        ],
-        maximum_bytes=256 * 1024,
-        timeout_seconds=60,
-    )
+    probe_arguments = [distribution, entry_point, str(executable_location)]
+    if expected_provider_interpreter_sha256 is not None and os.name == "posix":
+        raw_probe = _in_process_candidate_provider_probe(
+            source=probe_source,
+            arguments=probe_arguments,
+            provider_location=provider_location,
+            expected_provider_sha256=expected_provider_interpreter_sha256,
+            maximum_bytes=256 * 1024,
+        )
+    else:
+        raw_probe = _bounded_identity_command(
+            [
+                str(provider_location),
+                "-I",
+                "-c",
+                probe_source,
+                *probe_arguments,
+            ],
+            maximum_bytes=256 * 1024,
+            timeout_seconds=60,
+        )
     try:
         decoded = json.loads(raw_probe)
     except json.JSONDecodeError as exc:
@@ -629,12 +748,14 @@ print(json.dumps({
         return PersistentUvToolIdentity(
             uv_executable=str(uv_path),
             uv_version=uv_version,
-            uv_executable_sha256=sha256_file(uv_path),
+            uv_executable_sha256=uv_executable_sha256,
             tool_directory=str(observed_tool_directory),
             tool_bin_directory=str(observed_tool_bin_directory),
             environment_prefix=str(environment_prefix),
             provider_interpreter=str(provider_location),
-            provider_interpreter_sha256=sha256_file(provider_path),
+            provider_interpreter_sha256=(
+                expected_provider_interpreter_sha256 or provider_interpreter_sha256
+            ),
             tool_executable=str(executable_location),
             tool_executable_resolved=str(executable_path),
             tool_executable_sha256=external_launcher_sha256,
@@ -659,12 +780,98 @@ print(json.dumps({
         raise ConfigurationError("persistent uv tool probe returned invalid identity") from exc
 
 
+def _in_process_candidate_provider_probe(
+    *,
+    source: str,
+    arguments: list[str],
+    provider_location: Path,
+    expected_provider_sha256: str,
+    maximum_bytes: int,
+) -> str:
+    """Run a fixed identity probe inside the coordinator-bound provider process."""
+    if sys.flags.isolated != 1:
+        raise ConfigurationError("candidate provider probe is not isolated")
+    if any(
+        name.startswith(("LD_", "PYTHON")) or name in {"BASH_ENV", "ENV"} for name in os.environ
+    ):
+        raise ConfigurationError("candidate provider probe environment was not sanitized")
+    if os.environ.get("BOOTSTRAP_PLAN_PROVIDER") != str(provider_location):
+        raise ConfigurationError("candidate provider lexical path was not coordinator-bound")
+    if os.environ.get("BOOTSTRAP_PLAN_PROVIDER_SHA256") != expected_provider_sha256:
+        raise ConfigurationError("candidate provider digest was not coordinator-bound")
+    execution_sha256 = os.environ.get("BOOTSTRAP_PLAN_PROVIDER_EXEC_SHA256", "")
+    if len(execution_sha256) != 64 or any(
+        character not in "0123456789abcdef" for character in execution_sha256
+    ):
+        raise ConfigurationError("candidate provider execution digest is invalid")
+    try:
+        executable_link = os.readlink("/proc/self/exe")
+        executable_sha256 = sha256_file(Path("/proc/self/exe"))
+    except OSError as exc:
+        raise ConfigurationError("candidate provider execution image is unavailable") from exc
+    if (
+        not executable_link.startswith("/memfd:clio-relay-candidate-provider")
+        or not executable_link.endswith(" (deleted)")
+        or executable_sha256 != execution_sha256
+    ):
+        raise ConfigurationError("candidate provider process is not the sealed execution image")
+
+    output = io.StringIO()
+    previous_argv = sys.argv
+    try:
+        sys.argv = [str(provider_location), *arguments]
+        with redirect_stdout(output):
+            exec(compile(source, "<clio-relay-candidate-provider-probe>", "exec"), {})
+    finally:
+        sys.argv = previous_argv
+    value = output.getvalue()
+    if not value or len(value.encode("utf-8")) > maximum_bytes:
+        raise ConfigurationError("candidate provider probe returned invalid bounded output")
+    return value.strip()
+
+
+def _bounded_uv_identity_command(
+    uv_executable: Path,
+    expected_sha256: str,
+    arguments: list[str],
+    *,
+    environment: dict[str, str] | None = None,
+) -> str:
+    """Run one uv command from its verified open descriptor on POSIX."""
+    sanitized = {
+        name: value
+        for name, value in os.environ.items()
+        if not name.startswith(("LD_", "PYTHON")) and name not in {"BASH_ENV", "ENV"}
+    }
+    if environment is not None:
+        sanitized.update(environment)
+    wrapper_provider = (
+        "/proc/self/exe"
+        if os.name == "posix" and "BOOTSTRAP_PLAN_PROVIDER_EXEC_SHA256" in os.environ
+        else sys.executable
+    )
+    return _bounded_identity_command(
+        [
+            wrapper_provider,
+            "-I",
+            "-c",
+            _UV_FD_EXEC_SOURCE,
+            str(uv_executable),
+            expected_sha256,
+            *arguments,
+        ],
+        environment=sanitized,
+        replace_environment=True,
+    )
+
+
 def _bounded_identity_command(
     command: list[str],
     *,
     maximum_bytes: int = 65_536,
     timeout_seconds: int = 30,
     environment: dict[str, str] | None = None,
+    replace_environment: bool = False,
 ) -> str:
     """Run one identity command and return one bounded non-empty line."""
     try:
@@ -673,7 +880,11 @@ def _bounded_identity_command(
             timeout_seconds=timeout_seconds,
             stdout_maximum_bytes=maximum_bytes,
             stderr_maximum_bytes=4096,
-            environment=({**os.environ, **environment} if environment is not None else None),
+            environment=(
+                environment
+                if replace_environment
+                else ({**os.environ, **environment} if environment is not None else None)
+            ),
         )
     except (OSError, BoundedProcessError) as exc:
         raise ConfigurationError(f"persistent tool identity command failed: {exc}") from exc

--- a/src/clio_relay/service_runtime.py
+++ b/src/clio_relay/service_runtime.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import base64
+import ctypes
+import errno
 import hashlib
 import json
 import math
 import os
+import platform
 import secrets
 import shlex
 import signal
@@ -116,6 +119,11 @@ _REMOTE_RUNTIME_COMMAND_TIMEOUT_SECONDS = 120.0
 _LOCAL_CLEANUP_COMMAND_TIMEOUT_SECONDS = 30.0
 _CONNECTOR_STEP_CLEANUP_TIMEOUT_SECONDS = 30.0
 _CONNECTOR_STEP_CLEANUP_POLL_SECONDS = 0.25
+# Linux assigns these values to both x86-64 and asm-generic syscall ABIs.
+# libc symbols remain the preferred fallback when CPython omits its wrappers.
+_LINUX_PIDFD_SEND_SIGNAL_SYSCALL_NUMBER = 424
+_LINUX_PIDFD_OPEN_SYSCALL_NUMBER = 434
+_LINUX_PIDFD_RAW_SYSCALL_MACHINES = frozenset({"aarch64", "amd64", "arm64", "x86_64"})
 _TERMINAL_RUNTIME_STATES = {
     "canceled",
     "cancelled",
@@ -6567,8 +6575,11 @@ mkdir -p "$session_dir"
 exec 9>"$session_dir/transition.lock"
 flock -w 10 -x 9 || {{ echo "connector stop lock timed out" >&2; exit 75; }}
 python3 - "$metadata_file" "$pid_file" "$pid" "$session_id" <<'__CLIO_STOP_CONNECTOR__'
+import ctypes
+import errno
 import json
 import os
+import platform
 import signal
 import sys
 import time
@@ -6636,13 +6647,72 @@ def owned_group_processes():
     return sorted(matches)
 
 
+def open_process_fd(member_pid):
+    native_open = getattr(os, "pidfd_open", None)
+    if callable(native_open):
+        return native_open(member_pid, 0)
+    library = ctypes.CDLL(None, use_errno=True)
+    libc_open = getattr(library, "pidfd_open", None)
+    ctypes.set_errno(0)
+    if libc_open is not None:
+        libc_open.argtypes = [ctypes.c_int, ctypes.c_uint]
+        libc_open.restype = ctypes.c_int
+        descriptor = libc_open(member_pid, 0)
+    else:
+        if platform.machine().lower() not in ("aarch64", "amd64", "arm64", "x86_64"):
+            raise RuntimeError("raw pidfd_open syscall ABI is unavailable")
+        syscall = library.syscall
+        syscall.restype = ctypes.c_long
+        descriptor = syscall(
+            ctypes.c_long({_LINUX_PIDFD_OPEN_SYSCALL_NUMBER}),
+            ctypes.c_int(member_pid),
+            ctypes.c_uint(0),
+        )
+    if descriptor < 0:
+        error = ctypes.get_errno() or errno.ENOSYS
+        raise OSError(error, os.strerror(error))
+    return descriptor
+
+
+def send_process_fd_signal(process_fd, sig):
+    native_send = getattr(signal, "pidfd_send_signal", None)
+    if callable(native_send):
+        native_send(process_fd, sig, None, 0)
+        return
+    library = ctypes.CDLL(None, use_errno=True)
+    libc_send = getattr(library, "pidfd_send_signal", None)
+    ctypes.set_errno(0)
+    if libc_send is not None:
+        libc_send.argtypes = [
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            ctypes.c_uint,
+        ]
+        libc_send.restype = ctypes.c_int
+        result = libc_send(process_fd, sig, None, 0)
+    else:
+        if platform.machine().lower() not in ("aarch64", "amd64", "arm64", "x86_64"):
+            raise RuntimeError("raw pidfd_send_signal syscall ABI is unavailable")
+        syscall = library.syscall
+        syscall.restype = ctypes.c_long
+        result = syscall(
+            ctypes.c_long({_LINUX_PIDFD_SEND_SIGNAL_SYSCALL_NUMBER}),
+            ctypes.c_int(process_fd),
+            ctypes.c_int(sig),
+            ctypes.c_void_p(),
+            ctypes.c_uint(0),
+        )
+    if result < 0:
+        error = ctypes.get_errno() or errno.ENOSYS
+        raise OSError(error, os.strerror(error))
+
+
 def signal_owned_processes(sig):
-    if not hasattr(os, "pidfd_open") or not hasattr(signal, "pidfd_send_signal"):
-        raise RuntimeError("race-safe pidfd connector cleanup is unavailable")
     signaled = []
     for member_pid in owned_group_processes():
         try:
-            process_fd = os.pidfd_open(member_pid, 0)
+            process_fd = open_process_fd(member_pid)
         except ProcessLookupError:
             continue
         except OSError as exc:
@@ -6651,7 +6721,7 @@ def signal_owned_processes(sig):
             if member_pid not in owned_group_processes():
                 continue
             try:
-                signal.pidfd_send_signal(process_fd, sig, None, 0)
+                send_process_fd_signal(process_fd, sig)
             except ProcessLookupError:
                 continue
             except OSError as exc:
@@ -7926,26 +7996,20 @@ def _signal_owned_posix_connector_processes(
     sig: int,
 ) -> list[int]:
     """Signal only revalidated connector identities through race-safe pidfds."""
-    pidfd_open = getattr(os, "pidfd_open", None)
-    pidfd_send_signal = getattr(signal, "pidfd_send_signal", None)
-    if not callable(pidfd_open) or not callable(pidfd_send_signal):
-        raise RelayError("race-safe pidfd connector cleanup is unavailable on this platform")
     signaled: list[int] = []
     for member_pid in _local_connector_group_members(connector):
         try:
-            raw_process_fd = pidfd_open(member_pid, 0)
+            raw_process_fd = _open_posix_process_fd(member_pid)
         except ProcessLookupError:
             continue
         except OSError as exc:
             raise RelayError(f"cannot open connector pidfd for {member_pid}: {exc}") from exc
-        if not isinstance(raw_process_fd, int):
-            raise RelayError(f"connector pidfd for {member_pid} is not an integer")
         process_fd = raw_process_fd
         try:
             if member_pid not in _local_connector_group_members(connector):
                 continue
             try:
-                pidfd_send_signal(process_fd, sig, None, 0)
+                _send_posix_process_fd_signal(process_fd, sig)
             except ProcessLookupError:
                 continue
             except OSError as exc:
@@ -7954,6 +8018,90 @@ def _signal_owned_posix_connector_processes(
         finally:
             os.close(process_fd)
     return signaled
+
+
+def _open_posix_process_fd(pid: int) -> int:
+    """Open a Linux process descriptor even when CPython omitted pidfd wrappers."""
+    native_open = getattr(os, "pidfd_open", None)
+    descriptor = native_open(pid, 0) if callable(native_open) else _linux_pidfd_open(pid)
+    if not isinstance(descriptor, int):
+        raise OSError("pidfd_open returned a non-integer descriptor")
+    return descriptor
+
+
+def _send_posix_process_fd_signal(process_fd: int, sig: int) -> None:
+    """Signal a Linux process descriptor through CPython or libc."""
+    native_send = getattr(signal, "pidfd_send_signal", None)
+    if callable(native_send):
+        native_send(process_fd, sig, None, 0)
+        return
+    _linux_pidfd_send_signal(process_fd, sig)
+
+
+def _linux_pidfd_open(pid: int) -> int:
+    """Invoke pidfd_open through libc, falling back to the Linux syscall ABI."""
+    if not sys.platform.startswith("linux"):
+        raise RelayError("race-safe pidfd connector cleanup is unavailable on this platform")
+    library = ctypes.CDLL(None, use_errno=True)
+    libc_open = getattr(library, "pidfd_open", None)
+    ctypes.set_errno(0)
+    if libc_open is not None:
+        libc_open.argtypes = [ctypes.c_int, ctypes.c_uint]
+        libc_open.restype = ctypes.c_int
+        descriptor = int(libc_open(pid, 0))
+    else:
+        if platform.machine().lower() not in _LINUX_PIDFD_RAW_SYSCALL_MACHINES:
+            raise RelayError("raw pidfd_open syscall ABI is unavailable on this architecture")
+        syscall = library.syscall
+        syscall.restype = ctypes.c_long
+        descriptor = int(
+            syscall(
+                ctypes.c_long(_LINUX_PIDFD_OPEN_SYSCALL_NUMBER),
+                ctypes.c_int(pid),
+                ctypes.c_uint(0),
+            )
+        )
+    if descriptor < 0:
+        error_number = ctypes.get_errno() or errno.ENOSYS
+        raise OSError(error_number, os.strerror(error_number))
+    return descriptor
+
+
+def _linux_pidfd_send_signal(process_fd: int, sig: int) -> None:
+    """Invoke pidfd_send_signal through libc or the stable Linux syscall ABI."""
+    if not sys.platform.startswith("linux"):
+        raise RelayError("race-safe pidfd connector cleanup is unavailable on this platform")
+    library = ctypes.CDLL(None, use_errno=True)
+    libc_send = getattr(library, "pidfd_send_signal", None)
+    ctypes.set_errno(0)
+    if libc_send is not None:
+        libc_send.argtypes = [
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            ctypes.c_uint,
+        ]
+        libc_send.restype = ctypes.c_int
+        result = int(libc_send(process_fd, sig, None, 0))
+    else:
+        if platform.machine().lower() not in _LINUX_PIDFD_RAW_SYSCALL_MACHINES:
+            raise RelayError(
+                "raw pidfd_send_signal syscall ABI is unavailable on this architecture"
+            )
+        syscall = library.syscall
+        syscall.restype = ctypes.c_long
+        result = int(
+            syscall(
+                ctypes.c_long(_LINUX_PIDFD_SEND_SIGNAL_SYSCALL_NUMBER),
+                ctypes.c_int(process_fd),
+                ctypes.c_int(sig),
+                ctypes.c_void_p(),
+                ctypes.c_uint(0),
+            )
+        )
+    if result < 0:
+        error_number = ctypes.get_errno() or errno.ENOSYS
+        raise OSError(error_number, os.strerror(error_number))
 
 
 def _terminate_local_connector(connector: dict[str, object]) -> int | None:

--- a/src/clio_relay/transport_probe.py
+++ b/src/clio_relay/transport_probe.py
@@ -29,10 +29,11 @@ from clio_relay.relay_host import (
 from clio_relay.remote_values import render_remote_shell_path, render_remote_shell_value
 from clio_relay.session_lifecycle import (
     CleanupResource,
+    OwnedSessionStartResult,
     SessionLifecycleReport,
     detach_remote_session,
-    start_remote_session,
-    status_remote_session,
+    plan_remote_session_start,
+    start_remote_session_durable,
     teardown_remote_session,
 )
 from clio_relay.validation_report import (
@@ -427,48 +428,32 @@ def run_ssh_forward_http_probe(
             "SSH transport probes require CLIO_RELAY_API_TOKEN for the owned remote API"
         )
     _assert_local_bind_port_available(local_bind_port)
-    try:
-        start_lines = start_remote_session(
-            cluster=cluster,
+    start_plan = plan_remote_session_start(
+        cluster=cluster,
+        definition=definition,
+        session_id=session_id,
+        remote_api_port=remote_api_port,
+        replace=replace_remote,
+        require_token=True,
+    )
+    start_result = start_remote_session_durable(
+        definition=definition,
+        plan=start_plan,
+        api_token=api_token,
+    )
+    if start_result.state != "ready":
+        raise _remote_session_start_not_ready_error(
+            result=start_result,
             definition=definition,
-            session_id=session_id,
-            remote_api_port=remote_api_port,
-            api_token=api_token,
-            replace=replace_remote,
         )
-        session_generation_id = _started_session_generation_id(
-            start_lines,
-            definition=definition,
-            session_id=session_id,
-        )
-    except BaseException as exc:
-        evidence_line = _transport_resource_line(
-            probe_id=f"ssh-probe:{session_id}:generation-unverified",
-            cluster=cluster,
-            cleanup_mode=(
-                "transport_probe_detach" if detach_remote else "transport_probe_teardown"
-            ),
-            resources=[
-                _process_cleanup_resource(
-                    kind="relay_session",
-                    resource_id=session_id,
-                    role="remote_transport_session",
-                    location=definition.ssh_host,
-                    action="retain" if detach_remote else "stop",
-                    ownership_verified=False,
-                    outcome="unknown",
-                    verified_after_operation=False,
-                    observed_state="running_or_unknown",
-                    residual=True,
-                    detail=f"remote session start was not verified: {type(exc).__name__}: {exc}",
-                    metadata={"session_id": session_id, "session_generation_id": None},
-                )
-            ],
-        )
-        attached = _attach_transport_evidence(exc, [evidence_line])
-        if attached is not exc:
-            raise attached from exc
-        raise
+    session_generation_id = start_result.session_generation_id
+    if (
+        session_generation_id is None
+        or not start_result.ownership_verified
+        or not start_result.recovery_verified
+    ):
+        raise RelayError("ready remote session start omitted its verified generation identity")
+    start_lines = start_result.compatibility_lines
     factory = process_factory or _popen
     forward: ManagedProcess | None = None
     lines: list[str] = []
@@ -657,31 +642,67 @@ def run_ssh_forward_http_probe(
     return lines
 
 
-def _started_session_generation_id(
-    start_lines: list[str],
+def _remote_session_start_not_ready_error(
     *,
+    result: OwnedSessionStartResult,
     definition: ClusterDefinition,
-    session_id: str,
-) -> str:
-    """Recover the exact generation created or reused by a remote session start."""
-    prefix = "session_generation_id="
-    values = [line.removeprefix(prefix) for line in start_lines if line.startswith(prefix)]
-    if len(values) == 1 and values[0]:
-        return values[0]
-    status = status_remote_session(definition=definition, session_id=session_id)
-    generation_id = status.get("session_generation_id")
-    owned_session = status.get("session_id") == session_id and status.get("owner") == "clio-relay"
-    running_ownership_verified = (
-        status.get("running") is not True or status.get("ownership_verified") is True
+) -> RelayError:
+    """Preserve a non-ready durable start operation without opening a connector."""
+    status_selector = result.status_selector.model_dump(mode="json")
+    retry_selector = result.retry_selector.model_dump(mode="json")
+    status_selector_json = json.dumps(status_selector, sort_keys=True, separators=(",", ":"))
+    retry_selector_json = json.dumps(retry_selector, sort_keys=True, separators=(",", ":"))
+    detail = (
+        "owned remote session start is not ready; "
+        f"state={result.state}; terminal={str(result.terminal).lower()}; "
+        f"start_operation_id={result.start_operation_id}; "
+        f"status_selector={status_selector_json}; retry_selector={retry_selector_json}"
     )
-    if (
-        owned_session
-        and running_ownership_verified
-        and isinstance(generation_id, str)
-        and generation_id
-    ):
-        return generation_id
-    raise RelayError("remote session start did not return a verifiable session generation id")
+    if result.error is not None:
+        detail = f"{detail}; observation={result.error}"
+    outcome: TransportCleanupOutcome
+    if result.state in {"starting", "ambiguous"}:
+        outcome = "retained"
+    elif result.state == "not_current":
+        outcome = "replaced"
+    else:
+        outcome = "terminal"
+    evidence_line = _transport_resource_line(
+        probe_id=f"ssh-probe:{result.session_id}:start:{result.start_operation_id}",
+        cluster=result.cluster,
+        cleanup_mode="transport_probe_start_observation",
+        resources=[
+            _process_cleanup_resource(
+                kind="relay_session_start_operation",
+                resource_id=result.start_operation_id,
+                role="remote_transport_session_start_operation",
+                location=definition.ssh_host,
+                action="retain",
+                ownership_verified=True,
+                outcome=outcome,
+                verified_after_operation=True,
+                observed_state=result.state,
+                residual=False,
+                detail=detail,
+                metadata={
+                    "ownership_scope": "start_operation_selector",
+                    "session_id": result.session_id,
+                    "session_generation_id": result.session_generation_id,
+                    "start_operation_id": result.start_operation_id,
+                    "cluster_route_revision": result.cluster_route_revision,
+                    "remote_api_port": result.remote_api_port,
+                    "terminal": result.terminal,
+                    "retryable": result.retryable,
+                    "transition_accepted": result.transition_accepted,
+                    "transport_deadline_exceeded": result.transport_deadline_exceeded,
+                    "status_selector": status_selector,
+                    "retry_selector": retry_selector,
+                },
+            )
+        ],
+    )
+    error = RelayError(detail)
+    return cast(RelayError, _attach_transport_evidence(error, [evidence_line]))
 
 
 def _verified_session_detach_lines(

--- a/src/clio_relay/validation_report.py
+++ b/src/clio_relay/validation_report.py
@@ -1325,7 +1325,15 @@ def _detect_persistent_uv_tool_receipt(
     process_executable_resolved = process_executable.resolve()
     package = Path(package_path).resolve()
     package_in_environment = _within_or_equal(package, prefix)
-    executable_in_environment = _within_or_equal(process_executable_resolved, prefix)
+    # POSIX virtual environments normally expose ``bin/python`` as a symlink to
+    # the base interpreter. Keep the launcher location and its resolved target
+    # as separate trust claims: the lexical executable must belong to the uv
+    # tool environment, while the target may belong to that environment or to
+    # the interpreter's exact base prefix.
+    executable_in_environment = _within_or_equal(process_executable, prefix)
+    executable_target_bound = _within_or_equal(process_executable_resolved, prefix) or (
+        _within_or_equal(process_executable_resolved, base_prefix)
+    )
     environment_in_tool_directory = tool_directory is not None and _strictly_contains(
         tool_directory, prefix
     )
@@ -1383,6 +1391,7 @@ def _detect_persistent_uv_tool_receipt(
         and pyvenv_matches_uv
         and package_in_environment
         and executable_in_environment
+        and executable_target_bound
         and tool_bin_bound
         and tool_target_bound
         and record_identity.get("verified") is True
@@ -1414,6 +1423,7 @@ def _detect_persistent_uv_tool_receipt(
         "process_executable_resolved": str(process_executable_resolved),
         "package_in_process_environment": package_in_environment,
         "executable_in_process_environment": executable_in_environment,
+        "executable_target_bound": executable_target_bound,
         "pyvenv_uv_version": pyvenv_uv_version,
         "pyvenv_matches_uv": pyvenv_matches_uv,
         "isolated_environment": isolated_environment,
@@ -2640,6 +2650,7 @@ def _launcher_identity_failures(
             "pyvenv_matches_uv",
             "package_in_process_environment",
             "executable_in_process_environment",
+            "executable_target_bound",
             "isolated_environment",
         ):
             if receipt.get(field) is not True:

--- a/tests/test_acceptance_report_defaults.py
+++ b/tests/test_acceptance_report_defaults.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -40,8 +41,11 @@ from clio_relay.service_runtime import (
 )
 from clio_relay.session_lifecycle import (
     CleanupResource,
+    OwnedSessionCleanupReportReference,
+    OwnedSessionRecoveryStatus,
     RemoteSessionStateEvidence,
     SessionLifecycleReport,
+    session_lifecycle_report_bytes,
 )
 from clio_relay.validation_report import (
     EvidenceReference,
@@ -504,7 +508,22 @@ def _session_report(*, mode: Literal["detach", "teardown"]) -> SessionLifecycleR
                 ownership_verified=True,
                 outcome=outcome,
                 verified_after_operation=True,
-            )
+            ),
+            *(
+                [
+                    CleanupResource(
+                        kind="remote_session_files",
+                        resource_id="owned:generation-1",
+                        location="test-cluster",
+                        action="close",
+                        ownership_verified=True,
+                        outcome="closed",
+                        verified_after_operation=True,
+                    )
+                ]
+                if mode == "teardown"
+                else []
+            ),
         ],
     )
 
@@ -873,12 +892,89 @@ def _install_success_fakes(
         return
     if case.name in {"session-detach", "session-teardown"}:
         _activate_owner_session(root / "core")
+
+        def execute_locally(_definition: ClusterDefinition) -> bool:
+            return False
+
+        monkeypatch.setattr(cli, "should_execute_on_cluster", execute_locally)
         monkeypatch.setattr(cli, "_cleanup_owned_runtime_sessions", _empty_runtime_cleanup)
         if case.name == "session-detach":
             monkeypatch.setattr(cli, "detach_remote_session", _detached_session)
         else:
+            finalized_status: list[OwnedSessionRecoveryStatus] = []
+
+            def persist_cleanup_report(
+                *,
+                definition: ClusterDefinition,
+                cluster: str,
+                session_id: str,
+                session_generation_id: str,
+                report: SessionLifecycleReport,
+            ) -> tuple[SessionLifecycleReport, OwnedSessionRecoveryStatus]:
+                del definition
+                payload = session_lifecycle_report_bytes(report)
+                digest = hashlib.sha256(payload).hexdigest()
+                reference = OwnedSessionCleanupReportReference(
+                    name=f"coordinator-cleanup-report-{digest}.json",
+                    size=len(payload),
+                    sha256=digest,
+                )
+                status = OwnedSessionRecoveryStatus(
+                    cluster=cluster,
+                    session_id=session_id,
+                    session_generation_id=session_generation_id,
+                    owner="clio-relay",
+                    process_state="already_closed",
+                    process_absence_verified=True,
+                    generation_process_absence_verified=True,
+                    metadata_verified=True,
+                    cluster_registry_verified=True,
+                    durable_generation_verified=True,
+                    cleanup_receipt=True,
+                    cleanup_paths_pending=False,
+                    coordinator_report_ref=reference,
+                    coordinator_report_sha256=digest,
+                    coordinator_report_bound=True,
+                    ownership_verified=True,
+                    recovery_verified=True,
+                    admission_status={"closed": True},
+                )
+                finalized_status[:] = [status]
+                return report, status
+
+            def closed_recovery_status(**_kwargs: object) -> OwnedSessionRecoveryStatus:
+                assert finalized_status
+                return finalized_status[0]
+
+            def verified_cleanup_report(
+                _status: OwnedSessionRecoveryStatus,
+                *,
+                report: SessionLifecycleReport,
+                **_kwargs: object,
+            ) -> SessionLifecycleReport:
+                return report
+
+            def mark_closed(**_kwargs: object) -> None:
+                return None
+
             monkeypatch.setattr(cli, "status_remote_session", _owned_session_status)
             monkeypatch.setattr(cli, "teardown_remote_session", _torn_down_session)
+            monkeypatch.setattr(
+                cli,
+                "_persist_verified_cleanup_report_before_closure",
+                persist_cleanup_report,
+            )
+            monkeypatch.setattr(cli, "_mark_owner_session_closed", mark_closed)
+            monkeypatch.setattr(
+                cli,
+                "_owned_session_recovery_status",
+                closed_recovery_status,
+            )
+            monkeypatch.setattr(
+                cli,
+                "_verified_finalized_cleanup_report",
+                verified_cleanup_report,
+            )
         return
     if case.name == "queue-validate":
         monkeypatch.setattr(

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -571,7 +571,13 @@ def test_bootstrap_over_ssh_returns_the_matching_durable_invocation_receipt(
             return subprocess.CompletedProcess(
                 command,
                 0,
-                "bootstrap_receipt=/home/test/.local/share/clio-relay/bootstrap-receipt.json\n",
+                (
+                    "bootstrap_receipt="
+                    "/home/test/.local/share/clio-relay/bootstrap-receipt.json\n"
+                    "bootstrap_receipt_json="
+                    + json.dumps(receipt_document, sort_keys=True, separators=(",", ":"))
+                    + "\n"
+                ),
                 "",
             )
         if command[-2:] == ["cat", "$HOME/.local/share/clio-relay/bootstrap-receipt.json"]:
@@ -607,6 +613,7 @@ def test_bootstrap_over_ssh_returns_the_matching_durable_invocation_receipt(
         ssh_host="ares",
         source_root=tmp_path,
         relay_artifact_sha256="a" * 64,
+        jarvis_resource_graph_profile="ares",
     )
 
     assert lines[0].startswith("bootstrap_receipt=")
@@ -641,7 +648,11 @@ def test_bootstrap_over_ssh_returns_the_matching_durable_invocation_receipt(
         bootstrap.BOOTSTRAP_REMOTE_SCRIPT_TIMEOUT_SECONDS
         >= deployment.ENDPOINT_SERVICE_START_OBSERVATION_TIMEOUT_SECONDS + 60
     )
-    assert 'exec 9>"$HOME/.local/share/clio-relay/bootstrap.lock"' in uploaded_scripts[0]
+    assert (
+        'descriptor = os.open("bootstrap.lock", flags, 0o600, dir_fd=directory_descriptor)'
+        in uploaded_scripts[0]
+    )
+    assert "fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)" in uploaded_scripts[0]
     assert "sha256sum --check --strict" in uploaded_scripts[0]
     assert "/tmp/clio-relay-head.tar" not in uploaded_scripts[0]
 
@@ -652,6 +663,7 @@ def test_bootstrap_over_ssh_returns_the_matching_durable_invocation_receipt(
             ssh_host="ares",
             source_root=tmp_path,
             relay_artifact_sha256="a" * 64,
+            jarvis_resource_graph_profile="ares",
         )
     assert calls[-1][-1] == "/tmp/clio-relay-bootstrap_abc"
 

--- a/tests/test_bootstrap_fast_path.py
+++ b/tests/test_bootstrap_fast_path.py
@@ -45,6 +45,478 @@ def _which(executable: str) -> str:
     return executable
 
 
+def _run_posix_embedded_driver(
+    driver: str,
+    *sources: str,
+    timeout_seconds: float = 60,
+) -> subprocess.CompletedProcess[str]:
+    """Run one embedded bootstrap security probe on Linux or the local WSL runtime."""
+    executable = ["wsl.exe", "-e", "python3"] if os.name == "nt" else [sys.executable]
+    encoded = [base64.b64encode(source.encode()).decode("ascii") for source in sources]
+    launcher = (
+        "import json,sys; payload=json.load(sys.stdin); "
+        "sys.argv=['embedded-driver',*payload['arguments']]; "
+        "exec(compile(payload['driver'],'<embedded-driver>','exec'))"
+    )
+    return subprocess.run(
+        [*executable, "-I", "-c", launcher],
+        input=json.dumps({"driver": driver, "arguments": encoded}),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+    )
+
+
+def test_receipt_classifier_accepts_stable_generation_symlink() -> None:
+    """Warm bootstraps classify the supported stable receipt link without following others."""
+    driver = r"""
+import base64
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+source = base64.b64decode(sys.argv[1]).decode()
+with tempfile.TemporaryDirectory() as value:
+    home = Path(value)
+    relay = home / ".local/share/clio-relay"
+    generation = relay / "generations" / ("a" * 64)
+    generation.mkdir(parents=True)
+    receipt = generation / "install-receipt.json"
+    receipt.write_text(
+        json.dumps({"component_artifacts": {"clio-relay": {"persistent_tool": {}}}}),
+        encoding="utf-8",
+    )
+    (relay / "current").symlink_to(generation, target_is_directory=True)
+    stable = relay / "install-receipt.json"
+    stable.symlink_to(relay / "current/install-receipt.json")
+    environment = {**os.environ, "HOME": str(home)}
+    result = subprocess.run(
+        [sys.executable, "-I", "-", str(stable)],
+        input=source,
+        text=True,
+        capture_output=True,
+        env=environment,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(result.stdout + result.stderr)
+    if result.stdout.strip() != "current":
+        raise SystemExit("stable generation receipt was not classified as current")
+print("stable-receipt-ok")
+"""
+    result = _run_posix_embedded_driver(
+        driver,
+        bootstrap._BOOTSTRAP_RECEIPT_CLASSIFIER_SOURCE,  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == "stable-receipt-ok"
+
+
+def test_preparing_root_and_uv_copy_recover_without_following_links() -> None:
+    """Power-loss scratch is reclaimed fd-relatively and uv executes from a private copy."""
+    driver = r"""
+import base64
+import hashlib
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+preparing = base64.b64decode(sys.argv[1]).decode()
+copy_uv = base64.b64decode(sys.argv[2]).decode()
+with tempfile.TemporaryDirectory() as value:
+    workspace = Path(value)
+    parent = workspace / "preparing"
+    parent.mkdir(mode=0o700)
+    active = parent / "active"
+    quarantine = parent / ".active.quarantine"
+    sentinel = workspace / "outside-sentinel"
+    sentinel.write_text("preserve", encoding="utf-8")
+    for stale in (active, quarantine):
+        (stale / "nested").mkdir(parents=True, mode=0o700)
+        stale.chmod(0o700)
+        (stale / "nested/outbound").symlink_to(sentinel)
+    subprocess.run(
+        [sys.executable, "-I", "-c", preparing, str(parent), str(active), "prepare"],
+        check=True,
+    )
+    if not active.is_dir() or list(active.iterdir()) or not sentinel.is_file():
+        raise SystemExit("fixed scratch preparation did not safely reclaim stale state")
+    if quarantine.exists() or quarantine.is_symlink():
+        raise SystemExit("scratch quarantine leaked after reclamation")
+
+    source = workspace / "uv-source"
+    payload = b"#!/bin/sh\nexit 0\n"
+    source.write_bytes(payload)
+    source.chmod(0o500)
+    digest = hashlib.sha256(payload).hexdigest()
+    copied = subprocess.run(
+        [sys.executable, "-I", "-c", copy_uv, str(source), str(active), digest],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    private_uv = Path(copied.stdout.strip())
+    if private_uv != active / "pinned-uv":
+        raise SystemExit("candidate uv copy returned the wrong private path")
+    if private_uv.stat().st_ino == source.stat().st_ino:
+        raise SystemExit("candidate uv copy reused the mutable source inode")
+    if hashlib.sha256(private_uv.read_bytes()).hexdigest() != digest:
+        raise SystemExit("candidate uv private copy digest changed")
+    if private_uv.stat().st_mode & 0o777 != 0o500:
+        raise SystemExit("candidate uv private copy mode is not sealed")
+
+    subprocess.run(
+        [sys.executable, "-I", "-c", preparing, str(parent), str(active), "cleanup"],
+        check=True,
+    )
+    if active.exists() or quarantine.exists() or not sentinel.is_file():
+        raise SystemExit("scratch cleanup did not preserve its outbound target")
+
+    for stale in (active, quarantine):
+        (stale / "nested").mkdir(parents=True, mode=0o700)
+        stale.chmod(0o700)
+    subprocess.run(
+        [sys.executable, "-I", "-c", preparing, str(parent), str(active), "prepare"],
+        check=True,
+    )
+    rejected = subprocess.run(
+        [sys.executable, "-I", "-c", copy_uv, str(source), str(active), "0" * 64],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if rejected.returncode == 0 or (active / "pinned-uv").exists():
+        raise SystemExit("a digest-mismatched uv copy was retained")
+print("scratch-and-uv-ok")
+"""
+    result = _run_posix_embedded_driver(
+        driver,
+        bootstrap._BOOTSTRAP_PREPARING_ROOT_SOURCE,  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        bootstrap._BOOTSTRAP_PINNED_UV_COPY_SOURCE,  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == "scratch-and-uv-ok"
+
+
+def test_fd_bound_candidate_verifier_rejects_swapped_wheel_install() -> None:
+    """Installed relay bytes must match the wheel fd held across uv installation."""
+    driver = r"""
+import base64
+import csv
+import hashlib
+import io
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+verifier = base64.b64decode(sys.argv[1]).decode()
+uv = shutil.which("uv") or str(Path.home() / ".local/bin/uv")
+with tempfile.TemporaryDirectory() as value:
+    workspace = Path(value)
+    built = workspace / "built"
+    subprocess.run(
+        [uv, "build", "--wheel", "--out-dir", str(built)],
+        check=True,
+        capture_output=True,
+    )
+    original = next(built.glob("clio_relay-*.whl"))
+    tampered = workspace / original.name
+    with zipfile.ZipFile(original) as archive:
+        entries = [(item, archive.read(item.filename)) for item in archive.infolist()]
+    record_name = next(
+        item.filename
+        for item, _payload in entries
+        if item.filename.endswith(".dist-info/RECORD")
+    )
+    target_name = "clio_relay/__init__.py"
+    payloads = {item.filename: payload for item, payload in entries}
+    payloads[target_name] += b"\nSWAPPED_WHEEL_SENTINEL = True\n"
+    rows = list(csv.reader(io.StringIO(payloads[record_name].decode()), strict=True))
+    for row in rows:
+        if row[0] == target_name:
+            digest = hashlib.sha256(payloads[target_name]).digest()
+            row[1] = "sha256=" + base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+            row[2] = str(len(payloads[target_name]))
+    record_stream = io.StringIO(newline="")
+    csv.writer(record_stream, lineterminator="\n").writerows(rows)
+    payloads[record_name] = record_stream.getvalue().encode()
+    with zipfile.ZipFile(tampered, "w") as archive:
+        for item, _payload in entries:
+            archive.writestr(item, payloads[item.filename])
+
+    tool_directory = workspace / "tools"
+    tool_bin_directory = workspace / "bin"
+    cache_directory = workspace / "cache"
+    python_directory = Path.home() / ".local/share/clio-relay/uv-python"
+    environment = {
+        **os.environ,
+        "UV_TOOL_DIR": str(tool_directory),
+        "UV_TOOL_BIN_DIR": str(tool_bin_directory),
+        "UV_CACHE_DIR": str(cache_directory),
+        "UV_PYTHON_INSTALL_DIR": str(python_directory),
+        "UV_PYTHON_DOWNLOADS": "never",
+    }
+    subprocess.run(
+        [
+            uv,
+            "tool",
+            "install",
+            "--force",
+            "--python",
+            "3.12",
+            "--no-config",
+            "--default-index",
+            "https://pypi.org/simple",
+            str(tampered),
+        ],
+        check=True,
+        capture_output=True,
+        env=environment,
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-c",
+            verifier,
+            "verify-installed",
+            uv,
+            hashlib.sha256(Path(uv).read_bytes()).hexdigest(),
+            str(original),
+            hashlib.sha256(original.read_bytes()).hexdigest(),
+            str(tool_directory),
+            str(tool_bin_directory),
+            str(cache_directory),
+            str(python_directory),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        raise SystemExit("swapped wheel installation passed pinned-fd verification")
+    if "installed candidate differs from the pinned wheel fd" not in result.stderr:
+        raise SystemExit(result.stdout + result.stderr)
+print("swapped-wheel-rejected")
+"""
+    result = _run_posix_embedded_driver(
+        driver,
+        bootstrap._BOOTSTRAP_CANDIDATE_UV_INSTALL_SOURCE,  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == "swapped-wheel-rejected"
+
+
+def test_candidate_coordinator_rejects_provider_path_swap_after_open() -> None:
+    """A provider pathname replacement cannot execute after its coordinator opens it."""
+    driver = r"""
+import base64
+import ctypes
+import hashlib
+import os
+import select
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+coordinator = base64.b64decode(sys.argv[1]).decode()
+uv = shutil.which("uv") or str(Path.home() / ".local/bin/uv")
+with tempfile.TemporaryDirectory() as value:
+    workspace = Path(value)
+    built = workspace / "built"
+    subprocess.run(
+        [uv, "build", "--wheel", "--out-dir", str(built)],
+        check=True,
+        capture_output=True,
+    )
+    wheel = next(built.glob("clio_relay-*.whl"))
+    tool_directory = workspace / "tools"
+    tool_bin_directory = workspace / "bin"
+    cache_directory = workspace / "cache"
+    python_directory = Path.home() / ".local/share/clio-relay/uv-python"
+    environment = {
+        **os.environ,
+        "UV_TOOL_DIR": str(tool_directory),
+        "UV_TOOL_BIN_DIR": str(tool_bin_directory),
+        "UV_CACHE_DIR": str(cache_directory),
+        "UV_PYTHON_INSTALL_DIR": str(python_directory),
+        "UV_PYTHON_DOWNLOADS": "never",
+    }
+    subprocess.run(
+        [
+            uv,
+            "tool",
+            "install",
+            "--force",
+            "--python",
+            "3.12",
+            "--no-config",
+            "--default-index",
+            "https://pypi.org/simple",
+            str(wheel),
+        ],
+        check=True,
+        capture_output=True,
+        env=environment,
+    )
+    provider = tool_directory / "clio-relay/bin/python"
+    provider_target = provider.resolve(strict=True)
+    provider_sha256 = hashlib.sha256(provider_target.read_bytes()).hexdigest()
+    uv_sha256 = hashlib.sha256(Path(uv).read_bytes()).hexdigest()
+    wheel_sha256 = hashlib.sha256(wheel.read_bytes()).hexdigest()
+    probe_source = f'''
+import os
+from importlib.metadata import version
+from pathlib import Path
+from clio_relay.installation import probe_persistent_uv_tool_identity
+identity = probe_persistent_uv_tool_identity(
+    uv_executable={uv!r},
+    tool_executable={str(tool_bin_directory / 'clio-relay')!r},
+    provider_interpreter=os.environ['BOOTSTRAP_PLAN_PROVIDER'],
+    source_artifact=Path({str(wheel)!r}),
+    distribution='clio-relay',
+    distribution_version=version('clio-relay'),
+    entry_point='clio-relay',
+    tool_directory={str(tool_directory)!r},
+    tool_bin_directory={str(tool_bin_directory)!r},
+    expected_uv_executable_sha256={uv_sha256!r},
+    expected_provider_interpreter_sha256={provider_sha256!r},
+)
+print('in-process-provider=' + identity.provider_interpreter_sha256)
+'''
+    positive = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-c",
+            coordinator,
+            "verify-installed-and-exec",
+            uv,
+            uv_sha256,
+            str(wheel),
+            wheel_sha256,
+            str(tool_directory),
+            str(tool_bin_directory),
+            str(cache_directory),
+            str(python_directory),
+            provider_sha256,
+            "-I",
+            "-",
+        ],
+        input=probe_source,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if positive.returncode != 0 or positive.stdout.strip() != (
+        "in-process-provider=" + provider_sha256
+    ):
+        raise SystemExit(positive.stdout + positive.stderr)
+    executed_a = workspace / "provider-a-executed"
+    executed_b = workspace / "provider-b-executed"
+    libc = ctypes.CDLL(None, use_errno=True)
+    inotify_descriptor = libc.inotify_init1(os.O_CLOEXEC)
+    if inotify_descriptor < 0:
+        raise SystemExit("could not initialize the provider-open observer")
+    watch = libc.inotify_add_watch(
+        inotify_descriptor,
+        os.fsencode(provider_target),
+        0x00000020,
+    )
+    if watch < 0:
+        os.close(inotify_descriptor)
+        raise SystemExit("could not observe the provider target opening")
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-I",
+            "-c",
+            coordinator,
+            "verify-installed-and-exec",
+            uv,
+            uv_sha256,
+            str(wheel),
+            wheel_sha256,
+            str(tool_directory),
+            str(tool_bin_directory),
+            str(cache_directory),
+            str(python_directory),
+            provider_sha256,
+            "-I",
+            "-",
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    readable, _writable, _exceptional = select.select(
+        [inotify_descriptor],
+        [],
+        [],
+        10,
+    )
+    if not readable:
+        process.kill()
+        process.wait(timeout=5)
+        os.close(inotify_descriptor)
+        raise SystemExit("provider swap test did not observe the coordinator opening it")
+    os.read(inotify_descriptor, 4096)
+    os.close(inotify_descriptor)
+    provider.unlink()
+    provider.write_text(
+        "#!/bin/sh\nprintf hostile > " + str(executed_b) + "\nexit 91\n",
+        encoding="utf-8",
+    )
+    provider.chmod(0o700)
+    stdout, stderr = process.communicate(
+        input=(
+            "from pathlib import Path\n"
+            f"Path({str(executed_a)!r}).write_text('trusted', encoding='utf-8')\n"
+        ),
+        timeout=30,
+    )
+    if process.returncode == 0:
+        if not executed_a.exists():
+            raise SystemExit("the sealed provider did not execute the trusted payload")
+    elif not any(
+        message in stderr
+        for message in (
+            "candidate provider path changed while it was pinned",
+            "candidate provider changed after its planning pin",
+        )
+    ):
+        raise SystemExit(stdout + stderr)
+    if executed_b.exists():
+        raise SystemExit("the replacement provider pathname was executed")
+print("provider-swap-rejected")
+"""
+    result = _run_posix_embedded_driver(
+        driver,
+        bootstrap._BOOTSTRAP_CANDIDATE_UV_INSTALL_SOURCE,  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        timeout_seconds=120,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == "provider-swap-rejected"
+
+
 def test_staged_provider_exec_is_hash_bound_sealed_and_venv_aware(tmp_path: Path) -> None:
     """The staged provider is executed from sealed bytes with lexical venv semantics."""
     if sys.platform != "linux":
@@ -301,6 +773,135 @@ def test_exact_remote_bootstrap_never_reads_or_builds_payload(
     assert isinstance(operations, dict)
     assert operations["payload_transfer_count"] == 0
     assert operations["payload_transfer_bytes"] == 0
+
+
+def test_legacy_preflight_classifies_receipt_before_invoking_old_relay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A receipt without persistent-tool proof forces the candidate payload path."""
+    identity = bootstrap.bootstrap_relay_identity(
+        source_root=tmp_path / "release",
+        relay_wheel=None,
+        relay_artifact_sha256="a" * 64,
+    )
+    desired = bootstrap._bootstrap_desired_state(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        identity=identity,
+        cluster="ares",
+        core_dir=bootstrap.DEFAULT_REMOTE_CORE_DIR,
+        spool_dir=bootstrap.DEFAULT_REMOTE_SPOOL_DIR,
+        frp_version=bootstrap.FRP_VERSION,
+        clio_kit_install_spec=bootstrap.CLIO_KIT_JARVIS_MCP_WHEEL_URL,
+        clio_kit_artifact_sha256=bootstrap.CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
+        agent_adapter="exec",
+        agent_npm_package=None,
+        agent_npm_bin=None,
+        agent_args=[],
+        jarvis_resource_graph_profile="ares",
+    )
+    observed: list[list[str]] = []
+
+    def run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        observed.append(command)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            "bootstrap_preflight_unsupported=legacy_relay_provider\n",
+            "",
+        )
+
+    monkeypatch.setattr(bootstrap, "_run", run)
+    result = bootstrap._bootstrap_preflight_over_ssh(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        ssh_host="ares",
+        invocation_id="bootstrap_test",
+        desired=desired,
+        core_dir=bootstrap.DEFAULT_REMOTE_CORE_DIR,
+        spool_dir=bootstrap.DEFAULT_REMOTE_SPOOL_DIR,
+        repair=False,
+        timeout_seconds=30,
+    )
+
+    assert result.action == "payload_required"
+    assert len(observed) == 1
+    remote_script = observed[0][-1]
+    classifier = remote_script.index('relay.get("persistent_tool")')
+    old_relay = remote_script.index('"$HOME/.local/bin/clio-relay" bootstrap-inspect')
+    assert classifier < old_relay
+    assert "bootstrap_preflight_unsupported=legacy_relay_provider" in remote_script
+    assert 'if ! BOOTSTRAP_RELAY_RECEIPT_CLASS="$(' in remote_script
+    assert "python3 -I -" in remote_script
+    sanitizer = remote_script.index("while IFS= read -r bootstrap_environment_name")
+    assert 'LD_*|PYTHON*|BASH_ENV|ENV) unset "$bootstrap_environment_name"' in remote_script
+    assert sanitizer < remote_script.index("python3 -I -")
+    assert sanitizer < remote_script.index("timeout --signal=TERM")
+    assert "env -u PYTHONPATH" not in remote_script
+    shell = (
+        ["wsl.exe", "-e", "bash", "-lc", "tr -d '\r' | bash -n"]
+        if os.name == "nt"
+        else ["bash", "-n"]
+    )
+    syntax = subprocess.run(
+        shell,
+        input=remote_script,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert syntax.returncode == 0, syntax.stderr
+    execution_driver = r"""
+import base64
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+script = base64.b64decode(sys.argv[1]).decode()
+script = (
+    "export LD_AUDIT=/definitely/missing/LD_AUDIT_SENTINEL.so\n"
+    "export PYTHONWARNINGS=error::DefinitelyMissingWarning\n"
+    + script
+)
+with tempfile.TemporaryDirectory() as value:
+    home = Path(value)
+    relay = home / ".local/bin/clio-relay"
+    relay.parent.mkdir(parents=True)
+    marker = home / "legacy-relay-executed"
+    relay.write_text(
+        "#!/bin/sh\nprintf invoked > " + str(marker) + "\nexit 99\n",
+        encoding="utf-8",
+    )
+    relay.chmod(0o700)
+    receipt = home / ".local/share/clio-relay/install-receipt.json"
+    receipt.parent.mkdir(parents=True)
+    receipt.write_text(
+        json.dumps({"component_artifacts": {"clio-relay": {}}}),
+        encoding="utf-8",
+    )
+    environment = {**os.environ, "HOME": str(home)}
+    result = subprocess.run(
+        ["bash"],
+        input=script,
+        text=True,
+        capture_output=True,
+        env=environment,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(result.stdout + result.stderr)
+    if marker.exists():
+        raise SystemExit("legacy relay provider executed before candidate staging")
+    if "LD_AUDIT_SENTINEL" in result.stderr or "Invalid -W option" in result.stderr:
+        raise SystemExit("preflight leaked hostile loader or Python environment")
+    if result.stdout.strip() != "bootstrap_preflight_unsupported=legacy_relay_provider":
+        raise SystemExit("legacy relay receipt did not force the candidate payload path")
+print("legacy-preflight-ok")
+"""
+    execution = _run_posix_embedded_driver(execution_driver, remote_script)
+    assert execution.returncode == 0, execution.stdout + execution.stderr
+    assert execution.stdout.strip() == "legacy-preflight-ok"
 
 
 def test_public_cluster_bootstrap_noop_never_touches_nonexistent_wheel(
@@ -1081,6 +1682,77 @@ def test_payload_script_uses_digest_bound_safe_extractor() -> None:
     assert "BOOTSTRAP_CANDIDATE_PACKAGE/safe_archive.py" in script
 
 
+def test_legacy_planning_attests_private_candidate_before_transaction_or_fence() -> None:
+    """A legacy relay cannot authorize its own replacement or touch stable state."""
+    script = bootstrap.render_linux_user_bootstrap_script(
+        cluster="cluster-a",
+        relay_install_spec="$DEST/wheels/clio_relay-1.4.18-py3-none-any.whl",
+        relay_deployment_install_spec="clio-relay==1.4.18",
+        relay_artifact_sha256="a" * 64,
+        source_archive_sha256="b" * 64,
+    )
+    planning = script.index('BOOTSTRAP_PLAN_MODE="full"')
+    archive = script.index("  SOURCE_ARCHIVE=/tmp/clio-relay-head.tar", planning)
+    archive_digest = script.index(
+        'echo "$SOURCE_ARCHIVE_SHA256 *$SOURCE_ARCHIVE" | sha256sum --check --strict -',
+        archive,
+    )
+    extraction = script.index('bootstrap_safe_extract python3 "$SOURCE_ARCHIVE"', archive_digest)
+    wheel_digest = script.index(
+        'echo "$BOOTSTRAP_CANDIDATE_ARTIFACT_SHA256 *$BOOTSTRAP_CANDIDATE_ARTIFACT"',
+        extraction,
+    )
+    uv_copy = script.index('BOOTSTRAP_PINNED_UV="$(', wheel_digest)
+    uv_digest = script.index(
+        "candidate uv source changed or did not match its release pin",
+        uv_copy,
+    )
+    install = script.index("bootstrap_candidate_install=fd-bound-wheel-verified:", uv_digest)
+    chain_exec = script.index(" install-verify-and-exec ", install)
+    attestation = script.index("prove_bootstrap_replacement_provider(", install)
+    plan = script.index(
+        "plan_bootstrap_reconcile(desired, replacement_provider=evidence)",
+        attestation,
+    )
+    dispatch = script.index("  bootstrap_relay_only_reconcile", plan)
+    planning_heredoc = script[chain_exec:dispatch]
+    retained_planning = script[planning:dispatch]
+
+    assert archive < archive_digest < extraction < wheel_digest < uv_copy < uv_digest
+    assert uv_digest < install < chain_exec < attestation < plan < dispatch
+    assert "spec_from_file_location" not in planning_heredoc
+    assert "from clio_relay.bootstrap_reconcile import (" in planning_heredoc
+    assert '"UV_TOOL_DIR": str(tool_directory)' in script
+    assert '"UV_CACHE_DIR": str(cache_directory)' in script
+    assert 'BOOTSTRAP_PREPARING_ROOT="$BOOTSTRAP_PREPARING_PARENT/active"' in script
+    assert "BOOTSTRAP_CANDIDATE_INSTALL_SPEC='$DEST/wheels/" in script
+    assert 'UV_PYTHON_INSTALL_DIR="$HOME/.local/share/clio-relay/uv-python"' in script
+    assert 'UV_PYTHON_INSTALL_DIR="$BOOTSTRAP_PREPARING_ROOT/' not in script
+    assert '"$BOOTSTRAP_PINNED_UV" tool install' not in script
+    assert 'executable=f"/proc/self/fd/{uv_descriptor}"' in script
+    assert "installed candidate differs from the pinned wheel fd" in script
+    assert "install-and-verify" in script
+    assert "install-verify-and-exec" in planning_heredoc
+    assert 'BOOTSTRAP_PLAN_PROVIDER="$(sed' not in retained_planning
+    assert '"$BOOTSTRAP_PLAN_PROVIDER" -I' not in retained_planning
+    assert 'bootstrap_provider_exec "$@"' in script
+    assert '"$provider" -I - "$BOOTSTRAP_CANDIDATE_PYTHON_ROOT"' not in script
+    assert "expected_provider_interpreter_sha256" in planning_heredoc
+    assert planning_heredoc.index("from clio_relay.bootstrap_reconcile import (") < (
+        planning_heredoc.index("prove_bootstrap_replacement_provider(")
+    )
+    assert planning_heredoc.index("prove_bootstrap_replacement_provider(") < (
+        planning_heredoc.index("plan_bootstrap_reconcile(desired, replacement_provider=evidence)")
+    )
+    assert "shutil.rmtree" not in script
+    no_downloads = script.index('"UV_PYTHON_DOWNLOADS": "never"', uv_digest)
+    assert uv_digest < no_downloads < install
+    assert "bootstrap_cleanup_preparing_root" in script
+    assert script.index("BOOTSTRAP_LEGACY_RELAY_PROVIDER=1") < script.index(
+        '"$BOOTSTRAP_CURRENT_PROVIDER" -c'
+    )
+
+
 def test_staged_upgrade_uses_journal_bound_idempotent_forward_activation() -> None:
     """Legacy adoption and recovery share one staged-provider activation path."""
     script = bootstrap.render_linux_user_bootstrap_script(cluster="cluster-a")
@@ -1103,11 +1775,12 @@ def test_staged_upgrade_uses_journal_bound_idempotent_forward_activation() -> No
     assert "bootstrap_use_staged_provider()" in script
     assert "journal-phase prepared_manifest" in script
     assert provider_function.index("compgen -e") < provider_function.index("exec python3 -I -c")
-    assert 'LD_*|PYTHON*) unset "$bootstrap_environment_name"' in provider_function
+    assert 'LD_*|PYTHON*|BASH_ENV|ENV) unset "$bootstrap_environment_name"' in provider_function
     assert activation < finish < verify < activated < migration
     assert "bootstrap_candidate_action finish-activation" in recovery
     assert "phase_identities" in recovery
     assert "sha256sum --check --strict -" in recovery
+    assert "printf '%s\\n' \"bootstrap_reconcile_plan=$BOOTSTRAP_PLAN_JSON\" >&2" in script
     assert 'mv -Tf "$HOME/.local/share/clio-relay/.current.' not in script
     assert 'readlink "$HOME/.local/share/clio-relay/current"' not in script
     assert (

--- a/tests/test_bootstrap_reconcile.py
+++ b/tests/test_bootstrap_reconcile.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import shlex
+import shutil
 import stat
 import subprocess
 import sys
@@ -22,6 +23,7 @@ from clio_relay.bootstrap_reconcile import (
     BootstrapActivationPath,
     BootstrapDesiredState,
     BootstrapReconcilePlan,
+    BootstrapReplacementProviderEvidence,
     BootstrapTransactionJournal,
     BootstrapTransactionState,
     bootstrap_invocation_lock,
@@ -40,6 +42,8 @@ from clio_relay.bootstrap_reconcile import (
     write_jarvis_wrapper,
 )
 from clio_relay.errors import ConfigurationError
+from clio_relay.installation import PersistentUvToolIdentity
+from clio_relay.validation_report import sha256_file
 
 
 def _digest(value: bytes) -> str:
@@ -283,9 +287,14 @@ def test_matching_receipt_with_tampered_runtime_is_not_a_noop(
     assert "managed endpoint service is inactive" in inspection.reasons
 
 
+@pytest.mark.parametrize(
+    "relay_provider",
+    ["verified-old", "unverified-old", "staged-candidate", "tampered-candidate"],
+)
 def test_first_legacy_upgrade_plans_relay_only_and_reuses_verified_components(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    relay_provider: str,
 ) -> None:
     bin_dir = tmp_path / ".local/bin"
     bin_dir.mkdir(parents=True)
@@ -334,6 +343,41 @@ def test_first_legacy_upgrade_plans_relay_only_and_reuses_verified_components(
         }
     )
     info = _installation_info(desired)
+    if relay_provider != "verified-old":
+        component_runtime = cast(dict[str, object], info["component_runtime"])
+        component_runtime["clio-relay"] = {
+            "persistent_tool_verified": False,
+            "error": "source artifact is unavailable",
+        }
+    replacement_provider = None
+    if relay_provider in {"staged-candidate", "tampered-candidate"}:
+        info["receipt_matches_install"] = False
+        replacement_provider = BootstrapReplacementProviderEvidence.model_construct(
+            desired_fingerprint=desired.fingerprint,
+            relay_install_spec=desired.relay_install_spec,
+            preparing_root=str(tmp_path / ".local/share/clio-relay/preparing/invocation"),
+            extracted_source_root=str(
+                tmp_path / ".local/share/clio-relay/preparing/invocation/source"
+            ),
+            source_archive_sha256="f" * 64,
+            persistent_tool=PersistentUvToolIdentity.model_construct(),
+        )
+
+        def verify_replacement(
+            _desired: BootstrapDesiredState,
+            _evidence: BootstrapReplacementProviderEvidence,
+            *,
+            home: Path | None = None,
+        ) -> None:
+            assert home == tmp_path
+            if relay_provider == "tampered-candidate":
+                raise ConfigurationError("candidate RECORD closure changed")
+
+        monkeypatch.setattr(
+            bootstrap_reconcile_module,
+            "_verify_bootstrap_replacement_provider",
+            verify_replacement,
+        )
     receipt = cast(dict[str, object], info["receipt"])
     receipt.pop("deployment_fingerprint")
     receipt.pop("deployment_manifest")
@@ -389,7 +433,24 @@ def test_first_legacy_upgrade_plans_relay_only_and_reuses_verified_components(
         bounded_identity,
     )
 
-    plan = plan_bootstrap_reconcile(desired, home=tmp_path)
+    plan = plan_bootstrap_reconcile(
+        desired,
+        home=tmp_path,
+        replacement_provider=replacement_provider,
+    )
+
+    if relay_provider == "unverified-old":
+        assert plan.mode == "full"
+        assert plan.reasons == [
+            "clio-relay live provider is not reusable: source artifact is unavailable"
+        ]
+        return
+    if relay_provider == "tampered-candidate":
+        assert plan.mode == "full"
+        assert plan.reasons == [
+            "candidate replacement provider did not verify: candidate RECORD closure changed"
+        ]
+        return
 
     assert plan.mode == "relay-only", plan.reasons
     assert plan.component_actions == {
@@ -406,6 +467,161 @@ def test_first_legacy_upgrade_plans_relay_only_and_reuses_verified_components(
     assert plan.activation_paths["current"].before is None
     assert plan.activation_paths["managed_repo"].before is None
     assert plan.activation_paths["install_receipt"].before is not None
+    if relay_provider == "staged-candidate":
+        component_runtime = cast(dict[str, object], info["component_runtime"])
+        clio_kit_runtime = cast(dict[str, object], component_runtime["clio-kit"])
+        clio_kit_runtime["native_execution_capability_verified"] = False
+        rejected = plan_bootstrap_reconcile(
+            desired,
+            home=tmp_path,
+            replacement_provider=replacement_provider,
+        )
+        assert rejected.mode == "full"
+        assert rejected.reasons == ["clio-kit live runtime is not reusable"]
+
+
+def test_replacement_provider_attests_real_private_uv_tool(
+    tmp_path: Path,
+) -> None:
+    """The replacement proof is derived from a real wheel, uv receipt, and RECORD."""
+    uv_source = shutil.which("uv")
+    assert uv_source is not None
+    project = Path(__file__).parents[1]
+    built = tmp_path / "built"
+    subprocess.run(
+        [uv_source, "build", "--wheel", "--out-dir", str(built)],
+        cwd=project,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    wheels = list(built.glob("clio_relay-*.whl"))
+    assert len(wheels) == 1
+    version = wheels[0].name.removeprefix("clio_relay-").removesuffix("-py3-none-any.whl")
+
+    home = tmp_path / "home"
+    preparing_parent = home / ".local/share/clio-relay/preparing"
+    preparing_root = preparing_parent / "active"
+    preparing_root.mkdir(parents=True, mode=0o700)
+    preparing_parent.chmod(0o700)
+    preparing_root.chmod(0o700)
+    uv_executable = preparing_root / "pinned-uv"
+    shutil.copy2(uv_source, uv_executable)
+    uv_executable.chmod(0o500)
+    uv_version = (
+        subprocess.run(
+            [str(uv_executable), "--version"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        .stdout.strip()
+        .split()[1]
+    )
+    source_root = preparing_root / "source"
+    source_root.mkdir()
+    wheel = preparing_root / wheels[0].name
+    shutil.copy2(wheels[0], wheel)
+    tool_directory = preparing_root / "uv-tools"
+    tool_bin_directory = preparing_root / "uv-bin"
+    environment = {
+        **os.environ,
+        "UV_TOOL_DIR": str(tool_directory),
+        "UV_TOOL_BIN_DIR": str(tool_bin_directory),
+        "UV_CACHE_DIR": str(preparing_root / "uv-cache"),
+        "UV_PYTHON_INSTALL_DIR": str(home / ".local/share/clio-relay/uv-python"),
+        "UV_PYTHON_DOWNLOADS": "never",
+    }
+    subprocess.run(
+        [
+            str(uv_executable),
+            "tool",
+            "install",
+            "--force",
+            "--python",
+            "3.12",
+            "--no-config",
+            "--default-index",
+            "https://pypi.org/simple",
+            str(wheel),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        env=environment,
+    )
+    launcher = tool_bin_directory / ("clio-relay.exe" if os.name == "nt" else "clio-relay")
+    provider = (
+        tool_directory / "clio-relay" / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    )
+    assert launcher.is_file()
+    assert provider.is_file()
+    wheel_sha256 = sha256_file(wheel)
+    desired = _desired(
+        uv_sha256=sha256_file(uv_executable),
+        frpc_sha256="b" * 64,
+        frps_sha256="c" * 64,
+    ).model_copy(
+        update={
+            "relay_install_spec": f"clio-relay=={version}",
+            "relay_artifact_sha256": wheel_sha256,
+            "relay_source_identity": f"wheel:sha256:{wheel_sha256}",
+            "uv_version": uv_version,
+        }
+    )
+    desired_path = tmp_path / "desired.json"
+    desired_path.write_text(desired.model_dump_json(), encoding="utf-8")
+    proof = subprocess.run(
+        [
+            str(provider),
+            "-I",
+            "-c",
+            "\n".join(
+                [
+                    "import json,sys",
+                    "from pathlib import Path",
+                    "from clio_relay.bootstrap_reconcile import (",
+                    "    BootstrapDesiredState,prove_bootstrap_replacement_provider,",
+                    ")",
+                    "desired=BootstrapDesiredState.model_validate_json(Path(sys.argv[1]).read_text())",
+                    "evidence=prove_bootstrap_replacement_provider(",
+                    "    desired,",
+                    "    uv_executable=Path(sys.argv[2]),",
+                    "    tool_executable=Path(sys.argv[3]),",
+                    "    source_artifact=Path(sys.argv[4]),",
+                    "    tool_directory=Path(sys.argv[5]),",
+                    "    tool_bin_directory=Path(sys.argv[6]),",
+                    "    preparing_root=Path(sys.argv[7]),",
+                    "    extracted_source_root=Path(sys.argv[8]),",
+                    "    source_archive_sha256='f'*64,",
+                    "    home=Path(sys.argv[9]),",
+                    ")",
+                    "print(json.dumps(evidence.model_dump(mode='json'),sort_keys=True))",
+                ]
+            ),
+            str(desired_path),
+            str(uv_executable),
+            str(launcher),
+            str(wheel),
+            str(tool_directory),
+            str(tool_bin_directory),
+            str(preparing_root),
+            str(source_root),
+            str(home),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+    assert proof.returncode == 0, proof.stdout + proof.stderr
+    evidence = json.loads(proof.stdout)
+    assert evidence["schema_version"] == "clio-relay.bootstrap-replacement-provider.v1"
+    assert evidence["persistent_tool"]["source_artifact_sha256"] == wheel_sha256
 
 
 def test_existing_jarvis_144_plans_staged_component_upgrade_to_148(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -195,12 +195,41 @@ def _default_cli_mode(  # pyright: ignore[reportUnusedFunction]
         if finalized is None:
             return real_recovery_status(**kwargs)  # pyright: ignore[reportArgumentType]
         queue = cast(ClioCoreQueue, kwargs["queue"])
+        cluster = cast(str, kwargs["cluster"])
+        remote_execution = cast(bool, kwargs["remote_execution"])
         generation_id = finalized.session_generation_id
         assert generation_id is not None
-        admission = queue.owner_session_generation_status(
-            session_id,
+        admission_session_id = (
+            cli._desktop_owner_session_admission_id(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+                cluster=cluster,
+                session_id=session_id,
+            )
+            if remote_execution
+            else session_id
+        )
+        local_admission = queue.owner_session_generation_status(
+            admission_session_id,
             session_generation_id=generation_id,
         )
+        admission = local_admission
+        if remote_execution and local_admission.get("closed") is True:
+            local_closure = OwnerSessionClosure.model_validate(local_admission["closure"])
+            remote_closure = local_closure.model_copy(update={"owner_session_id": session_id})
+            finalized_admission = finalized.admission_status
+            assert isinstance(finalized_admission, dict)
+            admission = {
+                "schema_version": "clio-relay.owner-session-admission-status.v1",
+                "owner_session_id": session_id,
+                "session_generation_id": generation_id,
+                "active_generation_id": None,
+                "closing_generation_id": generation_id,
+                "active": False,
+                "closing": True,
+                "closed": True,
+                "open": False,
+                "cleanup_intent": finalized_admission["cleanup_intent"],
+                "closure": remote_closure.model_dump(mode="json"),
+            }
         return finalized.model_copy(
             update={
                 "process_state": (
@@ -5821,8 +5850,27 @@ def test_cli_dead_session_teardown_uses_recovery_without_canceling_jobs(
     def dead_status(**_kwargs: object) -> dict[str, object]:
         raise RelayError("session metadata was not present before the late start completed")
 
-    def recovered_status(**_kwargs: object) -> OwnedSessionRecoveryStatus:
+    def recovered_status(
+        *,
+        queue: ClioCoreQueue,
+        definition: ClusterDefinition,
+        remote_execution: bool,
+        cluster: str,
+        session_id: str,
+    ) -> OwnedSessionRecoveryStatus:
+        if recovery_calls:
+            return recover_after_finalization(
+                queue=queue,
+                definition=definition,
+                remote_execution=remote_execution,
+                cluster=cluster,
+                session_id=session_id,
+            )
+        recovery_calls.append("initial")
         return recovery
+
+    recover_after_finalization = cli._owned_session_recovery_status  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    recovery_calls: list[str] = []
 
     monkeypatch.setattr(cli, "status_remote_session", dead_status)
     monkeypatch.setattr(cli, "_owned_session_recovery_status", recovered_status)
@@ -5878,12 +5926,7 @@ def test_cli_dead_session_teardown_uses_recovery_without_canceling_jobs(
             encoding="utf-8"
         )
     )
-    recovery_resource = next(
-        resource for resource in report["resources"] if resource["kind"] == "owner_session_recovery"
-    )
-    assert recovery_resource["state"] == "verified"
-    assert recovery_resource["metadata"]["process_absence_verified"] is True
-    assert "late start completed" in recovery_resource["metadata"]["initial_status_error"]
+    assert report["status"] == "passed"
     quiesced_report = next(
         report
         for report in written_reports
@@ -5892,9 +5935,16 @@ def test_cli_dead_session_teardown_uses_recovery_without_canceling_jobs(
             for resource in report.resources
         )
     )
-    assert any(
-        resource.kind == "owner_session_recovery" and resource.state == "verified"
+    recovery_resource = next(
+        resource
         for resource in quiesced_report.resources
+        if resource.kind == "owner_session_recovery"
+    )
+    assert recovery_resource.state == "verified"
+    assert recovery_resource.metadata["process_absence_verified"] is True
+    assert "late start completed" in cast(
+        str,
+        recovery_resource.metadata["initial_status_error"],
     )
 
 

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -321,7 +321,7 @@ def test_native_jarvis_record_closure_rejects_a_tampered_installed_member(
     tmp_path: Path,
 ) -> None:
     environment = tmp_path / "environment"
-    venv.EnvBuilder(with_pip=False).create(environment)
+    venv.EnvBuilder(with_pip=False, symlinks=os.name != "nt").create(environment)
     python = environment / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
     completed = subprocess.run(
         [

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.18"
+    assert version == "1.4.19"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_service_runtime.py
+++ b/tests/test_service_runtime.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import ctypes
+import errno
 import gzip
 import hashlib
 import json
@@ -61,6 +63,30 @@ from tests.gateway_ownership_crash_fixture import (
 class FakeProcess:
     def __init__(self, pid: int) -> None:
         self.pid = pid
+
+
+class _PidfdSyscallFixture:
+    def __init__(self, outcomes: dict[int, tuple[int, int]]) -> None:
+        self.outcomes = outcomes
+        self.calls: list[int] = []
+        self.restype: object = None
+
+    def __call__(self, *arguments: object) -> int:
+        number = getattr(arguments[0], "value", None)
+        if not isinstance(number, int):
+            raise AssertionError("pidfd syscall number is not an integer")
+        self.calls.append(number)
+        result, error_number = self.outcomes[number]
+        ctypes.set_errno(error_number)
+        return result
+
+
+class _PidfdLibcWithoutSymbols:
+    pidfd_open: None = None
+    pidfd_send_signal: None = None
+
+    def __init__(self, syscall: _PidfdSyscallFixture) -> None:
+        self.syscall = syscall
 
 
 def test_local_connector_does_not_retain_captured_cli_pipes(tmp_path: Path) -> None:
@@ -960,8 +986,10 @@ def test_service_runtime_stop_keeps_scheduler_job_by_default(tmp_path: Path) -> 
     assert "process_group != pgid" not in owned_scan
     assert "proc.stat().st_uid != os.geteuid()" in stop_script
     assert "os.killpg" not in stop_script
-    assert "os.pidfd_open(member_pid, 0)" in stop_script
-    assert "signal.pidfd_send_signal(process_fd, sig, None, 0)" in stop_script
+    assert 'native_open = getattr(os, "pidfd_open", None)' in stop_script
+    assert "ctypes.c_long(434)" in stop_script
+    assert 'native_send = getattr(signal, "pidfd_send_signal", None)' in stop_script
+    assert "ctypes.c_long(424)" in stop_script
     assert "signal_owned_processes(signal.SIGTERM)" in stop_script
     assert "signal_owned_processes(signal.SIGKILL)" in stop_script
 
@@ -3096,6 +3124,143 @@ def test_posix_connector_cleanup_signals_only_revalidated_pidfd(
     assert result == [555]
     assert signaled == [(92, sigkill)]
     assert closed == [92]
+
+
+def test_posix_connector_cleanup_uses_libc_when_python_omits_pidfd_wrappers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scans = iter([[555], [555]])
+    opened: list[int] = []
+    closed: list[int] = []
+    signaled: list[tuple[int, int]] = []
+    connector: dict[str, object] = {
+        "pid": 555,
+        "process_group_id": 555,
+        "owner_token": "owner-token",
+        "connector_generation_id": "generation-1",
+        "config_path": "/owned/desktop-frpc.toml",
+    }
+
+    def group_members(_connector: dict[str, object]) -> list[int]:
+        return next(scans)
+
+    def libc_open(pid: int) -> int:
+        opened.append(pid)
+        return 93
+
+    def libc_send(process_fd: int, sig: int) -> None:
+        signaled.append((process_fd, sig))
+
+    monkeypatch.setattr(
+        service_runtime,
+        "_local_connector_group_members",
+        group_members,
+    )
+    monkeypatch.setattr(service_runtime.os, "pidfd_open", None, raising=False)
+    monkeypatch.setattr(
+        service_runtime.signal,
+        "pidfd_send_signal",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(service_runtime, "_linux_pidfd_open", libc_open)
+    monkeypatch.setattr(service_runtime, "_linux_pidfd_send_signal", libc_send)
+    monkeypatch.setattr(service_runtime.os, "close", closed.append)
+
+    result = service_runtime._signal_owned_posix_connector_processes(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        connector,
+        signal.SIGTERM,
+    )
+
+    assert result == [555]
+    assert opened == [555]
+    assert signaled == [(93, signal.SIGTERM)]
+    assert closed == [93]
+
+
+def test_linux_pidfd_raw_syscall_fallback_preserves_errno(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    syscall = _PidfdSyscallFixture(
+        {
+            424: (-1, errno.EPERM),
+            434: (-1, errno.ESRCH),
+        }
+    )
+    library = _PidfdLibcWithoutSymbols(syscall)
+
+    def load_libc(_name: object, *, use_errno: bool) -> _PidfdLibcWithoutSymbols:
+        assert use_errno is True
+        return library
+
+    monkeypatch.setattr(service_runtime.sys, "platform", "linux")
+    monkeypatch.setattr(service_runtime.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(service_runtime.ctypes, "CDLL", load_libc)
+
+    with pytest.raises(ProcessLookupError) as open_error:
+        service_runtime._linux_pidfd_open(555)  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    assert open_error.value.errno == errno.ESRCH
+
+    with pytest.raises(PermissionError) as send_error:
+        service_runtime._linux_pidfd_send_signal(93, signal.SIGTERM)  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    assert send_error.value.errno == errno.EPERM
+    assert syscall.calls == [434, 424]
+
+
+def test_remote_pidfd_helpers_fall_back_and_preserve_errno(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    syscall = _PidfdSyscallFixture(
+        {
+            424: (-1, errno.EPERM),
+            434: (93, 0),
+        }
+    )
+    library = _PidfdLibcWithoutSymbols(syscall)
+
+    def load_libc(_name: object, *, use_errno: bool) -> _PidfdLibcWithoutSymbols:
+        assert use_errno is True
+        return library
+
+    monkeypatch.setattr(service_runtime.os, "pidfd_open", None, raising=False)
+    monkeypatch.setattr(
+        service_runtime.signal,
+        "pidfd_send_signal",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(service_runtime.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(service_runtime.ctypes, "CDLL", load_libc)
+    stop_script = service_runtime._remote_stop_script(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        session_id="gateway-fixture",
+        pid=555,
+    )
+    stop_program = stop_script.split("<<'__CLIO_STOP_CONNECTOR__'\n", 1)[1].split(
+        "\n__CLIO_STOP_CONNECTOR__",
+        1,
+    )[0]
+    helper_start = stop_program.index("def open_process_fd")
+    helper_end = stop_program.index("\ndef signal_owned_processes", helper_start)
+    helper_program = stop_program[helper_start:helper_end]
+    namespace: dict[str, object] = {
+        "ctypes": service_runtime.ctypes,
+        "errno": errno,
+        "os": service_runtime.os,
+        "platform": service_runtime.platform,
+        "signal": service_runtime.signal,
+    }
+    exec(compile(helper_program, "remote-pidfd-helpers", "exec"), namespace)
+    open_process_fd = cast(Callable[[int], int], namespace["open_process_fd"])
+    send_process_fd_signal = cast(
+        Callable[[int, int], None],
+        namespace["send_process_fd_signal"],
+    )
+
+    assert open_process_fd(555) == 93
+    with pytest.raises(PermissionError) as send_error:
+        send_process_fd_signal(93, signal.SIGTERM)
+    assert send_error.value.errno == errno.EPERM
+    assert syscall.calls == [434, 424]
 
 
 def test_windows_connector_pid_reuse_is_not_authorized_by_descendant_scan(

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -2072,14 +2072,21 @@ def test_owned_session_recovery_rejects_symlinked_metadata(
 ) -> None:
     home, session_dir, proc_root, queue = _owned_session_recovery_fixture(tmp_path)
     metadata_path = session_dir / "metadata.json"
-    original_lstat = Path.lstat
+    if os.name == "posix":
+        # The POSIX reader opens metadata through the pinned session descriptor
+        # with O_NOFOLLOW, so exercise the real filesystem boundary.
+        symlink_target = metadata_path.with_name("metadata-symlink-target.json")
+        metadata_path.rename(symlink_target)
+        metadata_path.symlink_to(symlink_target)
+    else:
+        original_lstat = Path.lstat
 
-    def symlinked_metadata_lstat(path: Path) -> os.stat_result | SimpleNamespace:
-        if path == metadata_path:
-            return SimpleNamespace(st_mode=stat.S_IFLNK, st_uid=0)
-        return original_lstat(path)
+        def symlinked_metadata_lstat(path: Path) -> os.stat_result | SimpleNamespace:
+            if path == metadata_path:
+                return SimpleNamespace(st_mode=stat.S_IFLNK, st_uid=0)
+            return original_lstat(path)
 
-    monkeypatch.setattr(Path, "lstat", symlinked_metadata_lstat)
+        monkeypatch.setattr(Path, "lstat", symlinked_metadata_lstat)
 
     status = inspect_owned_session_recovery_status(
         cluster="ares",
@@ -2100,14 +2107,22 @@ def test_owned_session_recovery_rejects_symlinked_session_parent(
 ) -> None:
     home, session_dir, proc_root, queue = _owned_session_recovery_fixture(tmp_path)
     sessions_parent = session_dir.parent
-    original_lstat = Path.lstat
+    if os.name == "posix":
+        # The POSIX reader intentionally pins directories with openat/fstat and
+        # never consults Path.lstat. Exercise that real boundary instead of
+        # mocking an API the implementation correctly does not use.
+        symlink_target = sessions_parent.with_name("sessions-symlink-target")
+        sessions_parent.rename(symlink_target)
+        sessions_parent.symlink_to(symlink_target, target_is_directory=True)
+    else:
+        original_lstat = Path.lstat
 
-    def symlinked_parent_lstat(path: Path) -> os.stat_result | SimpleNamespace:
-        if path == sessions_parent:
-            return SimpleNamespace(st_mode=stat.S_IFLNK, st_uid=0)
-        return original_lstat(path)
+        def symlinked_parent_lstat(path: Path) -> os.stat_result | SimpleNamespace:
+            if path == sessions_parent:
+                return SimpleNamespace(st_mode=stat.S_IFLNK, st_uid=0)
+            return original_lstat(path)
 
-    monkeypatch.setattr(Path, "lstat", symlinked_parent_lstat)
+        monkeypatch.setattr(Path, "lstat", symlinked_parent_lstat)
 
     status = inspect_owned_session_recovery_status(
         cluster="ares",

--- a/tests/test_transport_probe.py
+++ b/tests/test_transport_probe.py
@@ -12,11 +12,14 @@ from typing import Any, cast
 import pytest
 from pytest import MonkeyPatch
 
+import clio_relay.session_lifecycle as session_lifecycle
 import clio_relay.transport_probe as transport_probe
 from clio_relay.cluster_config import ClusterDefinition, FrpTransportConfig
 from clio_relay.errors import ConfigurationError, RelayError
 from clio_relay.session_lifecycle import (
     CleanupResource,
+    OwnedSessionRecoveryStatus,
+    OwnedSessionStartStatusSelector,
     RemoteSessionStateEvidence,
     SessionLifecycleReport,
 )
@@ -35,6 +38,21 @@ def _frp_cluster_definition() -> ClusterDefinition:
         ssh_host="test-host",
         frp_transport=FrpTransportConfig(server_addr="relay.example.test"),
     )
+
+
+def _ready_owned_session_start_lines(kwargs: dict[str, object]) -> list[str]:
+    operation_id = cast(str, kwargs["start_operation_id"])
+    session_id = cast(str, kwargs["session_id"])
+    remote_api_port = cast(int, kwargs["remote_api_port"])
+    assert operation_id.startswith("start_")
+    assert kwargs["expected_cluster_route_revision"]
+    return [
+        f"session_started={session_id}",
+        f"start_operation_id={operation_id}",
+        "session_generation_id=generation-1",
+        f"remote_api_port={remote_api_port}",
+        "api_pid=123",
+    ]
 
 
 def test_frp_http_probe_starts_remote_proxy_and_local_visitor(monkeypatch: MonkeyPatch) -> None:
@@ -522,11 +540,8 @@ def test_ssh_forward_http_probe_starts_owned_remote_api_and_local_forward(
     def fake_start(**kwargs: object) -> list[str]:
         assert kwargs["session_id"] == "session-1"
         assert kwargs["remote_api_port"] == 9001
-        return [
-            "session_started=session-1",
-            "session_generation_id=generation-1",
-            "api_pid=123",
-        ]
+        assert kwargs["api_token"] == "token"
+        return _ready_owned_session_start_lines(kwargs)
 
     def fake_teardown(**kwargs: object) -> SessionLifecycleReport:
         teardowns.append(str(kwargs["session_id"]))
@@ -575,7 +590,7 @@ def test_ssh_forward_http_probe_starts_owned_remote_api_and_local_forward(
         http_bindings.append((local_url, session_id, generation_id))
         return ["transport.http_binding=verified"]
 
-    monkeypatch.setattr("clio_relay.transport_probe.start_remote_session", fake_start)
+    monkeypatch.setattr(session_lifecycle, "start_remote_session", fake_start)
     monkeypatch.setattr("clio_relay.transport_probe.teardown_remote_session", fake_teardown)
     monkeypatch.setattr("clio_relay.transport_probe._wait_for_healthz", fake_healthz)
 
@@ -612,7 +627,7 @@ def test_ssh_forward_http_probe_can_detach_remote_session(monkeypatch: MonkeyPat
     detaches: list[str] = []
 
     def fake_start(**_kwargs: object) -> list[str]:
-        return ["session_started=session-1", "session_generation_id=generation-1"]
+        return _ready_owned_session_start_lines(_kwargs)
 
     def fake_teardown(**kwargs: object) -> SessionLifecycleReport:
         teardowns.append(str(kwargs["session_id"]))
@@ -649,7 +664,8 @@ def test_ssh_forward_http_probe_can_detach_remote_session(monkeypatch: MonkeyPat
         return FakeProcess(command)
 
     monkeypatch.setattr(
-        "clio_relay.transport_probe.start_remote_session",
+        session_lifecycle,
+        "start_remote_session",
         fake_start,
     )
     monkeypatch.setattr(
@@ -680,60 +696,98 @@ def test_ssh_forward_http_probe_can_detach_remote_session(monkeypatch: MonkeyPat
     assert "transport.remote_session_ownership=verified" in lines
 
 
-def test_ssh_probe_recovers_generation_from_authoritative_status(
+@pytest.mark.parametrize(
+    ("expected_state", "attempt_verified"),
+    [("starting", True), ("ambiguous", False)],
+)
+def test_ssh_forward_probe_preserves_nonterminal_start_after_transport_deadline(
     monkeypatch: MonkeyPatch,
+    expected_state: str,
+    attempt_verified: bool,
 ) -> None:
     definition = ClusterDefinition(name="test-cluster", ssh_host="test-host")
+    start_invocations: list[dict[str, object]] = []
+    status_selectors: list[OwnedSessionStartStatusSelector] = []
 
-    def fake_status(**kwargs: object) -> dict[str, object]:
-        assert kwargs == {"definition": definition, "session_id": "session-1"}
-        return {
-            "session_id": "session-1",
-            "owner": "clio-relay",
-            "session_generation_id": "generation-from-status",
-            "running": True,
-            "ownership_verified": True,
-        }
-
-    monkeypatch.setattr(transport_probe, "status_remote_session", fake_status)
-
-    assert (
-        transport_probe._started_session_generation_id(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
-            ["session_started=session-1"],
-            definition=definition,
-            session_id="session-1",
+    def deadline(**kwargs: object) -> list[str]:
+        start_invocations.append(kwargs)
+        raise session_lifecycle._RemoteSessionCommandDeadline(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            "start transport deadline"
         )
-        == "generation-from-status"
-    )
 
-
-def test_ssh_probe_refuses_unverifiable_session_generation(
-    monkeypatch: MonkeyPatch,
-) -> None:
-    definition = ClusterDefinition(name="test-cluster", ssh_host="test-host")
-
-    def fake_status(**_kwargs: object) -> dict[str, object]:
-        return {"session_generation_id": None}
-
-    monkeypatch.setattr(
-        transport_probe,
-        "status_remote_session",
-        fake_status,
-    )
-
-    with pytest.raises(RelayError, match="verifiable session generation id"):
-        transport_probe._started_session_generation_id(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
-            ["session_started=session-1"],
-            definition=definition,
-            session_id="session-1",
+    def fake_status(
+        *,
+        definition: ClusterDefinition,
+        selector: OwnedSessionStartStatusSelector,
+    ) -> OwnedSessionRecoveryStatus:
+        assert definition == ClusterDefinition(name="test-cluster", ssh_host="test-host")
+        status_selectors.append(selector)
+        return OwnedSessionRecoveryStatus(
+            cluster=selector.cluster,
+            session_id=selector.session_id,
+            session_generation_id=("generation-starting" if attempt_verified else None),
+            start_operation_id=selector.start_operation_id,
+            cluster_route_revision=selector.cluster_route_revision,
+            remote_api_port=selector.remote_api_port if attempt_verified else None,
+            start_state="starting",
+            start_phase="admitted" if attempt_verified else None,
+            start_attempt_verified=attempt_verified,
+            start_retryable=True,
+            start_replace=selector.replace if attempt_verified else None,
+            start_require_token=selector.require_token if attempt_verified else None,
+            start_expected_api_release_identity_sha256=(
+                selector.expected_api_release_identity_sha256 if attempt_verified else None
+            ),
+            errors=[] if attempt_verified else ["start transition is not yet observable"],
         )
+
+    monkeypatch.setattr(session_lifecycle, "start_remote_session", deadline)
+    monkeypatch.setattr(session_lifecycle, "status_remote_session_start", fake_status)
+
+    with pytest.raises(RelayError, match=f"state={expected_state}") as raised:
+        run_ssh_forward_http_probe(
+            cluster="test-cluster",
+            definition=definition,
+            local_bind_port=19001,
+            remote_api_port=9001,
+            session_id="session-1",
+            api_token="token",
+            process_factory=_unexpected_process_factory,
+        )
+
+    assert len(start_invocations) == 1
+    assert len(status_selectors) == 1
+    operation_id = cast(str, start_invocations[0]["start_operation_id"])
+    assert operation_id == status_selectors[0].start_operation_id
+    evidence_lines = transport_evidence_lines_from_error(raised.value)
+    assert len(evidence_lines) == 1
+    evidence = parse_transport_probe_evidence(evidence_lines[0].partition("=")[2])
+    assert evidence.cleanup_mode == "transport_probe_start_observation"
+    resource = evidence.resources[0]
+    assert resource.kind == "relay_session_start_operation"
+    assert resource.resource_id == operation_id
+    assert resource.action == "retain"
+    assert resource.ownership_verified is True
+    assert resource.outcome == "retained"
+    assert resource.verified_after_operation is True
+    assert resource.observed_state == expected_state
+    assert resource.residual is False
+    assert resource.metadata["terminal"] is False
+    assert resource.metadata["retryable"] is True
+    assert resource.metadata["transport_deadline_exceeded"] is True
+    assert resource.metadata["start_operation_id"] == operation_id
+    assert resource.metadata["status_selector"] == status_selectors[0].model_dump(mode="json")
+    assert resource.metadata["retry_selector"] == {
+        **status_selectors[0].model_dump(mode="json"),
+        "operation": "session.start",
+    }
 
 
 def test_ssh_forward_http_probe_rejects_residual_remote_session(
     monkeypatch: MonkeyPatch,
 ) -> None:
     def fake_start(**_kwargs: object) -> list[str]:
-        return ["session_started=session-1", "session_generation_id=generation-1"]
+        return _ready_owned_session_start_lines(_kwargs)
 
     def fake_teardown(**_kwargs: object) -> SessionLifecycleReport:
         return SessionLifecycleReport(
@@ -758,7 +812,7 @@ def test_ssh_forward_http_probe_rejects_residual_remote_session(
     def fake_healthz(_url: str, *, timeout_seconds: float) -> None:
         del timeout_seconds
 
-    monkeypatch.setattr(transport_probe, "start_remote_session", fake_start)
+    monkeypatch.setattr(session_lifecycle, "start_remote_session", fake_start)
     monkeypatch.setattr(transport_probe, "teardown_remote_session", fake_teardown)
     monkeypatch.setattr(transport_probe, "_wait_for_healthz", fake_healthz)
 

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2343,13 +2343,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.18-py3-none-any.whl",
+            resource_id="clio-relay-1.4.19-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.18.tar.gz",
+            resource_id="clio_relay-1.4.19.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2488,7 +2488,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.18"
+    assert policy.release_version == "1.4.19"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -934,6 +934,8 @@ def test_real_uv_tool_scopes_launcher_to_isolated_bin(
     assert source["launcher_verified"] is True
     assert Path(source["launcher_receipt"]["tool_executable"]).resolve() == executable.resolve()
     assert source["launcher_receipt"]["tool_bin_bound"] is True
+    assert source["launcher_receipt"]["executable_in_process_environment"] is True
+    assert source["launcher_receipt"]["executable_target_bound"] is True
     assert source["launcher_receipt"]["uv_tool_receipt"]["launcher_bound"] is True
 
 
@@ -1109,6 +1111,7 @@ def _report(
                 "pyvenv_matches_uv": True,
                 "package_in_process_environment": True,
                 "executable_in_process_environment": True,
+                "executable_target_bound": True,
                 "isolated_environment": True,
                 "distribution_record": {
                     "verified": True,

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.18"
+version = "1.4.19"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- stage and attest the exact incoming clio-relay wheel before planning an upgrade from legacy bootstrap receipts
- preserve every non-relay bootstrap trust check while allowing the verified candidate provider to perform the generation migration
- make Linux release validation portable across uv-managed Python layouts and native pidfd availability
- harden bootstrap scratch cleanup, environment isolation, and uv executable pinning against path replacement and interrupted upgrades
- make SSH transport validation retain and report an exact durable session-start operation when its observation deadline expires

## Focused verification

- focused bootstrap migration and hostile-path tests on Windows and Linux/WSL
- release-policy and acceptance-runbook checks
- Ruff formatting/lint and strict Pyright for changed modules

No scheduler job is failed, canceled, or resubmitted by either an observation deadline or this bootstrap migration.
