### PR TITLE
fix: verify variable uv install metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.19` uses a release-first patch process. A maintainer builds the
+> Version `1.4.20` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.19"
+$Version = "1.4.20"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.19"
+release_version: "1.4.20"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 43eac4c693ed3bb2303975eb0f70df7beefad44638abb002299d621ded342faf
+acceptance_matrix_sha256: 869006639de763134c9c8fb1a53ed3eed413dce8a39675c23c5f28ab2404f311
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.19"
+$Tag = "v1.4.20"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.19" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.20" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.19",
-  "matrix_sha256": "43eac4c693ed3bb2303975eb0f70df7beefad44638abb002299d621ded342faf",
+  "release_version": "1.4.20",
+  "matrix_sha256": "869006639de763134c9c8fb1a53ed3eed413dce8a39675c23c5f28ab2404f311",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.19"
+version = "1.4.20"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.19"
+__version__ = "1.4.20"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -850,6 +850,7 @@ import ctypes
 import csv
 import fcntl
 import hashlib
+import json
 import os
 import signal
 import stat
@@ -1134,6 +1135,37 @@ def read_path(path, maximum, label):
     return payload
 
 
+def read_path_allow_empty(path, maximum, label):
+    before = path.lstat()
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode) or not 0 <= opened.st_size <= maximum:
+            raise SystemExit(f"{label} is not one bounded regular file")
+        chunks = []
+        remaining = maximum + 1
+        while remaining:
+            chunk = os.read(descriptor, min(1024 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        payload = b"".join(chunks)
+        after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    if (
+        len(payload) != opened.st_size
+        or len(payload) > maximum
+        or identity(before) != identity(opened)
+        or identity(after) != identity(opened)
+        or identity(path.lstat()) != identity(opened)
+    ):
+        raise SystemExit(f"{label} changed while it was pinned")
+    return payload
+
+
 action, *values = sys.argv[1:]
 if action not in {
     "install-and-verify",
@@ -1338,19 +1370,70 @@ try:
         except (UnicodeDecodeError, csv.Error) as error:
             raise SystemExit("installed candidate RECORD is malformed") from error
         installed_names = {row[0] for row in installed_rows if len(row) == 3}
-        generated = {
-            os.path.relpath(environment_prefix / "bin/clio-relay", site_packages).replace(
-                os.sep, "/"
-            ),
-            *(str(dist_info / name) for name in (
-                "INSTALLER",
-                "REQUESTED",
-                "direct_url.json",
-                "uv_cache.json",
-            )),
+        launcher_name = os.path.relpath(
+            environment_prefix / "bin/clio-relay", site_packages
+        ).replace(os.sep, "/")
+        required_generated = {
+            launcher_name,
+            str(dist_info / "INSTALLER"),
+            str(dist_info / "REQUESTED"),
+            str(dist_info / "direct_url.json"),
         }
-        if len(installed_names) != len(installed_rows) or installed_names != set(names) | generated:
+        optional_generated = {
+            str(dist_info / "uv_build.json"),
+            str(dist_info / "uv_cache.json"),
+        }
+        wheel_names = set(names)
+        if (
+            len(installed_names) != len(installed_rows)
+            or not wheel_names.issubset(installed_names)
+            or not required_generated.issubset(installed_names)
+            or not installed_names.issubset(
+                wheel_names | required_generated | optional_generated
+            )
+        ):
             raise SystemExit("installed candidate distribution contains unpinned members")
+        installed_row_map = {row[0]: row for row in installed_rows}
+        generated_payloads = {}
+        for name in installed_names - wheel_names:
+            row = installed_row_map[name]
+            generated_path = site_packages.joinpath(*PurePosixPath(name).parts)
+            if generated_path.is_symlink() or not generated_path.resolve(
+                strict=True
+            ).is_relative_to(environment_prefix):
+                raise SystemExit("installed candidate generated member escaped its environment")
+            payload = read_path_allow_empty(
+                generated_path,
+                8 * 1024 * 1024,
+                "installed candidate generated member",
+            )
+            expected_hash, expected_size_text = row[1:]
+            digest = hashlib.sha256(payload).digest()
+            encoded = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+            if (
+                expected_hash != "sha256=" + encoded
+                or not expected_size_text.isdigit()
+                or int(expected_size_text) != len(payload)
+            ):
+                raise SystemExit(
+                    "installed candidate generated member differs from its RECORD identity"
+                )
+            generated_payloads[name] = payload
+        if (
+            generated_payloads[str(dist_info / "INSTALLER")] != b"uv"
+            or generated_payloads[str(dist_info / "REQUESTED")] != b""
+        ):
+            raise SystemExit("installed candidate generated ownership metadata is invalid")
+        for name in (
+            str(dist_info / "direct_url.json"),
+            *(sorted(optional_generated & installed_names)),
+        ):
+            try:
+                document = json.loads(generated_payloads[name])
+            except (UnicodeDecodeError, json.JSONDecodeError) as error:
+                raise SystemExit("installed candidate generated JSON is invalid") from error
+            if not isinstance(document, dict):
+                raise SystemExit("installed candidate generated JSON must contain an object")
 
         total = 0
         for name in names:

--- a/tests/test_bootstrap_fast_path.py
+++ b/tests/test_bootstrap_fast_path.py
@@ -320,6 +320,137 @@ print("swapped-wheel-rejected")
     assert result.stdout.strip() == "swapped-wheel-rejected"
 
 
+def test_candidate_verifier_accepts_pinned_uv_metadata_subset_only() -> None:
+    """Pinned uv metadata may vary by build path, while unknown members fail closed."""
+    driver = r"""
+import base64
+import csv
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+verifier = base64.b64decode(sys.argv[1]).decode()
+uv = shutil.which("uv") or str(Path.home() / ".local/bin/uv")
+with tempfile.TemporaryDirectory() as value:
+    workspace = Path(value)
+    built = workspace / "built"
+    subprocess.run(
+        [uv, "build", "--wheel", "--out-dir", str(built)],
+        check=True,
+        capture_output=True,
+    )
+    wheel = next(built.glob("clio_relay-*.whl"))
+    tool_directory = workspace / "tools"
+    tool_bin_directory = workspace / "bin"
+    cache_directory = workspace / "cache"
+    python_directory = Path.home() / ".local/share/clio-relay/uv-python"
+    arguments = [
+        sys.executable,
+        "-I",
+        "-c",
+        verifier,
+        "install-and-verify",
+        uv,
+        hashlib.sha256(Path(uv).read_bytes()).hexdigest(),
+        str(wheel),
+        hashlib.sha256(wheel.read_bytes()).hexdigest(),
+        str(tool_directory),
+        str(tool_bin_directory),
+        str(cache_directory),
+        str(python_directory),
+    ]
+    accepted = subprocess.run(arguments, check=False, capture_output=True, text=True)
+    if accepted.returncode != 0:
+        raise SystemExit(accepted.stdout + accepted.stderr)
+
+    site_packages = next((tool_directory / "clio-relay").glob("lib/python*/site-packages"))
+    record = next(site_packages.glob("clio_relay-*.dist-info/RECORD"))
+    rows = list(csv.reader(record.read_text(encoding="utf-8").splitlines(), strict=True))
+    with zipfile.ZipFile(wheel) as archive:
+        wheel_names = {item.filename for item in archive.infolist() if not item.is_dir()}
+    launcher = os.path.relpath(
+        tool_directory / "clio-relay/bin/clio-relay", site_packages
+    ).replace(os.sep, "/")
+    installed_names = {row[0] for row in rows if len(row) == 3}
+    dist_info = record.parent.relative_to(site_packages).as_posix()
+    generated = {
+        launcher,
+        *(f"{dist_info}/{name}" for name in (
+            "INSTALLER",
+            "REQUESTED",
+            "direct_url.json",
+            "uv_build.json",
+            "uv_cache.json",
+        )),
+    }
+    if (
+        len(installed_names) != len(rows)
+        or not wheel_names.issubset(installed_names)
+        or not {
+            launcher,
+            f"{dist_info}/INSTALLER",
+            f"{dist_info}/REQUESTED",
+            f"{dist_info}/direct_url.json",
+        }.issubset(installed_names)
+        or not installed_names.issubset(wheel_names | generated)
+    ):
+        raise SystemExit("candidate install exposed an invalid uv metadata set")
+
+    uv_build = record.parent / "uv_build.json"
+    if not uv_build.exists():
+        payload = b'{"source":"focused-test"}'
+        uv_build.write_bytes(payload)
+        digest = base64.urlsafe_b64encode(hashlib.sha256(payload).digest()).rstrip(b"=").decode()
+        rows.append([
+            uv_build.relative_to(site_packages).as_posix(),
+            "sha256=" + digest,
+            str(len(payload)),
+        ])
+        with record.open("w", encoding="utf-8", newline="") as stream:
+            csv.writer(stream, lineterminator="\n").writerows(rows)
+    arguments[4] = "verify-installed"
+    accepted_with_build_metadata = subprocess.run(
+        arguments, check=False, capture_output=True, text=True
+    )
+    if accepted_with_build_metadata.returncode != 0:
+        raise SystemExit(
+            accepted_with_build_metadata.stdout + accepted_with_build_metadata.stderr
+        )
+
+    uv_build_payload = uv_build.read_bytes()
+    uv_build.write_bytes(uv_build_payload + b"tampered")
+    rejected_tamper = subprocess.run(arguments, check=False, capture_output=True, text=True)
+    if (
+        rejected_tamper.returncode == 0
+        or "generated member differs from its RECORD identity" not in rejected_tamper.stderr
+    ):
+        raise SystemExit(rejected_tamper.stdout + rejected_tamper.stderr)
+    uv_build.write_bytes(uv_build_payload)
+
+    unexpected = record.parent / "unexpected.json"
+    unexpected.write_text("{}", encoding="utf-8")
+    rows.append([unexpected.relative_to(site_packages).as_posix(), "", ""])
+    with record.open("w", encoding="utf-8", newline="") as stream:
+        csv.writer(stream, lineterminator="\n").writerows(rows)
+    rejected = subprocess.run(arguments, check=False, capture_output=True, text=True)
+    if rejected.returncode == 0 or "contains unpinned members" not in rejected.stderr:
+        raise SystemExit(rejected.stdout + rejected.stderr)
+print("bounded-uv-metadata-ok")
+"""
+    result = _run_posix_embedded_driver(
+        driver,
+        bootstrap._BOOTSTRAP_CANDIDATE_UV_INSTALL_SOURCE,  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == "bounded-uv-metadata-ok"
+
+
 def test_candidate_coordinator_rejects_provider_path_swap_after_open() -> None:
     """A provider pathname replacement cannot execute after its coordinator opens it."""
     driver = r"""
@@ -1747,6 +1878,7 @@ def test_legacy_planning_attests_private_candidate_before_transaction_or_fence()
     assert "shutil.rmtree" not in script
     no_downloads = script.index('"UV_PYTHON_DOWNLOADS": "never"', uv_digest)
     assert uv_digest < no_downloads < install
+    assert '"uv_build.json"' in script
     assert "bootstrap_cleanup_preparing_root" in script
     assert script.index("BOOTSTRAP_LEGACY_RELAY_PROVIDER=1") < script.index(
         '"$BOOTSTRAP_CURRENT_PROVIDER" -c'

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.19"
+    assert version == "1.4.20"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2343,13 +2343,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.19-py3-none-any.whl",
+            resource_id="clio-relay-1.4.20-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.19.tar.gz",
+            resource_id="clio_relay-1.4.20.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2488,7 +2488,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.19"
+    assert policy.release_version == "1.4.20"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.19"
+version = "1.4.20"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- accept the bounded installer-metadata variants emitted by the pinned uv 0.11.28 Linux wheel path, including `uv_build.json`
- require the launcher, installer ownership, request marker, and exact wheel source metadata before candidate planning
- hash and size-check every generated RECORD member and reject unknown or tampered members
- prepare the 1.4.20 patch release

## Live reproduction

The released 1.4.19 Ares legacy bootstrap installed the exact candidate wheel, then failed closed with `installed candidate distribution contains unpinned members`. No scheduler job was submitted and no stable generation was promoted.

## Focused verification

- variable pinned-uv metadata closure, tamper rejection, and unknown-member rejection
- swapped-wheel rejection
- provider-path swap rejection
- legacy candidate planning order and rendered Bash syntax
- release identity/policy consistency
- Ruff and Pyright
