### PR TITLE
fix: harden durable relay recovery and live acceptance

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.20` uses a release-first patch process. A maintainer builds the
+> Version `1.4.21` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do
@@ -138,6 +138,17 @@ The HTTP API exposes `/gateway-sessions`, `/gateway-sessions/{session_id}`, and 
 
 These generic gateway operations manage ordinary endpoint metadata only. They cannot write scheduler identity, relay runtime specifications or ownership intents, connector ownership, or relay owner metadata. Use `gateway start-runtime`, `detach-runtime`, and `stop-runtime` for relay-owned scheduler-backed services.
 
+`gateway start-runtime` submits at most once and makes one bounded readiness
+observation. A workload that is queued, allocated but not healthy yet, or temporarily
+unobservable returns `outcome: "pending"` with its durable gateway-session selector.
+Before the scheduler response is known, that selector contains the exact submission ID
+and marker; after acceptance, it contains the native scheduler job ID. Advance that
+exact submission with `gateway resume-runtime <gateway_session_id>` after any delay;
+hours or days of scheduler residence never become a relay failure, cancellation, or
+resubmission. Only provider-proven terminal scheduler state is terminal.
+`observation_unknown` records missing observation evidence without claiming that the
+scheduler job is still queued.
+
 When JARVIS already owns a live application, agents use the user-profile
 `relay_bind_jarvis_runtime` MCP tool instead of supplying a runtime specification.
 The relay verifies a completed `jarvis_get_execution` MCP result produced with
@@ -149,6 +160,15 @@ dataset identities, starts only
 the connector path, and returns local connect, health, stream, events, state, and
 command URLs. Detach and stop retain the scheduler job unless cancellation is
 explicitly requested and the original binding can be re-verified.
+The immutable JARVIS binding plus owner identity deterministically names one
+gateway. If connector delivery or the bounded health observation is inconclusive,
+the tool returns `outcome: "pending"`, an exact `retry_selector`,
+`scheduler_action: "none"`, `relay_action: "none"`, and null URLs. Reissue the
+same bind arguments after any delay to advance that gateway in place; it does not
+create another gateway, connector generation, scheduler job, cancellation, or
+resubmission. Changing its name, transport, or desktop-port policy is rejected.
+Only use the URLs after `outcome: "ready"`. Proven binding/authentication/integrity
+violations and provider-proven terminal scheduler states fail closed.
 New live services use `jarvis.service-runtime.v2`: every cluster-side endpoint
 requires an execution-owned bearer capability, but the public JARVIS report exposes
 only `authorization.scheme` and `authorization.token_sha256`. After re-verifying the

--- a/docs/ai/interface-context.md
+++ b/docs/ai/interface-context.md
@@ -161,9 +161,11 @@ generation match.
 `jarvis_get_execution(include_service_runtimes=true)` response supplies compact
 `service_runtime_bindings`; pass one exact entry unchanged as `binding`. It carries
 the configured cluster, completed source job and `mcp_result` artifact, exact
-package id/name, and service-instance id. Its output includes the
-durable gateway session and six local URLs: connect, health, stream, events, state,
-and command. The gateway stores the immutable source job/artifact digest,
+package id/name, and service-instance id. Its fixed output reports `ready` or
+`pending`; pending carries the exact same-gateway retry selector, no relay or
+scheduler action, and six null URLs. Reissue the identical bind to resume it.
+Ready includes the durable gateway session and six local URLs: connect, health,
+stream, events, state, and command. The gateway stores the immutable source job/artifact digest,
 execution and scheduler identities, service revision/report digest, and exact
 dataset descriptor/digest. The tool does not accept submit, status, cancel, host,
 port, path, descriptor overrides, or mixed compact/legacy selectors.

--- a/docs/ai/system-context.md
+++ b/docs/ai/system-context.md
@@ -109,7 +109,10 @@ metadata and lifecycle commands are rejected. A waited execution query emits a
 compact selector-only `service_runtime_bindings` handoff which is copied unchanged
 into the bind call; the source artifact is still re-read and fully verified.
 Binding starts no application or
-scheduler work; it starts only the relay connectors. Any later explicit scheduler
+scheduler work; it starts only the relay connectors. The binding and owner identity
+derive one deterministic gateway ID. Connector or health ambiguity remains a
+durable pending observation and identical bind calls reconcile that exact intent;
+they never replace it merely because a client observation expired. Any later explicit scheduler
 cancellation re-verifies the immutable source before invoking the provider.
 The public v2 report carries only the execution-owned capability's scheme and
 SHA-256; the raw bearer remains in JARVIS's owner-private sidecar. After re-reading
@@ -132,7 +135,9 @@ launcher if registration cannot be proven. Relay never treats the login-node `sr
 launcher PID as frpc. Detach proves the exact step remains active with
 `squeue --steps`, while stop uses `scancel job.step` and confirms step absence.
 The parent job remains retained unless scheduler-job cancellation is separately
-and explicitly requested. Placement or step ambiguity fails closed.
+and explicitly requested. Placement or step observation ambiguity stays pending
+without a replacement side effect; identity/integrity mismatch or provider-proven
+terminal state fails closed.
 Readiness is provenance-bearing and application-neutral: relay re-verifies the
 exact JARVIS execution, package, service, endpoint, dataset-descriptor, revision,
 and authorization identities, then proves authenticated v2 health is both protected

--- a/docs/ai/testing-context.md
+++ b/docs/ai/testing-context.md
@@ -94,6 +94,12 @@ success and after preflight or runtime failure unless the operator supplies an
 explicit path. `release gate` consumes those reports; it is not an acceptance-report
 producer.
 
+Long scheduler residence is represented as `pending`, never as workload failure.
+Resume `live-test` with `--resume-report`; the new sibling report observes the
+same run, job, idempotency key, and phase-specific JARVIS identities without a
+TTL, resubmission, or scheduler cancellation. Pending reports are diagnostic and
+are rejected by the release gate until the exact run produces a passed report.
+
 Use `clio-relay release validate-local` for the local quality report. Candidate
 wheel reports are sealed before PyPI publication and remain valuable regression
 evidence, but the final

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -667,6 +667,16 @@ adapters, stdout scraping, and `clio-kit.jarvis-package-progress.v1`
 notifications remain legacy compatibility paths and are invalid as 1.0
 acceptance evidence.
 
+`--wait-timeout-seconds` bounds one validation observation window; it is not a
+workload deadline. If the exact execution is still queued or running, or its
+terminal artifact page is not observable yet, the command writes a `pending`
+report containing a query-only resume checkpoint. Resume it with
+`jarvis-mcp-validate --cluster <cluster> --resume-report <report.json>` after any
+delay. Resume never calls `jarvis_run`, cancels the scheduler job, or creates a
+replacement execution. A pending report is useful operational evidence but
+cannot satisfy the release gate until the same execution reaches a validated
+terminal result with its requested artifacts.
+
 Cluster bootstrap stores the exact clio-kit wheel path, digest, persistent-tool
 environment, and JARVIS MCP command in the installation receipt. The worker
 service reads that receipt and invokes the installed executable directly; it
@@ -865,6 +875,14 @@ connector and desktop visitor and persists an
 immutable `clio-relay.jarvis-service-runtime-binding.v2` provenance record in the
 gateway session. The result returns the gateway session plus `connect_url`,
 `health_url`, `stream_url`, `events_url`, `state_url`, and `command_url`.
+Those URLs are strings only when `outcome` is `ready`. A connector or health
+observation miss returns a normal `outcome: "pending"` result with all six URLs
+null, `scheduler_action` and `relay_action` both `none`, and an exact
+`retry_selector`. Repeat `relay_bind_jarvis_runtime` with the same binding, name,
+and transport policy to resume the deterministic gateway; observation timeout
+never authorizes a second connector, scheduler submission, cancellation, or
+gateway. Immutable policy drift is rejected before mutation. The CLI
+`gateway attach-runtime` command preserves the same pending outcome and selector.
 
 Detach stops only the owned desktop connector. Stop removes the owned relay
 connectors while retaining the JARVIS scheduler job by default. An explicit
@@ -1163,5 +1181,27 @@ clio-relay live-test --cluster my-cluster --jarvis-yaml .\path\to\site-acceptanc
 ```
 
 A complete live acceptance should verify the cluster bootstrap, worker service, transport, JARVIS package execution, logs, artifacts, provenance, progress, and agent tool submission path.
+
+`--timeout-seconds` bounds one observation, not the lifetime of an HPC job. If
+the primary relay job remains queued or running, live JARVIS metadata is not yet
+available, or a secure-runtime query/bind remains nonterminal, `live-test`
+writes a `pending` report. Its strict checkpoint records the exact cluster,
+run id, relay job, idempotency key, phase, and any known pipeline, execution,
+source-artifact, service, or gateway identities. It has no TTL and requests no
+scheduler or relay cancellation.
+
+Resume that exact observation after any delay while passing the same semantic
+inputs:
+
+```powershell
+clio-relay live-test --cluster my-cluster --jarvis-yaml .\path\to\site-acceptance.yaml --resume-report .clio-relay\validation-reports\pending-live-test.json --timeout-seconds 900
+```
+
+The resume writes a new sibling report and preserves the source checkpoint. It
+queries the recorded phase/job in place; it does not submit another primary
+JARVIS run. Changed cluster configuration, pipeline content, validation intent,
+or checkpoint evidence is rejected before any remote command. A deterministic
+failed/canceled workload or malformed/integrity-invalid runtime result remains
+a failed validation. The release gate continues to reject `pending` reports.
 
 When a package adapter or runtime metadata artifact is present, the text and machine-readable reports also record `application_boundary`, `application_profile`, `package_adapter`, `package_owner`, `runtime_metadata_source`, `runtime_scheduler_provider`, `runtime_scheduler_job_id`, its field-level source, and the runtime artifact id. `structured_runtime_metadata=legacy_fallback` is evidence of a compatibility path, not proof that structured runtime ingestion passed the 1.0 gate.

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.20"
+$Version = "1.4.21"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }
@@ -1638,20 +1638,26 @@ This scenario polls the released remote `clio-relay job status` contract for
 valid structured runtime metadata while the outer relay/JARVIS/SLURM source job
 is still `running`. It must not call the outer `job wait` or the completed-job
 artifact verifier before exercising the service. A failed or canceled source
-job, invalid metadata, or the same bounded timeout fails the report. The inner
+job or invalid metadata fails the report. A bounded observation timeout instead
+writes a non-gating `pending` report with the exact source job and any known
+pipeline, execution, source-artifact, service, or gateway identities. Resume it
+with the same live-test arguments plus `--resume-report <pending.json>`; the
+checkpoint has no TTL, retains the scheduler allocation, and cannot submit a
+replacement JARVIS run. The inner
 `jarvis_get_execution(wait_for_terminal=true)` remains required because it waits
 for that MCP dispatch and durable result, not for the source scheduler job to
 finish. A zero-binding result is retried within the same deadline while a
 nonempty selector mismatch or ambiguous match fails immediately. The report
 records the source relay job as retained and never requests scheduler
-cancellation.
+cancellation. Only a later `passed` sibling report can satisfy the release gate.
 
 Detach and teardown inside this probe always pass
 `cancel_scheduler_job=false`. A naturally completed allocation is acceptable
 only when its exact identity and verified terminal disposition are recorded;
 the report must never claim that relay cancelled it. The probe cleans up any
-gateway or connector it created on a failed bind while retaining the scheduler
-job.
+gateway or connector it created on a deterministic failed bind while retaining
+the scheduler job. An observation-expired or explicitly pending bind retains its
+exact gateway and connector intents for idempotent resume.
 
 ## Verify and upload the exact report set
 

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.20"
+release_version: "1.4.21"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 869006639de763134c9c8fb1a53ed3eed413dce8a39675c23c5f28ab2404f311
+acceptance_matrix_sha256: fef11d9506323c61ae505af6e32131a669318c2851d49d31b68f154fb4f4aa4f
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.20"
+$Tag = "v1.4.21"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.20" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.21" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.20",
-  "matrix_sha256": "869006639de763134c9c8fb1a53ed3eed413dce8a39675c23c5f28ab2404f311",
+  "release_version": "1.4.21",
+  "matrix_sha256": "fef11d9506323c61ae505af6e32131a669318c2851d49d31b68f154fb4f4aa4f",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/jarvis-packages/clio_relay/clio_relay/mcp_call/runner.py
+++ b/jarvis-packages/clio_relay/clio_relay/mcp_call/runner.py
@@ -11,6 +11,7 @@ import math
 import os
 import re
 import secrets
+import shlex
 import shutil
 import signal
 import stat
@@ -3223,7 +3224,8 @@ def _persistent_tool_launcher_shebang(payload: bytes, *, executable_name: str) -
                 candidates[0].filename,
                 max_bytes=CLIO_KIT_WHEEL_MAX_LAUNCHER_BYTES,
             )
-    first_line = script.split(b"\n", 1)[0]
+    lines = script.split(b"\n", 3)
+    first_line = lines[0]
     if len(first_line) > 4096:
         raise ValueError("persistent tool launcher shebang exceeded its byte limit")
     shebang = first_line.decode("utf-8", errors="strict").rstrip("\r")
@@ -3231,6 +3233,28 @@ def _persistent_tool_launcher_shebang(payload: bytes, *, executable_name: str) -
         raise ValueError("persistent tool launcher has no direct Python interpreter shebang")
     if "\x00" in shebang:
         raise ValueError("persistent tool launcher shebang contains a null byte")
+    if shebang == "#!/bin/sh":
+        if len(lines) < 3 or any(len(line) > 4096 for line in lines[1:3]):
+            raise ValueError("persistent uv shell trampoline is incomplete or oversized")
+        execution_line = lines[1].decode("utf-8", errors="strict").rstrip("\r")
+        closing_line = lines[2].decode("utf-8", errors="strict").rstrip("\r")
+        try:
+            execution = shlex.split(execution_line, posix=True)
+        except ValueError as exc:
+            raise ValueError("persistent uv shell trampoline has invalid quoting") from exc
+        if len(execution) != 4 or execution[0] != "exec" or execution[2:] != ["$0", "$@"]:
+            raise ValueError("persistent uv shell trampoline has an unsupported exec contract")
+        provider = execution[1]
+        quoted_provider = "'" + provider.replace("'", "'\"'\"'") + "'"
+        canonical_execution_line = f"'''exec' {quoted_provider} \"$0\" \"$@\""
+        if (
+            not provider.startswith("/")
+            or "\x00" in provider
+            or execution_line != canonical_execution_line
+            or closing_line != "' '''"
+        ):
+            raise ValueError("persistent uv shell trampoline has an invalid provider contract")
+        return f"#!{provider}"
     return shebang
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.20"
+version = "1.4.21"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.20"
+__version__ = "1.4.21"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -78,6 +78,8 @@ JARVIS_CD_WHEEL_URL = (
 JARVIS_CD_WHEEL_SHA256 = "ebf5e5f375b921f20c79075d461926431a5a017ca8b45e598878a89b229b3935"
 DEFAULT_REMOTE_CORE_DIR = "$HOME/.local/share/clio-relay/core"
 DEFAULT_REMOTE_SPOOL_DIR = "$HOME/.local/share/clio-relay/spool"
+
+
 _STAGED_PROVIDER_ENVIRONMENT_SANITIZER = r"""
 while IFS= read -r bootstrap_environment_name; do
   case "$bootstrap_environment_name" in
@@ -91,6 +93,7 @@ import fcntl
 import hashlib
 import json
 import os
+import shlex
 import stat
 import struct
 import sys
@@ -357,8 +360,30 @@ try:
         os.close(relay_descriptor)
     if hashlib.sha256(relay_payload).hexdigest() != relay_sha256:
         raise SystemExit("staged relay launcher digest changed")
-    first_line = relay_payload.splitlines()[0].decode("utf-8")
-    if first_line != "#!" + provider:
+    launcher_lines = relay_payload.splitlines()
+    direct_shebang = bool(
+        launcher_lines and launcher_lines[0] == ("#!" + provider).encode("utf-8")
+    )
+    quoted_provider = {
+        shlex.quote(provider),
+        "'" + provider.replace("'", "'\"'\"'") + "'",
+    }
+    trampoline_lines = {
+        "'''exec' " + value + ' "$0" "$@"' for value in quoted_provider
+    }
+    try:
+        trampoline_command = (
+            launcher_lines[1].decode("utf-8") if len(launcher_lines) >= 2 else ""
+        )
+    except UnicodeDecodeError as exc:
+        raise SystemExit("staged relay launcher is not valid UTF-8") from exc
+    uv_shell_trampoline = bool(
+        len(launcher_lines) >= 3
+        and launcher_lines[0] == b"#!/bin/sh"
+        and trampoline_command in trampoline_lines
+        and launcher_lines[2] == b"' '''"
+    )
+    if not direct_shebang and not uv_shell_trampoline:
         raise SystemExit("staged relay launcher is not bound to its provider")
     provider_descriptor = os.open(
         os.path.relpath(provider, generation),
@@ -1347,7 +1372,7 @@ try:
         if set(wheel_rows) != set(names) or len(wheel_rows) != len(rows):
             raise SystemExit("candidate wheel RECORD does not close over its members")
 
-        environment_prefix = tool_directory / "clio-relay"
+        environment_prefix = (tool_directory / "clio-relay").resolve(strict=True)
         site_package_matches = list(environment_prefix.glob("lib/python*/site-packages"))
         if len(site_package_matches) != 1:
             raise SystemExit("candidate uv environment has no exact site-packages root")
@@ -1384,15 +1409,27 @@ try:
             str(dist_info / "uv_cache.json"),
         }
         wheel_names = set(names)
+        required_names = wheel_names | required_generated
+        allowed_names = required_names | optional_generated
+        missing_names = required_names - installed_names
+        unexpected_names = installed_names - allowed_names
         if (
             len(installed_names) != len(installed_rows)
-            or not wheel_names.issubset(installed_names)
-            or not required_generated.issubset(installed_names)
-            or not installed_names.issubset(
-                wheel_names | required_generated | optional_generated
-            )
+            or missing_names
+            or unexpected_names
         ):
-            raise SystemExit("installed candidate distribution contains unpinned members")
+            details = {
+                "row_count": len(installed_rows),
+                "unique_name_count": len(installed_names),
+                "missing_count": len(missing_names),
+                "missing": [name[:256] for name in sorted(missing_names)[:16]],
+                "unexpected_count": len(unexpected_names),
+                "unexpected": [name[:256] for name in sorted(unexpected_names)[:16]],
+            }
+            raise SystemExit(
+                "installed candidate distribution contains unpinned members: "
+                + json.dumps(details, sort_keys=True, separators=(",", ":"))
+            )
         installed_row_map = {row[0]: row for row in installed_rows}
         generated_payloads = {}
         for name in installed_names - wheel_names:
@@ -2346,6 +2383,51 @@ def _bootstrap_preflight_over_ssh(
             "    echo bootstrap_preflight_unsupported=missing_command",
             "    exit 0",
             "  fi",
+            '  if BOOTSTRAP_PREFLIGHT_OUTPUT="$BOOTSTRAP_PREFLIGHT_OUTPUT" '
+            "python3 -I - <<'__CLIO_RELAY_REPAIRABLE_QUEUE_ROOT__'",
+            "import json",
+            "import os",
+            "import sys",
+            "from pathlib import Path",
+            "",
+            'prefix = "error: "',
+            "matches = [line.removeprefix(prefix) for line in "
+            'os.environ["BOOTSTRAP_PREFLIGHT_OUTPUT"].splitlines() '
+            "if line.startswith(prefix)]",
+            "if len(matches) != 1:",
+            "    raise SystemExit(1)",
+            "try:",
+            "    report = json.loads(matches[0])",
+            "except json.JSONDecodeError:",
+            "    raise SystemExit(1) from None",
+            "expected = {",
+            '    "schema_version": "clio-relay.legacy-state-audit.v1",',
+            '    "family": "root",',
+            '    "reason": "queue directory is readable or writable by another user",',
+            '    "action": (',
+            '        "move the unsafe state aside or export records with portable durable IDs "',
+            '        "before retrying"',
+            "    ),",
+            "}",
+            'if not isinstance(report, dict) or set(report) != {*expected, "path"}:',
+            "    raise SystemExit(1)",
+            "if any(report.get(name) != value for name, value in expected.items()):",
+            "    raise SystemExit(1)",
+            'path = report.get("path")',
+            "if not isinstance(path, str):",
+            "    raise SystemExit(1)",
+            "try:",
+            "    observed = Path(path).resolve(strict=True)",
+            '    configured = Path(os.environ["CLIO_RELAY_CORE_DIR"]).resolve(strict=True)',
+            "except OSError:",
+            "    raise SystemExit(1) from None",
+            "if observed != configured:",
+            "    raise SystemExit(1)",
+            "__CLIO_RELAY_REPAIRABLE_QUEUE_ROOT__",
+            "  then",
+            "    echo bootstrap_preflight_unsupported=repairable_queue_permissions",
+            "    exit 0",
+            "  fi",
             "  printf '%s\\n' \"$BOOTSTRAP_PREFLIGHT_OUTPUT\" >&2",
             '  exit "$BOOTSTRAP_PREFLIGHT_STATUS"',
             "fi",
@@ -2371,6 +2453,7 @@ def _bootstrap_preflight_over_ssh(
                 "bootstrap_preflight_unsupported=not_installed",
                 "bootstrap_preflight_unsupported=missing_command",
                 "bootstrap_preflight_unsupported=legacy_relay_provider",
+                "bootstrap_preflight_unsupported=repairable_queue_permissions",
             }
         ]
         if len(unsupported) != 1:
@@ -3112,14 +3195,53 @@ def _validate_bootstrap_receipt(
             raise RelayError("bootstrap repair receipt reported JARVIS initialization")
         if jarvis_graph_action != "preserved" or command_count != 0:
             raise RelayError("bootstrap repair receipt reported JARVIS commands")
+        managed_repo = repository_update.get("managed_repo")
+        added_repositories = repository_update.get("added_managed_repos")
+        removed_repositories = repository_update.get("removed_previous_managed_repos")
         if (
             typed_jarvis_preservation.get("config_byte_identical") is not True
             or typed_jarvis_preservation.get("resource_graph_byte_identical") is not True
-            or typed_jarvis_preservation.get("repositories_byte_identical") is not True
-            or binding.get("link_action") != "reused"
-            or repository_update.get("action") != "reused"
         ):
             raise RelayError("bootstrap repair receipt reported JARVIS state mutation")
+        if (
+            not isinstance(managed_repo, str)
+            or not PurePosixPath(managed_repo).is_absolute()
+            or any(character in managed_repo for character in "\x00\r\n")
+            or binding.get("link") != managed_repo
+            or binding.get("link_action") not in {"reused", "created", "retargeted"}
+            or not isinstance(added_repositories, list)
+            or not isinstance(removed_repositories, list)
+            or not _is_sha256_value(typed_generation.get("previous"))
+        ):
+            raise RelayError("bootstrap managed JARVIS binding repair is invalid")
+        managed_suffix = "/.local/share/clio-relay/managed-jarvis-repo"
+        if not managed_repo.endswith(managed_suffix):
+            raise RelayError("bootstrap managed JARVIS binding repair is invalid")
+        remote_home = managed_repo[: -len(managed_suffix)]
+        expected_target = (
+            remote_home + "/.local/share/clio-relay/current/source/jarvis-packages/clio_relay"
+        )
+        expected_previous = remote_home + "/.local/src/clio-relay/jarvis-packages/clio_relay"
+        repository_action = repository_update.get("action")
+        if binding.get("target") != expected_target:
+            raise RelayError("bootstrap managed JARVIS binding repair is invalid")
+        if repository_action == "reused":
+            if (
+                typed_jarvis_preservation.get("repositories_byte_identical") is not True
+                or added_repositories
+                or removed_repositories
+            ):
+                raise RelayError("bootstrap managed JARVIS repository reuse is invalid")
+        elif repository_action == "updated":
+            if (
+                typed_jarvis_preservation.get("repositories_byte_identical") is not False
+                or added_repositories not in ([], [managed_repo])
+                or removed_repositories not in ([], [expected_previous])
+                or (not added_repositories and not removed_repositories)
+            ):
+                raise RelayError("bootstrap managed JARVIS repository repair is invalid")
+        else:
+            raise RelayError("bootstrap managed JARVIS repository repair is invalid")
     elif outcome == "reconciled":
         raw_transaction = receipt.get("transaction")
         transaction_mode = (
@@ -3297,7 +3419,14 @@ def _worker_upgrade_fence_script(
         ]
     )
     if not service_name:
-        return declarations, "", "clio-relay init", ""
+        no_service_fence = "\n".join(
+            [
+                declarations,
+                "bootstrap_restore_fenced_worker_on_failure() { :; }",
+                "bootstrap_release_worker_lifetime_guard() { :; }",
+            ]
+        )
+        return no_service_fence, "", "clio-relay init", ""
     initial_proof = _worker_writer_proof_shell(
         rendered_core_dir=rendered_core_dir,
         success_variable="WORKER_WRITER_PROOF",
@@ -3362,9 +3491,8 @@ def _worker_upgrade_fence_script(
             '  WORKER_RESTART_OUTCOME="$CLIO_RELAY_ENDPOINT_ACTIVATION_OUTCOME"',
             "  WORKER_RESTARTED=1",
             "}",
-            "bootstrap_worker_fence_exit() {",
-            "  status=$?",
-            "  trap - EXIT",
+            "bootstrap_restore_fenced_worker_on_failure() {",
+            '  local status="$1"',
             (
                 '  if [ "$status" -ne 0 ] && [ "$WORKER_WAS_ACTIVE" = "1" ]'
                 ' && [ "$WORKER_RESTARTED" != "1" ]; then'
@@ -3422,6 +3550,11 @@ def _worker_upgrade_fence_script(
             ),
             "    fi",
             "  fi",
+            "}",
+            "bootstrap_worker_fence_exit() {",
+            "  status=$?",
+            "  trap - EXIT",
+            '  bootstrap_restore_fenced_worker_on_failure "$status"',
             "  bootstrap_release_worker_lifetime_guard || true",
             "  if declare -F bootstrap_cleanup_preparing_root >/dev/null; then",
             "    bootstrap_cleanup_preparing_root || true",
@@ -3588,16 +3721,19 @@ import sys
 from pathlib import Path
 
 path, action, *arguments = sys.argv[1:]
-candidate_root = os.environ["BOOTSTRAP_CANDIDATE_PYTHON_ROOT"]
-if not sys.path or sys.path[0] != candidate_root:
-    sys.path.insert(0, candidate_root)
-name = "clio_relay.bootstrap_reconcile_candidate_action"
-spec = importlib.util.spec_from_file_location(name, path)
-if spec is None or spec.loader is None:
-    raise SystemExit("could not load candidate bootstrap reconciler")
-module = importlib.util.module_from_spec(spec)
-sys.modules[name] = module
-spec.loader.exec_module(module)
+if os.environ.get("BOOTSTRAP_STAGED_GENERATION") and action != "repair-legacy-cursors":
+    from clio_relay import bootstrap_reconcile as module
+else:
+    candidate_root = os.environ["BOOTSTRAP_CANDIDATE_PYTHON_ROOT"]
+    if not sys.path or sys.path[0] != candidate_root:
+        sys.path.insert(0, candidate_root)
+    name = "clio_relay.bootstrap_reconcile_candidate_action"
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise SystemExit("could not load candidate bootstrap reconciler")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
 journal_path = Path(os.environ["BOOTSTRAP_TRANSACTION_JOURNAL"])
 if action == "journal-create":
     service_value = os.environ["BOOTSTRAP_SERVICE_ACTIVE_BEFORE"]
@@ -3669,9 +3805,19 @@ elif action == "jarvis-wrapper":
         )
     )
 elif action == "finish-activation":
-    desired_payload = json.loads(os.environ["BOOTSTRAP_DESIRED_STATE"])
-    desired_payload["agent_npm_package"] = os.environ["AGENT_NPM_PACKAGE"] or None
-    desired_payload["agent_npm_bin"] = os.environ["AGENT_NPM_BIN"] or None
+    if os.environ.get("BOOTSTRAP_STAGED_GENERATION"):
+        receipt_payload = module._read_regular_bounded(
+            Path(arguments[0]) / "install-receipt.json",
+            maximum=4 * 1024 * 1024,
+        )
+        receipt_document = json.loads(receipt_payload)
+        desired_payload = receipt_document.get("deployment_manifest")
+        if not isinstance(desired_payload, dict):
+            raise SystemExit("staged install receipt omitted its desired state")
+    else:
+        desired_payload = json.loads(os.environ["BOOTSTRAP_DESIRED_STATE"])
+        desired_payload["agent_npm_package"] = os.environ["AGENT_NPM_PACKAGE"] or None
+        desired_payload["agent_npm_bin"] = os.environ["AGENT_NPM_BIN"] or None
     desired = module.BootstrapDesiredState.model_validate(desired_payload)
     print(
         json.dumps(
@@ -3680,6 +3826,39 @@ elif action == "finish-activation":
                 generation=Path(arguments[0]),
                 expected_manifest_sha256=arguments[1],
             ),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+elif action == "repair-legacy-cursors":
+    print(
+        json.dumps(
+            module.repair_legacy_cursor_permissions_for_upgrade(Path(arguments[0])),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+elif action == "repair-managed-binding":
+    desired_payload = json.loads(os.environ["BOOTSTRAP_DESIRED_STATE"])
+    desired_payload["agent_npm_package"] = os.environ["AGENT_NPM_PACKAGE"] or None
+    desired_payload["agent_npm_bin"] = os.environ["AGENT_NPM_BIN"] or None
+    desired = module.BootstrapDesiredState.model_validate(desired_payload)
+    before = module.inspect_jarvis_state(desired)
+    binding = module.repair_managed_jarvis_binding(
+        desired,
+        previous_managed_repos=(
+            Path.home() / ".local/src/clio-relay/jarvis-packages/clio_relay",
+        ),
+    )
+    after = module.inspect_jarvis_state(desired)
+    print(
+        json.dumps(
+            {{
+                "schema_version": "clio-relay.bootstrap-binding-repair.v1",
+                "before": before.model_dump(mode="json"),
+                "after": after.model_dump(mode="json"),
+                "binding": binding,
+            }},
             sort_keys=True,
             separators=(",", ":"),
         )
@@ -3751,7 +3930,7 @@ bootstrap_active_generation_identity() {{
     return 1
   fi
   target="$(readlink -f "$current")"
-  prefix="$HOME/.local/share/clio-relay/generations/"
+  prefix="$(readlink -f "$HOME/.local/share/clio-relay/generations")/"
   case "$target" in
     "$prefix"*) identity="${{target#"$prefix"}}" ;;
     *)
@@ -3770,6 +3949,18 @@ bootstrap_active_generation_identity() {{
     return 1
   fi
   echo "$identity"
+}}
+
+bootstrap_active_generation_provider() {{
+  local identity generations provider
+  identity="$(bootstrap_active_generation_identity)" || return 1
+  generations="$(readlink -f "$HOME/.local/share/clio-relay/generations")"
+  provider="$generations/$identity/tools/clio-relay/bin/python"
+  if [ ! -f "$provider" ] || [ ! -x "$provider" ]; then
+    echo "bootstrap active generation provider is unavailable" >&2
+    return 1
+  fi
+  echo "$provider"
 }}
 
 bootstrap_reconcile_transaction_exit() {{
@@ -3835,13 +4026,145 @@ bootstrap_recover_service() {{
   return 1
 }}
 
+bootstrap_fence_recovered_service() {{
+  local service_name="$1"
+  local load_state active_state stopped_state
+  [ -n "$service_name" ] || return 0
+  load_state="$(
+    systemctl --user show "$service_name" --property=LoadState --value
+  )" || return 1
+  active_state="$(
+    systemctl --user show "$service_name" --property=ActiveState --value
+  )" || return 1
+  case "$load_state:$active_state" in
+    loaded:active|loaded:activating|loaded:reloading|loaded:deactivating)
+      systemctl --user stop "$service_name"
+      stopped_state="$(
+        systemctl --user show "$service_name" --property=ActiveState --value
+      )" || return 1
+      case "$stopped_state" in
+        inactive|failed) return 0 ;;
+        *)
+          echo "bootstrap recovery could not fence endpoint service: $service_name" >&2
+          return 1
+          ;;
+      esac
+      ;;
+    loaded:inactive|loaded:failed|masked:inactive|not-found:inactive) return 0 ;;
+    *)
+      echo "bootstrap recovery found unknown endpoint service state: " \
+        "$load_state:$active_state:$service_name" >&2
+      return 1
+      ;;
+  esac
+}}
+
+bootstrap_recover_interrupted_repair() {{
+  local service_was_active="$1"
+  local cluster_name="$2"
+  local interrupted_service_name="$3"
+  local recovery_service_should_run=0
+  local recovery_queue recovery_worker recovery_worker_ready
+  if [ "$service_was_active" = "1" ]; then
+    recovery_service_should_run=1
+  fi
+
+{worker_fence}
+
+  if [ -n "$interrupted_service_name" ] && \
+     [ "$interrupted_service_name" != "$WORKER_SERVICE_NAME" ]; then
+    echo "bootstrap repair recovery service identity changed:" \
+      "$interrupted_service_name != $WORKER_SERVICE_NAME" >&2
+    return 1
+  fi
+
+  # A power loss releases the lifetime lock after the original fence.  Preserve
+  # both the journaled pre-transaction state and an operator restart observed
+  # at recovery entry, then keep the exact queue writer fence until readiness is
+  # sealed or the service restart relinquishes it.
+  if [ "$WORKER_WAS_ACTIVE" = "1" ]; then
+    recovery_service_should_run=1
+  elif [ "$service_was_active" = "1" ]; then
+    WORKER_WAS_ACTIVE=1
+    WORKER_STOP_CONFIRMED=1
+  fi
+
+{worker_recheck}
+
+  # The managed repository/link operation is exact and idempotent.  Re-running
+  # it covers interruption before, during, or after the original activation
+  # without depending on staged-generation evidence that repair never records.
+  bootstrap_candidate_action repair-managed-binding >/dev/null
+
+  recovery_queue="$(
+    CLIO_RELAY_CORE_DIR={rendered_core_dir} \
+      "$HOME/.local/bin/clio-relay" queue readiness-info 2>/dev/null || true
+  )"
+  export recovery_queue
+  if ! python3 -c \
+    'import json,os,sys; value=json.loads(os.environ["recovery_queue"]); '\
+'sys.exit(0 if value.get("complete") is True else 1)' \
+    2>/dev/null; then
+    CLIO_RELAY_CORE_DIR={rendered_core_dir} \
+    CLIO_RELAY_SPOOL_DIR={rendered_spool_dir} \
+    CLIO_RELAY_JARVIS_BIN="$HOME/.local/bin/jarvis" \
+    CLIO_RELAY_FRPC_BIN="$HOME/.local/bin/frpc" \
+    CLIO_RELAY_AGENT_BIN="${{AGENT_BIN:-agent}}" \
+    CLIO_RELAY_AGENT_ADAPTER={rendered_agent_adapter} \
+    CLIO_RELAY_AGENT_ARGS={rendered_agent_args} \
+    {WORKER_LIFETIME_GUARD_FD_ENV}="$WORKER_LIFETIME_GUARD_FD" \
+    {init_command}
+  fi
+  recovery_queue="$(
+    CLIO_RELAY_CORE_DIR={rendered_core_dir} \
+      "$HOME/.local/bin/clio-relay" queue readiness-info
+  )"
+  export recovery_queue
+  if ! python3 -c \
+    'import json,os,sys; value=json.loads(os.environ["recovery_queue"]); '\
+'sys.exit(0 if value.get("complete") is True else 1)'; then
+    echo "bootstrap repair recovery did not establish queue readiness" >&2
+    return 1
+  fi
+
+  if [ "$recovery_service_should_run" = "1" ] && [ -n "$WORKER_SERVICE_NAME" ]; then
+    if ! bootstrap_bounded_worker_restart; then
+      echo "bootstrap repair recovery could not restore endpoint service:" \
+        "$WORKER_SERVICE_NAME" >&2
+      return 1
+    fi
+    recovery_worker_ready=0
+    for _BOOTSTRAP_REPAIR_RECOVERY_WORKER_ATTEMPT in $(seq 1 90); do
+      recovery_worker="$(
+        CLIO_RELAY_CORE_DIR={rendered_core_dir} \
+          "$HOME/.local/bin/clio-relay" endpoint worker-info \
+            --cluster "$cluster_name" --freshness-seconds 120 2>/dev/null || true
+      )"
+      if printf '%s\\n' "$recovery_worker" | python3 -c \
+        'import json,sys; value=json.load(sys.stdin); '\
+'sys.exit(0 if value.get("running") is True else 1)' 2>/dev/null; then
+        recovery_worker_ready=1
+        break
+      fi
+      sleep 2
+    done
+    if [ "$recovery_worker_ready" != "1" ]; then
+      echo "bootstrap repair recovery did not observe a ready worker" >&2
+      return 1
+    fi
+  fi
+  BOOTSTRAP_REPAIR_RECOVERY_ACTIVE=1
+}}
+
 bootstrap_recover_previous_transaction() {{
   BOOTSTRAP_TRANSACTION_JOURNAL="$HOME/.local/share/clio-relay/bootstrap-transaction.json"
   export BOOTSTRAP_TRANSACTION_JOURNAL
   BOOTSTRAP_RECOVERY_JSON="$(bootstrap_candidate_action recovery-plan)"
   export BOOTSTRAP_RECOVERY_JSON
-  local recovery_mode interrupted_invocation service_name service_was_active cluster_name
+  local recovery_mode interrupted_mode interrupted_invocation service_name
+  local service_was_active cluster_name
   recovery_mode="$(bootstrap_recovery_value recovery_mode)"
+  interrupted_mode="$(bootstrap_recovery_value mode)"
   interrupted_invocation="$(bootstrap_recovery_value invocation_id)"
   service_name="$(bootstrap_recovery_value service_name)"
   service_was_active="$(bootstrap_recovery_value service_was_active)"
@@ -3870,8 +4193,12 @@ bootstrap_recover_previous_transaction() {{
       return 1
       ;;
     forward)
-      local prepared_generation prepared_manifest_sha256 recovery_generation
-      prepared_generation="$(bootstrap_recovery_value prepared_generation)"
+      if [ "$interrupted_mode" = "repair" ]; then
+        bootstrap_recover_interrupted_repair \
+          "$service_was_active" "$cluster_name" "$service_name"
+      else
+        local prepared_generation prepared_manifest_sha256 recovery_generation
+        prepared_generation="$(bootstrap_recovery_value prepared_generation)"
       case "$prepared_generation" in
         (*[!0-9a-f]*|'')
           echo "bootstrap forward recovery has an invalid generation" >&2
@@ -3913,6 +4240,7 @@ __CLIO_RELAY_RECOVERY_MANIFEST__
         sha256sum --check --strict -
       echo "$BOOTSTRAP_JARVIS_GRAPH_SHA256_BEFORE *$JARVIS_GRAPH_FILE" | \
         sha256sum --check --strict -
+      bootstrap_fence_recovered_service "$service_name"
       bootstrap_use_staged_provider "$recovery_generation" "$prepared_manifest_sha256"
       bootstrap_candidate_action finish-activation \
         "$recovery_generation" "$prepared_manifest_sha256" >/dev/null
@@ -3923,17 +4251,21 @@ __CLIO_RELAY_RECOVERY_MANIFEST__
         sha256sum --check --strict -
       mkdir -p -- {rendered_core_dir}
       exec 8<>"{rendered_core_dir}/{WORKER_LIFETIME_LOCK_NAME}"
+      WORKER_LIFETIME_GUARD_FD=8
       if ! flock -n 8; then
         echo "bootstrap forward recovery cannot prove exclusive queue ownership" >&2
         return 1
       fi
+      {WORKER_LIFETIME_GUARD_FD_ENV}="$WORKER_LIFETIME_GUARD_FD" \
+        bootstrap_candidate_action repair-legacy-cursors {rendered_core_dir} >/dev/null
       CLIO_RELAY_CORE_DIR={rendered_core_dir} \
       CLIO_RELAY_SPOOL_DIR={rendered_spool_dir} \
+      {WORKER_LIFETIME_GUARD_FD_ENV}="$WORKER_LIFETIME_GUARD_FD" \
         "$HOME/.local/bin/clio-relay" init --migrate-legacy-output
       CLIO_RELAY_CORE_DIR={rendered_core_dir} \
         "$HOME/.local/bin/clio-relay" queue readiness-info >/dev/null
       exec 8>&-
-      if [ "$service_was_active" = "1" ] && [ -n "$service_name" ]; then
+        if [ "$service_was_active" = "1" ] && [ -n "$service_name" ]; then
         bootstrap_recover_service "$service_name"
         local recovery_worker recovery_worker_ready
         recovery_worker_ready=0
@@ -3943,9 +4275,8 @@ __CLIO_RELAY_RECOVERY_MANIFEST__
               "$HOME/.local/bin/clio-relay" endpoint worker-info \
                 --cluster "$cluster_name" --freshness-seconds 120 2>/dev/null || true
           )"
-          export recovery_worker
-          if python3 -c \
-            'import json,os,sys; value=json.loads(os.environ["recovery_worker"]); '\
+          if printf '%s\\n' "$recovery_worker" | python3 -c \
+            'import json,sys; value=json.load(sys.stdin); '\
 'sys.exit(0 if value.get("running") is True else 1)' 2>/dev/null; then
             recovery_worker_ready=1
             break
@@ -3955,6 +4286,7 @@ __CLIO_RELAY_RECOVERY_MANIFEST__
         if [ "$recovery_worker_ready" != "1" ]; then
           echo "bootstrap forward recovery did not observe a ready worker" >&2
           return 1
+        fi
         fi
       fi
       ;;
@@ -3967,6 +4299,10 @@ __CLIO_RELAY_RECOVERY_MANIFEST__
       ;;
   esac
   bootstrap_candidate_action recovery-complete
+  if [ "${{BOOTSTRAP_REPAIR_RECOVERY_ACTIVE:-0}}" = "1" ]; then
+    bootstrap_release_worker_lifetime_guard
+    trap - EXIT
+  fi
 }}
 
 bootstrap_relay_only_reconcile() {{
@@ -4134,7 +4470,7 @@ bootstrap_relay_only_reconcile() {{
         "$HOME/.local/bin/uv" tool install --force --python 3.12 --no-config \
           --default-index https://pypi.org/simple "$JARVIS_MCP_ARTIFACT_PATH"
       test -x "$CLIO_KIT_EXECUTABLE"
-      CLIO_KIT_PROVIDER_PYTHON="$(sed -n '1{{s/^#!//;p;}}' "$CLIO_KIT_EXECUTABLE")"
+      CLIO_KIT_PROVIDER_PYTHON="$BOOTSTRAP_GENERATION/tools/clio-kit/bin/python"
       test -x "$CLIO_KIT_PROVIDER_PYTHON"
       test "$("$CLIO_KIT_PROVIDER_PYTHON" -c \
         'from importlib.metadata import version; print(version("clio-kit"))')" = \
@@ -4213,7 +4549,7 @@ __CLIO_RELAY_RECONCILE_PYPI_DIGEST__
         --default-index https://pypi.org/simple --with "$JARVIS_CD_WHEEL" \
         "$RELAY_INSTALL_TARGET"
     RELAY_EXECUTABLE="$BOOTSTRAP_GENERATION/bin/clio-relay"
-    RELAY_PROVIDER_PYTHON="$(sed -n '1{{s/^#!//;p;}}' "$RELAY_EXECUTABLE")"
+    RELAY_PROVIDER_PYTHON="$BOOTSTRAP_GENERATION/tools/clio-relay/bin/python"
     test -x "$RELAY_EXECUTABLE" -a -x "$RELAY_PROVIDER_PYTHON"
     bootstrap_candidate_action jarvis-wrapper \
       "$BOOTSTRAP_GENERATION/bin/jarvis" "$ACTIVE_JARVIS_PYTHON"
@@ -4393,14 +4729,65 @@ from pathlib import Path
 
 info = json.loads(Path(os.environ["BOOTSTRAP_GENERATION"] + "/installation-info.json").read_text())
 runtime = info.get("component_runtime", {{}})
-if not (
-    info.get("receipt_matches_install") is True
-    and runtime.get("clio-relay", {{}}).get("persistent_tool_verified") is True
-    and runtime.get("clio-kit", {{}}).get("persistent_tool_verified") is True
-    and runtime.get("clio-kit", {{}}).get("native_execution_capability_verified") is True
-    and runtime.get("jarvis-cd", {{}}).get("verified") is True
-):
-    raise SystemExit("prepared relay generation runtime identity did not verify")
+jarvis_runtime = runtime.get("jarvis-cd", {{}})
+checks = {{
+    "receipt_matches_install": info.get("receipt_matches_install") is True,
+    "clio-relay.persistent_tool_verified": (
+        runtime.get("clio-relay", {{}}).get("persistent_tool_verified") is True
+    ),
+    "clio-kit.persistent_tool_verified": (
+        runtime.get("clio-kit", {{}}).get("persistent_tool_verified") is True
+    ),
+    "clio-kit.native_execution_capability_verified": (
+        runtime.get("clio-kit", {{}}).get("native_execution_capability_verified") is True
+    ),
+    "jarvis-cd.verified": jarvis_runtime.get("verified") is True,
+}}
+if checks["jarvis-cd.verified"] is False:
+    record_closure = jarvis_runtime.get("execution_record_closure", {{}})
+    record_closure_error_code = (
+        record_closure.get("error_code") if isinstance(record_closure, dict) else None
+    )
+    checks.update({{
+        "jarvis-cd.distribution_identity_verified": (
+            jarvis_runtime.get("distribution_identity_verified") is True
+        ),
+        "jarvis-cd.runtime_artifact_path_verified": (
+            jarvis_runtime.get("runtime_artifact_path_verified") is True
+        ),
+        "jarvis-cd.artifact_sha256_verified": (
+            jarvis_runtime.get("artifact_sha256_verified") is True
+        ),
+        "jarvis-cd.execution_interpreter_verified": (
+            jarvis_runtime.get("execution_interpreter_verified") is True
+        ),
+        "jarvis-cd.execution_record_closure_verified": (
+            jarvis_runtime.get("execution_record_closure_verified") is True
+        ),
+        "jarvis-cd.native_execution_capability_verified": (
+            jarvis_runtime.get("native_execution_capability_verified") is True
+        ),
+        "jarvis-cd.jarvis_executable_verified": (
+            jarvis_runtime.get("jarvis_executable_verified") is True
+        ),
+    }})
+    if (
+        isinstance(record_closure_error_code, str)
+        and 0 < len(record_closure_error_code) <= 96
+        and all(
+            character.isascii() and (character.isalnum() or character == "-")
+            for character in record_closure_error_code
+        )
+    ):
+        checks[
+            "jarvis-cd.execution_record_closure_error." + record_closure_error_code
+        ] = False
+failed_checks = sorted(name for name, verified in checks.items() if not verified)
+if failed_checks:
+    raise SystemExit(
+        "prepared relay generation runtime identity did not verify: "
+        + ", ".join(failed_checks)
+    )
 __CLIO_RELAY_VERIFY_GENERATION__
     unset CLIO_RELAY_INSTALL_RECEIPT
     BOOTSTRAP_LEGACY_IDENTITY_AFTER="$(
@@ -4463,7 +4850,7 @@ __CLIO_RELAY_GENERATION_MANIFEST__
     echo "prepared generation relay launcher is not a symbolic link" >&2
     return 1
   fi
-  RELAY_PROVIDER_PYTHON="$(sed -n '1{{s/^#!//;p;}}' "$RELAY_EXECUTABLE")"
+  RELAY_PROVIDER_PYTHON="$BOOTSTRAP_GENERATION/tools/clio-relay/bin/python"
   if [ ! -x "$RELAY_PROVIDER_PYTHON" ]; then
     echo "prepared generation provider is unavailable" >&2
     return 1
@@ -4647,7 +5034,8 @@ __CLIO_RELAY_STAGED_REPOSITORY_EVIDENCE__
       if BOOTSTRAP_WORKER_EVIDENCE="$(
         CLIO_RELAY_CORE_DIR={rendered_core_dir} \
           "$HOME/.local/bin/clio-relay" endpoint worker-info \
-            --cluster "$WORKER_CLUSTER_NAME" --freshness-seconds 120 2>/dev/null
+            --cluster "$WORKER_CLUSTER_NAME" --freshness-seconds 120 \
+            --readiness-only 2>/dev/null
       )"; then
         export BOOTSTRAP_WORKER_EVIDENCE
         if python3 -c \
@@ -4678,7 +5066,7 @@ __CLIO_RELAY_STAGED_REPOSITORY_EVIDENCE__
 
   BOOTSTRAP_COMPLETED_NS="$(python3 -c 'import time; print(time.monotonic_ns())')"
   export BOOTSTRAP_COMPLETED_NS
-  "$CURRENT_RELAY_PROVIDER" - <<'__CLIO_RELAY_RECONCILE_RECEIPT__'
+  bootstrap_provider_exec - <<'__CLIO_RELAY_RECONCILE_RECEIPT__'
 import json
 import os
 from datetime import datetime
@@ -4823,6 +5211,7 @@ bootstrap_repair_transaction_exit() {{
   if [ "$status" -ne 0 ]; then
     echo "bootstrap readiness repair did not complete; queue migration state is retained" >&2
   fi
+  bootstrap_restore_fenced_worker_on_failure "$status"
   bootstrap_release_worker_lifetime_guard 2>/dev/null || true
   bootstrap_cleanup_preparing_root || true
   exit "$status"
@@ -4872,6 +5261,15 @@ bootstrap_reuse_repair() {{
 
   bootstrap_candidate_action journal-advance fenced
   bootstrap_candidate_action journal-advance activating
+  BOOTSTRAP_JARVIS_BINDING_REPAIR="$(
+    bootstrap_candidate_action repair-managed-binding
+  )"
+  export BOOTSTRAP_JARVIS_BINDING_REPAIR
+  BOOTSTRAP_JARVIS_BINDING_REPAIR_SHA256="$(
+    printf '%s' "$BOOTSTRAP_JARVIS_BINDING_REPAIR" | sha256sum | awk '{{print $1}}'
+  )"
+  bootstrap_candidate_action journal-phase managed_repository_repaired \
+    "$BOOTSTRAP_JARVIS_BINDING_REPAIR_SHA256"
   bootstrap_candidate_action journal-advance activated
   bootstrap_candidate_action journal-advance migration_started
   trap bootstrap_repair_transaction_exit EXIT
@@ -4941,7 +5339,8 @@ bootstrap_reuse_repair() {{
       if BOOTSTRAP_WORKER_EVIDENCE="$(
         CLIO_RELAY_CORE_DIR={rendered_core_dir} \
           "$HOME/.local/bin/clio-relay" endpoint worker-info \
-            --cluster "$WORKER_CLUSTER_NAME" --freshness-seconds 120 2>/dev/null
+            --cluster "$WORKER_CLUSTER_NAME" --freshness-seconds 120 \
+            --readiness-only 2>/dev/null
       )"; then
         export BOOTSTRAP_WORKER_EVIDENCE
         if python3 -c \
@@ -4967,7 +5366,8 @@ bootstrap_reuse_repair() {{
   bootstrap_candidate_action journal-advance committed
   BOOTSTRAP_COMPLETED_NS="$(python3 -c 'import time; print(time.monotonic_ns())')"
   export BOOTSTRAP_COMPLETED_NS
-  CURRENT_RELAY_PROVIDER="$(sed -n '1{{s/^#!//;p;}}' "$HOME/.local/bin/clio-relay")"
+  CURRENT_RELAY_PROVIDER="$BOOTSTRAP_CURRENT_PROVIDER"
+  test -x "$CURRENT_RELAY_PROVIDER"
   "$CURRENT_RELAY_PROVIDER" - <<'__CLIO_RELAY_REPAIR_RECEIPT__'
 import json
 import os
@@ -4977,6 +5377,7 @@ from pathlib import Path
 from clio_relay.bootstrap_reconcile import (
     BootstrapDesiredState,
     BootstrapTransactionJournal,
+    JarvisStateEvidence,
     inspect_exact_bootstrap_noop,
     make_bootstrap_receipt,
     write_bootstrap_receipt,
@@ -4998,6 +5399,14 @@ inspection = inspect_exact_bootstrap_noop(
 )
 if not inspection.exact_match:
     raise SystemExit("readiness repair did not pass exact inspection: " + repr(inspection.reasons))
+binding_repair = json.loads(os.environ["BOOTSTRAP_JARVIS_BINDING_REPAIR"])
+if (
+    binding_repair.get("schema_version") != "clio-relay.bootstrap-binding-repair.v1"
+    or binding_repair.get("after") != inspection.jarvis_state.model_dump(mode="json")
+    or not isinstance(binding_repair.get("before"), dict)
+    or not isinstance(binding_repair.get("binding"), dict)
+):
+    raise SystemExit("readiness repair JARVIS binding evidence is invalid")
 started_ns = int(os.environ["BOOTSTRAP_INVOCATION_STARTED_NS"])
 completed_ns = int(os.environ["BOOTSTRAP_COMPLETED_NS"])
 duration = (completed_ns - started_ns) / 1_000_000_000
@@ -5022,6 +5431,8 @@ receipt = make_bootstrap_receipt(
     queue_duration_seconds=(
         int(os.environ["BOOTSTRAP_QUEUE_DURATION_NS"]) / 1_000_000_000
     ),
+    jarvis_state_before=JarvisStateEvidence.model_validate(binding_repair["before"]),
+    jarvis_repo_reconciliation=binding_repair["binding"],
     payload_transfer_count=int(os.environ["BOOTSTRAP_PAYLOAD_TRANSFER_COUNT"]),
     payload_transfer_bytes=int(os.environ["BOOTSTRAP_PAYLOAD_TRANSFER_BYTES"]),
 )
@@ -5224,6 +5635,45 @@ while IFS= read -r variable_name; do
   esac
 done < <(compgen -e)
 mkdir -p "$HOME/.local/bin" "$HOME/.local/src" "$HOME/.local/share/clio-relay"
+bootstrap_active_generation_identity() {{
+  local current target prefix identity
+  current="$HOME/.local/share/clio-relay/current"
+  if [ ! -L "$current" ]; then
+    echo "bootstrap current generation pointer is not a symbolic link" >&2
+    return 1
+  fi
+  target="$(readlink -f "$current")"
+  prefix="$(readlink -f "$HOME/.local/share/clio-relay/generations")/"
+  case "$target" in
+    "$prefix"*) identity="${{target#"$prefix"}}" ;;
+    *)
+      echo "bootstrap current pointer does not name one managed generation" >&2
+      return 1
+      ;;
+  esac
+  case "$identity" in
+    (*[!0-9a-f]*|'')
+      echo "bootstrap current generation identity is invalid" >&2
+      return 1
+      ;;
+  esac
+  if [ "${{#identity}}" -ne 64 ]; then
+    echo "bootstrap current generation identity has an invalid length" >&2
+    return 1
+  fi
+  echo "$identity"
+}}
+bootstrap_active_generation_provider() {{
+  local identity generations provider
+  identity="$(bootstrap_active_generation_identity)" || return 1
+  generations="$(readlink -f "$HOME/.local/share/clio-relay/generations")"
+  provider="$generations/$identity/tools/clio-relay/bin/python"
+  if [ ! -f "$provider" ] || [ ! -x "$provider" ]; then
+    echo "bootstrap active generation provider is unavailable" >&2
+    return 1
+  fi
+  echo "$provider"
+}}
 command -v flock >/dev/null 2>&1 || {{
   echo "flock is required to serialize clio-relay bootstrap" >&2
   exit 1
@@ -5540,7 +5990,12 @@ __CLIO_RELAY_RECEIPT_CLASSIFY__
   fi
 fi
 if [ -x "$BOOTSTRAP_CURRENT_RELAY" ]; then
-  BOOTSTRAP_CURRENT_PROVIDER="$(sed -n '1{{s/^#!//;p;}}' "$BOOTSTRAP_CURRENT_RELAY")"
+  BOOTSTRAP_CURRENT_PROVIDER="$(bootstrap_active_generation_provider 2>/dev/null || true)"
+  if [ -z "$BOOTSTRAP_CURRENT_PROVIDER" ] && \
+     [ -f "$UV_TOOL_DIR/clio-relay/bin/python" ] && \
+     [ -x "$UV_TOOL_DIR/clio-relay/bin/python" ]; then
+    BOOTSTRAP_CURRENT_PROVIDER="$UV_TOOL_DIR/clio-relay/bin/python"
+  fi
 fi
 if [ "$BOOTSTRAP_RECOVERY_REQUIRED" = "0" ] && \
    [ "$BOOTSTRAP_LEGACY_RELAY_PROVIDER" = "0" ] && \
@@ -5575,7 +6030,7 @@ if [ "$BOOTSTRAP_RECOVERY_REQUIRED" = "0" ] && \
           CLIO_RELAY_CORE_DIR={rendered_core_dir} \
             timeout 20 "$BOOTSTRAP_CURRENT_RELAY" endpoint worker-info \
               --cluster {shlex.quote(cluster or "")} --freshness-seconds 120 \
-              2>/dev/null || true
+              --readiness-only 2>/dev/null || true
         )"
       fi
     fi
@@ -6498,7 +6953,7 @@ JARVIS_MCP_UV_EXECUTABLE="$(command -v uv)"
 test -x "$JARVIS_MCP_UV_EXECUTABLE"
 JARVIS_MCP_EXECUTABLE="$(uv tool dir --bin --no-config)/clio-kit"
 test -x "$JARVIS_MCP_EXECUTABLE"
-JARVIS_MCP_PROVIDER_PYTHON="$(sed -n '1{{s/^#!//;p;}}' "$JARVIS_MCP_EXECUTABLE")"
+JARVIS_MCP_PROVIDER_PYTHON="$UV_TOOL_DIR/clio-kit/bin/python"
 test -x "$JARVIS_MCP_PROVIDER_PYTHON"
 JARVIS_MCP_INSTALLED_VERSION="$("$JARVIS_MCP_PROVIDER_PYTHON" -c \
   'from importlib.metadata import version; print(version("clio-kit"))')"
@@ -6592,7 +7047,7 @@ RELAY_UV_EXECUTABLE="$(command -v uv)"
 test -x "$RELAY_UV_EXECUTABLE"
 RELAY_EXECUTABLE="$(uv tool dir --bin --no-config)/clio-relay"
 test -x "$RELAY_EXECUTABLE"
-RELAY_PROVIDER_PYTHON="$(sed -n '1{{s/^#!//;p;}}' "$RELAY_EXECUTABLE")"
+RELAY_PROVIDER_PYTHON="$UV_TOOL_DIR/clio-relay/bin/python"
 test -x "$RELAY_PROVIDER_PYTHON"
 uv pip install --python "$JARVIS_VENV/bin/python" \\
   --default-index https://pypi.org/simple \\
@@ -7284,7 +7739,8 @@ if [ "$BOOTSTRAP_SERVICE_ACTIVE_AFTER" = "1" ]; then
     if BOOTSTRAP_WORKER_EVIDENCE="$(
       CLIO_RELAY_CORE_DIR={rendered_core_dir} \
         "$HOME/.local/bin/clio-relay" endpoint worker-info \
-          --cluster "$WORKER_CLUSTER_NAME" --freshness-seconds 120 2>/dev/null
+          --cluster "$WORKER_CLUSTER_NAME" --freshness-seconds 120 \
+          --readiness-only 2>/dev/null
     )"; then
       export BOOTSTRAP_WORKER_EVIDENCE
       if python3 -c \

--- a/src/clio_relay/bootstrap_reconcile.py
+++ b/src/clio_relay/bootstrap_reconcile.py
@@ -13,6 +13,7 @@ import hashlib
 import json
 import os
 import shlex
+import shutil
 import stat
 import subprocess
 import sys
@@ -38,6 +39,7 @@ from clio_relay.validation_report import sha256_file
 from clio_relay.worker_lifetime_lock import (
     WorkerLifetimeLock,
     WorkerLifetimeLockUnavailable,
+    exclusive_migration_lifetime,
 )
 
 BOOTSTRAP_DESIRED_STATE_SCHEMA = "clio-relay.bootstrap-desired-state.v1"
@@ -56,6 +58,72 @@ _FCHMOD = cast(
 _GETUID = cast(Callable[[], int] | None, getattr(os, "getuid", None))
 _AT_FDCWD = -100
 _RENAME_EXCHANGE = 2
+
+
+def repair_legacy_cursor_permissions_for_upgrade(core_dir: Path) -> dict[str, object]:
+    """Privatize the fixed legacy cursor directory through a pinned queue root.
+
+    Forward recovery can execute a generation whose queue initializer predates
+    cursor-directory repair. The current candidate calls this compatibility
+    operation while holding the inherited exclusive writer-lifetime guard, so
+    the old generation can finish its journal before the candidate replaces it.
+    Missing cursors are a no-op; links, foreign ownership, and identity changes
+    fail closed.
+    """
+    if os.name != "posix" or _FCHMOD is None or _GETUID is None:
+        raise ConfigurationError("legacy cursor permission repair requires POSIX fchmod")
+    with exclusive_migration_lifetime(core_dir) as locked_core:
+        root_descriptor = locked_core.filesystem_root_descriptor
+        if root_descriptor is None:
+            raise ConfigurationError("legacy cursor permission repair has no pinned root")
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+        flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open("cursors", flags, dir_fd=root_descriptor)
+        except FileNotFoundError:
+            return {
+                "schema_version": "clio-relay.bootstrap-legacy-cursor-repair.v1",
+                "action": "absent",
+            }
+        except OSError as exc:
+            raise ConfigurationError(
+                "legacy cursor directory cannot be safely opened through the pinned root"
+            ) from exc
+        try:
+            try:
+                os.set_inheritable(descriptor, False)
+                before = os.fstat(descriptor)
+                if not stat.S_ISDIR(before.st_mode) or before.st_uid != _GETUID():
+                    raise ConfigurationError(
+                        "legacy cursor directory is not one owned real directory"
+                    )
+                action = "reused"
+                if stat.S_IMODE(before.st_mode) != 0o700:
+                    _FCHMOD(descriptor, 0o700)
+                    action = "repaired"
+                after = os.fstat(descriptor)
+                if (
+                    (after.st_dev, after.st_ino) != (before.st_dev, before.st_ino)
+                    or not stat.S_ISDIR(after.st_mode)
+                    or after.st_uid != _GETUID()
+                    or stat.S_IMODE(after.st_mode) != 0o700
+                ):
+                    raise ConfigurationError(
+                        "legacy cursor directory identity changed during permission repair"
+                    )
+                return {
+                    "schema_version": "clio-relay.bootstrap-legacy-cursor-repair.v1",
+                    "action": action,
+                    "device": after.st_dev,
+                    "inode": after.st_ino,
+                }
+            except OSError as exc:
+                raise ConfigurationError(
+                    "legacy cursor directory permissions could not be repaired"
+                ) from exc
+        finally:
+            with suppress(OSError):
+                os.close(descriptor)
 
 
 @contextmanager
@@ -625,21 +693,27 @@ def execution_environment_identity(
     executables: dict[str, Path],
 ) -> dict[str, object]:
     """Identify a reused execution boundary without scanning or copying its tree."""
+    lexical_root = Path(os.path.abspath(root.expanduser()))
     try:
-        root_details = root.lstat()
+        root_details = lexical_root.lstat()
     except OSError as exc:
         raise ConfigurationError("execution environment is unavailable") from exc
-    if root.is_symlink() or not root.is_dir():
+    if lexical_root.is_symlink() or not lexical_root.is_dir():
         raise ConfigurationError("execution environment is not one owned directory")
     identities: dict[str, object] = {}
-    resolved_root = root.resolve(strict=True)
+    resolved_root = lexical_root.resolve(strict=True)
     for name, executable in sorted(executables.items()):
         try:
-            lexical = executable.absolute()
-            lexical.relative_to(root.absolute())
+            lexical = Path(os.path.abspath(executable.expanduser()))
             before = lexical.lstat()
+            located = lexical.parent.resolve(strict=True) / lexical.name
             resolved = lexical.resolve(strict=True)
-            if not resolved.is_file() or not os.access(resolved, os.X_OK):
+            if (
+                located == resolved_root
+                or not located.is_relative_to(resolved_root)
+                or not resolved.is_file()
+                or not os.access(resolved, os.X_OK)
+            ):
                 raise ConfigurationError(f"execution boundary executable is invalid: {name}")
             digest = sha256_file(resolved)
             if _stat_identity(lexical.lstat()) != _stat_identity(before):
@@ -652,13 +726,13 @@ def execution_environment_identity(
             "sha256": digest,
             "size_bytes": resolved.stat().st_size,
         }
-    config_path = root / "pyvenv.cfg"
+    config_path = lexical_root / "pyvenv.cfg"
     config_sha256 = sha256_file(config_path) if config_path.is_file() else None
-    if _stat_identity(root.lstat()) != _stat_identity(root_details):
+    if _stat_identity(lexical_root.lstat()) != _stat_identity(root_details):
         raise ConfigurationError("execution environment changed during inspection")
     return {
         "schema_version": "clio-relay.execution-boundary.v1",
-        "root": str(resolved_root),
+        "root": str(lexical_root),
         "root_identity": {
             "device": root_details.st_dev,
             "inode": root_details.st_ino,
@@ -750,9 +824,9 @@ def inspect_exact_bootstrap_noop(
     The caller obtains systemd state and invokes the bounded queue/worker read
     commands.  No scheduler command is part of this contract.
     """
-    resolved_home = (home or Path.home()).resolve()
+    lexical_home = Path(os.path.abspath((home or Path.home()).expanduser()))
     reasons: list[str] = []
-    receipt_path = resolved_home / ".local/share/clio-relay/install-receipt.json"
+    receipt_path = lexical_home / ".local/share/clio-relay/install-receipt.json"
     install_receipt_sha256: str | None = None
     info: dict[str, object] | None = installation_snapshot
     try:
@@ -765,25 +839,25 @@ def inspect_exact_bootstrap_noop(
         _inspect_installation_identity(desired, info, reasons)
     active_generation, current_generation_target = _inspect_active_generation(
         desired,
-        home=resolved_home,
+        home=lexical_home,
         installation=info,
         reasons=reasons,
     )
 
     _verify_binary(
-        resolved_home / ".local/bin/frpc",
+        lexical_home / ".local/bin/frpc",
         desired.frpc_sha256,
         label="frpc",
         reasons=reasons,
     )
     _verify_binary(
-        resolved_home / ".local/bin/frps",
+        lexical_home / ".local/bin/frps",
         desired.frps_sha256,
         label="frps",
         reasons=reasons,
     )
-    _verify_uv(resolved_home / ".local/bin/uv", desired=desired, reasons=reasons)
-    jarvis_state = inspect_jarvis_state(desired, home=resolved_home)
+    _verify_uv(lexical_home / ".local/bin/uv", desired=desired, reasons=reasons)
+    jarvis_state = inspect_jarvis_state(desired, home=lexical_home)
     if not jarvis_state.initialized:
         reasons.append("JARVIS is not initialized")
     if not jarvis_state.managed_repo_registered:
@@ -837,8 +911,8 @@ def inspect_jarvis_state(
     home: Path | None = None,
 ) -> JarvisStateEvidence:
     """Validate initialized JARVIS roots and hash operator-owned state read-only."""
-    resolved_home = (home or Path.home()).resolve()
-    jarvis_root = _expand_home(desired.jarvis_root, resolved_home)
+    lexical_home = Path(os.path.abspath((home or Path.home()).expanduser()))
+    jarvis_root = _expand_home(desired.jarvis_root, lexical_home)
     config_file = jarvis_root / "jarvis_config.yaml"
     repos_file = jarvis_root / "repos.yaml"
     resource_graph_file = jarvis_root / "resource_graph.yaml"
@@ -902,8 +976,15 @@ def inspect_jarvis_state(
         not isinstance(value, str) or not value for value in typed_repo_values
     ):
         raise ConfigurationError("JARVIS repositories must contain a string list")
-    managed_repo = str(_expand_home(desired.managed_jarvis_repo, resolved_home).absolute())
+    managed_repo_path = _expand_home(desired.managed_jarvis_repo, lexical_home)
+    managed_repo = str(_canonical_path_preserving_final(managed_repo_path))
+    managed_aliases = {str(managed_repo_path.absolute()), managed_repo}
     repo_values = cast(list[str], raw_repo_values)
+    managed_matches = [value for value in repo_values if value in managed_aliases]
+    if len(managed_matches) > 1:
+        raise ConfigurationError(
+            "relay-managed JARVIS repository is registered through multiple path aliases"
+        )
     return JarvisStateEvidence(
         initialized=True,
         root=str(jarvis_root),
@@ -911,7 +992,7 @@ def inspect_jarvis_state(
         config_sha256=hashlib.sha256(raw_config).hexdigest(),
         repos_sha256=hashlib.sha256(raw_repos).hexdigest(),
         resource_graph_sha256=hashlib.sha256(raw_graph).hexdigest(),
-        managed_repo_registered=managed_repo in repo_values,
+        managed_repo_registered=len(managed_matches) == 1,
     )
 
 
@@ -1016,13 +1097,24 @@ def inspect_prepared_generation(
         raise ConfigurationError("prepared generation omitted runtime identity")
     typed_receipt = cast(dict[str, object], receipt)
     typed_runtime = cast(dict[str, object], runtime)
-    if not (
-        info.get("receipt_matches_install") is True
-        and typed_receipt.get("deployment_fingerprint") == desired.fingerprint
-        and typed_receipt.get("deployment_manifest") == desired.model_dump(mode="json")
-        and typed_receipt.get("generation") == desired.fingerprint
-    ):
-        raise ConfigurationError("prepared generation install receipt identity changed")
+    receipt_checks = {
+        "receipt_matches_install": info.get("receipt_matches_install") is True,
+        "deployment_fingerprint": (
+            typed_receipt.get("deployment_fingerprint") == desired.fingerprint
+        ),
+        "deployment_manifest": (
+            typed_receipt.get("deployment_manifest") == desired.model_dump(mode="json")
+        ),
+        "generation": typed_receipt.get("generation") == desired.fingerprint,
+    }
+    failed_receipt_checks = sorted(
+        name for name, verified in receipt_checks.items() if not verified
+    )
+    if failed_receipt_checks:
+        raise ConfigurationError(
+            "prepared generation install receipt identity changed: "
+            + ", ".join(failed_receipt_checks)
+        )
     raw_artifacts = typed_receipt.get("component_artifacts")
     raw_jarvis_artifact = (
         cast(dict[str, object], raw_artifacts).get("jarvis-cd")
@@ -1161,6 +1253,11 @@ def finish_staged_activation(
         expected=expected_managed_target,
         label="relay-managed repository",
     )
+    canonical_home = lexical_home.resolve(strict=True)
+    reported_managed_repo = canonical_home / ".local/share/clio-relay/managed-jarvis-repo"
+    reported_managed_target = (
+        canonical_home / ".local/share/clio-relay/current/source/jarvis-packages/clio_relay"
+    )
     actions = activation.get("actions")
     if not isinstance(actions, dict):  # pragma: no cover - produced above
         raise ConfigurationError("staged activation omitted link actions")
@@ -1170,8 +1267,8 @@ def finish_staged_activation(
         "activation": activation,
         "jarvis_repository": {
             "link_action": cast(dict[str, object], actions).get("managed_repo"),
-            "link": str(managed_repo),
-            "target": os.readlink(managed_repo),
+            "link": str(reported_managed_repo),
+            "target": str(reported_managed_target),
             "repositories": repositories,
         },
     }
@@ -1308,11 +1405,22 @@ def _verify_bootstrap_replacement_provider(
             identity.provider_interpreter
         ).resolve(strict=True) != current_provider.resolve(strict=True):
             raise ConfigurationError("candidate planner is not running under its attested provider")
-        expected_uv = root_lexical / "pinned-uv"
-        if Path(identity.uv_executable).absolute() != expected_uv or expected_uv.resolve(
-            strict=True
-        ) != Path(identity.uv_executable).resolve(strict=True):
-            raise ConfigurationError("candidate replacement did not use the pinned uv executable")
+        expected_uv_lexical = root_lexical / "pinned-uv"
+        expected_uv_details = expected_uv_lexical.lstat()
+        expected_uv = expected_uv_lexical.resolve(strict=True)
+        observed_uv = Path(identity.uv_executable).resolve(strict=True)
+        if (
+            expected_uv_lexical.is_symlink()
+            or not stat.S_ISREG(expected_uv_details.st_mode)
+            or expected_uv.parent != root
+            or expected_uv != observed_uv
+        ):
+            raise ConfigurationError(
+                "candidate replacement did not use the pinned uv executable: "
+                f"expected={expected_uv}, observed={observed_uv}, root={root}, "
+                f"lexical_symlink={expected_uv_lexical.is_symlink()}, "
+                f"regular={stat.S_ISREG(expected_uv_details.st_mode)}"
+            )
         environment = Path(identity.environment_prefix).resolve(strict=True)
         imported_module = Path(__file__).resolve(strict=True)
         provider_target = current_provider.resolve(strict=True)
@@ -1339,13 +1447,28 @@ def _verify_bootstrap_replacement_provider(
         identity.record_path,
     )
     try:
-        if any(
-            (lexical := Path(os.path.abspath(Path(value).expanduser()))) == root
-            or not lexical.is_relative_to(root)
-            or not lexical.exists()
-            for value in staged_paths
-        ):
-            raise ConfigurationError("candidate replacement runtime escaped its preparing root")
+        escaped_paths: list[dict[str, str]] = []
+        for value in staged_paths:
+            lexical = Path(os.path.abspath(Path(value).expanduser()))
+            located = lexical.parent.resolve(strict=True) / lexical.name
+            if (
+                not lexical.is_absolute()
+                or ".." in lexical.parts
+                or located == root
+                or not located.is_relative_to(root)
+                or not lexical.exists()
+            ):
+                escaped_paths.append(
+                    {
+                        "lexical": str(lexical)[:512],
+                        "located": str(located)[:512],
+                    }
+                )
+        if escaped_paths:
+            raise ConfigurationError(
+                "candidate replacement runtime escaped its preparing root: "
+                + json.dumps(escaped_paths[:16], sort_keys=True, separators=(",", ":"))
+            )
     except (OSError, RuntimeError, ValueError) as exc:
         raise ConfigurationError("candidate replacement runtime path is unavailable") from exc
     if imported_module == environment or not imported_module.is_relative_to(environment):
@@ -1443,7 +1566,9 @@ def plan_bootstrap_reconcile(
         if isinstance(raw_relay_executables, dict):
             relay_executable = cast(dict[str, object], raw_relay_executables).get("clio-relay")
     expected_relay_executable = lexical_home / ".local/bin/clio-relay"
-    if not isinstance(relay_executable, str) or relay_executable != str(expected_relay_executable):
+    if not replacement_verified and (
+        not isinstance(relay_executable, str) or relay_executable != str(expected_relay_executable)
+    ):
         return _full_plan(desired, "clio-relay launcher is not bound to its install receipt")
     expected_components = {
         "clio-kit": (desired.clio_kit_version, desired.clio_kit_artifact_sha256),
@@ -1514,12 +1639,13 @@ def plan_bootstrap_reconcile(
             )
         ):
             reasons.append("clio-kit live runtime is not reusable")
-    jarvis_runtime = runtime.get("jarvis-cd")
-    if (
-        not isinstance(jarvis_runtime, dict)
-        or cast(dict[str, object], jarvis_runtime).get("verified") is not True
-    ):
-        reasons.append("JARVIS-CD live execution runtime is not reusable")
+    if "jarvis-cd" not in upgrade_components:
+        jarvis_runtime = runtime.get("jarvis-cd")
+        if (
+            not isinstance(jarvis_runtime, dict)
+            or cast(dict[str, object], jarvis_runtime).get("verified") is not True
+        ):
+            reasons.append("JARVIS-CD live execution runtime is not reusable")
 
     _verify_binary(
         resolved_home / ".local/bin/frpc",
@@ -1557,7 +1683,20 @@ def plan_bootstrap_reconcile(
         else legacy_python.parent / ("jarvis.exe" if os.name == "nt" else "jarvis")
     )
     lexical_legacy_venv = legacy_python.parent.parent
+    supported_execution_roots: set[Path] = set()
     supported_legacy_venv = resolved_home / ".local/share/clio-relay/jarvis-venv"
+    try:
+        if supported_legacy_venv.is_dir() and not _path_is_directory_alias(supported_legacy_venv):
+            supported_execution_roots.add(supported_legacy_venv.resolve(strict=True))
+    except (OSError, RuntimeError, ValueError):
+        pass
+    managed_execution_root = _managed_generation_jarvis_environment(
+        receipt,
+        execution_environment=lexical_legacy_venv,
+        home=resolved_home,
+    )
+    if managed_execution_root is not None:
+        supported_execution_roots.add(managed_execution_root)
     expected_legacy_executable = legacy_python.parent / (
         "jarvis.exe" if os.name == "nt" else "jarvis"
     )
@@ -1567,7 +1706,6 @@ def plan_bootstrap_reconcile(
         legacy_executable_before = legacy_executable.lstat()
         expected_executable_before = expected_legacy_executable.lstat()
         resolved_legacy_venv = lexical_legacy_venv.resolve(strict=True)
-        resolved_supported_venv = supported_legacy_venv.resolve(strict=True)
         resolved_legacy_python_target = legacy_python.resolve(strict=True)
         legacy_python_target_before = resolved_legacy_python_target.lstat()
         resolved_legacy_executable = legacy_executable.resolve(strict=True)
@@ -1581,7 +1719,7 @@ def plan_bootstrap_reconcile(
             lexical_legacy_venv.is_absolute()
             and ".." not in lexical_legacy_venv.parts
             and not lexical_legacy_venv.is_symlink()
-            and resolved_legacy_venv == resolved_supported_venv
+            and resolved_legacy_venv in supported_execution_roots
             and legacy_python.is_file()
             and expected_legacy_executable.is_file()
             and bool(executable_payload)
@@ -1679,6 +1817,102 @@ def plan_bootstrap_reconcile(
     )
 
 
+def _path_is_directory_alias(path: Path) -> bool:
+    """Return whether a directory path is a symbolic-link or junction alias."""
+    if path.is_symlink():
+        return True
+    is_junction = getattr(path, "is_junction", None)
+    return bool(is_junction()) if callable(is_junction) else False
+
+
+def _managed_generation_jarvis_environment(
+    receipt: dict[str, object],
+    *,
+    execution_environment: Path,
+    home: Path,
+) -> Path | None:
+    """Return a receipt-bound relay generation's real JARVIS execution root.
+
+    Relay-only generations intentionally retain the JARVIS environment from
+    the preceding component generation.  The active receipt therefore binds
+    both the active generation and an execution root that may belong to a
+    different retained generation.
+    """
+    active_generation = receipt.get("generation")
+    if not isinstance(active_generation, str) or not _is_sha256(active_generation):
+        return None
+    relay_root = home / ".local/share/clio-relay"
+    generations_root = relay_root / "generations"
+    active_generation_root = generations_root / active_generation
+    current = relay_root / "current"
+    environment = Path(os.path.abspath(execution_environment.expanduser()))
+    try:
+        current_before = current.lstat()
+        generations_before = generations_root.lstat()
+        active_generation_before = active_generation_root.lstat()
+        environment_before = environment.lstat()
+        if (
+            not _path_is_directory_alias(current)
+            or not stat.S_ISDIR(generations_before.st_mode)
+            or _path_is_directory_alias(generations_root)
+            or not stat.S_ISDIR(active_generation_before.st_mode)
+            or _path_is_directory_alias(active_generation_root)
+            or not stat.S_ISDIR(environment_before.st_mode)
+            or _path_is_directory_alias(environment)
+            or not environment.is_absolute()
+            or ".." in environment.parts
+        ):
+            return None
+        resolved_generations = generations_root.resolve(strict=True)
+        resolved_active_generation = active_generation_root.resolve(strict=True)
+        resolved_environment = environment.resolve(strict=True)
+        if current.resolve(strict=True) != resolved_active_generation:
+            return None
+        relative_environment = resolved_environment.relative_to(resolved_generations)
+        if (
+            len(relative_environment.parts) != 2
+            or relative_environment.parts[1] != "jarvis-venv"
+            or not _is_sha256(relative_environment.parts[0])
+        ):
+            return None
+        execution_generation_root = generations_root / relative_environment.parts[0]
+        execution_generation_before = execution_generation_root.lstat()
+        if (
+            not stat.S_ISDIR(execution_generation_before.st_mode)
+            or _path_is_directory_alias(execution_generation_root)
+            or execution_generation_root.resolve(strict=True) != resolved_environment.parent
+        ):
+            return None
+        current_after = current.lstat()
+        generations_after = generations_root.lstat()
+        active_generation_after = active_generation_root.lstat()
+        execution_generation_after = execution_generation_root.lstat()
+        environment_after = environment.lstat()
+        if (
+            _stat_identity(current_after) != _stat_identity(current_before)
+            or _stat_identity(generations_after) != _stat_identity(generations_before)
+            or _stat_identity(active_generation_after) != _stat_identity(active_generation_before)
+            or _stat_identity(execution_generation_after)
+            != _stat_identity(execution_generation_before)
+            or _stat_identity(environment_after) != _stat_identity(environment_before)
+        ):
+            return None
+        getuid = getattr(os, "getuid", None)
+        if callable(getuid) and any(
+            details.st_uid != getuid()
+            for details in (
+                generations_after,
+                active_generation_after,
+                execution_generation_after,
+                environment_after,
+            )
+        ):
+            return None
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return resolved_environment
+
+
 def _full_plan(desired: BootstrapDesiredState, reason: str) -> BootstrapReconcilePlan:
     return BootstrapReconcilePlan(
         mode="full",
@@ -1723,8 +1957,11 @@ def _verify_jarvis_util_reuse(
         )
         if commit != desired.jarvis_util_commit or status:
             raise ConfigurationError("jarvis-util checkout commit or cleanliness changed")
+        receipt_python = reusable_paths.get("jarvis-cd_execution_interpreter")
         legacy_python = (
-            home
+            Path(receipt_python).expanduser()
+            if receipt_python is not None
+            else home
             / ".local/share/clio-relay/jarvis-venv"
             / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
         )
@@ -2141,7 +2378,8 @@ def _managed_repository_payload(
     raw: bytes,
     *,
     managed: str,
-    previous: set[str],
+    managed_aliases: set[str],
+    previous_aliases: dict[str, str],
 ) -> tuple[bytes, list[str], list[str]]:
     """Return the exact converged repository bytes and mutation evidence."""
     document = _yaml_mapping(raw, label="JARVIS repositories")
@@ -2152,21 +2390,29 @@ def _managed_repository_payload(
     ):
         raise ConfigurationError("JARVIS repositories must contain a string list")
     repos = list(cast(list[str], raw_repos))
-    managed_count = repos.count(managed)
-    if managed_count > 1:
-        raise ConfigurationError("relay-managed JARVIS repository is registered more than once")
-    if any(repos.count(value) > 1 for value in previous):
+    managed_matches = [value for value in repos if value in managed_aliases]
+    if len(managed_matches) > 1:
         raise ConfigurationError(
-            "a proven previous relay-managed JARVIS repository is registered more than once"
+            "relay-managed JARVIS repository is registered through multiple path aliases"
         )
-    removed_previous = sorted(previous.intersection(repos))
-    if managed_count == 1 and not removed_previous:
+    previous_matches: dict[str, list[str]] = {}
+    for value in repos:
+        normalized = previous_aliases.get(value)
+        if normalized is not None:
+            previous_matches.setdefault(normalized, []).append(value)
+    if any(len(values) > 1 for values in previous_matches.values()):
+        raise ConfigurationError(
+            "a proven previous relay-managed JARVIS repository is registered through "
+            "multiple path aliases"
+        )
+    removed_previous = sorted(previous_matches)
+    if managed_matches == [managed] and not removed_previous:
         return raw, [], []
-    updated = [value for value in repos if value not in previous]
-    added_managed: list[str] = []
-    if managed_count == 0:
-        updated.insert(0, managed)
-        added_managed.append(managed)
+    updated = [
+        value for value in repos if value not in managed_aliases and value not in previous_aliases
+    ]
+    updated.insert(0, managed)
+    added_managed = [managed] if managed_matches != [managed] else []
     document["repos"] = updated
     return (
         yaml.safe_dump(document, sort_keys=False).encode("utf-8"),
@@ -2193,9 +2439,20 @@ def reconcile_managed_jarvis_repository(
     bootstrap lock; the final byte-and-file-identity comparison also detects
     non-cooperating writers before the atomic replacement.
     """
-    managed = str(managed_repo.absolute())
-    previous = {str(path.absolute()) for path in previous_managed_repos}
-    previous.discard(managed)
+    lexical_managed = str(Path(os.path.abspath(managed_repo.expanduser())))
+    managed = str(_canonical_path_preserving_final(managed_repo))
+    managed_aliases = {lexical_managed, managed}
+    previous_aliases: dict[str, str] = {}
+    for path in previous_managed_repos:
+        lexical_previous = str(Path(os.path.abspath(path.expanduser())))
+        try:
+            canonical_previous = str(_canonical_path_preserving_final(path))
+        except ConfigurationError:
+            canonical_previous = lexical_previous
+        if canonical_previous in managed_aliases:
+            continue
+        previous_aliases[lexical_previous] = canonical_previous
+        previous_aliases[canonical_previous] = canonical_previous
     token = exchange_identity or hashlib.sha256(managed.encode("utf-8")).hexdigest()
     try:
         _require_sha256(token, field="repository_exchange_identity")
@@ -2209,7 +2466,8 @@ def reconcile_managed_jarvis_repository(
     payload, added_managed, removed_previous = _managed_repository_payload(
         raw,
         managed=managed,
-        previous=previous,
+        managed_aliases=managed_aliases,
+        previous_aliases=previous_aliases,
     )
     if temporary.exists() or temporary.is_symlink():
         displaced, _displaced_identity = _read_regular_bounded_with_identity(
@@ -2219,7 +2477,8 @@ def reconcile_managed_jarvis_repository(
         displaced_payload, displaced_added, displaced_removed = _managed_repository_payload(
             displaced,
             managed=managed,
-            previous=previous,
+            managed_aliases=managed_aliases,
+            previous_aliases=previous_aliases,
         )
         if displaced != displaced_payload and displaced_payload == raw:
             temporary.unlink()
@@ -2339,7 +2598,12 @@ def repair_managed_jarvis_binding(
     resolved_home = lexical_home.resolve(strict=True)
     generation_path = lexical_home / ".local/share/clio-relay/generations" / desired.fingerprint
     generation = generation_path.resolve(strict=True)
-    if generation_path.is_symlink() or generation != generation_path:
+    generations = (lexical_home / ".local/share/clio-relay/generations").resolve(strict=True)
+    if (
+        generation_path.is_symlink()
+        or generation.parent != generations
+        or generation.name != desired.fingerprint
+    ):
         raise ConfigurationError("desired generation path is not one owned directory")
     current = lexical_home / ".local/share/clio-relay/current"
     _verify_stable_symlink(current, expected=generation, label="active generation")
@@ -2356,14 +2620,33 @@ def repair_managed_jarvis_binding(
     )
     if snapshot.before is not None:
         lexical_target = _activation_symlink_lexical_target(snapshot)
-        if lexical_target != expected_target:
+        try:
+            target_is_current = lexical_target.resolve(strict=True) == expected_target.resolve(
+                strict=True
+            )
+        except (OSError, RuntimeError, ValueError):
+            target_is_current = False
+        if lexical_target != expected_target and not target_is_current:
             proven_targets = {
                 Path(os.path.abspath(path.expanduser())) for path in previous_managed_repos
             }
-            if lexical_target not in proven_targets or not _is_generation_repository_target(
-                lexical_target.resolve(strict=True),
-                home=resolved_home,
-            ):
+            fixed_legacy_target = lexical_home / ".local/src/clio-relay/jarvis-packages/clio_relay"
+            try:
+                target_is_fixed_legacy = (
+                    lexical_target == fixed_legacy_target
+                    or lexical_target.resolve(strict=True)
+                    == fixed_legacy_target.resolve(strict=True)
+                )
+            except (OSError, RuntimeError, ValueError):
+                target_is_fixed_legacy = lexical_target == fixed_legacy_target
+            target_is_proven_generation = bool(
+                lexical_target in proven_targets
+                and _is_generation_repository_target(
+                    lexical_target.resolve(strict=True),
+                    home=resolved_home,
+                )
+            )
+            if not target_is_fixed_legacy and not target_is_proven_generation:
                 raise ConfigurationError(
                     "relay-managed repository link target is not proven by an earlier receipt"
                 )
@@ -2380,10 +2663,13 @@ def repair_managed_jarvis_binding(
         previous_managed_repos=previous_managed_repos,
         exchange_identity=desired.fingerprint,
     )
+    canonical_home = lexical_home.resolve(strict=True)
     return {
         "link_action": link_action,
-        "link": str(managed),
-        "target": str(expected_target),
+        "link": str(canonical_home / ".local/share/clio-relay/managed-jarvis-repo"),
+        "target": str(
+            canonical_home / ".local/share/clio-relay/current/source/jarvis-packages/clio_relay"
+        ),
         "repositories": repo_evidence,
     }
 
@@ -2555,10 +2841,28 @@ def _verify_active_generation_jarvis_wrapper(
     if set(manifest) != expected_manifest_keys:
         raise ConfigurationError("active generation manifest has an unknown shape")
     expected_receipt_path = generation / "install-receipt.json"
+    manifest_receipt_value = manifest.get("install_receipt")
+    manifest_receipt_matches = False
+    if isinstance(manifest_receipt_value, str):
+        manifest_receipt_path = Path(manifest_receipt_value)
+        if (
+            manifest_receipt_path.is_absolute()
+            and os.path.normpath(manifest_receipt_value) == manifest_receipt_value
+            and not any(character in manifest_receipt_value for character in "\x00\r\n")
+            and manifest_receipt_path.name == "install-receipt.json"
+        ):
+            try:
+                manifest_receipt_matches = manifest_receipt_path.parent.resolve(
+                    strict=True
+                ) == generation.resolve(strict=True) and manifest_receipt_path.resolve(
+                    strict=True
+                ) == expected_receipt_path.resolve(strict=True)
+            except (OSError, RuntimeError, ValueError):
+                manifest_receipt_matches = False
     if not (
         manifest.get("schema_version") == "clio-relay.bootstrap-generation.v1"
         and manifest.get("fingerprint") == desired.fingerprint
-        and manifest.get("install_receipt") == str(expected_receipt_path)
+        and manifest_receipt_matches
         and manifest.get("install_receipt_sha256") == sha256_file(expected_receipt_path)
     ):
         raise ConfigurationError("active generation manifest identity changed")
@@ -2643,6 +2947,188 @@ def _verify_active_generation_jarvis_wrapper(
         or not os.access(wrapper, os.X_OK)
     ):
         raise ConfigurationError("active generation JARVIS wrapper identity changed")
+
+
+def _relay_managed_jarvis_launcher_selected(
+    stable_launcher: Path,
+    *,
+    lexical_home: Path,
+) -> bool:
+    """Return whether one stable launcher names the relay activation namespace.
+
+    ``~/.local/bin`` is a conventional location shared by uv, pipx, and manual
+    installations.  The path alone therefore proves no relay ownership.  A
+    relay-managed launcher is distinguished by its stable symlink target: the
+    current relay generation, or the equivalent direct generation target used
+    by an older activation.  Receipt and generation validation remains the
+    caller's fail-closed responsibility after this ownership boundary is met.
+    """
+    try:
+        before = stable_launcher.lstat()
+    except (OSError, RuntimeError, ValueError):
+        return False
+    if not stat.S_ISLNK(before.st_mode):
+        return False
+    try:
+        raw_target = os.readlink(stable_launcher)
+    except (OSError, RuntimeError, ValueError):
+        return False
+    target = Path(raw_target)
+    if not target.is_absolute():
+        target = stable_launcher.parent / target
+    target = Path(os.path.abspath(target))
+    try:
+        canonical_home = lexical_home.resolve(strict=True)
+    except (OSError, RuntimeError, ValueError):
+        return False
+    home_aliases = {lexical_home, canonical_home}
+    current_targets = {root / ".local/share/clio-relay/current/bin/jarvis" for root in home_aliases}
+    relay_target = target in current_targets
+    if not relay_target and target.name == "jarvis" and target.parent.name == "bin":
+        generation = target.parent.parent
+        generation_name = generation.name
+        generation_roots = {root / ".local/share/clio-relay/generations" for root in home_aliases}
+        relay_target = bool(
+            generation.parent in generation_roots
+            and len(generation_name) == 64
+            and all(character in "0123456789abcdef" for character in generation_name)
+        )
+    if not relay_target:
+        return False
+    try:
+        after = stable_launcher.lstat()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ConfigurationError(
+            "relay-managed JARVIS launcher changed during ownership inspection"
+        ) from exc
+    if _stat_identity(after) != _stat_identity(before):
+        raise ConfigurationError(
+            "relay-managed JARVIS launcher changed during ownership inspection"
+        )
+    return True
+
+
+def resolve_receipt_bound_jarvis_python(
+    jarvis_bin: str,
+    *,
+    home: Path | None = None,
+) -> str | None:
+    """Return the verified interpreter for a relay-managed JARVIS launcher.
+
+    Non-managed launchers return ``None`` so an explicitly unmanaged provider can
+    retain its compatibility discovery.  A conventional ``~/.local/bin/jarvis``
+    file or external symlink is not relay ownership evidence.  Once the exact
+    relay activation symlink is selected, every receipt, generation, runtime,
+    and wrapper mismatch fails closed instead of falling back to an ambient
+    Python interpreter.
+    """
+    lexical_home = Path(os.path.abspath((home or Path.home()).expanduser()))
+    launcher = Path(jarvis_bin).expanduser()
+    if not launcher.is_absolute():
+        discovered = shutil.which(jarvis_bin)
+        if discovered is None:
+            return None
+        launcher = Path(discovered)
+    lexical_launcher = Path(os.path.abspath(launcher))
+    stable_launcher = lexical_home / ".local/bin/jarvis"
+    if lexical_launcher != stable_launcher:
+        try:
+            canonical_launcher = (
+                lexical_launcher.parent.resolve(strict=True) / lexical_launcher.name
+            )
+            canonical_stable = stable_launcher.parent.resolve(strict=True) / stable_launcher.name
+        except (OSError, RuntimeError, ValueError):
+            return None
+        if canonical_launcher != canonical_stable:
+            return None
+    if not _relay_managed_jarvis_launcher_selected(
+        stable_launcher,
+        lexical_home=lexical_home,
+    ):
+        return None
+
+    stable_receipt = lexical_home / ".local/share/clio-relay/install-receipt.json"
+    try:
+        installation = installation_info(stable_receipt)
+    except (ConfigurationError, OSError, ValueError) as exc:
+        raise ConfigurationError("relay-managed JARVIS installation receipt is invalid") from exc
+    if (
+        installation.get("schema_version") != "clio-relay.installation-info.v1"
+        or installation.get("receipt_matches_install") is not True
+    ):
+        raise ConfigurationError(
+            "relay-managed JARVIS installation receipt does not match this worker"
+        )
+    raw_receipt = installation.get("receipt")
+    raw_runtime = installation.get("component_runtime")
+    if not isinstance(raw_receipt, dict) or not isinstance(raw_runtime, dict):
+        raise ConfigurationError("relay-managed JARVIS installation identity is incomplete")
+    receipt = cast(dict[str, object], raw_receipt)
+    runtime = cast(dict[str, object], raw_runtime)
+    jarvis_runtime = runtime.get("jarvis-cd")
+    if (
+        not isinstance(jarvis_runtime, dict)
+        or cast(dict[str, object], jarvis_runtime).get("verified") is not True
+    ):
+        raise ConfigurationError("relay-managed JARVIS runtime did not verify its receipt")
+
+    raw_manifest = receipt.get("deployment_manifest")
+    fingerprint = receipt.get("deployment_fingerprint")
+    generation_name = receipt.get("generation")
+    try:
+        desired = BootstrapDesiredState.model_validate(raw_manifest)
+    except ValueError as exc:
+        raise ConfigurationError(
+            "relay-managed JARVIS receipt omitted a valid deployment manifest"
+        ) from exc
+    if (
+        not isinstance(fingerprint, str)
+        or fingerprint != desired.fingerprint
+        or generation_name != fingerprint
+    ):
+        raise ConfigurationError("relay-managed JARVIS generation identity changed")
+
+    generation = lexical_home / ".local/share/clio-relay/generations" / fingerprint
+    _verify_stable_symlink(
+        lexical_home / ".local/share/clio-relay/current",
+        expected=generation,
+        label="current generation pointer",
+    )
+    _verify_stable_symlink(
+        stable_receipt,
+        expected=generation / "install-receipt.json",
+        label="stable install receipt",
+    )
+    _verify_stable_symlink(
+        stable_launcher,
+        expected=generation / "bin/jarvis",
+        label="stable JARVIS launcher",
+    )
+    _verify_active_generation_jarvis_wrapper(
+        generation,
+        desired=desired,
+        installation=installation,
+    )
+
+    raw_artifacts = receipt.get("component_artifacts")
+    raw_jarvis_artifact = (
+        cast(dict[str, object], raw_artifacts).get("jarvis-cd")
+        if isinstance(raw_artifacts, dict)
+        else None
+    )
+    raw_interpreters = (
+        cast(dict[str, object], raw_jarvis_artifact).get("runtime_interpreters")
+        if isinstance(raw_jarvis_artifact, dict)
+        else None
+    )
+    execution_python = (
+        cast(dict[str, object], raw_interpreters).get("execution")
+        if isinstance(raw_interpreters, dict)
+        else None
+    )
+    if not isinstance(execution_python, str):
+        raise ConfigurationError("relay-managed JARVIS receipt omitted its interpreter")
+    return execution_python
 
 
 def _verify_stable_symlink(path: Path, *, expected: Path, label: str) -> Path:
@@ -2827,9 +3313,20 @@ def _capture_reconcile_activation_paths(
             lexical_home / ".local/src/clio-relay/jarvis-packages/clio_relay",
             share / "current/source/jarvis-packages/clio_relay",
         }
-        if managed_target not in allowed_targets and not _is_generation_repository_target(
-            managed_target.resolve(strict=True),
-            home=lexical_home.resolve(strict=True),
+        try:
+            target_matches_allowed_alias = any(
+                managed_target.resolve(strict=True) == target.resolve(strict=True)
+                for target in allowed_targets
+            )
+        except (OSError, RuntimeError, ValueError):
+            target_matches_allowed_alias = False
+        if (
+            managed_target not in allowed_targets
+            and not target_matches_allowed_alias
+            and not _is_generation_repository_target(
+                managed_target.resolve(strict=True),
+                home=lexical_home.resolve(strict=True),
+            )
         ):
             raise ConfigurationError(
                 "relay-managed repository link is not one proven legacy binding"
@@ -3129,7 +3626,11 @@ def _worker_readiness_verified(
 ) -> bool:
     return bool(
         evidence is not None
-        and evidence.get("schema_version") == "clio-relay.worker-runtime-info.v1"
+        and evidence.get("schema_version")
+        in {
+            "clio-relay.worker-runtime-info.v1",
+            "clio-relay.worker-readiness.v1",
+        }
         and evidence.get("cluster") == cluster
         and evidence.get("fresh") is True
         and evidence.get("process_running") is True
@@ -3211,6 +3712,20 @@ def _expand_home(value: str, home: Path) -> Path:
     if not path.is_absolute():
         raise ConfigurationError(f"bootstrap state path is not absolute: {value}")
     return path
+
+
+def _canonical_path_preserving_final(path: Path) -> Path:
+    """Canonicalize ancestor aliases without following the final path component."""
+    lexical = Path(os.path.abspath(path.expanduser()))
+    if any(character in str(lexical) for character in "\x00\r\n"):
+        raise ConfigurationError("managed path contains unsafe characters")
+    try:
+        parent = lexical.parent.resolve(strict=True)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ConfigurationError("managed path parent is unavailable") from exc
+    if not parent.is_dir():  # pragma: no cover - resolve(strict=True) normally proves this
+        raise ConfigurationError("managed path parent is not a directory")
+    return parent / lexical.name
 
 
 def _yaml_mapping(raw: bytes, *, label: str) -> dict[str, object]:

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -19,7 +19,7 @@ import sys
 from collections import Counter
 from collections.abc import Callable
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from importlib import import_module
 from json import JSONDecodeError
@@ -234,13 +234,17 @@ from clio_relay.remote_mcp import (
     resolve_registered_remote_mcp_admission,
 )
 from clio_relay.retention import TerminalRetentionCoordinator
+from clio_relay.runtime_metadata import RUNTIME_METADATA_SCHEMA, native_execution_documents
 from clio_relay.scheduler_providers import (
     allocation_connector_provider_for_scheduler,
     provider_for_scheduler,
     validation_provider_for_scheduler,
 )
 from clio_relay.scheduler_validation import run_scheduler_lifecycle_validation
-from clio_relay.service_runtime import ServiceRuntimeSupervisor
+from clio_relay.service_runtime import (
+    ServiceRuntimePendingResult,
+    ServiceRuntimeSupervisor,
+)
 from clio_relay.session_api import (
     OWNED_SESSION_WAIT_RESPONSE_GRACE_SECONDS,
     submit_owned_session_job,
@@ -295,6 +299,7 @@ from clio_relay.validation_report import (
     EvidenceReference,
     LiveValidationReport,
     SoftwareIdentity,
+    ValidationCheck,
     ValidationRecorder,
     ValidationResource,
     ValidationStatus,
@@ -1728,6 +1733,10 @@ def endpoint_worker_info(
         float,
         typer.Option(help="Maximum acceptable durable worker heartbeat age."),
     ] = 120.0,
+    readiness_only: Annotated[
+        bool,
+        typer.Option(help="Return bounded readiness flags without detailed installation records."),
+    ] = False,
 ) -> None:
     """Report fresh process-bound identity for the active cluster worker."""
     _run_or_exit(
@@ -1736,6 +1745,7 @@ def endpoint_worker_info(
                 worker_runtime_info(
                     cluster=cluster,
                     freshness_seconds=freshness_seconds,
+                    readiness_only=readiness_only,
                 ),
                 indent=2,
             )
@@ -9776,8 +9786,19 @@ def gateway_start_runtime(
             ),
         )
         report_id[0] = canonical.report_id
-        _write_remote_verified_report(canonical, definition, canonical_report_path)
+        if isinstance(result, ServiceRuntimePendingResult):
+            # A nonterminal report cannot satisfy the release gate. Persist and
+            # return its exact retry selector without adding another fallible
+            # remote observation that could hide the already-durable result.
+            write_validation_report(canonical, canonical_report_path)
+        else:
+            _write_remote_verified_report(canonical, definition, canonical_report_path)
         payload = public_gateway_session(result.session)
+        if isinstance(result, ServiceRuntimePendingResult):
+            payload["outcome"] = result.outcome
+            payload["retry_selector"] = result.retry_selector()
+            payload["scheduler_action"] = result.scheduler_action
+            payload["relay_action"] = result.relay_action
         payload["validation_report"] = str(canonical_report_path.resolve())
         typer.echo(_public_json(payload))
 
@@ -9807,6 +9828,155 @@ def gateway_start_runtime(
                 recorder.record_failure(
                     "gateway.start-runtime",
                     "start scheduler-backed gateway runtime",
+                    exc,
+                )
+                recorder.finish(exc)
+                recorder.write(canonical_report_path)
+            raise
+
+    _run_or_exit(guarded_action)
+
+
+@gateway_app.command("resume-runtime")
+@_acceptance_report_command
+def gateway_resume_runtime(
+    session_id: str,
+    cluster: Annotated[str, typer.Option(help="Configured cluster name.")],
+    token: Annotated[
+        str | None,
+        typer.Option(help="frp authentication token. Defaults to cluster token_env."),
+    ] = None,
+    secret_key: Annotated[
+        str | None,
+        typer.Option(help="stcp shared secret. Defaults to cluster stcp_secret_env."),
+    ] = None,
+    validation_report: Annotated[
+        Path | None,
+        typer.Option(
+            help="Canonical gateway-runtime validation JSON path. Defaults under .clio-relay."
+        ),
+    ] = None,
+    validation_launcher: Annotated[
+        str | None,
+        typer.Option(help="Launcher evidence, such as uv-tool."),
+    ] = None,
+    validation_install_source: Annotated[
+        str | None,
+        typer.Option(help="Explicit kind:reference install evidence."),
+    ] = None,
+    validation_artifact: Annotated[
+        Path | None,
+        typer.Option(
+            help="Optional wheel whose SHA-256 is recorded in gateway evidence.",
+            exists=True,
+            dir_okay=False,
+        ),
+    ] = None,
+) -> None:
+    """Advance one exact submitted runtime without creating another scheduler job."""
+    canonical_report_path = validation_report or default_report_path(cluster)
+    report_id: list[str | None] = [None]
+
+    def action() -> None:
+        definition = _require_cluster(cluster)
+        settings = RelaySettings.from_env()
+        queue = storage_managed_queue(settings)
+        supervisor = ServiceRuntimeSupervisor(
+            settings=settings,
+            queue=queue,
+            cluster=cluster,
+            definition=definition,
+            token=_resolve_env_secret(token, definition.frp_transport.token_env, "frp token"),
+            secret_key=_resolve_env_secret(
+                secret_key,
+                definition.frp_transport.stcp_secret_env,
+                "stcp secret",
+            ),
+        )
+        session = queue.get_gateway_session(session_id)
+        owner_session_id = session.metadata.get("owner_session_id")
+        owner_generation_id = session.metadata.get("owner_session_generation_id")
+        owner_admission_id = session.metadata.get("owner_session_admission_id")
+        owner_values = (owner_session_id, owner_generation_id, owner_admission_id)
+        if all(value is None for value in owner_values):
+            result = supervisor.resume_start(session_id=session_id)
+        else:
+            if not all(isinstance(value, str) and value for value in owner_values):
+                raise RelayError(
+                    "owned gateway runtime omitted its exact owner-session admission identity"
+                )
+            typed_owner_session_id = cast(str, owner_session_id)
+            typed_owner_generation_id = cast(str, owner_generation_id)
+            typed_owner_admission_id = cast(str, owner_admission_id)
+            expected_admission_id = _desktop_owner_session_admission_id(
+                cluster=cluster,
+                session_id=typed_owner_session_id,
+            )
+            if typed_owner_admission_id != expected_admission_id:
+                raise RelayError("owned gateway runtime admission identity changed")
+            with owner_session_gateway_admission(
+                queue=queue,
+                definition=definition,
+                cluster=cluster,
+                session_id=typed_owner_session_id,
+                session_generation_id=typed_owner_generation_id,
+                transition_lock_factory=_session_transition_lock,
+                session_status_reader=status_remote_session,
+                admission_status_reader=_owner_session_admission_status,
+            ) as admission:
+                if admission.owner_session_admission_id != typed_owner_admission_id:
+                    raise RelayError("owned gateway runtime admission identity changed")
+                result = supervisor.resume_start(session_id=session_id)
+        canonical = result.to_live_validation_report(
+            launcher=validation_launcher,
+            install_source=validation_install_source,
+            artifact_sha256=(
+                sha256_file(validation_artifact) if validation_artifact is not None else None
+            ),
+        )
+        report_id[0] = canonical.report_id
+        if isinstance(result, ServiceRuntimePendingResult):
+            # Pending is an operational checkpoint, not release evidence. Its
+            # successful return must not depend on a second worker-provenance
+            # observation after the exact runtime query already completed.
+            write_validation_report(canonical, canonical_report_path)
+        else:
+            _write_remote_verified_report(canonical, definition, canonical_report_path)
+        payload = public_gateway_session(result.session)
+        if isinstance(result, ServiceRuntimePendingResult):
+            payload["outcome"] = result.outcome
+            payload["retry_selector"] = result.retry_selector()
+            payload["scheduler_action"] = result.scheduler_action
+            payload["relay_action"] = result.relay_action
+        payload["validation_report"] = str(canonical_report_path.resolve())
+        typer.echo(_public_json(payload))
+
+    def guarded_action() -> None:
+        try:
+            action()
+        except BaseException as exc:
+            report_already_written = False
+            if report_id[0] is not None:
+                with suppress(ConfigurationError):
+                    report_already_written = (
+                        load_validation_report(canonical_report_path).report_id == report_id[0]
+                    )
+            if not report_already_written:
+                artifact_sha256: str | None = None
+                if validation_artifact is not None:
+                    with suppress(OSError):
+                        artifact_sha256 = sha256_file(validation_artifact)
+                failed_report = new_live_validation_report(
+                    scenario="gateway-runtime",
+                    cluster=cluster,
+                    launcher=validation_launcher,
+                    install_source=validation_install_source,
+                    artifact_sha256=artifact_sha256,
+                )
+                recorder = ValidationRecorder(failed_report)
+                recorder.record_failure(
+                    "gateway.resume-runtime",
+                    "resume exact scheduler-backed gateway runtime",
                     exc,
                 )
                 recorder.finish(exc)
@@ -10015,9 +10185,37 @@ def gateway_attach_runtime(
                 "stcp secret",
             ),
         )
-        typer.echo(
-            _public_json(public_gateway_session(supervisor.attach(session_id=session_id).session))
+        result = supervisor.attach(session_id=session_id)
+        payload = public_gateway_session(result.session)
+        if isinstance(result, ServiceRuntimePendingResult):
+            gateway = cast(dict[str, object], payload.get("gateway", {}))
+            for key in (
+                "connect_url",
+                "health_url",
+                "stream_url",
+                "events_url",
+                "state_url",
+                "command_url",
+                "compatibility_urls",
+            ):
+                gateway.pop(key, None)
+            payload["gateway"] = gateway
+        payload.update(
+            {
+                "outcome": (
+                    result.outcome if isinstance(result, ServiceRuntimePendingResult) else "ready"
+                ),
+                "retry_selector": (
+                    result.retry_selector()
+                    if isinstance(result, ServiceRuntimePendingResult)
+                    else None
+                ),
+                "scheduler_action": "none",
+                "relay_action": "none",
+                "scheduler_cancel_requested": False,
+            }
         )
+        typer.echo(_public_json(payload))
 
     _run_or_exit(action)
 
@@ -10756,13 +10954,31 @@ def jarvis_mcp_validate(
         Path | None,
         typer.Option(help="Path to a JSON object argument file for virtual jarvis_run."),
     ] = None,
+    resume_report: Annotated[
+        Path | None,
+        typer.Option(
+            help=(
+                "Pending report to resume its exact idempotent jarvis_run dispatch or "
+                "JARVIS execution query; never creates a new workload identity."
+            ),
+            exists=True,
+            dir_okay=False,
+        ),
+    ] = None,
     profile: Annotated[
         str,
         typer.Option(help="Local MCP profile used for tools/list and tools/call."),
     ] = "user",
     wait_timeout_seconds: Annotated[
         float,
-        typer.Option(help="Maximum time to wait for the durable JARVIS MCP call.", min=1),
+        typer.Option(
+            help=(
+                "Maximum observation window for durable JARVIS MCP calls, not the workload "
+                "lifetime. Expiry after an idempotent intent, relay receipt, or execution "
+                "identity writes a resumable pending checkpoint without cancellation."
+            ),
+            min=1,
+        ),
     ] = 600,
     poll_seconds: Annotated[
         float,
@@ -10790,12 +11006,34 @@ def jarvis_mcp_validate(
     ] = None,
 ) -> None:
     """Exercise JARVIS run/query semantics and persist release acceptance evidence."""
-    report_path = report or default_report_path(cluster)
+    report_path = report or resume_report or default_report_path(cluster)
+    failure_report_path = report_path
+    if resume_report is not None and report_path.resolve() == resume_report.resolve():
+        suffix = report_path.suffix or ".json"
+        failure_report_path = report_path.with_name(
+            f"{report_path.stem}.resume-failure-{uuid4().hex}{suffix}"
+        )
     report_written = [False]
 
-    def preflight() -> tuple[dict[str, Any], ClusterDefinition, str]:
+    def preflight() -> tuple[
+        dict[str, Any],
+        ClusterDefinition,
+        str,
+        dict[str, Any] | None,
+    ]:
         if profile not in {"user", "admin", "operator", "all"}:
             raise typer.BadParameter("--profile must be user, admin, operator, or all")
+        definition = _require_cluster(cluster)
+        if resume_report is not None:
+            if package_search_query or arguments_json != "{}" or arguments_json_file is not None:
+                raise typer.BadParameter(
+                    "--resume-report cannot be combined with run or package-search arguments"
+                )
+            checkpoint = _load_jarvis_validation_resume_checkpoint(
+                resume_report,
+                cluster=cluster,
+            )
+            return {}, definition, "", checkpoint
         normalized_package_search_query = " ".join(package_search_query.split())
         if not normalized_package_search_query:
             raise typer.BadParameter("--package-search-query must not be blank")
@@ -10803,6 +11041,11 @@ def jarvis_mcp_validate(
             raise typer.BadParameter("--package-search-query must not exceed 256 characters")
         arguments_source = _json_text_from_option(arguments_json, arguments_json_file)
         arguments = _json_object(arguments_source)
+        if redact_sensitive_values(arguments) != arguments:
+            raise typer.BadParameter(
+                "JARVIS validation arguments cannot contain credential-valued fields because "
+                "durable resume reports are always credential-redacted"
+            )
         if "cluster" in arguments:
             raise typer.BadParameter(
                 "JARVIS tool arguments must not contain reserved key 'cluster'"
@@ -10815,13 +11058,18 @@ def jarvis_mcp_validate(
             )
         if not isinstance(arguments.get("pipeline_id"), str):
             raise typer.BadParameter("jarvis-mcp-validate requires a string pipeline_id argument")
-        return arguments, _require_cluster(cluster), normalized_package_search_query
+        return arguments, definition, normalized_package_search_query, None
 
     try:
-        arguments, definition, normalized_package_search_query = preflight()
+        (
+            arguments,
+            definition,
+            normalized_package_search_query,
+            resume_checkpoint,
+        ) = preflight()
     except BaseException as exc:
         _write_failed_acceptance_report(
-            path=report_path,
+            path=failure_report_path,
             scenario="remote-mcp",
             cluster=cluster,
             check_id="jarvis-mcp.preflight",
@@ -10837,151 +11085,281 @@ def jarvis_mcp_validate(
         settings = RelaySettings.from_env()
         queue = storage_managed_queue(settings)
         queue.initialize()
-        (
-            remote_discovery_job_id,
-            remote_tools_list_result,
-            remote_discovery_artifacts,
-            remote_discovery_payload,
-        ) = _run_jarvis_remote_contract_discovery(
-            cluster=cluster,
-            definition=definition,
-            queue=queue,
-            wait_timeout_seconds=wait_timeout_seconds,
-            poll_seconds=poll_seconds,
-        )
-        _persist_jarvis_remote_contract_discovery(
-            cluster=cluster,
-            discovery_job_id=remote_discovery_job_id,
-            result=remote_tools_list_result,
-            artifacts=remote_discovery_artifacts,
-            artifact_payload=remote_discovery_payload,
-        )
-        package_search = _run_jarvis_package_search_query(
-            cluster=cluster,
-            definition=definition,
-            queue=queue,
-            profile=profile,
-            query=normalized_package_search_query,
-            wait_timeout_seconds=wait_timeout_seconds,
-            poll_seconds=poll_seconds,
-        )
-        stdio_session = run_packaged_mcp_stdio_session(
-            profile=profile,
-            tool="jarvis_run",
-            arguments={"cluster": cluster, **arguments},
-            timeout_seconds=min(60.0, max(0.001, wait_timeout_seconds)),
-        )
-        tools_list_response = stdio_session.tools_list_response
-        call_response = stdio_session.tools_call_response
-        job_id = _mcp_response_job_id(call_response)
-        remote_install_info: dict[str, object] | None = None
-        if should_execute_on_cluster(definition):
-            remote_install_info = _remote_worker_info(definition)
-            call_status = _wait_for_remote_job_terminal(
-                definition,
-                job_id,
-                timeout_seconds=wait_timeout_seconds,
+
+        def emit(validation: LiveValidationReport, *, attach_worker: bool = False) -> None:
+            if attach_worker and should_execute_on_cluster(definition):
+                attach_verified_worker_identity(validation, _remote_worker_info(definition))
+            write_validation_report(validation, report_path)
+            report_written[0] = True
+            typer.echo(validation.model_dump_json(indent=2))
+            if validation.status is ValidationStatus.FAILED:
+                raise typer.Exit(code=1)
+
+        def retain_existing_pending_report() -> None:
+            if resume_report is None:  # pragma: no cover - guarded by resume_checkpoint
+                raise RelayError("JARVIS validation resume source disappeared")
+            emit(load_validation_report(resume_report))
+
+        def finish_execution_query(
+            *,
+            builder_inputs: dict[str, Any],
+            execution_query: _JarvisExecutionQueryAcceptance | _JarvisExecutionQueryPending,
+            checkpoint_profile: str,
+        ) -> None:
+            selector = execution_query.retry_selector()
+            builder_inputs = {
+                **builder_inputs,
+                "scheduler_cluster": selector["scheduler_cluster"],
+            }
+            observations = (
+                []
+                if isinstance(execution_query, _JarvisExecutionQueryPending)
+                else list(execution_query.lifecycle_observations)
+            )
+            checkpoint = {
+                "schema_version": _JARVIS_VALIDATION_RESUME_CHECKPOINT_SCHEMA,
+                "phase": _JARVIS_VALIDATION_PHASE_QUERY,
+                "observation_state": "not_observed" if not observations else "observed",
+                "profile": checkpoint_profile,
+                "retry_selector": selector,
+                "builder_inputs": builder_inputs,
+                "lifecycle_observations": observations,
+            }
+            if isinstance(execution_query, _JarvisExecutionQueryPending):
+                validation = _build_unobserved_jarvis_query_pending_report(
+                    builder_inputs=builder_inputs,
+                    execution_query=execution_query,
+                    checkpoint=checkpoint,
+                )
+            else:
+                validation = build_jarvis_mcp_validation_report(
+                    **builder_inputs,
+                    query_tools_list_response=execution_query.tools_list_response,
+                    query_call_response=execution_query.call_response,
+                    query_call_job_id=execution_query.call_job_id,
+                    query_call_status=execution_query.call_status,
+                    query_artifacts=execution_query.artifacts,
+                    query_mcp_result=execution_query.mcp_result,
+                    query_provenance=execution_query.provenance,
+                    query_initialize_response=execution_query.initialize_response,
+                    query_stdio_evidence=execution_query.stdio_evidence,
+                    query_lifecycle_observations=observations,
+                )
+                if execution_query.outcome != "terminal":
+                    validation = _mark_jarvis_validation_pending(
+                        validation,
+                        execution_query=execution_query,
+                        resume_checkpoint=checkpoint,
+                    )
+            emit(validation, attach_worker=validation.status is not ValidationStatus.PENDING)
+
+        checkpoint = resume_checkpoint
+        checkpoint_profile = profile
+        if checkpoint is not None:
+            checkpoint_profile = cast(str, checkpoint["profile"])
+            phase = checkpoint.get("phase", _JARVIS_VALIDATION_PHASE_QUERY)
+            if phase == _JARVIS_VALIDATION_PHASE_QUERY:
+                selector = cast(dict[str, Any], checkpoint["retry_selector"])
+                query_selector: dict[str, object] = {
+                    **cast(dict[str, object], selector),
+                    "last_query_job_id": None,
+                }
+                execution_query = _run_post_run_jarvis_execution_query(
+                    cluster=cluster,
+                    definition=definition,
+                    queue=queue,
+                    profile=checkpoint_profile,
+                    pipeline_id=cast(str, selector["pipeline_id"]),
+                    execution_id=cast(str, selector["execution_id"]),
+                    retry_selector=query_selector,
+                    wait_timeout_seconds=wait_timeout_seconds,
+                    poll_seconds=poll_seconds,
+                )
+                _require_same_jarvis_resume_identity(
+                    expected=selector,
+                    observed=execution_query.retry_selector(),
+                )
+                if isinstance(execution_query, _JarvisExecutionQueryPending):
+                    retain_existing_pending_report()
+                    return
+                prior_observations = [
+                    cast(dict[str, Any], observation)
+                    for observation in cast(list[object], checkpoint["lifecycle_observations"])
+                    if isinstance(observation, dict)
+                ]
+                execution_query = replace(
+                    execution_query,
+                    lifecycle_observations=_merge_jarvis_execution_query_observations(
+                        prior_observations,
+                        execution_query.lifecycle_observations,
+                    ),
+                )
+                finish_execution_query(
+                    builder_inputs=cast(dict[str, Any], checkpoint["builder_inputs"]),
+                    execution_query=execution_query,
+                    checkpoint_profile=checkpoint_profile,
+                )
+                return
+
+        if checkpoint is None:
+            (
+                remote_discovery_job_id,
+                remote_tools_list_result,
+                remote_discovery_artifacts,
+                remote_discovery_payload,
+            ) = _run_jarvis_remote_contract_discovery(
+                cluster=cluster,
+                definition=definition,
+                queue=queue,
+                wait_timeout_seconds=wait_timeout_seconds,
                 poll_seconds=poll_seconds,
             )
-            progress = _complete_remote_collection(
-                definition,
-                ["job", "progress", job_id],
-                record_key="progress",
-                label=f"JARVIS MCP dispatch progress for {job_id}",
+            _persist_jarvis_remote_contract_discovery(
+                cluster=cluster,
+                discovery_job_id=remote_discovery_job_id,
+                result=remote_tools_list_result,
+                artifacts=remote_discovery_artifacts,
+                artifact_payload=remote_discovery_payload,
             )
-            live_progress_observation = None
-            artifacts = _remote_artifact_records(definition, job_id)
-            mcp_result = _read_remote_json_artifact_kind(definition, artifacts, kind="mcp_result")
-            provenance = _read_remote_json_artifact_kind(definition, artifacts, kind="provenance")
-            runtime_metadata = _read_remote_json_artifact_kind(
-                definition, artifacts, kind="runtime_metadata"
+            package_search = _run_jarvis_package_search_query(
+                cluster=cluster,
+                definition=definition,
+                queue=queue,
+                profile=profile,
+                query=normalized_package_search_query,
+                wait_timeout_seconds=wait_timeout_seconds,
+                poll_seconds=poll_seconds,
             )
+            validation_artifact_sha256 = (
+                sha256_file(validation_artifact) if validation_artifact is not None else None
+            )
+            pre_dispatch_inputs: dict[str, Any] = {
+                "cluster": cluster,
+                "tool": "jarvis_run",
+                "remote_tools_list_result": remote_tools_list_result,
+                "remote_discovery_job_id": remote_discovery_job_id,
+                "remote_discovery_artifacts": remote_discovery_artifacts,
+                "package_search_query": normalized_package_search_query,
+                "package_search_tools_list_response": package_search.tools_list_response,
+                "package_search_call_response": package_search.call_response,
+                "package_search_call_job_id": package_search.call_job_id,
+                "package_search_call_status": package_search.call_status,
+                "package_search_artifacts": package_search.artifacts,
+                "package_search_mcp_result": package_search.mcp_result,
+                "package_search_provenance": package_search.provenance,
+                "package_search_initialize_response": package_search.initialize_response,
+                "package_search_stdio_evidence": package_search.stdio_evidence,
+                "launcher": validation_launcher,
+                "install_source": validation_install_source,
+                "artifact_sha256": validation_artifact_sha256,
+            }
+            idempotency_key = _new_jarvis_validation_idempotency_key(
+                cluster=cluster,
+                profile=profile,
+                arguments=arguments,
+            )
+            execution_intent = _jarvis_run_execution_intent(
+                cluster=cluster,
+                profile=profile,
+                arguments=arguments,
+                idempotency_key=idempotency_key,
+            )
+            checkpoint = _new_jarvis_intent_resume_checkpoint(
+                execution_intent=execution_intent,
+                pre_dispatch_inputs=pre_dispatch_inputs,
+            )
+            # Persist the replayable identity before crossing the ambiguous stdio boundary.
+            # A process or host failure can therefore resume with this exact key.
+            write_validation_report(_new_jarvis_intent_pending_report(checkpoint), report_path)
         else:
-            call_status = _wait_for_local_job_terminal(
-                queue,
-                job_id,
-                timeout_seconds=wait_timeout_seconds,
+            execution_intent = cast(dict[str, object], checkpoint["execution_intent"])
+            pre_dispatch_inputs = cast(dict[str, Any], checkpoint["pre_dispatch_inputs"])
+
+        if checkpoint["phase"] == _JARVIS_VALIDATION_PHASE_INTENT:
+            try:
+                stdio_session = run_packaged_mcp_stdio_session(
+                    profile=checkpoint_profile,
+                    tool="jarvis_run",
+                    arguments=cast(dict[str, Any], execution_intent["arguments"]),
+                    timeout_seconds=min(60.0, max(0.001, wait_timeout_seconds)),
+                )
+            except ObservationTimeoutError:
+                if resume_checkpoint is not None:
+                    retain_existing_pending_report()
+                else:
+                    emit(_new_jarvis_intent_pending_report(checkpoint))
+                return
+            call_response = stdio_session.tools_call_response
+            job_id = _mcp_response_job_id(call_response)
+            builder_inputs: dict[str, Any] = {
+                **pre_dispatch_inputs,
+                "scheduler_cluster": None,
+                "tools_list_response": stdio_session.tools_list_response,
+                "call_response": call_response,
+                "call_job_id": job_id,
+                "call_status": {},
+                "artifacts": [],
+                "mcp_result": None,
+                "provenance": None,
+                "runtime_metadata": None,
+                "progress": [],
+                "live_progress_observation": None,
+                "initialize_response": stdio_session.initialize_response,
+                "stdio_evidence": stdio_session.evidence(),
+            }
+            checkpoint = _promote_jarvis_intent_to_dispatch_checkpoint(
+                checkpoint,
+                job_id=job_id,
+                builder_inputs=builder_inputs,
+            )
+
+        try:
+            builder_inputs = _complete_jarvis_run_dispatch(
+                definition=definition,
+                queue=queue,
+                checkpoint=checkpoint,
+                wait_timeout_seconds=wait_timeout_seconds,
                 poll_seconds=poll_seconds,
             )
-            progress = _complete_local_progress_records(queue, job_id)
-            live_progress_observation = None
-            artifacts = _complete_local_artifact_records(queue, job_id)
-            mcp_result = _read_local_json_artifact_kind(queue, artifacts, kind="mcp_result")
-            provenance = _read_local_json_artifact_kind(queue, artifacts, kind="provenance")
-            runtime_metadata = _read_local_json_artifact_kind(
-                queue, artifacts, kind="runtime_metadata"
-            )
-        pipeline_id = runtime_metadata.get("pipeline_id") if runtime_metadata else None
-        execution_id = runtime_metadata.get("execution_id") if runtime_metadata else None
+        except ObservationTimeoutError:
+            emit(_build_jarvis_dispatch_pending_report(checkpoint))
+            return
+        raw_runtime_metadata = builder_inputs.get("runtime_metadata")
+        runtime_metadata = (
+            cast(dict[str, Any], raw_runtime_metadata)
+            if isinstance(raw_runtime_metadata, dict)
+            else None
+        )
+        if runtime_metadata is None:
+            raise RelayError("JARVIS run metadata artifact is unavailable")
+        pipeline_id = runtime_metadata.get("pipeline_id")
+        execution_id = runtime_metadata.get("execution_id")
         if not isinstance(pipeline_id, str) or not pipeline_id:
             raise RelayError("JARVIS run metadata omitted the pipeline_id required for its query")
         if not isinstance(execution_id, str) or not execution_id:
             raise RelayError("JARVIS run metadata omitted the execution_id required for its query")
+        retry_selector = _jarvis_execution_retry_selector_from_runtime_metadata(
+            runtime_metadata,
+            cluster=cluster,
+            pipeline_id=pipeline_id,
+            execution_id=execution_id,
+        )
         execution_query = _run_post_run_jarvis_execution_query(
             cluster=cluster,
             definition=definition,
             queue=queue,
-            profile=profile,
+            profile=checkpoint_profile,
             pipeline_id=pipeline_id,
             execution_id=execution_id,
+            retry_selector=retry_selector,
             wait_timeout_seconds=wait_timeout_seconds,
             poll_seconds=poll_seconds,
         )
-        validation = build_jarvis_mcp_validation_report(
-            cluster=cluster,
-            tool="jarvis_run",
-            tools_list_response=tools_list_response,
-            call_response=call_response,
-            call_job_id=job_id,
-            call_status=call_status,
-            artifacts=artifacts,
-            mcp_result=mcp_result,
-            provenance=provenance,
-            runtime_metadata=runtime_metadata,
-            progress=progress,
-            live_progress_observation=live_progress_observation,
-            remote_tools_list_result=remote_tools_list_result,
-            remote_discovery_job_id=remote_discovery_job_id,
-            remote_discovery_artifacts=remote_discovery_artifacts,
-            initialize_response=stdio_session.initialize_response,
-            stdio_evidence=stdio_session.evidence(),
-            package_search_query=normalized_package_search_query,
-            package_search_tools_list_response=package_search.tools_list_response,
-            package_search_call_response=package_search.call_response,
-            package_search_call_job_id=package_search.call_job_id,
-            package_search_call_status=package_search.call_status,
-            package_search_artifacts=package_search.artifacts,
-            package_search_mcp_result=package_search.mcp_result,
-            package_search_provenance=package_search.provenance,
-            package_search_initialize_response=package_search.initialize_response,
-            package_search_stdio_evidence=package_search.stdio_evidence,
-            query_tools_list_response=execution_query.tools_list_response,
-            query_call_response=execution_query.call_response,
-            query_call_job_id=execution_query.call_job_id,
-            query_call_status=execution_query.call_status,
-            query_artifacts=execution_query.artifacts,
-            query_mcp_result=execution_query.mcp_result,
-            query_provenance=execution_query.provenance,
-            query_initialize_response=execution_query.initialize_response,
-            query_stdio_evidence=execution_query.stdio_evidence,
-            query_lifecycle_observations=getattr(
-                execution_query,
-                "lifecycle_observations",
-                [],
-            ),
-            launcher=validation_launcher,
-            install_source=validation_install_source,
-            artifact_sha256=(
-                sha256_file(validation_artifact) if validation_artifact is not None else None
-            ),
+        finish_execution_query(
+            builder_inputs=builder_inputs,
+            execution_query=execution_query,
+            checkpoint_profile=checkpoint_profile,
         )
-        if remote_install_info is not None:
-            attach_verified_worker_identity(validation, remote_install_info)
-        write_validation_report(validation, report_path)
-        report_written[0] = True
-        typer.echo(validation.model_dump_json(indent=2))
-        if validation.status.value != "passed":
-            raise typer.Exit(code=1)
 
     def guarded_action() -> None:
         try:
@@ -11004,7 +11382,7 @@ def jarvis_mcp_validate(
                     "jarvis-mcp.completed", "complete virtual JARVIS MCP acceptance", exc
                 )
                 recorder.finish(exc)
-                recorder.write(report_path)
+                recorder.write(failure_report_path)
             raise
 
     _run_or_exit(guarded_action)
@@ -11446,6 +11824,17 @@ def live_test(
         Path | None,
         typer.Option(help="Optional human-readable Markdown rendering of the JSON report."),
     ] = None,
+    resume_report: Annotated[
+        Path | None,
+        typer.Option(
+            help=(
+                "Resume the exact nonterminal workload recorded by a PENDING live-test report. "
+                "The source checkpoint is never overwritten."
+            ),
+            exists=True,
+            dir_okay=False,
+        ),
+    ] = None,
     validation_launcher: Annotated[
         str | None,
         typer.Option(
@@ -11491,7 +11880,15 @@ def live_test(
     poll_seconds: Annotated[float, typer.Option(help="Polling interval.")] = 2,
 ) -> None:
     """Run configurable live acceptance checks for a cluster."""
-    report_path = report or default_report_path(cluster)
+    report_path = report or (
+        _live_acceptance_resume_output_path(resume_report)
+        if resume_report is not None
+        else default_report_path(cluster)
+    )
+    if resume_report is not None and report_path.resolve() == resume_report.resolve():
+        raise typer.BadParameter(
+            "--report must differ from --resume-report so the checkpoint is preserved"
+        )
     seed_report = new_live_validation_report(
         scenario=validation_scenario,
         cluster=cluster,
@@ -11501,7 +11898,8 @@ def live_test(
             sha256_file(validation_artifact) if validation_artifact is not None else None
         ),
     )
-    write_validation_report(seed_report, report_path)
+    if resume_report is None:
+        write_validation_report(seed_report, report_path)
     try:
         definition = _require_cluster(cluster)
         should_verify_transport = (
@@ -11597,6 +11995,7 @@ def live_test(
                     validation_scenario=validation_scenario,
                     verify_cluster_deployment=verify_cluster_deployment,
                     report_id=seed_report.report_id,
+                    resume_report_path=resume_report,
                 )
             )
             current_report = _load_current_acceptance_report(
@@ -11605,7 +12004,9 @@ def live_test(
             )
             if current_report is None:
                 raise RelayError("live acceptance did not persist the current invocation report")
-            if should_execute_on_cluster(definition):
+            if current_report.status is ValidationStatus.PASSED and should_execute_on_cluster(
+                definition
+            ):
                 _write_remote_verified_report(
                     current_report,
                     definition,
@@ -11638,6 +12039,11 @@ def live_test(
 def _file_idempotency_key(path: Path, text: str) -> str:
     digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
     return f"jarvis:{path.resolve()}:{digest}"
+
+
+def _live_acceptance_resume_output_path(source: Path) -> Path:
+    """Return a collision-resistant sibling without altering the source checkpoint."""
+    return source.with_name(f"{source.stem}.resume-{uuid4().hex[:8]}{source.suffix}")
 
 
 def _none_if_blank(value: str | None) -> str | None:
@@ -14562,6 +14968,10 @@ def _run_jarvis_package_search_query(
 class _JarvisExecutionQueryAcceptance:
     """Durable evidence from one post-run unified JARVIS execution query."""
 
+    cluster: str
+    pipeline_id: str
+    execution_id: str
+    outcome: Literal["terminal", "observation_unknown", "terminal_artifacts_pending"]
     tools_list_response: dict[str, Any]
     call_response: dict[str, Any]
     call_job_id: str
@@ -14572,6 +14982,57 @@ class _JarvisExecutionQueryAcceptance:
     initialize_response: dict[str, Any]
     stdio_evidence: dict[str, Any]
     lifecycle_observations: list[dict[str, Any]]
+    scheduler_action: Literal["none"] = "none"
+    relay_action: Literal["none"] = "none"
+
+    def retry_selector(self) -> dict[str, object]:
+        """Return the exact execution identity for a later query-only observation."""
+        if not self.lifecycle_observations:
+            raise RelayError("JARVIS execution observation omitted durable lifecycle evidence")
+        latest = self.lifecycle_observations[-1]
+        handle = latest.get("execution_handle")
+        if not isinstance(handle, dict):
+            raise RelayError("JARVIS execution observation omitted its durable handle")
+        typed_handle = cast(dict[str, object], handle)
+        scheduler_cluster = typed_handle.get("cluster")
+        if scheduler_cluster is not None and (
+            not isinstance(scheduler_cluster, str) or not scheduler_cluster
+        ):
+            raise RelayError("JARVIS execution observation returned an invalid scheduler cluster")
+        return {
+            "cluster": self.cluster,
+            "scheduler_cluster": scheduler_cluster,
+            "pipeline_id": self.pipeline_id,
+            "execution_id": self.execution_id,
+            "scheduler_provider": typed_handle.get("scheduler_provider"),
+            "scheduler_native_id": typed_handle.get("scheduler_native_id"),
+            "last_query_job_id": self.call_job_id,
+        }
+
+
+@dataclass(frozen=True)
+class _JarvisExecutionQueryPending:
+    """Exact query-only resume identity before the first execution snapshot arrives."""
+
+    cluster: str
+    pipeline_id: str
+    execution_id: str
+    selector: dict[str, object]
+    outcome: Literal["observation_pending"] = "observation_pending"
+    lifecycle_observations: tuple[()] = ()
+    scheduler_action: Literal["none"] = "none"
+    relay_action: Literal["retain"] = "retain"
+
+    def retry_selector(self) -> dict[str, object]:
+        """Return the exact execution identity without inventing query evidence."""
+        if (
+            self.selector.get("cluster") != self.cluster
+            or self.selector.get("pipeline_id") != self.pipeline_id
+            or self.selector.get("execution_id") != self.execution_id
+            or self.selector.get("last_query_job_id") is not None
+        ):
+            raise RelayError("unobserved JARVIS execution selector is inconsistent")
+        return dict(self.selector)
 
 
 @dataclass(frozen=True)
@@ -14586,7 +15047,1054 @@ class _JarvisExecutionQueryAttempt:
     provenance: dict[str, Any] | None
 
 
+_JARVIS_NONTERMINAL_VALIDATION_CHECKS = frozenset(
+    {
+        "remote-mcp.jarvis-live-progress",
+        "remote-mcp.jarvis-execution-query",
+    }
+)
+_JARVIS_VALIDATION_RESUME_CHECKPOINT_SCHEMA_V1 = "clio-relay.jarvis-mcp-validation-resume.v1"
+_JARVIS_VALIDATION_RESUME_CHECKPOINT_SCHEMA = "clio-relay.jarvis-mcp-validation-resume.v2"
+_JARVIS_VALIDATION_PHASE_INTENT = "jarvis_run_intent"
+_JARVIS_VALIDATION_PHASE_DISPATCH = "jarvis_run_dispatch"
+_JARVIS_VALIDATION_PHASE_QUERY = "execution_query"
+
+
+def _canonical_jarvis_validation_digest(value: object) -> str:
+    """Hash one finite JSON value using the checkpoint's canonical encoding."""
+    try:
+        payload = json.dumps(
+            value,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise RelayError("JARVIS validation checkpoint evidence must be finite JSON") from exc
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _new_jarvis_validation_idempotency_key(
+    *,
+    cluster: str,
+    profile: str,
+    arguments: dict[str, Any],
+) -> str:
+    """Create a run-specific stable key before crossing the stdio dispatch boundary."""
+    intent_digest = _canonical_jarvis_validation_digest(
+        {
+            "cluster": cluster,
+            "profile": profile,
+            "tool": "jarvis_run",
+            "arguments": arguments,
+        }
+    )
+    return f"validation:jarvis-run:{cluster}:{intent_digest}:{uuid4().hex}"
+
+
+def _jarvis_run_execution_intent(
+    *,
+    cluster: str,
+    profile: str,
+    arguments: dict[str, Any],
+    idempotency_key: str,
+) -> dict[str, object]:
+    """Return the exact replayable virtual-tool request, including relay idempotency."""
+    return {
+        "cluster": cluster,
+        "profile": profile,
+        "tool": "jarvis_run",
+        "arguments": {
+            "cluster": cluster,
+            **arguments,
+            "idempotency_key": idempotency_key,
+        },
+    }
+
+
+def _new_jarvis_intent_resume_checkpoint(
+    *,
+    execution_intent: dict[str, object],
+    pre_dispatch_inputs: dict[str, Any],
+) -> dict[str, Any]:
+    """Persist an idempotent intent before a relay receipt is observable."""
+    cluster = cast(str, execution_intent["cluster"])
+    profile = cast(str, execution_intent["profile"])
+    arguments = cast(dict[str, object], execution_intent["arguments"])
+    idempotency_key = cast(str, arguments["idempotency_key"])
+    pipeline_id = cast(str, arguments["pipeline_id"])
+    selector: dict[str, object] = {
+        "cluster": cluster,
+        "pipeline_id": pipeline_id,
+        "relay_job_id": None,
+        "idempotency_key": idempotency_key,
+        "idempotency_key_sha256": hashlib.sha256(idempotency_key.encode("utf-8")).hexdigest(),
+        "execution_intent_sha256": _canonical_jarvis_validation_digest(execution_intent),
+        "pre_dispatch_inputs_sha256": _canonical_jarvis_validation_digest(pre_dispatch_inputs),
+        "call_response_sha256": None,
+        "dispatch_evidence_sha256": None,
+    }
+    return {
+        "schema_version": _JARVIS_VALIDATION_RESUME_CHECKPOINT_SCHEMA,
+        "phase": _JARVIS_VALIDATION_PHASE_INTENT,
+        "profile": profile,
+        "retry_selector": selector,
+        "execution_intent": execution_intent,
+        "pre_dispatch_inputs": pre_dispatch_inputs,
+    }
+
+
+def _promote_jarvis_intent_to_dispatch_checkpoint(
+    intent_checkpoint: dict[str, Any],
+    *,
+    job_id: str,
+    builder_inputs: dict[str, Any],
+) -> dict[str, Any]:
+    """Bind a pre-dispatch intent to the one durable relay receipt it returned."""
+    checkpoint = dict(intent_checkpoint)
+    selector = dict(cast(dict[str, object], checkpoint["retry_selector"]))
+    call_response = builder_inputs.get("call_response")
+    typed_call_response = (
+        cast(dict[str, Any], call_response) if isinstance(call_response, dict) else None
+    )
+    if typed_call_response is None or _mcp_response_job_id(typed_call_response) != job_id:
+        raise RelayError("JARVIS validation dispatch response changed its relay job identity")
+    selector.update(
+        {
+            "relay_job_id": job_id,
+            "call_response_sha256": _canonical_jarvis_validation_digest(typed_call_response),
+            "dispatch_evidence_sha256": _canonical_jarvis_validation_digest(builder_inputs),
+        }
+    )
+    checkpoint.update(
+        {
+            "phase": _JARVIS_VALIDATION_PHASE_DISPATCH,
+            "retry_selector": selector,
+            "builder_inputs": builder_inputs,
+        }
+    )
+    return checkpoint
+
+
+def _new_jarvis_intent_pending_report(
+    checkpoint: dict[str, Any],
+) -> LiveValidationReport:
+    """Represent an ambiguous stdio response as replayable intent, never workload failure."""
+    selector = cast(dict[str, object], checkpoint["retry_selector"])
+    inputs = cast(dict[str, object], checkpoint["pre_dispatch_inputs"])
+    report = new_live_validation_report(
+        scenario="remote-mcp",
+        cluster=cast(str, selector["cluster"]),
+        launcher=cast(str | None, inputs.get("launcher")),
+        install_source=cast(str | None, inputs.get("install_source")),
+        artifact_sha256=cast(str | None, inputs.get("artifact_sha256")),
+    )
+    now = datetime.now(UTC)
+    report.completed_at = now
+    report.status = ValidationStatus.PENDING
+    report.checks = [
+        ValidationCheck(
+            check_id="remote-mcp.jarvis-run-intent",
+            summary="idempotent jarvis_run dispatch response remains observable",
+            status=ValidationStatus.PENDING,
+            started_at=report.started_at,
+            completed_at=now,
+            evidence=[
+                EvidenceReference(
+                    kind="jarvis_run_intent_resume_selector",
+                    excerpt=json.dumps(selector, sort_keys=True),
+                    metadata={
+                        **selector,
+                        "scheduler_action": "none",
+                        "relay_action": "replay_same_idempotency_key",
+                    },
+                )
+            ],
+        )
+    ]
+    report.resources = [
+        ValidationResource(
+            kind="jarvis_dispatch_intent",
+            resource_id=cast(str, selector["execution_intent_sha256"]),
+            role="resumable_jarvis_run_intent",
+            cluster=cast(str, selector["cluster"]),
+            state="response_unobserved",
+            metadata={
+                "retry_selector": selector,
+                "outcome": "observation_pending",
+                "scheduler_action": "none",
+                "relay_action": "replay_same_idempotency_key",
+                "resume_checkpoint": checkpoint,
+            },
+        )
+    ]
+    return report
+
+
+def _convert_jarvis_checks_to_pending(
+    report: LiveValidationReport,
+    *,
+    pending_check_ids: frozenset[str],
+    resource: ValidationResource,
+) -> LiveValidationReport:
+    """Downgrade only checks whose evidence is unavailable within this observation window."""
+    failed_ids = {
+        check.check_id for check in report.checks if check.status is ValidationStatus.FAILED
+    }
+    if not failed_ids or failed_ids - pending_check_ids:
+        return report
+    updated_checks = [
+        check.model_copy(update={"status": ValidationStatus.PENDING, "error": None})
+        if check.status is ValidationStatus.FAILED and check.check_id in pending_check_ids
+        else check
+        for check in report.checks
+    ]
+    return report.model_copy(
+        update={
+            "status": ValidationStatus.PENDING,
+            "error": None,
+            "checks": updated_checks,
+            "resources": [*report.resources, resource],
+        }
+    )
+
+
+def _build_jarvis_dispatch_pending_report(
+    checkpoint: dict[str, Any],
+) -> LiveValidationReport:
+    """Retain one accepted relay job while its terminal result remains unobserved."""
+    builder_inputs = cast(dict[str, Any], checkpoint["builder_inputs"])
+    selector = cast(dict[str, object], checkpoint["retry_selector"])
+    report = build_jarvis_mcp_validation_report(
+        **builder_inputs,
+        query_tools_list_response=None,
+        query_call_response=None,
+        query_call_job_id="",
+        query_call_status={},
+        query_artifacts=[],
+        query_mcp_result=None,
+        query_provenance=None,
+        query_initialize_response=None,
+        query_stdio_evidence=None,
+        query_lifecycle_observations=[],
+    )
+    resource = ValidationResource(
+        kind="relay_job",
+        resource_id=cast(str, selector["relay_job_id"]),
+        role="resumable_jarvis_run_dispatch",
+        cluster=cast(str, selector["cluster"]),
+        state="observation_pending",
+        metadata={
+            "retry_selector": selector,
+            "outcome": "observation_pending",
+            "scheduler_action": "none",
+            "relay_action": "retain",
+            "resume_checkpoint": checkpoint,
+        },
+    )
+    return _convert_jarvis_checks_to_pending(
+        report,
+        pending_check_ids=frozenset(
+            {
+                "remote-mcp.jarvis-call",
+                "remote-mcp.server-artifact",
+                "remote-mcp.durable-result",
+                "remote-mcp.jarvis-live-progress",
+                "jarvis.spack-runtime-environment",
+                "jarvis.structured-runtime-metadata",
+                "remote-mcp.jarvis-execution-query",
+            }
+        ),
+        resource=resource,
+    )
+
+
+def _build_unobserved_jarvis_query_pending_report(
+    *,
+    builder_inputs: dict[str, Any],
+    execution_query: _JarvisExecutionQueryPending,
+    checkpoint: dict[str, Any],
+) -> LiveValidationReport:
+    """Retain exact execution identity when no query result arrives in the window."""
+    selector = execution_query.retry_selector()
+    report = build_jarvis_mcp_validation_report(
+        **builder_inputs,
+        query_tools_list_response=None,
+        query_call_response=None,
+        query_call_job_id="",
+        query_call_status={},
+        query_artifacts=[],
+        query_mcp_result=None,
+        query_provenance=None,
+        query_initialize_response=None,
+        query_stdio_evidence=None,
+        query_lifecycle_observations=[],
+    )
+    provider = selector.get("scheduler_provider")
+    resource = ValidationResource(
+        kind="jarvis_execution",
+        resource_id=execution_query.execution_id,
+        role="resumable_acceptance_workload",
+        cluster=execution_query.cluster,
+        provider=provider if isinstance(provider, str) else None,
+        state="observation_pending",
+        metadata={
+            "retry_selector": selector,
+            "outcome": execution_query.outcome,
+            "scheduler_action": execution_query.scheduler_action,
+            "relay_action": execution_query.relay_action,
+            "resume_checkpoint": checkpoint,
+        },
+    )
+    return _convert_jarvis_checks_to_pending(
+        report,
+        pending_check_ids=_JARVIS_NONTERMINAL_VALIDATION_CHECKS,
+        resource=resource,
+    )
+
+
+def _mark_jarvis_validation_pending(
+    report: LiveValidationReport,
+    *,
+    execution_query: _JarvisExecutionQueryAcceptance,
+    resume_checkpoint: dict[str, Any] | None = None,
+) -> LiveValidationReport:
+    """Convert only terminal-dependent failures into honest resumable evidence."""
+    failed_check_ids = {
+        check.check_id for check in report.checks if check.status is ValidationStatus.FAILED
+    }
+    unexpected_failures = failed_check_ids - _JARVIS_NONTERMINAL_VALIDATION_CHECKS
+    if unexpected_failures or not _jarvis_nonterminal_failures_are_resumable(
+        report,
+        execution_query=execution_query,
+    ):
+        return report
+    selector = execution_query.retry_selector()
+    latest = execution_query.lifecycle_observations[-1]
+    updated_checks = [
+        check.model_copy(
+            update={
+                "status": ValidationStatus.PENDING,
+                "error": None,
+                "evidence": [
+                    *check.evidence,
+                    EvidenceReference(
+                        kind="jarvis_execution_resume_selector",
+                        excerpt=json.dumps(selector, sort_keys=True),
+                        metadata={
+                            **selector,
+                            "scheduler_action": execution_query.scheduler_action,
+                            "relay_action": execution_query.relay_action,
+                        },
+                    ),
+                ],
+            }
+        )
+        if check.check_id in _JARVIS_NONTERMINAL_VALIDATION_CHECKS
+        and check.status is ValidationStatus.FAILED
+        else check
+        for check in report.checks
+    ]
+    provider = selector.get("scheduler_provider")
+    resource = ValidationResource(
+        kind="jarvis_execution",
+        resource_id=execution_query.execution_id,
+        role="resumable_acceptance_workload",
+        cluster=execution_query.cluster,
+        provider=provider if isinstance(provider, str) else None,
+        state=str(latest.get("state")) if latest.get("state") is not None else None,
+        metadata={
+            "retry_selector": selector,
+            "outcome": execution_query.outcome,
+            "scheduler_action": execution_query.scheduler_action,
+            "relay_action": execution_query.relay_action,
+            **({"resume_checkpoint": resume_checkpoint} if resume_checkpoint is not None else {}),
+        },
+    )
+    return report.model_copy(
+        update={
+            "status": ValidationStatus.PENDING,
+            "error": None,
+            "checks": updated_checks,
+            "resources": [*report.resources, resource],
+        }
+    )
+
+
+def _jarvis_nonterminal_failures_are_resumable(
+    report: LiveValidationReport,
+    *,
+    execution_query: _JarvisExecutionQueryAcceptance,
+) -> bool:
+    """Require all nonterminal integrity assertions before downgrading terminal checks."""
+    required_assertions = {
+        "remote-mcp.jarvis-live-progress": {
+            "observation_count_bounded",
+            "query_identities_coherent",
+            "scheduler_identity_optional_coherent_and_stable",
+            "lifecycle_prefix_coherent",
+            "package_progress_nonregressing",
+        },
+        "remote-mcp.jarvis-execution-query": {
+            "local_query_surface_verified",
+            "server_artifact_binding_verified",
+            "resumable_query_job_verified",
+            "resumable_result_transport_verified",
+            "resumable_result_envelope_verified",
+            "resumable_identity_coherent",
+            "resumable_lifecycle_coherent",
+            "resumable_runner_semantic_validation_verified",
+        },
+    }
+    if not execution_query.lifecycle_observations:
+        return False
+    latest = execution_query.lifecycle_observations[-1]
+    terminal = latest.get("terminal")
+    if execution_query.outcome == "observation_unknown" and terminal is not False:
+        return False
+    if execution_query.outcome == "terminal_artifacts_pending" and terminal is not True:
+        return False
+    for check in report.checks:
+        required = required_assertions.get(check.check_id)
+        if check.status is not ValidationStatus.FAILED or required is None:
+            continue
+        if len(check.evidence) != 1:
+            return False
+        assertions = check.evidence[0].metadata.get("assertions")
+        if not isinstance(assertions, dict) or not all(
+            cast(dict[str, object], assertions).get(name) is True for name in required
+        ):
+            return False
+    return True
+
+
+def _load_jarvis_validation_resume_checkpoint(
+    path: Path,
+    *,
+    cluster: str,
+) -> dict[str, Any]:
+    """Load one exact pending acceptance checkpoint without trusting caller selectors."""
+    report = load_validation_report(path)
+    if report.scenario != "remote-mcp" or report.cluster != cluster:
+        raise ConfigurationError(
+            "JARVIS validation resume report does not match the requested cluster/scenario"
+        )
+    if report.status is not ValidationStatus.PENDING:
+        raise ConfigurationError("JARVIS validation resume requires a pending report")
+    candidates = [
+        (resource, resource.metadata.get("resume_checkpoint"))
+        for resource in report.resources
+        if isinstance(resource.metadata.get("resume_checkpoint"), dict)
+        and (
+            (
+                resource.kind == "jarvis_execution"
+                and resource.role == "resumable_acceptance_workload"
+            )
+            or (resource.kind == "relay_job" and resource.role == "resumable_jarvis_run_dispatch")
+            or (
+                resource.kind == "jarvis_dispatch_intent"
+                and resource.role == "resumable_jarvis_run_intent"
+            )
+        )
+    ]
+    if len(candidates) != 1:
+        raise ConfigurationError(
+            "pending JARVIS validation report must contain one resume checkpoint"
+        )
+    resource, raw_checkpoint = candidates[0]
+    checkpoint = cast(dict[str, Any], raw_checkpoint)
+    schema_version = checkpoint.get("schema_version")
+    if schema_version == _JARVIS_VALIDATION_RESUME_CHECKPOINT_SCHEMA_V1:
+        phase = _JARVIS_VALIDATION_PHASE_QUERY
+    elif schema_version == _JARVIS_VALIDATION_RESUME_CHECKPOINT_SCHEMA:
+        phase = checkpoint.get("phase")
+    else:
+        raise ConfigurationError("pending JARVIS validation resume checkpoint is invalid")
+    if phase in {_JARVIS_VALIDATION_PHASE_INTENT, _JARVIS_VALIDATION_PHASE_DISPATCH}:
+        return _validate_jarvis_dispatch_resume_checkpoint(
+            checkpoint,
+            resource=resource,
+            cluster=cluster,
+        )
+    if phase != _JARVIS_VALIDATION_PHASE_QUERY:
+        raise ConfigurationError("pending JARVIS validation resume checkpoint phase is invalid")
+    selector = checkpoint.get("retry_selector")
+    builder_inputs = checkpoint.get("builder_inputs")
+    observations = checkpoint.get("lifecycle_observations")
+    profile = checkpoint.get("profile")
+    unobserved = (
+        schema_version == _JARVIS_VALIDATION_RESUME_CHECKPOINT_SCHEMA
+        and checkpoint.get("observation_state") == "not_observed"
+    )
+    if (
+        not isinstance(selector, dict)
+        or resource.kind != "jarvis_execution"
+        or resource.role != "resumable_acceptance_workload"
+        or cast(dict[str, object], selector).get("cluster") != cluster
+        or not isinstance(cast(dict[str, object], selector).get("pipeline_id"), str)
+        or not cast(str, cast(dict[str, object], selector).get("pipeline_id"))
+        or not isinstance(cast(dict[str, object], selector).get("execution_id"), str)
+        or not cast(str, cast(dict[str, object], selector).get("execution_id"))
+        or not isinstance(builder_inputs, dict)
+        or cast(dict[str, object], builder_inputs).get("cluster") != cluster
+        or "scheduler_cluster" not in cast(dict[str, object], builder_inputs)
+        or cast(dict[str, object], builder_inputs).get("tool") != "jarvis_run"
+        or not isinstance(cast(dict[str, object], builder_inputs).get("runtime_metadata"), dict)
+        or not isinstance(observations, list)
+        or (not observations and not unobserved)
+        or (bool(cast(list[object], observations)) and unobserved)
+        or len(cast(list[object], observations)) > _MAX_JARVIS_EXECUTION_QUERY_OBSERVATIONS
+        or profile not in {"user", "admin", "operator", "all"}
+        or (
+            schema_version == _JARVIS_VALIDATION_RESUME_CHECKPOINT_SCHEMA
+            and checkpoint.get("observation_state") not in {"not_observed", "observed"}
+        )
+    ):
+        raise ConfigurationError("pending JARVIS validation resume checkpoint is invalid")
+    typed_selector = cast(dict[str, object], selector)
+    pipeline_id = cast(str, typed_selector["pipeline_id"])
+    execution_id = cast(str, typed_selector["execution_id"])
+    scheduler_cluster = typed_selector.get("scheduler_cluster")
+    scheduler_provider = typed_selector.get("scheduler_provider")
+    scheduler_native_id = typed_selector.get("scheduler_native_id")
+    last_query_job_id = typed_selector.get("last_query_job_id")
+    builder_scheduler_cluster = cast(dict[str, object], builder_inputs).get("scheduler_cluster")
+    expected_mode = "scheduler" if scheduler_provider is not None else "direct"
+    if (
+        "scheduler_cluster" not in typed_selector
+        or builder_scheduler_cluster != scheduler_cluster
+        or (
+            scheduler_cluster is not None
+            and (not isinstance(scheduler_cluster, str) or not scheduler_cluster)
+        )
+        or (
+            scheduler_provider is not None
+            and (not isinstance(scheduler_provider, str) or not scheduler_provider)
+        )
+        or (
+            scheduler_native_id is not None
+            and (not isinstance(scheduler_native_id, str) or not scheduler_native_id)
+        )
+        or (scheduler_provider is None and scheduler_native_id is not None)
+        or (
+            unobserved
+            and (
+                last_query_job_id is not None
+                or resource.state != "observation_pending"
+                or resource.metadata.get("outcome") != "observation_pending"
+            )
+        )
+        or (not unobserved and (not isinstance(last_query_job_id, str) or not last_query_job_id))
+        or resource.resource_id != execution_id
+        or resource.cluster != cluster
+        or resource.provider != scheduler_provider
+        or resource.metadata.get("retry_selector") != selector
+    ):
+        raise ConfigurationError("pending JARVIS validation resume identity is invalid")
+    typed_observations: list[dict[str, object]] = []
+    validated_prefix: list[dict[str, Any]] = []
+    scheduler_native_id_assigned = False
+    scheduler_cluster_assigned = False
+    for raw_observation in cast(list[object], observations):
+        if not isinstance(raw_observation, dict):
+            raise ConfigurationError("pending JARVIS validation observation is invalid")
+        observation = {
+            str(key): value for key, value in cast(dict[object, object], raw_observation).items()
+        }
+        handle = observation.get("execution_handle")
+        if not isinstance(handle, dict):
+            raise ConfigurationError("pending JARVIS validation observation is invalid")
+        typed_handle = cast(dict[str, object], handle)
+        observation_scheduler_cluster = typed_handle.get("cluster")
+        observation_native_id = typed_handle.get("scheduler_native_id")
+        if (
+            observation.get("pipeline_id") != pipeline_id
+            or observation.get("execution_id") != execution_id
+            or not isinstance(observation.get("query_job_id"), str)
+            or not observation.get("query_job_id")
+            or typed_handle.get("pipeline_id") != pipeline_id
+            or typed_handle.get("execution_id") != execution_id
+            or typed_handle.get("mode") != expected_mode
+            or typed_handle.get("scheduler_provider") != scheduler_provider
+        ):
+            raise ConfigurationError("pending JARVIS validation observation identity changed")
+        if scheduler_native_id is None:
+            if observation_native_id is not None:
+                raise ConfigurationError("pending JARVIS validation observation identity changed")
+        elif observation_native_id is None:
+            if scheduler_native_id_assigned:
+                raise ConfigurationError("pending JARVIS validation observation identity changed")
+        elif observation_native_id != scheduler_native_id:
+            raise ConfigurationError("pending JARVIS validation observation identity changed")
+        else:
+            scheduler_native_id_assigned = True
+        if scheduler_cluster is None:
+            if observation_scheduler_cluster is not None:
+                raise ConfigurationError("pending JARVIS validation observation identity changed")
+        elif observation_scheduler_cluster is None:
+            if scheduler_cluster_assigned:
+                raise ConfigurationError("pending JARVIS validation observation identity changed")
+        elif observation_scheduler_cluster != scheduler_cluster:
+            raise ConfigurationError("pending JARVIS validation observation identity changed")
+        else:
+            scheduler_cluster_assigned = True
+        if observation.get(_JARVIS_QUERY_INTEGRITY_KEY) is not None:
+            raise ConfigurationError("pending JARVIS validation observation integrity failed")
+        gap_marker = observation.get(_JARVIS_VERIFIED_GAP_KEY)
+        crossed_verified_gap = gap_marker is not None
+        if crossed_verified_gap and (
+            not validated_prefix
+            or not _valid_jarvis_verified_gap_marker(
+                gap_marker,
+                previous=validated_prefix[-1],
+                current=cast(dict[str, Any], observation),
+            )
+        ):
+            raise ConfigurationError("pending JARVIS validation observation gap is invalid")
+        integrity_violation = _jarvis_query_integrity_violation(
+            validated_prefix,
+            cast(dict[str, Any], observation),
+            crossed_verified_gap=crossed_verified_gap,
+        )
+        if integrity_violation is not None:
+            raise ConfigurationError(
+                "pending JARVIS validation observation integrity failed: "
+                f"{integrity_violation['reason']}"
+            )
+        validated_prefix.append(cast(dict[str, Any], observation))
+        typed_observations.append(observation)
+    if typed_observations:
+        latest = typed_observations[-1]
+        latest_handle = cast(dict[str, object], latest["execution_handle"])
+        if (
+            latest.get("query_job_id") != last_query_job_id
+            or resource.state != latest.get("state")
+            or latest_handle.get("cluster") != scheduler_cluster
+            or latest_handle.get("scheduler_native_id") != scheduler_native_id
+        ):
+            raise ConfigurationError("pending JARVIS validation latest observation changed")
+    typed_runtime = cast(
+        dict[str, Any],
+        cast(dict[str, object], builder_inputs)["runtime_metadata"],
+    )
+    runtime_scheduler_job_id = typed_runtime.get("scheduler_job_id")
+    runtime_details = typed_runtime.get("details")
+    runtime_native_execution = (
+        cast(dict[str, object], runtime_details).get("native_execution")
+        if isinstance(runtime_details, dict)
+        else None
+    )
+    if (
+        typed_runtime.get("schema_version") != RUNTIME_METADATA_SCHEMA
+        or typed_runtime.get("source") != "jarvis_mcp"
+        or typed_runtime.get("pipeline_id") != pipeline_id
+        or typed_runtime.get("execution_id") != execution_id
+        or typed_runtime.get("scheduler_provider") != scheduler_provider
+        or (
+            runtime_scheduler_job_id is not None and runtime_scheduler_job_id != scheduler_native_id
+        )
+    ):
+        raise ConfigurationError("pending JARVIS validation runtime identity changed")
+    if not isinstance(runtime_native_execution, dict):
+        raise ConfigurationError("pending JARVIS validation runtime identity changed")
+    try:
+        native_documents = native_execution_documents(
+            cast(dict[str, Any], runtime_native_execution)
+        )
+    except (ValidationError, ValueError) as exc:
+        raise ConfigurationError("pending JARVIS validation runtime identity changed") from exc
+    if native_documents is None:
+        raise ConfigurationError("pending JARVIS validation runtime identity changed")
+    runtime_handle = native_documents.execution_handle
+    runtime_record = native_documents.execution_record
+    runtime_progress = native_documents.progress
+    runtime_terminal = typed_runtime.get("terminal")
+    if not isinstance(runtime_terminal, dict):
+        raise ConfigurationError("pending JARVIS validation runtime identity changed")
+    typed_runtime_terminal = cast(dict[str, object], runtime_terminal)
+    first_state = typed_observations[0].get("state") if typed_observations else runtime_record.state
+    runtime_rank = _JARVIS_EXECUTION_STATE_RANK.get(runtime_record.state)
+    first_rank = (
+        _JARVIS_EXECUTION_STATE_RANK.get(first_state) if isinstance(first_state, str) else None
+    )
+    if (
+        runtime_handle.pipeline_id != pipeline_id
+        or runtime_handle.execution_id != execution_id
+        or runtime_handle.mode != expected_mode
+        or runtime_handle.scheduler_provider != scheduler_provider
+        or runtime_handle.scheduler_native_id != runtime_scheduler_job_id
+        or (
+            runtime_handle.scheduler_native_id is not None
+            and runtime_handle.scheduler_native_id != scheduler_native_id
+        )
+        or (runtime_handle.cluster is not None and runtime_handle.cluster != scheduler_cluster)
+        or typed_runtime_terminal.get("state") != runtime_record.state
+        or typed_runtime_terminal.get("terminal") is not runtime_record.terminal
+        or typed_runtime_terminal.get("returncode") != runtime_record.return_code
+        or typed_runtime_terminal.get("reason") != runtime_record.error
+        or runtime_progress.pipeline_id != pipeline_id
+        or runtime_progress.execution_id != execution_id
+        or (runtime_rank is not None and first_rank is not None and first_rank < runtime_rank)
+        or (
+            typed_observations
+            and runtime_record.terminal
+            and (
+                typed_observations[0].get("terminal") is not True
+                or first_state != runtime_record.state
+            )
+        )
+    ):
+        raise ConfigurationError("pending JARVIS validation runtime identity changed")
+    return checkpoint
+
+
+def _validate_jarvis_dispatch_resume_checkpoint(
+    checkpoint: dict[str, Any],
+    *,
+    resource: ValidationResource,
+    cluster: str,
+) -> dict[str, Any]:
+    """Fail closed on any change to a pre-query JARVIS dispatch identity."""
+    phase = checkpoint.get("phase")
+    profile = checkpoint.get("profile")
+    selector = checkpoint.get("retry_selector")
+    intent = checkpoint.get("execution_intent")
+    pre_dispatch_inputs = checkpoint.get("pre_dispatch_inputs")
+    if (
+        checkpoint.get("schema_version") != _JARVIS_VALIDATION_RESUME_CHECKPOINT_SCHEMA
+        or phase not in {_JARVIS_VALIDATION_PHASE_INTENT, _JARVIS_VALIDATION_PHASE_DISPATCH}
+        or profile not in {"user", "admin", "operator", "all"}
+        or not isinstance(selector, dict)
+        or not isinstance(intent, dict)
+        or not isinstance(pre_dispatch_inputs, dict)
+    ):
+        raise ConfigurationError("pending JARVIS dispatch checkpoint is invalid")
+    typed_selector = cast(dict[str, object], selector)
+    typed_intent = cast(dict[str, object], intent)
+    typed_pre_dispatch_inputs = cast(dict[str, Any], pre_dispatch_inputs)
+    raw_arguments = typed_intent.get("arguments")
+    if not isinstance(raw_arguments, dict):
+        raise ConfigurationError("pending JARVIS dispatch intent is invalid")
+    arguments = cast(dict[str, object], raw_arguments)
+    idempotency_key = arguments.get("idempotency_key")
+    pipeline_id = arguments.get("pipeline_id")
+    expected_selector_fields = {
+        "cluster",
+        "pipeline_id",
+        "relay_job_id",
+        "idempotency_key",
+        "idempotency_key_sha256",
+        "execution_intent_sha256",
+        "pre_dispatch_inputs_sha256",
+        "call_response_sha256",
+        "dispatch_evidence_sha256",
+    }
+    if (
+        set(typed_selector) != expected_selector_fields
+        or typed_intent.get("cluster") != cluster
+        or typed_intent.get("profile") != profile
+        or typed_intent.get("tool") != "jarvis_run"
+        or arguments.get("cluster") != cluster
+        or not isinstance(pipeline_id, str)
+        or not pipeline_id
+        or not isinstance(idempotency_key, str)
+        or not idempotency_key
+        or len(idempotency_key) > 512
+        or typed_selector.get("cluster") != cluster
+        or typed_selector.get("pipeline_id") != pipeline_id
+        or typed_selector.get("idempotency_key") != idempotency_key
+        or typed_selector.get("execution_intent_sha256")
+        != _canonical_jarvis_validation_digest(typed_intent)
+        or typed_selector.get("pre_dispatch_inputs_sha256")
+        != _canonical_jarvis_validation_digest(typed_pre_dispatch_inputs)
+        or typed_selector.get("idempotency_key_sha256")
+        != hashlib.sha256(idempotency_key.encode("utf-8")).hexdigest()
+        or typed_pre_dispatch_inputs.get("cluster") != cluster
+        or typed_pre_dispatch_inputs.get("tool") != "jarvis_run"
+        or not isinstance(typed_pre_dispatch_inputs.get("package_search_query"), str)
+        or not typed_pre_dispatch_inputs.get("package_search_query")
+    ):
+        raise ConfigurationError("pending JARVIS dispatch identity changed")
+    if (
+        resource.cluster != cluster
+        or resource.provider is not None
+        or resource.metadata.get("retry_selector") != selector
+        or resource.metadata.get("resume_checkpoint") != checkpoint
+        or resource.metadata.get("outcome") != "observation_pending"
+        or resource.metadata.get("scheduler_action") != "none"
+    ):
+        raise ConfigurationError("pending JARVIS dispatch resource identity changed")
+    relay_job_id = typed_selector.get("relay_job_id")
+    if phase == _JARVIS_VALIDATION_PHASE_INTENT:
+        if (
+            relay_job_id is not None
+            or typed_selector.get("call_response_sha256") is not None
+            or typed_selector.get("dispatch_evidence_sha256") is not None
+            or "builder_inputs" in checkpoint
+            or resource.kind != "jarvis_dispatch_intent"
+            or resource.role != "resumable_jarvis_run_intent"
+            or resource.resource_id != typed_selector.get("execution_intent_sha256")
+            or resource.state != "response_unobserved"
+            or resource.metadata.get("relay_action") != "replay_same_idempotency_key"
+        ):
+            raise ConfigurationError("pending JARVIS dispatch intent changed")
+        return checkpoint
+    builder_inputs = checkpoint.get("builder_inputs")
+    if (
+        not isinstance(builder_inputs, dict)
+        or not isinstance(relay_job_id, str)
+        or not relay_job_id
+    ):
+        raise ConfigurationError("pending JARVIS relay dispatch checkpoint is invalid")
+    typed_builder = cast(dict[str, Any], builder_inputs)
+    call_response = typed_builder.get("call_response")
+    typed_call_response = (
+        cast(dict[str, Any], call_response) if isinstance(call_response, dict) else None
+    )
+    try:
+        response_job_id = (
+            _mcp_response_job_id(typed_call_response) if typed_call_response is not None else None
+        )
+    except RelayError as exc:
+        raise ConfigurationError("pending JARVIS relay dispatch response is invalid") from exc
+    if (
+        response_job_id != relay_job_id
+        or typed_builder.get("cluster") != cluster
+        or typed_builder.get("tool") != "jarvis_run"
+        or typed_builder.get("call_job_id") != relay_job_id
+        or typed_builder.get("scheduler_cluster") is not None
+        or typed_builder.get("call_status") != {}
+        or typed_builder.get("artifacts") != []
+        or typed_builder.get("mcp_result") is not None
+        or typed_builder.get("provenance") is not None
+        or typed_builder.get("runtime_metadata") is not None
+        or typed_builder.get("progress") != []
+        or typed_builder.get("live_progress_observation") is not None
+        or any(typed_builder.get(key) != value for key, value in typed_pre_dispatch_inputs.items())
+        or typed_selector.get("call_response_sha256")
+        != _canonical_jarvis_validation_digest(typed_call_response)
+        or typed_selector.get("dispatch_evidence_sha256")
+        != _canonical_jarvis_validation_digest(typed_builder)
+        or resource.kind != "relay_job"
+        or resource.role != "resumable_jarvis_run_dispatch"
+        or resource.resource_id != relay_job_id
+        or resource.state != "observation_pending"
+        or resource.metadata.get("relay_action") != "retain"
+    ):
+        raise ConfigurationError("pending JARVIS relay dispatch identity changed")
+    return checkpoint
+
+
+def _require_same_jarvis_resume_identity(
+    *,
+    expected: dict[str, Any],
+    observed: dict[str, object],
+) -> None:
+    """Reject a resume snapshot whose durable workload identity changed."""
+    for field in ("cluster", "pipeline_id", "execution_id", "scheduler_provider"):
+        if observed.get(field) != expected.get(field):
+            raise RelayError(f"JARVIS validation resume changed {field}")
+    expected_native_id = expected.get("scheduler_native_id")
+    observed_native_id = observed.get("scheduler_native_id")
+    if expected_native_id is not None and observed_native_id != expected_native_id:
+        raise RelayError("JARVIS validation resume changed scheduler_native_id")
+    if observed_native_id is not None and (
+        not isinstance(observed_native_id, str) or not observed_native_id
+    ):
+        raise RelayError("JARVIS validation resume returned an invalid scheduler_native_id")
+    expected_scheduler_cluster = expected.get("scheduler_cluster")
+    observed_scheduler_cluster = observed.get("scheduler_cluster")
+    if (
+        expected_scheduler_cluster is not None
+        and observed_scheduler_cluster != expected_scheduler_cluster
+    ):
+        raise RelayError("JARVIS validation resume changed scheduler_cluster")
+    if observed_scheduler_cluster is not None and (
+        not isinstance(observed_scheduler_cluster, str) or not observed_scheduler_cluster
+    ):
+        raise RelayError("JARVIS validation resume returned an invalid scheduler_cluster")
+
+
+def _jarvis_execution_retry_selector_from_runtime_metadata(
+    runtime_metadata: dict[str, Any],
+    *,
+    cluster: str,
+    pipeline_id: str,
+    execution_id: str,
+) -> dict[str, object]:
+    """Bind a query-only selector to JARVIS's structured native execution authority."""
+    details = runtime_metadata.get("details")
+    native_execution = (
+        cast(dict[str, object], details).get("native_execution")
+        if isinstance(details, dict)
+        else None
+    )
+    if (
+        runtime_metadata.get("schema_version") != RUNTIME_METADATA_SCHEMA
+        or runtime_metadata.get("source") != "jarvis_mcp"
+        or runtime_metadata.get("pipeline_id") != pipeline_id
+        or runtime_metadata.get("execution_id") != execution_id
+        or not isinstance(native_execution, dict)
+    ):
+        raise RelayError("JARVIS run metadata omitted its structured execution identity")
+    try:
+        documents = native_execution_documents(cast(dict[str, Any], native_execution))
+    except (ValidationError, ValueError) as exc:
+        raise RelayError(
+            "JARVIS run metadata contains an invalid native execution identity"
+        ) from exc
+    if documents is None:
+        raise RelayError("JARVIS run metadata omitted its native execution identity")
+    handle = documents.execution_handle
+    scheduler_provider = runtime_metadata.get("scheduler_provider")
+    scheduler_native_id = runtime_metadata.get("scheduler_job_id")
+    if (
+        handle.pipeline_id != pipeline_id
+        or handle.execution_id != execution_id
+        or handle.scheduler_provider != scheduler_provider
+        or handle.scheduler_native_id != scheduler_native_id
+        or (scheduler_provider is None and scheduler_native_id is not None)
+    ):
+        raise RelayError("JARVIS run metadata contains inconsistent scheduler identity")
+    return {
+        "cluster": cluster,
+        "scheduler_cluster": handle.cluster,
+        "pipeline_id": pipeline_id,
+        "execution_id": execution_id,
+        "scheduler_provider": scheduler_provider,
+        "scheduler_native_id": scheduler_native_id,
+        "last_query_job_id": None,
+    }
+
+
+def _require_jarvis_run_dispatch_job_identity(
+    status: dict[str, object],
+    *,
+    cluster: str,
+    job_id: str,
+    pipeline_id: str,
+    idempotency_key: str,
+) -> None:
+    """Verify that a resumed receipt still denotes the exact accepted jarvis_run call."""
+    raw_job = status.get("job")
+    job = cast(dict[str, object], raw_job) if isinstance(raw_job, dict) else {}
+    raw_spec = job.get("spec")
+    spec = cast(dict[str, object], raw_spec) if isinstance(raw_spec, dict) else {}
+    raw_arguments = spec.get("arguments")
+    arguments = cast(dict[str, object], raw_arguments) if isinstance(raw_arguments, dict) else {}
+    if (
+        status.get("terminal") is not True
+        or job.get("job_id") != job_id
+        or job.get("cluster") != cluster
+        or job.get("kind") != "mcp_call"
+        or job.get("idempotency_key") != idempotency_key
+        or spec.get("operation") != "tools/call"
+        or spec.get("tool") != "jarvis_run"
+        or arguments.get("pipeline_id") != pipeline_id
+    ):
+        raise RelayError("resumed JARVIS relay job changed its dispatch identity")
+
+
+def _complete_jarvis_run_dispatch(
+    *,
+    definition: ClusterDefinition,
+    queue: ClioCoreQueue,
+    checkpoint: dict[str, Any],
+    wait_timeout_seconds: float,
+    poll_seconds: float,
+) -> dict[str, Any]:
+    """Wait and collect one exact relay dispatch without ever resubmitting it."""
+    selector = cast(dict[str, object], checkpoint["retry_selector"])
+    cluster = cast(str, selector["cluster"])
+    job_id = cast(str, selector["relay_job_id"])
+    pipeline_id = cast(str, selector["pipeline_id"])
+    idempotency_key = cast(str, selector["idempotency_key"])
+    if should_execute_on_cluster(definition):
+        call_status = _wait_for_remote_job_terminal(
+            definition,
+            job_id,
+            timeout_seconds=wait_timeout_seconds,
+            poll_seconds=poll_seconds,
+        )
+        _require_jarvis_run_dispatch_job_identity(
+            call_status,
+            cluster=cluster,
+            job_id=job_id,
+            pipeline_id=pipeline_id,
+            idempotency_key=idempotency_key,
+        )
+        progress = _complete_remote_collection(
+            definition,
+            ["job", "progress", job_id],
+            record_key="progress",
+            label=f"JARVIS MCP dispatch progress for {job_id}",
+        )
+        artifacts = _remote_artifact_records(definition, job_id)
+        mcp_result = _read_remote_json_artifact_kind(definition, artifacts, kind="mcp_result")
+        provenance = _read_remote_json_artifact_kind(definition, artifacts, kind="provenance")
+        runtime_metadata = _read_remote_json_artifact_kind(
+            definition, artifacts, kind="runtime_metadata"
+        )
+    else:
+        call_status = _wait_for_local_job_terminal(
+            queue,
+            job_id,
+            timeout_seconds=wait_timeout_seconds,
+            poll_seconds=poll_seconds,
+        )
+        _require_jarvis_run_dispatch_job_identity(
+            call_status,
+            cluster=cluster,
+            job_id=job_id,
+            pipeline_id=pipeline_id,
+            idempotency_key=idempotency_key,
+        )
+        progress = _complete_local_progress_records(queue, job_id)
+        artifacts = _complete_local_artifact_records(queue, job_id)
+        mcp_result = _read_local_json_artifact_kind(queue, artifacts, kind="mcp_result")
+        provenance = _read_local_json_artifact_kind(queue, artifacts, kind="provenance")
+        runtime_metadata = _read_local_json_artifact_kind(queue, artifacts, kind="runtime_metadata")
+    return {
+        **cast(dict[str, Any], checkpoint["builder_inputs"]),
+        "call_status": call_status,
+        "artifacts": artifacts,
+        "mcp_result": mcp_result,
+        "provenance": provenance,
+        "runtime_metadata": runtime_metadata,
+        "progress": progress,
+        "live_progress_observation": None,
+    }
+
+
+def _merge_jarvis_execution_query_observations(
+    prior: list[dict[str, Any]],
+    current: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Merge bounded query snapshots while preserving lifecycle order across retries."""
+    merged: list[dict[str, Any]] = []
+    for observation in [*prior, *current]:
+        _append_bounded_jarvis_execution_query_observation(merged, observation)
+    return merged
+
+
 _MAX_JARVIS_EXECUTION_QUERY_OBSERVATIONS = 512
+_JARVIS_QUERY_INTEGRITY_KEY = "relay_query_integrity"
+_JARVIS_QUERY_INTEGRITY_SCHEMA = "clio-relay.jarvis-query-integrity.v1"
+_JARVIS_VERIFIED_GAP_KEY = "relay_query_verified_gap"
+_JARVIS_VERIFIED_GAP_SCHEMA = "clio-relay.jarvis-query-verified-gap.v1"
+_JARVIS_EXECUTION_STATE_RANK = {
+    "preparing": 0,
+    "scripted": 1,
+    "submitting": 2,
+    "submitted": 3,
+    "running": 4,
+    "completed": 5,
+    "failed": 5,
+    "canceled": 5,
+}
+_JARVIS_PACKAGE_PROGRESS_STATES = frozenset(
+    {"pending", "starting", "running", "ready", "completed", "failed", "canceled"}
+)
 
 
 def _append_bounded_jarvis_execution_query_observation(
@@ -14594,6 +16102,46 @@ def _append_bounded_jarvis_execution_query_observation(
     observation: dict[str, Any],
 ) -> None:
     """Retain ordered lifecycle evidence without failing a healthy long run."""
+    prior_violation = any(
+        _valid_jarvis_query_integrity_marker(item.get(_JARVIS_QUERY_INTEGRITY_KEY))
+        for item in observations
+    )
+    incoming_marker = observation.get(_JARVIS_QUERY_INTEGRITY_KEY)
+    incoming_gap = observation.get(_JARVIS_VERIFIED_GAP_KEY)
+    gap_invalid = incoming_gap is not None and (
+        not observations
+        or not _valid_jarvis_verified_gap_marker(
+            incoming_gap,
+            previous=observations[-1],
+            current=observation,
+        )
+    )
+    if gap_invalid:
+        observation = {
+            **observation,
+            _JARVIS_QUERY_INTEGRITY_KEY: _jarvis_query_integrity_summary(
+                "verified_gap_invalid",
+                observations[-1].get("state") if observations else None,
+                observation.get("state"),
+            ),
+        }
+    elif incoming_marker is not None and not _valid_jarvis_query_integrity_marker(incoming_marker):
+        observation = {
+            **observation,
+            _JARVIS_QUERY_INTEGRITY_KEY: _jarvis_query_integrity_summary(
+                "integrity_marker_invalid",
+                observations[-1].get("state") if observations else None,
+                observation.get("state"),
+            ),
+        }
+    elif not prior_violation and incoming_marker is None:
+        violation = _jarvis_query_integrity_violation(
+            observations,
+            observation,
+            crossed_verified_gap=incoming_gap is not None,
+        )
+        if violation is not None:
+            observation = {**observation, _JARVIS_QUERY_INTEGRITY_KEY: violation}
     observations.append(observation)
     if len(observations) <= _MAX_JARVIS_EXECUTION_QUERY_OBSERVATIONS:
         return
@@ -14610,6 +16158,8 @@ def _append_bounded_jarvis_execution_query_observation(
         )
         state_key = (state, item.get("terminal"))
         first_state_indexes.setdefault(state_key, index)
+        if _valid_jarvis_query_integrity_marker(item.get(_JARVIS_QUERY_INTEGRITY_KEY)):
+            protected_indexes.add(index)
         if first_live_progress_index is None and _has_live_jarvis_package_progress(item):
             first_live_progress_index = index
     protected_indexes.update(first_state_indexes.values())
@@ -14625,9 +16175,562 @@ def _append_bounded_jarvis_execution_query_observation(
             for index in range(available_slots)
         }
         protected_indexes.update(selected)
-    observations[:] = [
-        item for index, item in enumerate(observations) if index in protected_indexes
-    ]
+    selected_indexes = sorted(protected_indexes)
+    compacted: list[dict[str, Any]] = []
+    prior_selected_index: int | None = None
+    for index in selected_indexes:
+        item = observations[index]
+        if prior_selected_index is not None and index > prior_selected_index + 1:
+            discarded = observations[prior_selected_index + 1 : index]
+            item = {
+                **item,
+                _JARVIS_VERIFIED_GAP_KEY: _jarvis_verified_gap_marker(
+                    previous=observations[prior_selected_index],
+                    current=item,
+                    discarded=discarded,
+                ),
+            }
+        compacted.append(item)
+        prior_selected_index = index
+    observations[:] = compacted
+
+
+def _jarvis_verified_gap_marker(
+    *,
+    previous: dict[str, Any],
+    current: dict[str, Any],
+    discarded: list[dict[str, Any]],
+) -> dict[str, object]:
+    """Record a relay-trusted summary after checking every sampled transition."""
+    nested_gap = current.get(_JARVIS_VERIFIED_GAP_KEY)
+    nested_discarded_count = (
+        cast(dict[str, Any], nested_gap).get("discarded_observation_count")
+        if isinstance(nested_gap, dict)
+        else 0
+    )
+    if (
+        not isinstance(nested_discarded_count, int)
+        or isinstance(nested_discarded_count, bool)
+        or nested_discarded_count < 0
+    ):
+        nested_discarded_count = 0
+    canonical = json.dumps(
+        {"discarded": discarded, "nested_current_gap": nested_gap},
+        allow_nan=False,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return {
+        "schema_version": _JARVIS_VERIFIED_GAP_SCHEMA,
+        "verified": True,
+        "discarded_observation_count": len(discarded) + nested_discarded_count,
+        "discarded_observations_sha256": hashlib.sha256(canonical).hexdigest(),
+        "previous_query_job_id": previous.get("query_job_id"),
+        "current_query_job_id": current.get("query_job_id"),
+    }
+
+
+def _valid_jarvis_verified_gap_marker(
+    value: object,
+    *,
+    previous: dict[str, Any],
+    current: dict[str, Any],
+) -> bool:
+    """Accept one exact relay-trusted local summary bound to adjacent retained snapshots."""
+    if not isinstance(value, dict):
+        return False
+    marker = cast(dict[str, object], value)
+    digest = marker.get("discarded_observations_sha256")
+    count = marker.get("discarded_observation_count")
+    return bool(
+        set(marker)
+        == {
+            "schema_version",
+            "verified",
+            "discarded_observation_count",
+            "discarded_observations_sha256",
+            "previous_query_job_id",
+            "current_query_job_id",
+        }
+        and marker.get("schema_version") == _JARVIS_VERIFIED_GAP_SCHEMA
+        and marker.get("verified") is True
+        and isinstance(count, int)
+        and not isinstance(count, bool)
+        and count > 0
+        and isinstance(digest, str)
+        and len(digest) == 64
+        and all(character in "0123456789abcdef" for character in digest)
+        and marker.get("previous_query_job_id") == previous.get("query_job_id")
+        and marker.get("current_query_job_id") == current.get("query_job_id")
+    )
+
+
+def _jarvis_query_integrity_violation(
+    observations: list[dict[str, Any]],
+    current: dict[str, Any],
+    *,
+    crossed_verified_gap: bool = False,
+) -> dict[str, object] | None:
+    """Return a sticky summary when compaction must not erase an integrity failure."""
+    handle = current.get("execution_handle")
+    record = current.get("execution_record")
+    progress = current.get("progress")
+    if (
+        not isinstance(handle, dict)
+        or not isinstance(record, dict)
+        or not isinstance(progress, dict)
+    ):
+        return _jarvis_query_integrity_summary("native_document_missing", None, None)
+    handle = cast(dict[str, Any], handle)
+    record = cast(dict[str, Any], record)
+    progress = cast(dict[str, Any], progress)
+    expected_pipeline_id = current.get("pipeline_id")
+    expected_execution_id = current.get("execution_id")
+    if observations:
+        expected_pipeline_id = observations[0].get("pipeline_id")
+        expected_execution_id = observations[0].get("execution_id")
+    if not (
+        isinstance(current.get("query_job_id"), str)
+        and bool(current.get("query_job_id"))
+        and current.get("pipeline_id") == expected_pipeline_id
+        and current.get("execution_id") == expected_execution_id
+        and handle.get("pipeline_id") == expected_pipeline_id
+        and handle.get("execution_id") == expected_execution_id
+        and record.get("pipeline_id") == expected_pipeline_id
+        and record.get("execution_id") == expected_execution_id
+        and progress.get("pipeline_id") == expected_pipeline_id
+        and progress.get("execution_id") == expected_execution_id
+        and handle.get("schema_version") == "jarvis.execution.handle.v1"
+        and record.get("schema_version") == "jarvis.execution.record.v1"
+        and progress.get("schema_version") == "jarvis.execution.progress.v1"
+        and record.get("state") == current.get("state")
+        and record.get("terminal") is current.get("terminal")
+        and progress.get("execution_state") == current.get("state")
+        and progress.get("terminal") is current.get("terminal")
+    ):
+        return _jarvis_query_integrity_summary(
+            "query_identity_changed",
+            observations[-1].get("state") if observations else None,
+            current.get("state"),
+        )
+
+    stable_fields = ("execution_id", "pipeline_id", "mode", "scheduler_provider")
+    snapshot_fields = (*stable_fields, "scheduler_native_id", "cluster")
+    if any(handle.get(field) != record.get(field) for field in snapshot_fields):
+        return _jarvis_query_integrity_summary(
+            "handle_record_identity_changed",
+            observations[-1].get("state") if observations else None,
+            current.get("state"),
+        )
+    if observations:
+        first_handle = observations[0].get("execution_handle")
+        if not isinstance(first_handle, dict):
+            return _jarvis_query_integrity_summary(
+                "durable_identity_changed",
+                observations[-1].get("state"),
+                current.get("state"),
+            )
+        typed_first_handle = cast(dict[str, Any], first_handle)
+        if any(handle.get(field) != typed_first_handle.get(field) for field in stable_fields):
+            return _jarvis_query_integrity_summary(
+                "durable_identity_changed",
+                observations[-1].get("state"),
+                current.get("state"),
+            )
+    mode = handle.get("mode")
+    provider = handle.get("scheduler_provider")
+    native_id = handle.get("scheduler_native_id")
+    scheduler_cluster = handle.get("cluster")
+    if mode == "direct":
+        if provider is not None or native_id is not None or scheduler_cluster is not None:
+            return _jarvis_query_integrity_summary(
+                "direct_scheduler_identity_present",
+                observations[-1].get("state") if observations else None,
+                current.get("state"),
+            )
+    elif mode == "scheduler":
+        if not isinstance(provider, str) or not provider:
+            return _jarvis_query_integrity_summary(
+                "scheduler_provider_invalid",
+                observations[-1].get("state") if observations else None,
+                current.get("state"),
+            )
+        assigned_native_id: object = None
+        assigned_scheduler_cluster: object = None
+        for item in observations:
+            prior_handle = item.get("execution_handle")
+            if not isinstance(prior_handle, dict):
+                continue
+            typed_prior_handle = cast(dict[str, Any], prior_handle)
+            candidate_native_id = typed_prior_handle.get("scheduler_native_id")
+            if candidate_native_id is not None:
+                assigned_native_id = candidate_native_id
+            candidate_scheduler_cluster = typed_prior_handle.get("cluster")
+            if candidate_scheduler_cluster is not None:
+                assigned_scheduler_cluster = candidate_scheduler_cluster
+        if native_id is not None and (not isinstance(native_id, str) or not native_id):
+            return _jarvis_query_integrity_summary(
+                "scheduler_native_id_invalid",
+                observations[-1].get("state") if observations else None,
+                current.get("state"),
+            )
+        if assigned_native_id is not None and native_id != assigned_native_id:
+            return _jarvis_query_integrity_summary(
+                "scheduler_native_id_changed",
+                observations[-1].get("state"),
+                current.get("state"),
+            )
+        if scheduler_cluster is not None and (
+            not isinstance(scheduler_cluster, str) or not scheduler_cluster
+        ):
+            return _jarvis_query_integrity_summary(
+                "scheduler_cluster_invalid",
+                observations[-1].get("state") if observations else None,
+                current.get("state"),
+            )
+        if (
+            assigned_scheduler_cluster is not None
+            and scheduler_cluster != assigned_scheduler_cluster
+        ):
+            return _jarvis_query_integrity_summary(
+                "scheduler_cluster_changed",
+                observations[-1].get("state"),
+                current.get("state"),
+            )
+    else:
+        return _jarvis_query_integrity_summary(
+            "execution_mode_invalid",
+            observations[-1].get("state") if observations else None,
+            current.get("state"),
+        )
+
+    current_state = current.get("state")
+    current_terminal = current.get("terminal")
+    current_rank = (
+        _JARVIS_EXECUTION_STATE_RANK.get(current_state) if isinstance(current_state, str) else None
+    )
+    if current_state != "unknown" and current_rank is None:
+        return _jarvis_query_integrity_summary("invalid_state", None, current_state)
+    if current_terminal is True:
+        if current_state not in {"completed", "failed", "canceled"}:
+            return _jarvis_query_integrity_summary(
+                "terminal_state_invalid",
+                observations[-1].get("state") if observations else None,
+                current_state,
+            )
+    elif current_terminal is False:
+        if (
+            current_state in {"completed", "failed", "canceled"}
+            or record.get("return_code") is not None
+            or record.get("error") is not None
+        ):
+            return _jarvis_query_integrity_summary(
+                "nonterminal_result_present",
+                observations[-1].get("state") if observations else None,
+                current_state,
+            )
+    else:
+        return _jarvis_query_integrity_summary(
+            "terminal_flag_invalid",
+            observations[-1].get("state") if observations else None,
+            current_state,
+        )
+
+    prior_known = next(
+        (
+            item
+            for item in reversed(observations)
+            if item.get("state") in _JARVIS_EXECUTION_STATE_RANK
+        ),
+        None,
+    )
+    if prior_known is not None and current_rank is not None:
+        prior_state = cast(str, prior_known["state"])
+        if current_rank < _JARVIS_EXECUTION_STATE_RANK[prior_state]:
+            return _jarvis_query_integrity_summary(
+                "state_regression",
+                prior_state,
+                current_state,
+            )
+
+    prior_terminal = next(
+        (item for item in observations if item.get("terminal") is True),
+        None,
+    )
+    if prior_terminal is None:
+        return _jarvis_package_progress_integrity_violation(
+            observations,
+            current,
+            crossed_verified_gap=crossed_verified_gap,
+        )
+    if current_terminal is not True:
+        return _jarvis_query_integrity_summary(
+            "terminal_regression",
+            prior_terminal.get("state"),
+            current_state,
+        )
+    prior_record = prior_terminal.get("execution_record")
+    current_record = current.get("execution_record")
+    if not isinstance(prior_record, dict) or not isinstance(current_record, dict):
+        return _jarvis_query_integrity_summary(
+            "terminal_record_missing",
+            prior_terminal.get("state"),
+            current_state,
+        )
+    typed_prior_record = cast(dict[str, Any], prior_record)
+    typed_current_record = cast(dict[str, Any], current_record)
+    prior_result = (
+        prior_terminal.get("state"),
+        typed_prior_record.get("return_code"),
+        typed_prior_record.get("error"),
+    )
+    current_result = (
+        current_state,
+        typed_current_record.get("return_code"),
+        typed_current_record.get("error"),
+    )
+    if current_result != prior_result:
+        return _jarvis_query_integrity_summary(
+            "terminal_snapshot_changed",
+            prior_terminal.get("state"),
+            current_state,
+        )
+    return _jarvis_package_progress_integrity_violation(
+        observations,
+        current,
+        crossed_verified_gap=crossed_verified_gap,
+    )
+
+
+def _jarvis_package_progress_integrity_violation(
+    observations: list[dict[str, Any]],
+    current: dict[str, Any],
+    *,
+    crossed_verified_gap: bool,
+) -> dict[str, object] | None:
+    """Reject package-progress corruption before bounded observation sampling."""
+    progress = cast(dict[str, Any], current["progress"])
+    packages = progress.get("packages")
+    if not isinstance(packages, list):
+        return _jarvis_query_integrity_summary(
+            "package_progress_invalid",
+            observations[-1].get("state") if observations else None,
+            current.get("state"),
+        )
+    prior_packages: dict[tuple[object, object], tuple[int, int, dict[str, Any] | None]] = {}
+    for observation in observations:
+        prior_progress = observation.get("progress")
+        if not isinstance(prior_progress, dict):
+            continue
+        typed_prior_progress = cast(dict[str, Any], prior_progress)
+        if not isinstance(typed_prior_progress.get("packages"), list):
+            continue
+        for raw_package in cast(list[object], typed_prior_progress["packages"]):
+            if not isinstance(raw_package, dict):
+                continue
+            package = cast(dict[str, Any], raw_package)
+            summary = _jarvis_package_progress_summary(
+                package,
+                expected_execution_id=observation.get("execution_id"),
+            )
+            if summary is not None:
+                prior_packages[(package.get("package_id"), package.get("package_name"))] = summary
+    for raw_package in cast(list[object], packages):
+        if not isinstance(raw_package, dict):
+            return _jarvis_query_integrity_summary(
+                "package_progress_invalid",
+                observations[-1].get("state") if observations else None,
+                current.get("state"),
+            )
+        package = cast(dict[str, Any], raw_package)
+        summary = _jarvis_package_progress_summary(
+            package,
+            expected_execution_id=current.get("execution_id"),
+        )
+        if summary is None:
+            return _jarvis_query_integrity_summary(
+                "package_progress_invalid",
+                observations[-1].get("state") if observations else None,
+                current.get("state"),
+            )
+        key = (package.get("package_id"), package.get("package_name"))
+        prior = prior_packages.get(key)
+        if prior is None:
+            continue
+        event_count, sequence, latest = summary
+        prior_event_count, prior_sequence, prior_latest = prior
+        if event_count < prior_event_count or sequence < prior_sequence:
+            return _jarvis_query_integrity_summary(
+                "package_progress_regressed",
+                observations[-1].get("state"),
+                current.get("state"),
+            )
+        if latest is not None and prior_latest is not None:
+            current_signature = _jarvis_package_progress_signature(latest)
+            prior_signature = _jarvis_package_progress_signature(prior_latest)
+            if sequence == prior_sequence and (
+                event_count != prior_event_count or current_signature != prior_signature
+            ):
+                return _jarvis_query_integrity_summary(
+                    "package_progress_changed_without_sequence",
+                    observations[-1].get("state"),
+                    current.get("state"),
+                )
+            if sequence > prior_sequence and (
+                event_count <= prior_event_count
+                or (
+                    not crossed_verified_gap
+                    and not _jarvis_package_progress_transition_nonregressing(
+                        prior_latest,
+                        latest,
+                    )
+                )
+            ):
+                return _jarvis_query_integrity_summary(
+                    "package_progress_regressed",
+                    observations[-1].get("state"),
+                    current.get("state"),
+                )
+    return None
+
+
+def _jarvis_package_progress_summary(
+    package: dict[str, Any],
+    *,
+    expected_execution_id: object,
+) -> tuple[int, int, dict[str, Any] | None] | None:
+    """Return validated counters used by the query-integrity accumulator."""
+    package_id = package.get("package_id")
+    package_name = package.get("package_name")
+    event_count = package.get("event_count")
+    latest = package.get("latest")
+    if (
+        not isinstance(package_id, str)
+        or not package_id
+        or not isinstance(package_name, str)
+        or not package_name
+        or not isinstance(event_count, int)
+        or isinstance(event_count, bool)
+        or event_count < 0
+    ):
+        return None
+    if event_count == 0 and latest is None:
+        return 0, -1, None
+    if not isinstance(latest, dict):
+        return None
+    typed_latest = cast(dict[str, Any], latest)
+    sequence = typed_latest.get("sequence")
+    if (
+        typed_latest.get("schema_version") != "jarvis.progress.v1"
+        or typed_latest.get("execution_id") != expected_execution_id
+        or typed_latest.get("package_id") != package_id
+        or typed_latest.get("package_name") != package_name
+        or not isinstance(sequence, int)
+        or isinstance(sequence, bool)
+        or sequence < 0
+        or not _jarvis_package_progress_semantics_valid(typed_latest)
+    ):
+        return None
+    return event_count, sequence, typed_latest
+
+
+def _jarvis_package_progress_semantics_valid(progress: dict[str, Any]) -> bool:
+    """Validate package progress fields that could otherwise disappear during sampling."""
+    state = progress.get("state")
+    label = progress.get("label")
+    if (
+        state not in _JARVIS_PACKAGE_PROGRESS_STATES
+        or not isinstance(label, str)
+        or not label.strip()
+        or len(label) > 256
+    ):
+        return False
+    current = progress.get("current")
+    total = progress.get("total")
+    if current is not None and (
+        isinstance(current, bool)
+        or not isinstance(current, (int, float))
+        or not math.isfinite(current)
+        or current < 0
+    ):
+        return False
+    if total is not None and (
+        isinstance(total, bool)
+        or not isinstance(total, (int, float))
+        or not math.isfinite(total)
+        or total <= 0
+        or current is None
+        or current > total
+    ):
+        return False
+    unit = progress.get("unit")
+    if unit is not None and (not isinstance(unit, str) or not unit.strip() or len(unit) > 256):
+        return False
+    determinate = progress.get("determinate")
+    return isinstance(determinate, bool) and determinate is (
+        current is not None and total is not None
+    )
+
+
+def _jarvis_package_progress_signature(progress: dict[str, Any]) -> tuple[object, ...]:
+    """Return fields that cannot change without a new native progress sequence."""
+    return tuple(
+        progress.get(field)
+        for field in ("state", "label", "determinate", "current", "total", "unit")
+    )
+
+
+def _jarvis_package_progress_transition_nonregressing(
+    previous: dict[str, Any],
+    current: dict[str, Any],
+) -> bool:
+    """Allow quantitative reset only after an explicit package phase change."""
+    if (previous.get("state"), previous.get("label")) != (
+        current.get("state"),
+        current.get("label"),
+    ):
+        return True
+    if previous.get("unit") is not None and current.get("unit") != previous.get("unit"):
+        return False
+    if previous.get("total") is not None and current.get("total") != previous.get("total"):
+        return False
+    previous_value = previous.get("current")
+    current_value = current.get("current")
+    return previous_value is None or bool(
+        current_value is not None and cast(float, current_value) >= cast(float, previous_value)
+    )
+
+
+def _jarvis_query_integrity_summary(
+    reason: str,
+    previous_state: object,
+    current_state: object,
+) -> dict[str, object]:
+    """Create one bounded machine-readable integrity accumulator entry."""
+    return {
+        "schema_version": _JARVIS_QUERY_INTEGRITY_SCHEMA,
+        "valid": False,
+        "reason": reason,
+        "previous_state": previous_state,
+        "current_state": current_state,
+    }
+
+
+def _valid_jarvis_query_integrity_marker(value: object) -> bool:
+    """Accept only relay-generated, fail-closed query-integrity summaries."""
+    if not isinstance(value, dict):
+        return False
+    marker = cast(dict[str, object], value)
+    return bool(
+        set(marker) == {"schema_version", "valid", "reason", "previous_state", "current_state"}
+        and marker.get("schema_version") == _JARVIS_QUERY_INTEGRITY_SCHEMA
+        and marker.get("valid") is False
+        and isinstance(marker.get("reason"), str)
+        and marker.get("reason")
+        and (marker.get("previous_state") is None or isinstance(marker.get("previous_state"), str))
+        and (marker.get("current_state") is None or isinstance(marker.get("current_state"), str))
+    )
 
 
 def _has_live_jarvis_package_progress(observation: dict[str, Any]) -> bool:
@@ -14663,10 +16766,11 @@ def _run_post_run_jarvis_execution_query(
     profile: str,
     pipeline_id: str,
     execution_id: str,
+    retry_selector: dict[str, object] | None = None,
     wait_timeout_seconds: float,
     poll_seconds: float,
-) -> _JarvisExecutionQueryAcceptance:
-    """Observe one handle-first JARVIS run to terminal through durable queries."""
+) -> _JarvisExecutionQueryAcceptance | _JarvisExecutionQueryPending:
+    """Observe one handle-first run without treating a bounded wait as execution failure."""
     _validate_progress_wait(timeout_seconds=wait_timeout_seconds, poll_seconds=poll_seconds)
     query_arguments: dict[str, Any] = {
         "cluster": cluster,
@@ -14676,21 +16780,49 @@ def _run_post_run_jarvis_execution_query(
     }
     deadline = monotonic() + wait_timeout_seconds
     lifecycle_observations: list[dict[str, Any]] = []
+    latest_attempt: _JarvisExecutionQueryAttempt | None = None
     while True:
         remaining = deadline - monotonic()
         if remaining <= 0:
-            raise TimeoutError(
-                "JARVIS execution did not reach terminal state through "
-                f"jarvis_get_execution before timeout: {execution_id}"
+            if latest_attempt is not None:
+                return _nonterminal_jarvis_execution_query_acceptance(
+                    cluster=cluster,
+                    pipeline_id=pipeline_id,
+                    execution_id=execution_id,
+                    attempt=latest_attempt,
+                    lifecycle_observations=lifecycle_observations,
+                )
+            return _unobserved_jarvis_execution_query_pending(
+                cluster=cluster,
+                pipeline_id=pipeline_id,
+                execution_id=execution_id,
+                retry_selector=retry_selector,
             )
-        attempt = _execute_jarvis_execution_query(
-            definition=definition,
-            queue=queue,
-            profile=profile,
-            arguments=query_arguments,
-            deadline=deadline,
-            poll_seconds=poll_seconds,
-        )
+        try:
+            attempt = _execute_jarvis_execution_query(
+                definition=definition,
+                queue=queue,
+                profile=profile,
+                arguments=query_arguments,
+                deadline=deadline,
+                poll_seconds=poll_seconds,
+            )
+        except ObservationTimeoutError:
+            if latest_attempt is None:
+                return _unobserved_jarvis_execution_query_pending(
+                    cluster=cluster,
+                    pipeline_id=pipeline_id,
+                    execution_id=execution_id,
+                    retry_selector=retry_selector,
+                )
+            return _nonterminal_jarvis_execution_query_acceptance(
+                cluster=cluster,
+                pipeline_id=pipeline_id,
+                execution_id=execution_id,
+                attempt=latest_attempt,
+                lifecycle_observations=lifecycle_observations,
+            )
+        latest_attempt = attempt
         observation = _jarvis_execution_lifecycle_observation(
             attempt.mcp_result,
             query_job_id=attempt.call_job_id,
@@ -14704,18 +16836,32 @@ def _run_post_run_jarvis_execution_query(
         if observation["terminal"] is True:
             remaining = deadline - monotonic()
             if remaining <= 0:
-                raise TimeoutError(
-                    "JARVIS execution reached terminal state without enough time for its "
-                    f"bounded artifact query: {execution_id}"
+                return _nonterminal_jarvis_execution_query_acceptance(
+                    cluster=cluster,
+                    pipeline_id=pipeline_id,
+                    execution_id=execution_id,
+                    attempt=attempt,
+                    lifecycle_observations=lifecycle_observations,
+                    outcome="terminal_artifacts_pending",
                 )
-            terminal_attempt = _execute_jarvis_execution_query(
-                definition=definition,
-                queue=queue,
-                profile=profile,
-                arguments={**query_arguments, "artifacts": {"page_size": 25}},
-                deadline=deadline,
-                poll_seconds=poll_seconds,
-            )
+            try:
+                terminal_attempt = _execute_jarvis_execution_query(
+                    definition=definition,
+                    queue=queue,
+                    profile=profile,
+                    arguments={**query_arguments, "artifacts": {"page_size": 25}},
+                    deadline=deadline,
+                    poll_seconds=poll_seconds,
+                )
+            except ObservationTimeoutError:
+                return _nonterminal_jarvis_execution_query_acceptance(
+                    cluster=cluster,
+                    pipeline_id=pipeline_id,
+                    execution_id=execution_id,
+                    attempt=attempt,
+                    lifecycle_observations=lifecycle_observations,
+                    outcome="terminal_artifacts_pending",
+                )
             terminal_observation = _jarvis_execution_lifecycle_observation(
                 terminal_attempt.mcp_result,
                 query_job_id=terminal_attempt.call_job_id,
@@ -14726,8 +16872,15 @@ def _run_post_run_jarvis_execution_query(
                 raise RelayError(
                     "JARVIS execution regressed from terminal during its artifact query"
                 )
-            lifecycle_observations[-1] = terminal_observation
+            _append_bounded_jarvis_execution_query_observation(
+                lifecycle_observations,
+                terminal_observation,
+            )
             return _JarvisExecutionQueryAcceptance(
+                cluster=cluster,
+                pipeline_id=pipeline_id,
+                execution_id=execution_id,
+                outcome="terminal",
                 tools_list_response=terminal_attempt.session.tools_list_response,
                 call_response=terminal_attempt.session.tools_call_response,
                 call_job_id=terminal_attempt.call_job_id,
@@ -14741,8 +16894,76 @@ def _run_post_run_jarvis_execution_query(
             )
         remaining = deadline - monotonic()
         if remaining <= 0:
-            continue
+            return _nonterminal_jarvis_execution_query_acceptance(
+                cluster=cluster,
+                pipeline_id=pipeline_id,
+                execution_id=execution_id,
+                attempt=attempt,
+                lifecycle_observations=lifecycle_observations,
+            )
         sleep(min(poll_seconds, remaining))
+
+
+def _unobserved_jarvis_execution_query_pending(
+    *,
+    cluster: str,
+    pipeline_id: str,
+    execution_id: str,
+    retry_selector: dict[str, object] | None,
+) -> _JarvisExecutionQueryPending:
+    """Preserve an exact query selector when the first observation window expires."""
+    selector: dict[str, object] = {
+        "cluster": cluster,
+        "scheduler_cluster": None,
+        "pipeline_id": pipeline_id,
+        "execution_id": execution_id,
+        "scheduler_provider": None,
+        "scheduler_native_id": None,
+        "last_query_job_id": None,
+    }
+    if retry_selector is not None:
+        selector.update(retry_selector)
+    if (
+        selector.get("cluster") != cluster
+        or selector.get("pipeline_id") != pipeline_id
+        or selector.get("execution_id") != execution_id
+        or selector.get("last_query_job_id") is not None
+    ):
+        raise RelayError("JARVIS execution query retry selector changed its durable identity")
+    return _JarvisExecutionQueryPending(
+        cluster=cluster,
+        pipeline_id=pipeline_id,
+        execution_id=execution_id,
+        selector=selector,
+    )
+
+
+def _nonterminal_jarvis_execution_query_acceptance(
+    *,
+    cluster: str,
+    pipeline_id: str,
+    execution_id: str,
+    attempt: _JarvisExecutionQueryAttempt,
+    lifecycle_observations: list[dict[str, Any]],
+    outcome: Literal["observation_unknown", "terminal_artifacts_pending"] = "observation_unknown",
+) -> _JarvisExecutionQueryAcceptance:
+    """Return the last proven snapshot with a query-only retry selector."""
+    return _JarvisExecutionQueryAcceptance(
+        cluster=cluster,
+        pipeline_id=pipeline_id,
+        execution_id=execution_id,
+        outcome=outcome,
+        tools_list_response=attempt.session.tools_list_response,
+        call_response=attempt.session.tools_call_response,
+        call_job_id=attempt.call_job_id,
+        call_status=attempt.call_status,
+        artifacts=attempt.artifacts,
+        mcp_result=attempt.mcp_result,
+        provenance=attempt.provenance,
+        initialize_response=attempt.session.initialize_response,
+        stdio_evidence=attempt.session.evidence(),
+        lifecycle_observations=lifecycle_observations,
+    )
 
 
 def _execute_jarvis_execution_query(
@@ -14757,7 +16978,7 @@ def _execute_jarvis_execution_query(
     """Execute one query with the workload deadline applied to every boundary."""
     remaining = deadline - monotonic()
     if remaining <= 0:
-        raise TimeoutError("JARVIS execution query deadline expired before MCP dispatch")
+        raise ObservationTimeoutError("JARVIS execution query deadline expired before MCP dispatch")
     timeout_seconds = min(60.0, max(0.001, remaining))
     session = run_packaged_mcp_stdio_session(
         profile=profile,
@@ -14768,7 +16989,9 @@ def _execute_jarvis_execution_query(
     call_job_id = _mcp_response_job_id(session.tools_call_response)
     timeout_seconds = deadline - monotonic()
     if timeout_seconds <= 0:
-        raise TimeoutError(f"JARVIS execution query dispatch exceeded its deadline: {call_job_id}")
+        raise ObservationTimeoutError(
+            f"JARVIS execution query dispatch exceeded its deadline: {call_job_id}"
+        )
     if should_execute_on_cluster(definition):
         call_status = _wait_for_remote_job_terminal(
             definition,
@@ -14903,7 +17126,9 @@ def _wait_for_remote_job_terminal(
             return status
         remaining = effective_deadline - monotonic()
         if remaining <= 0:
-            raise TimeoutError(f"job did not reach terminal state before timeout: {job_id}")
+            raise ObservationTimeoutError(
+                f"job did not reach terminal state before timeout: {job_id}"
+            )
         sleep(min(poll_seconds, remaining))
 
 
@@ -14923,7 +17148,9 @@ def _wait_for_local_job_terminal(
             return status
         remaining = deadline - monotonic()
         if remaining <= 0:
-            raise TimeoutError(f"job did not reach terminal state before timeout: {job_id}")
+            raise ObservationTimeoutError(
+                f"job did not reach terminal state before timeout: {job_id}"
+            )
         sleep(min(poll_seconds, remaining))
 
 
@@ -15212,7 +17439,7 @@ def _run_remote_clio_before_deadline(
         return run_remote_clio(definition, args)
     remaining = deadline - monotonic()
     if remaining <= 0:
-        raise RelayError("remote worker identity observation timed out")
+        raise ObservationTimeoutError("remote worker identity observation timed out")
     with remote_command_timeout(remaining):
         return run_remote_clio(definition, args)
 

--- a/src/clio_relay/core_queue.py
+++ b/src/clio_relay/core_queue.py
@@ -312,6 +312,7 @@ _INITIALIZED_QUEUE_FAMILIES = (
     "gc_trash",
     "global_order",
 )
+_LEGACY_ONLY_QUEUE_FAMILIES = ("cursors",)
 _GC_TERMINAL_SCHEDULER_PHASES = {
     SchedulerPhase.COMPLETED.value,
     SchedulerPhase.FAILED.value,
@@ -2636,6 +2637,7 @@ class ClioCoreQueue:
             raise ConfigurationError("locked queue permission repair has no pinned root descriptor")
         relative_paths = [Path()]
         relative_paths.extend(Path(family) for family in _INITIALIZED_QUEUE_FAMILIES)
+        relative_paths.extend(Path(family) for family in _LEGACY_ONLY_QUEUE_FAMILIES)
         relative_paths.extend(Path("global_order") / family for family in _GLOBAL_ORDER_FAMILIES)
         relative_paths.extend(
             Path("global_order") / family / child

--- a/src/clio_relay/endpoint.py
+++ b/src/clio_relay/endpoint.py
@@ -30,6 +30,7 @@ import yaml
 from filelock import FileLock, Timeout
 
 from clio_relay import process_containment
+from clio_relay.bootstrap_reconcile import resolve_receipt_bound_jarvis_python
 from clio_relay.command_evidence import bounded_error_detail
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import DEFAULT_EXACT_RECORD_LIMIT, ClioCoreQueue
@@ -342,12 +343,20 @@ class EndpointWorker:
                     "worker storage runtime must match its managed queue instance"
                 )
             self.queue = resolved_queue
-            self.provider = provider or JarvisCdProvider(
-                jarvis_bin=settings.jarvis_bin,
-                agent_bin=settings.agent_bin,
-                agent_adapter=settings.agent_adapter,
-                agent_args=settings.agent_args,
-            )
+            if provider is None:
+                execution_python = (
+                    resolve_receipt_bound_jarvis_python(settings.jarvis_bin)
+                    if self.role == EndpointRole.WORKER
+                    else None
+                )
+                provider = JarvisCdProvider(
+                    jarvis_bin=settings.jarvis_bin,
+                    execution_python=execution_python,
+                    agent_bin=settings.agent_bin,
+                    agent_adapter=settings.agent_adapter,
+                    agent_args=settings.agent_args,
+                )
+            self.provider = provider
             self.scheduler_provider = scheduler_provider
             self.storage_runtime = storage_runtime or managed_runtime
             self._scheduler_last_poll: dict[tuple[str, str], float] = {}

--- a/src/clio_relay/installation.py
+++ b/src/clio_relay/installation.py
@@ -1157,6 +1157,7 @@ def worker_runtime_info(
     cluster: str,
     freshness_seconds: float = 120.0,
     current_installation: dict[str, object] | None = None,
+    readiness_only: bool = False,
 ) -> dict[str, object]:
     """Prove the active worker process loaded the same exact installation receipt."""
     from clio_relay.config import RelaySettings
@@ -1196,7 +1197,7 @@ def worker_runtime_info(
     process_running = _worker_process_matches(endpoint.pid)
     identity_matches_current = endpoint_installation == current
     scheduler_provider = endpoint.metadata.get("scheduler_provider")
-    return {
+    readiness: dict[str, object] = {
         "schema_version": "clio-relay.worker-runtime-info.v1",
         "cluster": cluster,
         "observed_at": observed_at.isoformat(),
@@ -1207,6 +1208,12 @@ def worker_runtime_info(
         "identity_matches_current": identity_matches_current,
         "scheduler_provider": scheduler_provider,
         "running": fresh and process_running and identity_matches_current,
+    }
+    if readiness_only:
+        readiness["schema_version"] = "clio-relay.worker-readiness.v1"
+        return readiness
+    return {
+        **readiness,
         "endpoint": endpoint.model_dump(mode="json"),
         "installation": current,
         "endpoint_installation": endpoint_installation,
@@ -2456,6 +2463,37 @@ print(json.dumps({
     return {str(key): value for key, value in cast(dict[object, object], loaded).items()}
 
 
+_PYTHON_RECORD_CLOSURE_SAFE_ERRORS = frozenset(
+    {
+        "execution environment has no scripts installation path",
+        "execution scripts path is outside its environment",
+        "installed console script is not a canonical declared wrapper",
+        "installed wheel script body does not match its wheel member",
+        "installed wheel script disagrees with distribution RECORD",
+        "installed wheel script exceeds the byte bound",
+        "installed wheel script has an invalid POSIX shell trampoline",
+        "installed wheel script is not bound to the execution interpreter",
+        "installed wheel script is not executable",
+        "installed wheel script is not owned by distribution RECORD",
+        "installed wheel script must not be a symbolic link",
+        "wheel script does not use an exact #!python shebang",
+        "wheel script has an ambiguous console_scripts declaration",
+        "wheel script has an unsafe member name",
+        "wheel script is not installed in the execution environment",
+        "wheel script console_scripts target is not canonical",
+        "wheel script exceeds the byte bound",
+        "wheel scripts must use one flat member name",
+    }
+)
+
+
+def _python_record_closure_error_code(error: str) -> str:
+    """Return a bounded public diagnostic code for one known script error."""
+    if error not in _PYTHON_RECORD_CLOSURE_SAFE_ERRORS:
+        return "unclassified-record-closure-error"
+    return error.replace("#!", "hashbang-").replace("_", "-").replace(" ", "-")
+
+
 def _probe_python_distribution_record_closure(
     python: str | None,
     distribution_name: str,
@@ -2477,15 +2515,19 @@ import csv
 import hashlib
 import io
 import json
+import keyword
 import os
+import shlex
 import stat
 import sys
+import sysconfig
 import zipfile
 from importlib import metadata
 from pathlib import Path, PurePosixPath
 
 MAX_FILES = 100_000
 MAX_BYTES = 4 * 1024 * 1024 * 1024
+MAX_SCRIPT_BYTES = 16 * 1024 * 1024
 
 
 def digest_stream(stream):
@@ -2517,11 +2559,15 @@ allowed_roots = (distribution_root, environment_prefix)
 installed_closure = hashlib.sha256()
 installed_bytes = 0
 installed_record_paths = []
+installed_record_locations = {}
 for item in sorted(installed_files, key=lambda value: str(value)):
     relative = str(item).replace("\\", "/")
     location = Path(installed.locate_file(item)).resolve(strict=True)
     if not within(location, allowed_roots) or not location.is_file():
         raise SystemExit("installed RECORD contains a file outside its environment")
+    location_key = os.path.normcase(str(location))
+    if location_key in installed_record_locations:
+        raise SystemExit("installed RECORD maps multiple members to one file")
     with location.open("rb") as stream:
         digest, size = digest_stream(stream)
     installed_bytes += size
@@ -2538,6 +2584,11 @@ for item in sorted(installed_files, key=lambda value: str(value)):
         raise SystemExit("installed RECORD member omitted its digest")
     if relative.endswith(".dist-info/RECORD"):
         installed_record_paths.append(location)
+    installed_record_locations[location_key] = {
+        "relative": relative,
+        "sha256": digest.digest(),
+        "size": size,
+    }
     installed_closure.update(relative.encode("utf-8"))
     installed_closure.update(b"\0")
     installed_closure.update(digest.hexdigest().encode("ascii"))
@@ -2547,9 +2598,172 @@ for item in sorted(installed_files, key=lambda value: str(value)):
 if len(installed_record_paths) != 1:
     raise SystemExit("installed distribution RECORD ownership is ambiguous")
 
+console_scripts = {}
+for entry_point in installed.entry_points:
+    if entry_point.group == "console_scripts":
+        console_scripts.setdefault(entry_point.name, []).append(entry_point.value)
+
+
+def console_script_target(script_name):
+    values = console_scripts.get(script_name, [])
+    if not values:
+        return None
+    if len(values) != 1:
+        raise SystemExit("wheel script has an ambiguous console_scripts declaration")
+    value = values[0]
+    if not isinstance(value, str) or value != value.strip() or "[" in value or "]" in value:
+        raise SystemExit("wheel script console_scripts target is not canonical")
+    module, separator, attribute = value.partition(":")
+    identifiers = [*module.split("."), attribute]
+    if (
+        separator != ":"
+        or not module
+        or not attribute
+        or "." in attribute
+        or any(not item.isidentifier() or keyword.iskeyword(item) for item in identifiers)
+    ):
+        raise SystemExit("wheel script console_scripts target is not canonical")
+    return module, attribute, value
+
+
+def canonical_console_script_bodies(module, attribute):
+    current = (
+        "import sys\n"
+        f"from {module} import {attribute}\n"
+        "if __name__ == '__main__':\n"
+        "    sys.argv[0] = sys.argv[0].removesuffix('.exe')\n"
+        f"    sys.exit({attribute}())\n"
+    ).encode("utf-8")
+    legacy = (
+        "# -*- coding: utf-8 -*-\n"
+        "import re\n"
+        "import sys\n"
+        f"from {module} import {attribute}\n"
+        "if __name__ == '__main__':\n"
+        r"    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])"
+        "\n"
+        f"    sys.exit({attribute}())\n"
+    ).encode("utf-8")
+    return current, legacy
+
+
+def wheel_script_body(payload):
+    for shebang in (b"#!python\n", b"#!python\r\n", b"#!pythonw\n", b"#!pythonw\r\n"):
+        if payload.startswith(shebang):
+            return payload[len(shebang):], shebang.rstrip(b"\r\n").decode("ascii")
+    raise SystemExit("wheel script does not use an exact #!python shebang")
+
+
+def installed_launcher_body(payload):
+    executable = os.fsencode(sys.executable)
+    for shebang in (b"#!" + executable + b"\n", b"#!" + executable + b"\r\n"):
+        if payload.startswith(shebang):
+            return payload[len(shebang):], "direct-interpreter"
+    if os.name != "posix":
+        raise SystemExit("installed wheel script is not bound to the execution interpreter")
+    lines = payload.split(b"\n", 3)
+    if len(lines) != 4 or lines[0] != b"#!/bin/sh":
+        raise SystemExit("installed wheel script is not bound to the execution interpreter")
+    if any(len(line) > 4096 for line in lines[:3]):
+        raise SystemExit("installed wheel script trampoline exceeds its byte bound")
+    try:
+        execution_line = lines[1].decode("utf-8")
+        closing_line = lines[2].decode("utf-8")
+        execution = shlex.split(execution_line, posix=True)
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise SystemExit("installed wheel script has an invalid POSIX shell trampoline") from exc
+    quoted_executable = "'" + sys.executable.replace("'", "'\"'\"'") + "'"
+    canonical_uv_line = f"'''exec' {quoted_executable} \"$0\" \"$@\""
+    canonical_pip_line = f"'''exec' {sys.executable} \"$0\" \"$@\""
+    if (
+        len(execution) != 4
+        or execution[0] != "exec"
+        or execution[1] != sys.executable
+        or execution[2:] != ["$0", "$@"]
+        or closing_line != "' '''"
+    ):
+        raise SystemExit("installed wheel script has an invalid POSIX shell trampoline")
+    if execution_line == canonical_uv_line:
+        launcher_kind = "uv-posix-trampoline"
+    elif shlex.quote(sys.executable) == sys.executable and execution_line == canonical_pip_line:
+        launcher_kind = "pip-posix-trampoline"
+    else:
+        raise SystemExit("installed wheel script has an invalid POSIX shell trampoline")
+    return lines[3], launcher_kind
+
+
+def verify_wheel_script(archive, info, member, path):
+    if len(path.parts) != 3:
+        raise SystemExit("wheel scripts must use one flat member name")
+    script_name = path.parts[2]
+    if (
+        not script_name
+        or script_name.startswith(".")
+        or not script_name.isascii()
+        or any(not (character.isalnum() or character in "._+-") for character in script_name)
+    ):
+        raise SystemExit("wheel script has an unsafe member name")
+    scripts_value = sysconfig.get_path("scripts")
+    if not isinstance(scripts_value, str) or not scripts_value:
+        raise SystemExit("execution environment has no scripts installation path")
+    scripts_root = Path(scripts_value).resolve(strict=True)
+    if not within(scripts_root, (environment_prefix,)):
+        raise SystemExit("execution scripts path is outside its environment")
+    candidate = scripts_root / script_name
+    if candidate.is_symlink():
+        raise SystemExit("installed wheel script must not be a symbolic link")
+    installed_location = candidate.resolve(strict=True)
+    if not within(installed_location, (environment_prefix,)) or not installed_location.is_file():
+        raise SystemExit("wheel script is not installed in the execution environment")
+    if os.name == "posix" and installed_location.stat().st_mode & 0o111 == 0:
+        raise SystemExit("installed wheel script is not executable")
+    installed_record = installed_record_locations.get(
+        os.path.normcase(str(installed_location))
+    )
+    if installed_record is None:
+        raise SystemExit("installed wheel script is not owned by distribution RECORD")
+    if info.file_size > MAX_SCRIPT_BYTES:
+        raise SystemExit("wheel script exceeds the byte bound")
+    with archive.open(info) as stream:
+        wheel_payload = stream.read(MAX_SCRIPT_BYTES + 1)
+    if len(wheel_payload) > MAX_SCRIPT_BYTES:
+        raise SystemExit("wheel script exceeds the byte bound")
+    with installed_location.open("rb") as stream:
+        installed_payload = stream.read(MAX_SCRIPT_BYTES + 1)
+    if len(installed_payload) > MAX_SCRIPT_BYTES:
+        raise SystemExit("installed wheel script exceeds the byte bound")
+    installed_digest = hashlib.sha256(installed_payload).digest()
+    if (
+        installed_record["size"] != len(installed_payload)
+        or installed_record["sha256"] != installed_digest
+    ):
+        raise SystemExit("installed wheel script disagrees with distribution RECORD")
+    source_body, source_shebang = wheel_script_body(wheel_payload)
+    installed_body, launcher_kind = installed_launcher_body(installed_payload)
+    target = console_script_target(script_name)
+    if target is None:
+        if installed_body != source_body:
+            raise SystemExit("installed wheel script body does not match its wheel member")
+        transform_kind = "interpreter-shebang"
+        entry_point = None
+    else:
+        module, attribute, entry_point = target
+        if installed_body not in canonical_console_script_bodies(module, attribute):
+            raise SystemExit("installed console script is not a canonical declared wrapper")
+        transform_kind = "declared-console-wrapper"
+    return {
+        "member": member,
+        "installed_record_member": installed_record["relative"],
+        "transform": transform_kind,
+        "launcher": launcher_kind,
+        "source_shebang": source_shebang,
+        "entry_point": entry_point,
+    }
+
 wheel_closure = hashlib.sha256()
 wheel_bytes = 0
 wheel_members = 0
+wheel_script_transforms = []
 with zipfile.ZipFile(wheel) as archive:
     infos = archive.infolist()
     if not infos or len(infos) > MAX_FILES:
@@ -2613,21 +2827,29 @@ with zipfile.ZipFile(wheel) as archive:
         if encoded != expected_digest.removeprefix("sha256="):
             raise SystemExit("retained wheel member digest does not match RECORD")
         parts = path.parts
-        if len(parts) >= 3 and parts[0].endswith(".data"):
-            if parts[1] not in {"purelib", "platlib"}:
+        script_transform = None
+        if parts and parts[0].endswith(".data"):
+            if len(parts) < 3:
                 raise SystemExit("retained wheel uses an unsupported installation scheme")
-            installed_relative = PurePosixPath(*parts[2:])
+            if parts[1] == "scripts":
+                script_transform = verify_wheel_script(archive, info, member, path)
+                wheel_script_transforms.append(script_transform)
+            elif parts[1] in {"purelib", "platlib"}:
+                installed_relative = PurePosixPath(*parts[2:])
+            else:
+                raise SystemExit("retained wheel uses an unsupported installation scheme")
         else:
             installed_relative = path
-        installed_location = Path(
-            installed.locate_file(str(installed_relative))
-        ).resolve(strict=True)
-        if not within(installed_location, allowed_roots) or not installed_location.is_file():
-            raise SystemExit("wheel-owned distribution member is not installed")
-        with installed_location.open("rb") as stream:
-            installed_digest, installed_size = digest_stream(stream)
-        if installed_size != size or installed_digest.digest() != digest.digest():
-            raise SystemExit("wheel-owned installed member digest mismatch")
+        if script_transform is None:
+            installed_location = Path(
+                installed.locate_file(str(installed_relative))
+            ).resolve(strict=True)
+            if not within(installed_location, allowed_roots) or not installed_location.is_file():
+                raise SystemExit("wheel-owned distribution member is not installed")
+            with installed_location.open("rb") as stream:
+                installed_digest, installed_size = digest_stream(stream)
+            if installed_size != size or installed_digest.digest() != digest.digest():
+                raise SystemExit("wheel-owned installed member digest mismatch")
         wheel_closure.update(member.encode("utf-8"))
         wheel_closure.update(b"\0")
         wheel_closure.update(digest.hexdigest().encode("ascii"))
@@ -2650,6 +2872,8 @@ print(json.dumps({
     "wheel_payload_closure_sha256": wheel_closure.hexdigest(),
     "wheel_payload_file_count": wheel_members,
     "wheel_payload_bytes": wheel_bytes,
+    "wheel_script_transform_count": len(wheel_script_transforms),
+    "wheel_script_transforms": wheel_script_transforms,
     "tree_scanned": False,
     "tree_copied": False,
 }, sort_keys=True))
@@ -2670,9 +2894,11 @@ print(json.dumps({
             "tree_copied": False,
         }
     if completed.returncode != 0:
+        error = completed.stderr.strip() or completed.stdout.strip()
         return {
             "verified": False,
-            "error": completed.stderr.strip() or completed.stdout.strip(),
+            "error": error,
+            "error_code": _python_record_closure_error_code(error),
             "tree_scanned": False,
             "tree_copied": False,
         }

--- a/src/clio_relay/jarvis_mcp.py
+++ b/src/clio_relay/jarvis_mcp.py
@@ -473,6 +473,8 @@ def _persistent_clio_kit_tool_identity(
             distribution="clio-kit",
             distribution_version=component.distribution_version or "",
             entry_point="clio-kit",
+            tool_directory=expected_identity.tool_directory,
+            tool_bin_directory=expected_identity.tool_bin_directory,
         )
     except ConfigurationError as exc:
         evidence["error"] = str(exc)

--- a/src/clio_relay/jarvis_mcp_validation.py
+++ b/src/clio_relay/jarvis_mcp_validation.py
@@ -49,6 +49,7 @@ _JARVIS_PROGRESS_STATES = frozenset(
     {"pending", "starting", "running", "ready", "completed", "failed", "canceled"}
 )
 _MAX_JARVIS_PROGRESS_IDENTITY_TEXT = 256
+_UNBOUND_JARVIS_IDENTITY = object()
 
 
 def build_jarvis_mcp_validation_report(
@@ -90,6 +91,7 @@ def build_jarvis_mcp_validation_report(
     query_initialize_response: JSON | None,
     query_stdio_evidence: JSON | None,
     query_lifecycle_observations: list[JSON] | None = None,
+    scheduler_cluster: object = _UNBOUND_JARVIS_IDENTITY,
     launcher: str | None = None,
     install_source: str | None = None,
     artifact_sha256: str | None = None,
@@ -371,6 +373,14 @@ def build_jarvis_mcp_validation_report(
             observations=query_lifecycle_observations,
             pipeline_id=expected_pipeline_id,
             execution_id=expected_execution_id,
+            scheduler_cluster=(
+                _jarvis_runtime_scheduler_cluster(runtime_metadata)
+                if scheduler_cluster is _UNBOUND_JARVIS_IDENTITY
+                else scheduler_cluster
+            ),
+            scheduler_provider=(
+                runtime_metadata.get("scheduler_provider") if runtime_metadata is not None else None
+            ),
         )
         progress_summary = (
             "jarvis_get_execution observed provider-valid in-flight progress and a coherent "
@@ -436,14 +446,16 @@ def build_jarvis_mcp_validation_report(
     scheduler_pair_coherent = (scheduler_provider is None and scheduler_job_id is None) or (
         isinstance(scheduler_provider, str)
         and bool(scheduler_provider)
-        and isinstance(scheduler_job_id, str)
-        and bool(scheduler_job_id)
+        and (
+            scheduler_job_id is None
+            or (isinstance(scheduler_job_id, str) and bool(scheduler_job_id))
+        )
     )
     scheduler_sources_coherent = (
         scheduler_provider_source is None and scheduler_job_id_source is None
         if scheduler_provider is None
         else scheduler_provider_source in authoritative_runtime_sources
-        and scheduler_job_id_source in authoritative_runtime_sources
+        and (scheduler_job_id is None or scheduler_job_id_source in authoritative_runtime_sources)
     )
     initial_terminal_coherent = bool(
         native_record is not None
@@ -487,6 +499,21 @@ def build_jarvis_mcp_validation_report(
         and native_record.get("scheduler_provider") == scheduler_provider
         and native_handle.get("scheduler_native_id") == scheduler_job_id
         and native_record.get("scheduler_native_id") == scheduler_job_id
+        and (
+            native_handle.get("cluster") is None
+            or (
+                isinstance(native_handle.get("cluster"), str) and bool(native_handle.get("cluster"))
+            )
+        )
+        and native_record.get("cluster") == native_handle.get("cluster")
+        and (
+            scheduler_cluster is _UNBOUND_JARVIS_IDENTITY
+            or native_handle.get("cluster") is None
+            or native_handle.get("cluster") == scheduler_cluster
+        )
+        and native_handle.get("mode")
+        == ("scheduler" if scheduler_provider is not None else "direct")
+        and native_record.get("mode") == native_handle.get("mode")
         and initial_terminal_coherent
         and "runtime_metadata" in artifacts_by_kind
     )
@@ -1023,7 +1050,7 @@ def _jarvis_execution_query_evidence(
     arguments = _mapping(spec.get("arguments")) or {}
     artifact_request = _mapping(arguments.get("artifacts"))
     page_size = artifact_request.get("page_size") if artifact_request else None
-    request_bounded = (
+    artifact_request_bounded = (
         isinstance(pipeline_id, str)
         and bool(pipeline_id)
         and isinstance(execution_id, str)
@@ -1037,6 +1064,16 @@ def _jarvis_execution_query_evidence(
         and _positive_int(page_size)
         and page_size <= 100
     )
+    progress_request_bounded = (
+        isinstance(pipeline_id, str)
+        and bool(pipeline_id)
+        and isinstance(execution_id, str)
+        and bool(execution_id)
+        and set(arguments) == {"pipeline_id", "execution_id", "include_progress"}
+        and arguments.get("pipeline_id") == pipeline_id
+        and arguments.get("execution_id") == execution_id
+        and arguments.get("include_progress") is True
+    )
     response_job_id = _response_job_id(call_response)
     durable_artifacts = {
         str(artifact.get("kind")): artifact
@@ -1045,7 +1082,7 @@ def _jarvis_execution_query_evidence(
     }
     required_artifacts = {"stdout", "stderr", "mcp_result", "provenance"}
     provenance_job = _mapping(provenance.get("job")) if provenance else None
-    job_passed = (
+    durable_job_base_passed = (
         response_job_id == call_job_id
         and job.get("job_id") == call_job_id
         and job.get("cluster") == cluster
@@ -1054,10 +1091,13 @@ def _jarvis_execution_query_evidence(
         and call_status.get("terminal") is True
         and spec.get("operation") == "tools/call"
         and spec.get("tool") == "jarvis_get_execution"
-        and request_bounded
         and required_artifacts.issubset(durable_artifacts)
         and provenance_job is not None
         and provenance_job.get("job_id") == call_job_id
+    )
+    job_passed = durable_job_base_passed and artifact_request_bounded
+    resumable_job_passed = durable_job_base_passed and (
+        artifact_request_bounded or progress_request_bounded
     )
 
     result_server_artifact = _mapping(mcp_result.get("server_artifact")) if mcp_result else None
@@ -1109,6 +1149,16 @@ def _jarvis_execution_query_evidence(
         and artifact_page is not None
         and service_runtimes is None
     )
+    progress_envelope_passed = (
+        structured is not None
+        and set(structured) == expected_envelope
+        and structured.get("schema_version") == CLIO_KIT_JARVIS_EXECUTION_SCHEMA
+        and handle is not None
+        and record is not None
+        and progress is not None
+        and artifact_page is None
+        and service_runtimes is None
+    )
     identity_fields = (
         "execution_id",
         "pipeline_id",
@@ -1137,6 +1187,22 @@ def _jarvis_execution_query_evidence(
         and artifact_page.get("execution_id") == execution_id
         and all(artifact.get("execution_id") == execution_id for artifact in generated_artifacts)
     )
+    progress_identity_passed = bool(
+        progress_envelope_passed
+        and isinstance(pipeline_id, str)
+        and isinstance(execution_id, str)
+        and structured is not None
+        and structured.get("pipeline_id") == pipeline_id
+        and structured.get("execution_id") == execution_id
+        and handle is not None
+        and record is not None
+        and all(handle.get(key) == record.get(key) for key in identity_fields)
+        and handle.get("pipeline_id") == pipeline_id
+        and handle.get("execution_id") == execution_id
+        and progress is not None
+        and progress.get("pipeline_id") == pipeline_id
+        and progress.get("execution_id") == execution_id
+    )
     state = record.get("state") if record else None
     terminal = record.get("terminal") if record else None
     lifecycle_passed = (
@@ -1151,6 +1217,28 @@ def _jarvis_execution_query_evidence(
         and artifact_page is not None
         and artifact_page.get("execution_state") == state
         and artifact_page.get("terminal") is terminal
+    )
+    progress_lifecycle_passed = bool(
+        progress_identity_passed
+        and isinstance(state, str)
+        and isinstance(terminal, bool)
+        and record is not None
+        and progress is not None
+        and progress.get("execution_state") == state
+        and progress.get("terminal") is terminal
+        and (
+            (
+                terminal is False
+                and record.get("return_code") is None
+                and record.get("error") is None
+            )
+            or (
+                terminal is True
+                and state == "completed"
+                and record.get("return_code") == 0
+                and record.get("error") is None
+            )
+        )
     )
 
     returned = artifact_page.get("returned_artifact_count") if artifact_page else None
@@ -1199,6 +1287,22 @@ def _jarvis_execution_query_evidence(
         and runner_validation.get("returned_artifact_count") == returned
         and runner_validation.get("next_cursor_present") is (next_cursor is not None)
     )
+    progress_runner_attested = (
+        runner_validation is not None
+        and runner_validation.get("schema_version")
+        == "clio-relay.jarvis-execution-query-validation.v1"
+        and runner_validation.get("pipeline_id") == pipeline_id
+        and runner_validation.get("execution_id") == execution_id
+        and runner_validation.get("include_progress") is True
+        and runner_validation.get("progress_included") is True
+        and runner_validation.get("include_service_runtimes") is False
+        and runner_validation.get("service_runtimes_included") is False
+        and runner_validation.get("service_runtime_count") == 0
+        and runner_validation.get("artifacts_requested") is False
+        and runner_validation.get("artifact_filters") == {}
+        and runner_validation.get("returned_artifact_count") == 0
+        and runner_validation.get("next_cursor_present") is False
+    )
     result_passed = (
         mcp_result is not None
         and mcp_result.get("returncode") == 0
@@ -1212,6 +1316,17 @@ def _jarvis_execution_query_evidence(
         and filters_passed
         and runner_attested
     )
+    resumable_result_passed = (
+        mcp_result is not None
+        and mcp_result.get("returncode") == 0
+        and mcp_result.get("operation") == "tools/call"
+        and mcp_result.get("tool") == "jarvis_get_execution"
+        and mcp_result.get("protocol_error") is None
+        and (envelope_passed or progress_envelope_passed)
+        and (identity_passed or progress_identity_passed)
+        and (lifecycle_passed or progress_lifecycle_passed)
+        and (runner_attested or progress_runner_attested)
+    )
     assertions: JSON = {
         "local_query_surface_verified": local_surface_passed,
         "durable_query_job_verified": job_passed,
@@ -1224,6 +1339,14 @@ def _jarvis_execution_query_evidence(
         "pagination_coherent": pagination_passed,
         "artifact_filters_coherent": filters_passed,
         "runner_semantic_validation_verified": runner_attested,
+        "resumable_query_job_verified": resumable_job_passed,
+        "resumable_result_transport_verified": resumable_result_passed,
+        "resumable_result_envelope_verified": envelope_passed or progress_envelope_passed,
+        "resumable_identity_coherent": identity_passed or progress_identity_passed,
+        "resumable_lifecycle_coherent": lifecycle_passed or progress_lifecycle_passed,
+        "resumable_runner_semantic_validation_verified": (
+            runner_attested or progress_runner_attested
+        ),
     }
     evidence: JSON = {
         "execution_id": structured.get("execution_id") if structured else None,
@@ -1279,11 +1402,58 @@ def _artifact_matches_query(artifact: JSON, query: JSON) -> bool:
     )
 
 
+def _valid_query_integrity_marker(value: object) -> bool:
+    """Recognize only the relay's bounded fail-closed integrity accumulator."""
+    marker = _mapping(value)
+    if marker is None:
+        return False
+    return bool(
+        set(marker) == {"schema_version", "valid", "reason", "previous_state", "current_state"}
+        and marker.get("schema_version") == "clio-relay.jarvis-query-integrity.v1"
+        and marker.get("valid") is False
+        and isinstance(marker.get("reason"), str)
+        and marker.get("reason")
+        and (marker.get("previous_state") is None or isinstance(marker.get("previous_state"), str))
+        and (marker.get("current_state") is None or isinstance(marker.get("current_state"), str))
+    )
+
+
+def _valid_query_verified_gap(
+    value: object,
+    *,
+    previous: JSON,
+    current: JSON,
+) -> bool:
+    """Validate one relay-trusted local summary for a sampled observation span."""
+    marker = _mapping(value)
+    if marker is None:
+        return False
+    return bool(
+        set(marker)
+        == {
+            "schema_version",
+            "verified",
+            "discarded_observation_count",
+            "discarded_observations_sha256",
+            "previous_query_job_id",
+            "current_query_job_id",
+        }
+        and marker.get("schema_version") == "clio-relay.jarvis-query-verified-gap.v1"
+        and marker.get("verified") is True
+        and _positive_int(marker.get("discarded_observation_count"))
+        and _is_sha256(marker.get("discarded_observations_sha256"))
+        and marker.get("previous_query_job_id") == previous.get("query_job_id")
+        and marker.get("current_query_job_id") == current.get("query_job_id")
+    )
+
+
 def _jarvis_query_lifecycle_progress_evidence(
     *,
     observations: list[JSON],
     pipeline_id: object,
     execution_id: object,
+    scheduler_cluster: object = _UNBOUND_JARVIS_IDENTITY,
+    scheduler_provider: object = _UNBOUND_JARVIS_IDENTITY,
 ) -> tuple[JSON, bool, JSON | None]:
     """Validate in-flight and terminal progress obtained through execution queries."""
     state_rank = {
@@ -1299,6 +1469,7 @@ def _jarvis_query_lifecycle_progress_evidence(
     normalized: list[tuple[JSON, JSON, JSON, JSON]] = []
     identities_valid = isinstance(pipeline_id, str) and bool(pipeline_id)
     identities_valid = identities_valid and isinstance(execution_id, str) and bool(execution_id)
+    expected_mode = "scheduler" if scheduler_provider is not None else "direct"
     bounded = 0 < len(observations) <= 512
     for observation in observations:
         handle = _mapping(observation.get("execution_handle"))
@@ -1316,6 +1487,15 @@ def _jarvis_query_lifecycle_progress_evidence(
             and handle.get("execution_id") == execution_id
             and progress.get("pipeline_id") == pipeline_id
             and progress.get("execution_id") == execution_id
+            and (
+                scheduler_provider is _UNBOUND_JARVIS_IDENTITY
+                or (
+                    handle.get("mode") == expected_mode
+                    and record.get("mode") == expected_mode
+                    and handle.get("scheduler_provider") == scheduler_provider
+                    and record.get("scheduler_provider") == scheduler_provider
+                )
+            )
             and handle.get("schema_version") == "jarvis.execution.handle.v1"
             and record.get("state") == observation.get("state")
             and record.get("terminal") is observation.get("terminal")
@@ -1324,6 +1504,7 @@ def _jarvis_query_lifecycle_progress_evidence(
             and record.get("schema_version") == "jarvis.execution.record.v1"
             and progress.get("schema_version") == "jarvis.execution.progress.v1"
             and isinstance(observation.get("query_job_id"), str)
+            and bool(observation.get("query_job_id"))
         ):
             identities_valid = False
         normalized.append((observation, handle, record, progress))
@@ -1333,12 +1514,16 @@ def _jarvis_query_lifecycle_progress_evidence(
         "pipeline_id",
         "mode",
         "scheduler_provider",
-        "cluster",
     )
-    snapshot_identity_fields = (*base_identity_fields, "scheduler_native_id")
+    snapshot_identity_fields = (*base_identity_fields, "scheduler_native_id", "cluster")
     stable_identity: tuple[object, ...] | None = None
     assigned_scheduler_native_id: str | None = None
-    scheduler_identity_valid = True
+    assigned_scheduler_cluster: str | None = None
+    scheduler_identity_valid = bool(
+        scheduler_cluster is _UNBOUND_JARVIS_IDENTITY
+        or scheduler_cluster is None
+        or (isinstance(scheduler_cluster, str) and bool(scheduler_cluster))
+    )
     for observation, handle, record, _progress in normalized:
         identity = tuple(handle.get(field) for field in base_identity_fields)
         if stable_identity is None:
@@ -1350,8 +1535,9 @@ def _jarvis_query_lifecycle_progress_evidence(
         mode = handle.get("mode")
         provider = handle.get("scheduler_provider")
         native_id = handle.get("scheduler_native_id")
+        native_cluster = handle.get("cluster")
         if mode == "direct":
-            if provider is not None or native_id is not None:
+            if provider is not None or native_id is not None or native_cluster is not None:
                 scheduler_identity_valid = False
             continue
         if mode != "scheduler" or not isinstance(provider, str) or not provider:
@@ -1360,50 +1546,128 @@ def _jarvis_query_lifecycle_progress_evidence(
         if native_id is None:
             if assigned_scheduler_native_id is not None or observation.get("terminal") is True:
                 scheduler_identity_valid = False
-            continue
-        if not isinstance(native_id, str) or not native_id:
+        elif not isinstance(native_id, str) or not native_id:
             scheduler_identity_valid = False
-            continue
-        if assigned_scheduler_native_id is None:
+        elif assigned_scheduler_native_id is None:
             assigned_scheduler_native_id = native_id
         elif native_id != assigned_scheduler_native_id:
             scheduler_identity_valid = False
-    if (
-        stable_identity is not None
-        and stable_identity[2] == "scheduler"
-        and assigned_scheduler_native_id is None
-    ):
-        scheduler_identity_valid = False
-
-    lifecycle_valid = bool(normalized) and identities_valid and scheduler_identity_valid
-    last_known_rank = -1
+        if native_cluster is None:
+            if assigned_scheduler_cluster is not None:
+                scheduler_identity_valid = False
+        elif not isinstance(native_cluster, str) or not native_cluster:
+            scheduler_identity_valid = False
+        elif assigned_scheduler_cluster is None:
+            assigned_scheduler_cluster = native_cluster
+        elif native_cluster != assigned_scheduler_cluster:
+            scheduler_identity_valid = False
+    if scheduler_cluster is not _UNBOUND_JARVIS_IDENTITY:
+        if scheduler_cluster is None:
+            if assigned_scheduler_cluster is not None:
+                scheduler_identity_valid = False
+        elif assigned_scheduler_cluster != scheduler_cluster:
+            scheduler_identity_valid = False
+    integrity_violations: list[JSON] = []
+    for observation, _handle, _record, _progress in normalized:
+        marker = observation.get("relay_query_integrity")
+        if marker is None:
+            continue
+        if _valid_query_integrity_marker(marker):
+            integrity_violations.append(cast(JSON, marker))
+        else:
+            integrity_violations.append(
+                {
+                    "schema_version": "clio-relay.jarvis-query-integrity.v1",
+                    "valid": False,
+                    "reason": "integrity_marker_invalid",
+                    "previous_state": None,
+                    "current_state": observation.get("state"),
+                }
+            )
+    verified_gap_counts: list[int] = []
+    invalid_verified_gaps: list[JSON] = []
+    verified_gap_count = 0
     for index, (observation, _handle, _record, _progress) in enumerate(normalized):
+        marker = observation.get("relay_query_verified_gap")
+        if marker is not None:
+            if index == 0 or not _valid_query_verified_gap(
+                marker,
+                previous=normalized[index - 1][0],
+                current=observation,
+            ):
+                invalid_verified_gaps.append(
+                    {
+                        "index": index,
+                        "query_job_id": observation.get("query_job_id"),
+                    }
+                )
+            else:
+                verified_gap_count += 1
+        verified_gap_counts.append(verified_gap_count)
+    lifecycle_prefix_valid = bool(
+        normalized
+        and identities_valid
+        and scheduler_identity_valid
+        and not integrity_violations
+        and not invalid_verified_gaps
+    )
+    last_known_rank = -1
+    terminal_snapshot: tuple[object, object, object] | None = None
+    terminal_seen = False
+    for index, (observation, _handle, record, _progress) in enumerate(normalized):
         state = observation.get("state")
         if state == "unknown":
-            if observation.get("terminal") is not False or index == len(normalized) - 1:
-                lifecycle_valid = False
+            if (
+                observation.get("terminal") is not False
+                or index == len(normalized) - 1
+                or terminal_seen
+            ):
+                lifecycle_prefix_valid = False
             continue
         rank = state_rank.get(state) if isinstance(state, str) else None
         if rank is None:
-            lifecycle_valid = False
+            lifecycle_prefix_valid = False
             continue
         if rank < last_known_rank:
-            lifecycle_valid = False
+            lifecycle_prefix_valid = False
         last_known_rank = max(last_known_rank, rank)
-        if index < len(normalized) - 1 and observation.get("terminal") is not False:
-            lifecycle_valid = False
-    lifecycle_valid = bool(
-        lifecycle_valid
+        terminal = observation.get("terminal")
+        if terminal is True:
+            if state not in {"completed", "failed", "canceled"}:
+                lifecycle_prefix_valid = False
+            snapshot = (state, record.get("return_code"), record.get("error"))
+            if terminal_snapshot is None:
+                terminal_snapshot = snapshot
+            elif snapshot != terminal_snapshot:
+                lifecycle_prefix_valid = False
+            terminal_seen = True
+        elif terminal is False:
+            if (
+                terminal_seen
+                or state in {"completed", "failed", "canceled"}
+                or record.get("return_code") is not None
+                or record.get("error") is not None
+            ):
+                lifecycle_prefix_valid = False
+        else:
+            lifecycle_prefix_valid = False
+    terminal_success_valid = bool(
+        lifecycle_prefix_valid
         and normalized[-1][0].get("state") == "completed"
         and normalized[-1][0].get("terminal") is True
         and normalized[-1][2].get("return_code") == 0
         and normalized[-1][2].get("error") is None
     )
 
-    live_package: tuple[JSON, JSON, JSON] | None = None
+    live_package: tuple[int, JSON, JSON, JSON] | None = None
     progress_monotonic = True
-    package_counters: dict[tuple[object, object], tuple[int, int, JSON | None]] = {}
-    for observation, _handle, _record, execution_progress in normalized:
+    package_counters: dict[tuple[object, object], tuple[int, int, JSON | None, int]] = {}
+    for observation_index, (
+        observation,
+        _handle,
+        _record,
+        execution_progress,
+    ) in enumerate(normalized):
         packages = execution_progress.get("packages")
         if not isinstance(packages, list):
             progress_monotonic = False
@@ -1445,6 +1709,7 @@ def _jarvis_query_lifecycle_progress_evidence(
                 if counters[0] < prior[0] or counters[1] < prior[1]:
                     progress_monotonic = False
                 prior_latest = prior[2]
+                crossed_verified_gap = verified_gap_counts[observation_index] > prior[3]
                 if prior_latest is not None and latest is not None:
                     if counters[1] == prior[1]:
                         if counters[0] != prior[0] or _jarvis_progress_semantic_signature(
@@ -1453,13 +1718,21 @@ def _jarvis_query_lifecycle_progress_evidence(
                             progress_monotonic = False
                     elif counters[1] > prior[1] and (
                         counters[0] <= prior[0]
-                        or not _jarvis_progress_transition_nonregressing(
-                            prior_latest,
-                            latest,
+                        or (
+                            not crossed_verified_gap
+                            and not _jarvis_progress_transition_nonregressing(
+                                prior_latest,
+                                latest,
+                            )
                         )
                     ):
                         progress_monotonic = False
-            package_counters[key] = (counters[0], counters[1], latest)
+            package_counters[key] = (
+                counters[0],
+                counters[1],
+                latest,
+                verified_gap_counts[observation_index],
+            )
         if observation.get("state") != "running" or observation.get("terminal") is not False:
             continue
         for raw_package in cast(list[object], packages):
@@ -1476,11 +1749,11 @@ def _jarvis_query_lifecycle_progress_evidence(
                 and _valid_jarvis_progress_semantics(latest)
                 and _nonnegative_int(latest.get("sequence"))
             ):
-                live_package = (observation, package, latest)
+                live_package = (observation_index, observation, package, latest)
 
     terminal_package: tuple[JSON, JSON] | None = None
     if live_package is not None and normalized:
-        live_summary = live_package[1]
+        live_summary = live_package[2]
         terminal_packages = normalized[-1][3].get("packages")
         if isinstance(terminal_packages, list):
             for raw_package in cast(list[object], terminal_packages):
@@ -1497,7 +1770,7 @@ def _jarvis_query_lifecycle_progress_evidence(
 
     progress_valid = False
     if live_package is not None and terminal_package is not None:
-        _live_observation, live_summary, live_latest = live_package
+        live_index, _live_observation, live_summary, live_latest = live_package
         terminal_summary, terminal_latest = terminal_package
         progress_valid = bool(
             terminal_latest.get("schema_version") == "jarvis.progress.v1"
@@ -1509,7 +1782,10 @@ def _jarvis_query_lifecycle_progress_evidence(
             and _nonnegative_int(terminal_latest.get("sequence"))
             and cast(int, terminal_latest["sequence"]) >= cast(int, live_latest["sequence"])
             and _valid_jarvis_progress_semantics(terminal_latest)
-            and _jarvis_progress_transition_nonregressing(live_latest, terminal_latest)
+            and (
+                verified_gap_counts[-1] > verified_gap_counts[live_index]
+                or _jarvis_progress_transition_nonregressing(live_latest, terminal_latest)
+            )
         )
 
     compact_observations = [
@@ -1517,6 +1793,8 @@ def _jarvis_query_lifecycle_progress_evidence(
             "query_job_id": observation.get("query_job_id"),
             "state": observation.get("state"),
             "terminal": observation.get("terminal"),
+            "query_integrity": observation.get("relay_query_integrity"),
+            "verified_gap": observation.get("relay_query_verified_gap"),
             "package_count": (
                 len(cast(list[object], progress.get("packages")))
                 if isinstance(progress.get("packages"), list)
@@ -1532,7 +1810,8 @@ def _jarvis_query_lifecycle_progress_evidence(
         "observation_count_bounded": bounded,
         "query_identities_coherent": identities_valid,
         "scheduler_identity_optional_coherent_and_stable": scheduler_identity_valid,
-        "lifecycle_monotonic_and_completed": lifecycle_valid,
+        "lifecycle_prefix_coherent": lifecycle_prefix_valid,
+        "terminal_success_verified": terminal_success_valid,
         "in_flight_package_progress_observed": live_package is not None,
         "package_progress_nonregressing": progress_monotonic,
         "terminal_package_progress_bound": progress_valid,
@@ -1543,8 +1822,11 @@ def _jarvis_query_lifecycle_progress_evidence(
         "observation_count": len(observations),
         "observations": compact_observations,
         "observations_truncated": observations_truncated,
+        "query_integrity_violations": integrity_violations,
+        "verified_gap_count": verified_gap_count,
+        "invalid_verified_gaps": invalid_verified_gaps,
         "live_progress": (
-            _compact_package_progress(live_package[2]) if live_package is not None else {}
+            _compact_package_progress(live_package[3]) if live_package is not None else {}
         ),
         "terminal_progress": (
             _compact_package_progress(terminal_package[1]) if terminal_package is not None else {}
@@ -1554,7 +1836,7 @@ def _jarvis_query_lifecycle_progress_evidence(
     passed = all(assertions.values())
     if live_package is None or terminal_package is None:
         return evidence, passed, None
-    live_observation, _live_summary, live_latest = live_package
+    _live_index, live_observation, _live_summary, live_latest = live_package
     terminal_summary, terminal_latest = terminal_package
     resource: JSON = {
         "resource_id": f"{execution_id}:{live_latest.get('package_id', 'package')}",
@@ -1573,7 +1855,8 @@ def _jarvis_query_lifecycle_progress_evidence(
             "native_documents_validated": identities_valid,
             "query_identity_validated": identities_valid,
             "live_observed_while_running": True,
-            "lifecycle_query_validated": lifecycle_valid,
+            "lifecycle_prefix_validated": lifecycle_prefix_valid,
+            "terminal_success_validated": terminal_success_valid,
             "terminal_query_bound": progress_valid,
             "live_query_job_id": live_observation.get("query_job_id"),
             "terminal_query_job_id": normalized[-1][0].get("query_job_id"),
@@ -2273,6 +2556,14 @@ def _spack_environment_metadata(runtime_metadata: JSON | None) -> JSON | None:
     runtime = _mapping(details.get("runtime_metadata")) if details else None
     runtime_details = _mapping(runtime.get("details")) if runtime else None
     return _mapping(runtime_details.get("environment")) if runtime_details else None
+
+
+def _jarvis_runtime_scheduler_cluster(runtime_metadata: JSON | None) -> object:
+    """Return JARVIS's scheduler-native cluster, which is not the relay route alias."""
+    details = _mapping(runtime_metadata.get("details")) if runtime_metadata else None
+    native_execution = _mapping(details.get("native_execution")) if details else None
+    handle = _mapping(native_execution.get("execution_handle")) if native_execution else None
+    return handle.get("cluster") if handle is not None else _UNBOUND_JARVIS_IDENTITY
 
 
 def _is_sha256(value: object) -> bool:

--- a/src/clio_relay/jarvis_provider.py
+++ b/src/clio_relay/jarvis_provider.py
@@ -81,11 +81,13 @@ class JarvisCdProvider:
         self,
         *,
         jarvis_bin: str = "jarvis",
+        execution_python: str | None = None,
         agent_bin: str = "agent",
         agent_adapter: str = "exec",
         agent_args: list[str] | None = None,
     ) -> None:
         self.jarvis_bin = jarvis_bin
+        self.execution_python = execution_python
         self.agent_bin = agent_bin
         self.agent_adapter = agent_adapter
         self.agent_args = agent_args or []
@@ -467,7 +469,7 @@ class JarvisCdProvider:
     def named_pipeline_command(self, pipeline_name: str) -> list[str]:
         """Return the command used to execute a named JARVIS pipeline."""
         return named_jarvis_command(
-            python_bin=_jarvis_python(self.jarvis_bin),
+            python_bin=self._execution_python(),
             pipeline_name=pipeline_name,
         )
 
@@ -478,13 +480,19 @@ class JarvisCdProvider:
             provider_for_scheduler(scheduler_name)
             return scheduled_jarvis_command(
                 scheduler_name,
-                python_bin=_jarvis_python(self.jarvis_bin),
+                python_bin=self._execution_python(),
                 pipeline_path=pipeline_path,
             )
         return yaml_jarvis_command(
-            python_bin=_jarvis_python(self.jarvis_bin),
+            python_bin=self._execution_python(),
             pipeline_path=pipeline_path,
         )
+
+    def _execution_python(self) -> str:
+        """Return the receipt-bound interpreter or use unmanaged discovery explicitly."""
+        if self.execution_python is not None:
+            return self.execution_python
+        return _unmanaged_jarvis_python(self.jarvis_bin)
 
 
 def _drop_none(value: Any) -> Any:
@@ -591,7 +599,8 @@ def _document_scheduler_name(document: object) -> str | None:
     return None
 
 
-def _jarvis_python(jarvis_bin: str) -> str:
+def _unmanaged_jarvis_python(jarvis_bin: str) -> str:
+    """Best-effort interpreter discovery for unmanaged and development launchers."""
     jarvis_path = Path(jarvis_bin)
     if jarvis_path.parent.name == "bin":
         candidate = jarvis_path.parent / "python"

--- a/src/clio_relay/live_acceptance.py
+++ b/src/clio_relay/live_acceptance.py
@@ -21,7 +21,7 @@ from base64 import b64decode
 from collections.abc import Generator, Iterable
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal, Protocol, cast
 from uuid import uuid4
@@ -34,7 +34,7 @@ from clio_relay.browser_gateway import BrowserAttachmentGrant
 from clio_relay.cluster_config import ClusterDefinition
 from clio_relay.config import RelaySettings
 from clio_relay.doctor import run_cluster_doctor
-from clio_relay.errors import ConfigurationError, RelayError
+from clio_relay.errors import ConfigurationError, ObservationTimeoutError, RelayError
 from clio_relay.identifiers import DurableRecordId, validate_durable_record_id
 from clio_relay.installation import (
     verify_remote_clio_kit_native_execution_component,
@@ -85,9 +85,13 @@ from clio_relay.transport_probe import (
 from clio_relay.validation_report import (
     CleanupEvidence,
     EvidenceReference,
+    LiveValidationReport,
+    ValidationCheck,
     ValidationRecorder,
     ValidationResource,
+    ValidationStatus,
     detect_software_identity,
+    load_validation_report,
     new_live_validation_report,
     redact_sensitive_values,
 )
@@ -111,6 +115,124 @@ MAX_SECURE_RUNTIME_RESPONSE_BYTES = 1024 * 1024
 MAX_SECURE_RUNTIME_SSE_EVENT_BYTES = 256 * 1024
 SECURE_RUNTIME_ACCEPTANCE_SCHEMA = "clio-relay.secure-runtime-acceptance.v1"
 SECURE_RUNTIME_HTTP_EVIDENCE_SCHEMA = "clio-relay.secure-runtime-http-evidence.v1"
+LIVE_ACCEPTANCE_CHECKPOINT_SCHEMA = "clio-relay.live-acceptance-checkpoint.v1"
+LIVE_ACCEPTANCE_CHECKPOINT_RESOURCE_KIND = "live_acceptance_checkpoint"
+LiveAcceptancePendingPhase = Literal[
+    "primary_job_wait",
+    "secure_runtime_metadata",
+    "secure_runtime_query",
+    "secure_runtime_bind",
+    "agent_job_wait",
+    "agent_child_job_wait",
+]
+
+
+class LiveAcceptanceCheckpoint(BaseModel):
+    """Strict, non-expiring selector for resuming one exact live acceptance run."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    schema_version: Literal["clio-relay.live-acceptance-checkpoint.v1"] = (
+        LIVE_ACCEPTANCE_CHECKPOINT_SCHEMA
+    )
+    source_report_id: DurableRecordId
+    cluster: str = Field(min_length=1, max_length=256)
+    scenario: str = Field(min_length=1, max_length=256)
+    run_id: str = Field(min_length=1, max_length=512)
+    phase: LiveAcceptancePendingPhase
+    intent_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    pipeline_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    remote_pipeline_path: str = Field(min_length=1, max_length=4096)
+    primary_job_id: str = Field(min_length=1, max_length=256)
+    primary_idempotency_key: str = Field(min_length=1, max_length=512)
+    agent_prompt: str | None = Field(default=None, max_length=4096)
+    agent_job_id: str | None = Field(default=None, min_length=1, max_length=256)
+    agent_child_job_id: str | None = Field(default=None, min_length=1, max_length=256)
+    pipeline_id: str | None = Field(default=None, min_length=1, max_length=512)
+    execution_id: str | None = Field(default=None, min_length=1, max_length=512)
+    source_job_id: str | None = Field(default=None, min_length=1, max_length=256)
+    source_artifact_id: str | None = Field(default=None, min_length=1, max_length=256)
+    service_instance_id: str | None = Field(default=None, min_length=1, max_length=512)
+    gateway_session_id: str | None = Field(default=None, min_length=1, max_length=256)
+    scheduler_action: Literal["none"] = "none"
+    relay_action: Literal["observe_existing"] = "observe_existing"
+    integrity_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+    @model_validator(mode="after")
+    def validate_phase_and_integrity(self) -> LiveAcceptanceCheckpoint:
+        """Reject incomplete selectors and any altered checkpoint field."""
+        if not self.primary_job_id.startswith("job_"):
+            raise ValueError("live acceptance checkpoint primary job id is invalid")
+        expected_idempotency = f"live-test:{self.cluster}:{self.run_id}:jarvis"
+        if self.primary_idempotency_key != expected_idempotency:
+            raise ValueError("live acceptance checkpoint idempotency identity changed")
+        if self.phase in {"secure_runtime_query", "secure_runtime_bind"} and (
+            self.pipeline_id is None or self.execution_id is None
+        ):
+            raise ValueError("secure runtime checkpoint omitted pipeline or execution identity")
+        if self.phase == "secure_runtime_bind" and (
+            self.source_job_id is None
+            or self.source_artifact_id is None
+            or self.service_instance_id is None
+        ):
+            raise ValueError("secure runtime bind checkpoint omitted its exact source identity")
+        if self.phase in {"agent_job_wait", "agent_child_job_wait"} and self.agent_job_id is None:
+            raise ValueError("agent checkpoint omitted its exact relay job identity")
+        if self.phase == "agent_child_job_wait" and self.agent_child_job_id is None:
+            raise ValueError("agent child checkpoint omitted its exact relay job identity")
+        expected_integrity = _live_acceptance_checkpoint_sha256(
+            self.model_dump(mode="json", exclude={"integrity_sha256"})
+        )
+        if self.integrity_sha256 != expected_integrity:
+            raise ValueError("live acceptance checkpoint integrity digest changed")
+        return self
+
+    def retry_selector(self) -> dict[str, object]:
+        """Return the exact non-mutating selector to observe on the next invocation."""
+        selector: dict[str, object] = {
+            "cluster": self.cluster,
+            "run_id": self.run_id,
+            "phase": self.phase,
+            "primary_job_id": self.primary_job_id,
+            "primary_idempotency_key": self.primary_idempotency_key,
+        }
+        for name in (
+            "agent_job_id",
+            "agent_child_job_id",
+            "pipeline_id",
+            "execution_id",
+            "source_job_id",
+            "source_artifact_id",
+            "service_instance_id",
+            "gateway_session_id",
+        ):
+            value = getattr(self, name)
+            if value is not None:
+                selector[name] = value
+        return selector
+
+
+class _AcceptanceObservationPending(RelayError):
+    """A bounded observation expired while the durable workload remains nonterminal."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        phase: LiveAcceptancePendingPhase,
+        identifiers: dict[str, str] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.phase = phase
+        self.identifiers = dict(identifiers or {})
+
+
+class _LiveAcceptancePending(RelayError):
+    """Internal control result carrying one fully bound resumable checkpoint."""
+
+    def __init__(self, message: str, *, checkpoint: LiveAcceptanceCheckpoint) -> None:
+        super().__init__(message)
+        self.checkpoint = checkpoint
 
 
 class SecureRuntimeEndpointAdapter(BaseModel):
@@ -400,6 +522,397 @@ class LiveAcceptanceOptions:
     validation_scenario: str = "live-test"
     verify_cluster_deployment: bool = False
     report_id: DurableRecordId | None = None
+    resume_report_path: Path | None = None
+
+
+@dataclass
+class _LiveAcceptanceState:
+    """Mutable identities accumulated before a bounded observation can expire."""
+
+    run_id: str
+    intent_sha256: str
+    pipeline_sha256: str
+    remote_pipeline_path: str
+    primary_idempotency_key: str
+    primary_job_id: str | None = None
+    agent_prompt: str | None = None
+    agent_job_id: str | None = None
+    agent_child_job_id: str | None = None
+    pipeline_id: str | None = None
+    execution_id: str | None = None
+    source_job_id: str | None = None
+    source_artifact_id: str | None = None
+    service_instance_id: str | None = None
+    gateway_session_id: str | None = None
+
+    @classmethod
+    def from_checkpoint(cls, checkpoint: LiveAcceptanceCheckpoint) -> _LiveAcceptanceState:
+        """Restore every durable identity without inventing a new run or submission."""
+        return cls(
+            run_id=checkpoint.run_id,
+            intent_sha256=checkpoint.intent_sha256,
+            pipeline_sha256=checkpoint.pipeline_sha256,
+            remote_pipeline_path=checkpoint.remote_pipeline_path,
+            primary_idempotency_key=checkpoint.primary_idempotency_key,
+            primary_job_id=checkpoint.primary_job_id,
+            agent_prompt=checkpoint.agent_prompt,
+            agent_job_id=checkpoint.agent_job_id,
+            agent_child_job_id=checkpoint.agent_child_job_id,
+            pipeline_id=checkpoint.pipeline_id,
+            execution_id=checkpoint.execution_id,
+            source_job_id=checkpoint.source_job_id,
+            source_artifact_id=checkpoint.source_artifact_id,
+            service_instance_id=checkpoint.service_instance_id,
+            gateway_session_id=checkpoint.gateway_session_id,
+        )
+
+
+def _live_acceptance_checkpoint_sha256(value: object) -> str:
+    """Hash one finite checkpoint payload using its canonical wire representation."""
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _live_acceptance_intent_sha256(
+    options: LiveAcceptanceOptions,
+    *,
+    jarvis_yaml: Path,
+    pipeline_sha256: str,
+    monitor_pattern: str | None,
+    progress_pattern: str | None,
+    progress_action_payload: dict[str, object],
+    agent_prompt: str | None,
+    agent_mcp_config: str | None,
+    agent_child_jarvis_yaml: Path | None,
+    require_agent_child_job: bool,
+    verify_transport: bool,
+    verify_direct_transport: bool,
+    allow_direct_transport_fallback: bool,
+) -> str:
+    """Bind a checkpoint to every semantic input while allowing a new wait window."""
+    child_sha256 = (
+        hashlib.sha256(agent_child_jarvis_yaml.read_bytes()).hexdigest()
+        if agent_child_jarvis_yaml is not None
+        else None
+    )
+    intent = {
+        "cluster": options.cluster,
+        "definition": options.definition.model_dump(mode="json"),
+        "jarvis_yaml": str(jarvis_yaml.resolve()),
+        "pipeline_sha256": pipeline_sha256,
+        "monitor_pattern": monitor_pattern,
+        "progress_pattern": progress_pattern,
+        "progress_action_payload": progress_action_payload,
+        "agent_prompt": agent_prompt,
+        "agent_mcp_config": agent_mcp_config,
+        "agent_child_jarvis_yaml": (
+            str(agent_child_jarvis_yaml.resolve()) if agent_child_jarvis_yaml is not None else None
+        ),
+        "agent_child_jarvis_sha256": child_sha256,
+        "require_agent_child_job": require_agent_child_job,
+        "verify_transport": verify_transport,
+        "verify_direct_transport": verify_direct_transport,
+        "verify_ssh_transport": options.verify_ssh_transport,
+        "allow_direct_transport_fallback": allow_direct_transport_fallback,
+        "transport_local_bind_port": options.transport_local_bind_port,
+        "transport_remote_api_port": options.transport_remote_api_port,
+        "transport_proxy_name": options.transport_proxy_name,
+        "ssh_transport_local_bind_port": options.ssh_transport_local_bind_port,
+        "ssh_transport_remote_api_port": options.ssh_transport_remote_api_port,
+        "ssh_transport_session_id": options.ssh_transport_session_id,
+        "require_structured_runtime_metadata": options.require_structured_runtime_metadata,
+        "validation_scenario": options.validation_scenario,
+        "verify_cluster_deployment": options.verify_cluster_deployment,
+    }
+    return _live_acceptance_checkpoint_sha256(intent)
+
+
+def _current_live_acceptance_intent(
+    options: LiveAcceptanceOptions,
+) -> tuple[str, str]:
+    """Resolve and hash all local resume inputs without performing remote work."""
+    jarvis_yaml = options.jarvis_yaml or _configured_path(options.definition.live_test.jarvis_yaml)
+    if jarvis_yaml is None or not jarvis_yaml.exists():
+        raise ConfigurationError("resume report requires the original live-test JARVIS YAML")
+    source_pipeline = jarvis_yaml.read_text(encoding="utf-8")
+    pipeline_sha256 = hashlib.sha256(source_pipeline.encode("utf-8")).hexdigest()
+    monitor_pattern = options.monitor_pattern or options.definition.live_test.monitor_pattern
+    progress_pattern = options.progress_pattern or options.definition.live_test.progress_pattern
+    progress_action_payload = (
+        options.progress_action_payload
+        if options.progress_action_payload
+        else options.definition.live_test.progress_action_payload
+    )
+    agent_prompt = options.agent_prompt or options.definition.live_test.agent_prompt
+    child_yaml = options.agent_child_jarvis_yaml or _configured_path(
+        options.definition.live_test.agent_child_jarvis_yaml
+    )
+    agent_mcp_config = options.agent_mcp_config or options.definition.live_test.agent_mcp_config
+    require_agent_child_job = (
+        agent_mcp_config is not None
+        if options.require_agent_child_job is None
+        else options.require_agent_child_job
+    )
+    verify_transport = (
+        options.definition.live_test.verify_transport
+        if options.verify_transport is None
+        else options.verify_transport
+    )
+    verify_direct = (
+        options.definition.live_test.verify_direct_transport
+        if options.verify_direct_transport is None
+        else options.verify_direct_transport
+    )
+    allow_direct_fallback = (
+        options.definition.live_test.allow_direct_transport_fallback
+        if options.allow_direct_transport_fallback is None
+        else options.allow_direct_transport_fallback
+    )
+    return pipeline_sha256, _live_acceptance_intent_sha256(
+        options,
+        jarvis_yaml=jarvis_yaml,
+        pipeline_sha256=pipeline_sha256,
+        monitor_pattern=monitor_pattern,
+        progress_pattern=progress_pattern,
+        progress_action_payload=progress_action_payload,
+        agent_prompt=agent_prompt,
+        agent_mcp_config=agent_mcp_config,
+        agent_child_jarvis_yaml=child_yaml,
+        require_agent_child_job=require_agent_child_job,
+        verify_transport=verify_transport,
+        verify_direct_transport=verify_direct,
+        allow_direct_transport_fallback=allow_direct_fallback,
+    )
+
+
+def _load_live_acceptance_resume(
+    options: LiveAcceptanceOptions,
+) -> tuple[LiveValidationReport, LiveAcceptanceCheckpoint]:
+    """Validate one pending checkpoint completely before any remote command executes."""
+    assert options.resume_report_path is not None
+    report = load_validation_report(options.resume_report_path)
+    if report.status is not ValidationStatus.PENDING:
+        raise ConfigurationError("--resume-report must contain a pending live-test report")
+    if report.cluster != options.cluster or report.scenario != options.validation_scenario:
+        raise ConfigurationError("resume report cluster or scenario changed")
+    checkpoint_resources = [
+        resource
+        for resource in report.resources
+        if resource.kind == LIVE_ACCEPTANCE_CHECKPOINT_RESOURCE_KIND
+        and resource.role == "resume_checkpoint"
+    ]
+    if len(checkpoint_resources) != 1:
+        raise ConfigurationError("resume report must contain exactly one live-test checkpoint")
+    resource = checkpoint_resources[0]
+    raw_checkpoint = resource.metadata.get("checkpoint")
+    try:
+        checkpoint = LiveAcceptanceCheckpoint.model_validate(raw_checkpoint)
+    except ValueError as exc:
+        raise ConfigurationError(f"live-test resume checkpoint is invalid: {exc}") from exc
+    if (
+        checkpoint.source_report_id != report.report_id
+        or checkpoint.cluster != report.cluster
+        or checkpoint.scenario != report.scenario
+        or resource.resource_id != checkpoint.run_id
+        or resource.cluster != checkpoint.cluster
+        or resource.state != ValidationStatus.PENDING.value
+        or resource.metadata.get("retry_selector") != checkpoint.retry_selector()
+        or resource.metadata.get("scheduler_action") != "none"
+        or resource.metadata.get("relay_action") != "observe_existing"
+    ):
+        raise ConfigurationError("live-test resume checkpoint disagrees with its report evidence")
+    pipeline_sha256, intent_sha256 = _current_live_acceptance_intent(options)
+    if checkpoint.pipeline_sha256 != pipeline_sha256 or checkpoint.intent_sha256 != intent_sha256:
+        raise ConfigurationError("live-test resume inputs changed from the pending checkpoint")
+    primary_resources = [
+        item
+        for item in report.resources
+        if item.kind == "relay_job"
+        and item.resource_id == checkpoint.primary_job_id
+        and item.cluster == checkpoint.cluster
+    ]
+    if len(primary_resources) != 1:
+        raise ConfigurationError("resume report omitted its exact primary relay job evidence")
+    primary = primary_resources[0]
+    if (
+        primary.metadata.get("idempotency_key") != checkpoint.primary_idempotency_key
+        or primary.metadata.get("retained") is not True
+        or primary.metadata.get("scheduler_cancel_requested") is not False
+    ):
+        raise ConfigurationError("resume report primary relay job evidence was altered")
+    matching_checks = [
+        check
+        for check in report.checks
+        if check.check_id == "live-test.observation"
+        and check.status is ValidationStatus.PENDING
+        and any(
+            evidence.metadata.get("retry_selector") == checkpoint.retry_selector()
+            for evidence in check.evidence
+        )
+    ]
+    if len(matching_checks) != 1:
+        raise ConfigurationError("resume report omitted its exact pending observation evidence")
+    if report.cleanup.cancel_scheduler_jobs:
+        raise ConfigurationError("pending live-test report unexpectedly requested job cancellation")
+    return report, checkpoint
+
+
+def _resumed_live_acceptance_report(
+    source: LiveValidationReport,
+    *,
+    report_id: DurableRecordId | None,
+) -> LiveValidationReport:
+    """Create a sibling observation report while preserving the original checkpoint."""
+    return source.model_copy(
+        deep=True,
+        update={
+            "report_id": report_id or f"validation_{uuid4().hex}",
+            "started_at": datetime.now(UTC),
+            "completed_at": None,
+            "status": ValidationStatus.FAILED,
+            "error": None,
+            "checks": [check for check in source.checks if check.status is ValidationStatus.PASSED],
+            "resources": [
+                resource
+                for resource in source.resources
+                if resource.kind != LIVE_ACCEPTANCE_CHECKPOINT_RESOURCE_KIND
+            ],
+        },
+    )
+
+
+def _live_acceptance_pending(
+    options: LiveAcceptanceOptions,
+    *,
+    state: _LiveAcceptanceState,
+    recorder: ValidationRecorder | None,
+    pending: _AcceptanceObservationPending,
+) -> _LiveAcceptancePending:
+    """Bind a bounded observation to the exact durable acceptance identities."""
+    if recorder is None or state.primary_job_id is None:
+        raise ConfigurationError("pending live acceptance omitted durable report or job identity")
+    for name, value in pending.identifiers.items():
+        if not hasattr(state, name):
+            raise RelayError(f"pending live acceptance used an unknown identity: {name}")
+        prior = getattr(state, name)
+        if prior is not None and prior != value:
+            raise RelayError(f"pending live acceptance changed its {name}")
+        setattr(state, name, value)
+    payload: dict[str, object] = {
+        "schema_version": LIVE_ACCEPTANCE_CHECKPOINT_SCHEMA,
+        "source_report_id": recorder.report.report_id,
+        "cluster": options.cluster,
+        "scenario": options.validation_scenario,
+        "run_id": state.run_id,
+        "phase": pending.phase,
+        "intent_sha256": state.intent_sha256,
+        "pipeline_sha256": state.pipeline_sha256,
+        "remote_pipeline_path": state.remote_pipeline_path,
+        "primary_job_id": state.primary_job_id,
+        "primary_idempotency_key": state.primary_idempotency_key,
+        "agent_prompt": state.agent_prompt,
+        "agent_job_id": state.agent_job_id,
+        "agent_child_job_id": state.agent_child_job_id,
+        "pipeline_id": state.pipeline_id,
+        "execution_id": state.execution_id,
+        "source_job_id": state.source_job_id,
+        "source_artifact_id": state.source_artifact_id,
+        "service_instance_id": state.service_instance_id,
+        "gateway_session_id": state.gateway_session_id,
+        "scheduler_action": "none",
+        "relay_action": "observe_existing",
+    }
+    payload["integrity_sha256"] = _live_acceptance_checkpoint_sha256(payload)
+    checkpoint = LiveAcceptanceCheckpoint.model_validate(payload)
+    return _LiveAcceptancePending(str(pending), checkpoint=checkpoint)
+
+
+def _record_live_acceptance_pending(
+    recorder: ValidationRecorder,
+    pending: _LiveAcceptancePending,
+) -> None:
+    """Persist a nonterminal observation without manufacturing failure or cleanup."""
+    checkpoint = pending.checkpoint
+    recorder.report.checks = [
+        check
+        for check in recorder.report.checks
+        if not (
+            check.status is ValidationStatus.FAILED
+            and check.error is not None
+            and str(pending) in check.error
+        )
+    ]
+    now = datetime.now(UTC)
+    retry_selector = checkpoint.retry_selector()
+    recorder.report.checks.append(
+        ValidationCheck(
+            check_id="live-test.observation",
+            summary="bounded live acceptance observation remains resumable",
+            status=ValidationStatus.PENDING,
+            started_at=now,
+            completed_at=now,
+            evidence=[
+                EvidenceReference(
+                    kind="live_acceptance_resume_selector",
+                    reference=(f"relay-job://{checkpoint.cluster}/{checkpoint.primary_job_id}"),
+                    excerpt=str(pending),
+                    metadata={
+                        "retry_selector": retry_selector,
+                        "scheduler_action": "none",
+                        "relay_action": "observe_existing",
+                        "checkpoint_has_ttl": False,
+                    },
+                )
+            ],
+        )
+    )
+    recorder.report.resources = [
+        resource
+        for resource in recorder.report.resources
+        if resource.kind != LIVE_ACCEPTANCE_CHECKPOINT_RESOURCE_KIND
+    ]
+    recorder.add_resource(
+        ValidationResource(
+            kind=LIVE_ACCEPTANCE_CHECKPOINT_RESOURCE_KIND,
+            resource_id=checkpoint.run_id,
+            role="resume_checkpoint",
+            cluster=checkpoint.cluster,
+            state=ValidationStatus.PENDING.value,
+            metadata={
+                "checkpoint": checkpoint.model_dump(mode="json"),
+                "retry_selector": retry_selector,
+                "scheduler_action": "none",
+                "relay_action": "observe_existing",
+                "checkpoint_has_ttl": False,
+            },
+        )
+    )
+    recorder.add_resource(
+        ValidationResource(
+            kind="relay_job",
+            resource_id=checkpoint.primary_job_id,
+            role="primary",
+            cluster=checkpoint.cluster,
+            state="pending",
+            metadata={
+                "idempotency_key": checkpoint.primary_idempotency_key,
+                "retained": True,
+                "scheduler_cancel_requested": False,
+                "resume_phase": checkpoint.phase,
+            },
+        )
+    )
+    recorder.report.status = ValidationStatus.PENDING
+    recorder.report.completed_at = now
+    recorder.report.error = None
+    recorder.report.cleanup.cancel_scheduler_jobs = False
 
 
 def run_live_acceptance(
@@ -409,6 +922,16 @@ def run_live_acceptance(
 ) -> list[str]:
     """Run live checks and persist a report even when acceptance fails."""
     command_runner = runner or _run_command
+    resume_report: LiveValidationReport | None = None
+    resume_checkpoint: LiveAcceptanceCheckpoint | None = None
+    if options.resume_report_path is not None:
+        if options.report_path is None:
+            raise ConfigurationError("resuming live acceptance requires a new report path")
+        if options.report_path.resolve() == options.resume_report_path.resolve():
+            raise ConfigurationError(
+                "--report must differ from --resume-report so the checkpoint is preserved"
+            )
+        resume_report, resume_checkpoint = _load_live_acceptance_resume(options)
     recorder: ValidationRecorder | None = None
     if options.report_path is not None:
         transport_modes: list[str] = []
@@ -428,8 +951,13 @@ def run_live_acceptance(
             transport_modes.append("frp-direct")
         if options.verify_ssh_transport:
             transport_modes.append("ssh-forward")
-        recorder = ValidationRecorder(
-            new_live_validation_report(
+        report = (
+            _resumed_live_acceptance_report(
+                resume_report,
+                report_id=options.report_id,
+            )
+            if resume_report is not None
+            else new_live_validation_report(
                 scenario=options.validation_scenario,
                 cluster=options.cluster,
                 transport_modes=transport_modes,
@@ -439,6 +967,7 @@ def run_live_acceptance(
                 report_id=options.report_id,
             )
         )
+        recorder = ValidationRecorder(report)
         if transport_modes:
             recorder.report.cleanup = CleanupEvidence(
                 requested=True,
@@ -446,7 +975,28 @@ def run_live_acceptance(
                 cancel_scheduler_jobs=False,
             )
     try:
-        lines = _run_live_acceptance(options, runner=command_runner, recorder=recorder)
+        lines = _run_live_acceptance(
+            options,
+            runner=command_runner,
+            recorder=recorder,
+            resume_checkpoint=resume_checkpoint,
+        )
+    except _LiveAcceptancePending as pending:
+        if recorder is None or options.report_path is None:
+            raise ConfigurationError(
+                "a pending live acceptance observation requires a machine-readable report"
+            ) from pending
+        _record_live_acceptance_pending(recorder, pending)
+        recorder.write(options.report_path, options.markdown_report_path)
+        return [
+            "validation.status=pending",
+            f"acceptance.run_id={pending.checkpoint.run_id}",
+            f"acceptance.job_id={pending.checkpoint.primary_job_id}",
+            f"acceptance.pending_phase={pending.checkpoint.phase}",
+            "acceptance.scheduler_action=none",
+            "acceptance.relay_action=observe_existing",
+            f"validation.report={options.report_path.resolve()}",
+        ]
     except BaseException as exc:
         if recorder is not None:
             for evidence_line in transport_evidence_lines_from_error(exc):
@@ -478,6 +1028,7 @@ def _run_live_acceptance(
     *,
     runner: CommandRunner,
     recorder: ValidationRecorder | None,
+    resume_checkpoint: LiveAcceptanceCheckpoint | None = None,
 ) -> list[str]:
     """Execute the acceptance workflow while emitting structured facts."""
     command_runner = runner
@@ -540,15 +1091,47 @@ def _run_live_acceptance(
             token=options.transport_token,
             secret_key=options.transport_secret_key,
         )
-    run_id = _acceptance_run_id(jarvis_yaml)
-    pipeline_yaml_text = jarvis_yaml.read_text(encoding="utf-8")
-    secure_runtime_probe = _secure_runtime_probe_config(pipeline_yaml_text)
+    source_pipeline_yaml = jarvis_yaml.read_text(encoding="utf-8")
+    pipeline_sha256 = hashlib.sha256(source_pipeline_yaml.encode("utf-8")).hexdigest()
+    intent_sha256 = _live_acceptance_intent_sha256(
+        options,
+        jarvis_yaml=jarvis_yaml,
+        pipeline_sha256=pipeline_sha256,
+        monitor_pattern=monitor_pattern,
+        progress_pattern=progress_pattern,
+        progress_action_payload=progress_action_payload,
+        agent_prompt=agent_prompt,
+        agent_mcp_config=agent_mcp_config,
+        agent_child_jarvis_yaml=agent_child_jarvis_yaml,
+        require_agent_child_job=require_agent_child_job,
+        verify_transport=verify_transport,
+        verify_direct_transport=verify_direct_transport,
+        allow_direct_transport_fallback=allow_direct_transport_fallback,
+    )
+    if resume_checkpoint is None:
+        run_id = _acceptance_run_id(jarvis_yaml)
+        remote_yaml = f".local/share/clio-relay/live-tests/{run_id}/pipeline.yaml"
+        state = _LiveAcceptanceState(
+            run_id=run_id,
+            intent_sha256=intent_sha256,
+            pipeline_sha256=pipeline_sha256,
+            remote_pipeline_path=remote_yaml,
+            primary_idempotency_key=f"live-test:{options.cluster}:{run_id}:jarvis",
+            agent_prompt=agent_prompt,
+        )
+    else:
+        state = _LiveAcceptanceState.from_checkpoint(resume_checkpoint)
+        run_id = state.run_id
+        remote_yaml = state.remote_pipeline_path
+        agent_prompt = state.agent_prompt
+    secure_runtime_probe = _secure_runtime_probe_config(source_pipeline_yaml)
     pipeline_yaml_text = _stage_acceptance_files(
         options.definition,
         jarvis_yaml=jarvis_yaml,
-        pipeline_yaml_text=pipeline_yaml_text,
+        pipeline_yaml_text=source_pipeline_yaml,
         run_id=run_id,
         runner=command_runner,
+        write_remote=resume_checkpoint is None,
     )
     expected_progress_adapter = _expected_progress_adapter(pipeline_yaml_text)
     expected_progress_package = _expected_progress_package(pipeline_yaml_text)
@@ -562,9 +1145,13 @@ def _run_live_acceptance(
         lines.append(f"acceptance.package_adapter={expected_progress_adapter}")
         lines.append(f"acceptance.package_owner={expected_progress_package}")
 
-    lines.extend(run_cluster_doctor(options.definition))
-    lines.append("acceptance.cluster_doctor=passed")
-    if options.verify_cluster_deployment:
+    if resume_checkpoint is None:
+        lines.extend(run_cluster_doctor(options.definition))
+        lines.append("acceptance.cluster_doctor=passed")
+    else:
+        lines.append(f"acceptance.resume_run_id={run_id}")
+        lines.append(f"acceptance.resume_phase={resume_checkpoint.phase}")
+    if options.verify_cluster_deployment and resume_checkpoint is None:
         lines.extend(
             _verify_cluster_deployment(
                 options.definition,
@@ -575,7 +1162,7 @@ def _run_live_acceptance(
                 ),
             )
         )
-    if secure_runtime_probe is not None:
+    if secure_runtime_probe is not None and resume_checkpoint is None:
         if recorder is None:
             raise ConfigurationError(
                 "secure runtime acceptance requires a machine-readable report path"
@@ -593,7 +1180,7 @@ def _run_live_acceptance(
                 evidence=evidence,
             )
         lines.append("secure-runtime.control_query_capacity=ready")
-    if verify_transport:
+    if verify_transport and resume_checkpoint is None:
         assert transport_token is not None
         assert transport_secret_key is not None
         lines.extend(
@@ -606,7 +1193,7 @@ def _run_live_acceptance(
                 expected_progress_package=expected_progress_package,
             )
         )
-    if verify_direct_transport:
+    if verify_direct_transport and resume_checkpoint is None:
         assert transport_token is not None
         assert transport_secret_key is not None
         direct_lines = _verify_direct_transport(
@@ -621,17 +1208,17 @@ def _run_live_acceptance(
         if not allow_direct_transport_fallback:
             _assert_direct_xtcp_acceptance(direct_lines)
         lines.extend(direct_lines)
-    if options.verify_ssh_transport:
+    if options.verify_ssh_transport and resume_checkpoint is None:
         lines.extend(_verify_ssh_transport(options, pipeline_yaml=pipeline_yaml_text))
-    remote_yaml = f".local/share/clio-relay/live-tests/{run_id}/pipeline.yaml"
-    _remote_write_file(
-        options.definition.ssh_host,
-        remote_yaml,
-        pipeline_yaml_text.encode("utf-8"),
-        runner=command_runner,
-    )
+    if resume_checkpoint is None:
+        _remote_write_file(
+            options.definition.ssh_host,
+            remote_yaml,
+            pipeline_yaml_text.encode("utf-8"),
+            runner=command_runner,
+        )
     lines.append(f"acceptance.pipeline={remote_yaml}")
-    if agent_child_jarvis_yaml is not None:
+    if agent_child_jarvis_yaml is not None and resume_checkpoint is None:
         agent_prompt = _write_generated_agent_prompt(
             options.definition,
             cluster=options.cluster,
@@ -639,29 +1226,46 @@ def _run_live_acceptance(
             child_yaml=agent_child_jarvis_yaml,
             runner=command_runner,
         )
+        state.agent_prompt = agent_prompt
+        lines.append(f"acceptance.agent_prompt={agent_prompt}")
+    elif agent_prompt is not None:
         lines.append(f"acceptance.agent_prompt={agent_prompt}")
 
-    submit = _remote_clio_json(
-        options.definition,
-        [
-            "job",
-            "submit",
-            "--cluster",
-            options.cluster,
-            "--jarvis-yaml",
-            remote_yaml,
-            "--idempotency-key",
-            f"live-test:{options.cluster}:{run_id}:jarvis",
-        ],
-        runner=command_runner,
-        raw_text=True,
-    )
-    job_id = submit.strip().splitlines()[-1]
-    if not job_id.startswith("job_"):
-        raise RelayError(f"live-test submit did not return a job id: {submit}")
+    if resume_checkpoint is None:
+        submit = _remote_clio_json(
+            options.definition,
+            [
+                "job",
+                "submit",
+                "--cluster",
+                options.cluster,
+                "--jarvis-yaml",
+                remote_yaml,
+                "--idempotency-key",
+                state.primary_idempotency_key,
+            ],
+            runner=command_runner,
+            raw_text=True,
+        )
+        job_id = submit.strip().splitlines()[-1]
+        if not job_id.startswith("job_"):
+            raise RelayError(f"live-test submit did not return a job id: {submit}")
+        state.primary_job_id = job_id
+    else:
+        assert state.primary_job_id is not None
+        job_id = state.primary_job_id
     lines.append(f"acceptance.job_id={job_id}")
 
-    if expected_progress_adapter is not None:
+    resume_phase = resume_checkpoint.phase if resume_checkpoint is not None else None
+    post_primary_phases = {
+        "secure_runtime_metadata",
+        "secure_runtime_query",
+        "secure_runtime_bind",
+        "agent_job_wait",
+        "agent_child_job_wait",
+    }
+
+    if expected_progress_adapter is not None and resume_checkpoint is None:
         _verify_live_package_progress(
             options.definition,
             job_id,
@@ -675,82 +1279,118 @@ def _run_live_acceptance(
 
     secure_runtime_forbidden_values: set[str] = set()
     if secure_runtime_probe is None:
-        _wait_for_success(
-            options.definition,
-            job_id,
-            timeout_seconds=options.timeout_seconds,
-            poll_seconds=options.poll_seconds,
-            runner=command_runner,
-        )
-        lines.append("acceptance.job_state=succeeded")
-        if options.verify_cluster_deployment:
-            lines.append("worker.execute=passed")
+        if resume_phase not in post_primary_phases:
+            try:
+                _wait_for_success(
+                    options.definition,
+                    job_id,
+                    timeout_seconds=options.timeout_seconds,
+                    poll_seconds=options.poll_seconds,
+                    runner=command_runner,
+                    pending_phase="primary_job_wait",
+                )
+            except _AcceptanceObservationPending as pending:
+                raise _live_acceptance_pending(
+                    options,
+                    state=state,
+                    recorder=recorder,
+                    pending=pending,
+                ) from None
+            lines.append("acceptance.job_state=succeeded")
+            if options.verify_cluster_deployment:
+                lines.append("worker.execute=passed")
 
-        _verify_completed_job(
-            options.definition,
-            job_id,
-            line_prefix="acceptance",
-            lines=lines,
-            runner=command_runner,
-            expected_progress_adapter=expected_progress_adapter,
-            expected_progress_package=expected_progress_package,
-            recorder=recorder,
-            require_structured_runtime_metadata=options.require_structured_runtime_metadata,
-        )
-    else:
-        assert recorder is not None
-        with _validation_check(
-            recorder,
-            "secure-runtime.source-live-metadata",
-            "observe trusted runtime metadata while retaining the running source job",
-            forbidden_values=set(),
-        ) as evidence:
-            runtime_metadata = _wait_for_live_structured_runtime_metadata(
+            _verify_completed_job(
                 options.definition,
                 job_id,
                 line_prefix="acceptance",
                 lines=lines,
-                timeout_seconds=options.timeout_seconds,
-                poll_seconds=options.poll_seconds,
                 runner=command_runner,
+                expected_progress_adapter=expected_progress_adapter,
+                expected_progress_package=expected_progress_package,
+                recorder=recorder,
+                require_structured_runtime_metadata=options.require_structured_runtime_metadata,
             )
-            runtime_document = runtime_metadata.document
-            runtime_source = str(runtime_document["source"])
-            evidence.append(
-                EvidenceReference(
-                    kind="relay_job_status",
-                    reference=f"relay-job://{options.cluster}/{job_id}",
-                    metadata={
-                        "state": JobState.RUNNING.value,
-                        "runtime_metadata_source": runtime_source,
-                        "source_job_retained": True,
-                        "cancel_scheduler_job": False,
-                    },
-                )
+    else:
+        assert recorder is not None
+        if resume_phase in {"secure_runtime_query", "secure_runtime_bind"}:
+            assert state.pipeline_id is not None and state.execution_id is not None
+            runtime_document = {
+                "pipeline_id": state.pipeline_id,
+                "execution_id": state.execution_id,
+            }
+        else:
+            try:
+                with _validation_check(
+                    recorder,
+                    "secure-runtime.source-live-metadata",
+                    "observe trusted runtime metadata while retaining the running source job",
+                    forbidden_values=set(),
+                ) as evidence:
+                    runtime_metadata = _wait_for_live_structured_runtime_metadata(
+                        options.definition,
+                        job_id,
+                        line_prefix="acceptance",
+                        lines=lines,
+                        timeout_seconds=options.timeout_seconds,
+                        poll_seconds=options.poll_seconds,
+                        runner=command_runner,
+                    )
+                    runtime_document = runtime_metadata.document
+                    runtime_source = str(runtime_document["source"])
+                    evidence.append(
+                        EvidenceReference(
+                            kind="relay_job_status",
+                            reference=f"relay-job://{options.cluster}/{job_id}",
+                            metadata={
+                                "state": JobState.RUNNING.value,
+                                "runtime_metadata_source": runtime_source,
+                                "source_job_retained": True,
+                                "cancel_scheduler_job": False,
+                            },
+                        )
+                    )
+                    recorder.add_resource(
+                        ValidationResource(
+                            kind="relay_job",
+                            resource_id=job_id,
+                            role="secure_runtime_source",
+                            cluster=options.cluster,
+                            state=JobState.RUNNING.value,
+                            metadata={
+                                "runtime_metadata_source": runtime_source,
+                                "retained": True,
+                                "cancel_scheduler_job": False,
+                            },
+                        )
+                    )
+            except _AcceptanceObservationPending as pending:
+                raise _live_acceptance_pending(
+                    options,
+                    state=state,
+                    recorder=recorder,
+                    pending=pending,
+                ) from None
+            state.pipeline_id = cast(str, runtime_document["pipeline_id"])
+            state.execution_id = cast(str, runtime_document["execution_id"])
+        try:
+            secure_runtime_forbidden_values = _verify_secure_runtime_acceptance(
+                options,
+                config=secure_runtime_probe,
+                runtime_metadata=runtime_document,
+                recorder=recorder,
             )
-            recorder.add_resource(
-                ValidationResource(
-                    kind="relay_job",
-                    resource_id=job_id,
-                    role="secure_runtime_source",
-                    cluster=options.cluster,
-                    state=JobState.RUNNING.value,
-                    metadata={
-                        "runtime_metadata_source": runtime_source,
-                        "retained": True,
-                        "cancel_scheduler_job": False,
-                    },
-                )
-            )
-        secure_runtime_forbidden_values = _verify_secure_runtime_acceptance(
-            options,
-            config=secure_runtime_probe,
-            runtime_metadata=runtime_metadata.document,
-            recorder=recorder,
-        )
+        except _AcceptanceObservationPending as pending:
+            raise _live_acceptance_pending(
+                options,
+                state=state,
+                recorder=recorder,
+                pending=pending,
+            ) from None
         lines.append("secure-runtime.acceptance=ok")
 
-    if monitor_pattern is not None:
+    resuming_agent_phase = resume_phase in {"agent_job_wait", "agent_child_job_wait"}
+    if monitor_pattern is not None and not resuming_agent_phase:
         _remote_clio_json(
             options.definition,
             [
@@ -773,7 +1413,7 @@ def _run_live_acceptance(
             raise RelayError(f"acceptance monitor pattern did not match: {monitor_pattern}")
         lines.append("acceptance.monitor=ok")
 
-    if progress_pattern is not None:
+    if progress_pattern is not None and not resuming_agent_phase:
         _verify_progress_monitor(
             options.definition,
             job_id,
@@ -784,48 +1424,81 @@ def _run_live_acceptance(
         )
 
     if agent_prompt is not None:
-        agent_args = [
-            "agent",
-            "run",
-            "--cluster",
-            options.cluster,
-            "--prompt",
-            agent_prompt,
-            "--idempotency-key",
-            f"live-test:{options.cluster}:{run_id}:agent",
-        ]
-        if agent_mcp_config is not None:
-            agent_args.extend(["--mcp-config", agent_mcp_config])
-        agent_submit = _remote_clio_json(
-            options.definition,
-            agent_args,
-            runner=command_runner,
-            raw_text=True,
-        )
-        agent_job_id = agent_submit.strip().splitlines()[-1]
-        agent_job = _wait_for_success(
-            options.definition,
-            agent_job_id,
-            timeout_seconds=options.timeout_seconds,
-            poll_seconds=options.poll_seconds,
-            runner=command_runner,
-        )
+        if resuming_agent_phase:
+            assert state.agent_job_id is not None
+            agent_job_id = state.agent_job_id
+        else:
+            agent_args = [
+                "agent",
+                "run",
+                "--cluster",
+                options.cluster,
+                "--prompt",
+                agent_prompt,
+                "--idempotency-key",
+                f"live-test:{options.cluster}:{run_id}:agent",
+            ]
+            if agent_mcp_config is not None:
+                agent_args.extend(["--mcp-config", agent_mcp_config])
+            agent_submit = _remote_clio_json(
+                options.definition,
+                agent_args,
+                runner=command_runner,
+                raw_text=True,
+            )
+            agent_job_id = agent_submit.strip().splitlines()[-1]
+            if not agent_job_id.startswith("job_"):
+                raise RelayError(f"live-test agent submit did not return a job id: {agent_submit}")
+            state.agent_job_id = agent_job_id
+        if resume_phase != "agent_child_job_wait":
+            try:
+                agent_job = _wait_for_success(
+                    options.definition,
+                    agent_job_id,
+                    timeout_seconds=options.timeout_seconds,
+                    poll_seconds=options.poll_seconds,
+                    runner=command_runner,
+                    pending_phase="agent_job_wait",
+                )
+            except _AcceptanceObservationPending as pending:
+                raise _live_acceptance_pending(
+                    options,
+                    state=state,
+                    recorder=recorder,
+                    pending=pending,
+                ) from None
+        else:
+            agent_job = {}
         lines.append(f"acceptance.agent_job_id={agent_job_id}")
         lines.append("acceptance.agent_state=succeeded")
         if require_agent_child_job:
-            child_job_id = _find_agent_child_job(
-                options.definition,
-                agent_job_id,
-                agent_created_at=str(agent_job["created_at"]),
-                runner=command_runner,
-            )
-            _wait_for_success(
-                options.definition,
-                child_job_id,
-                timeout_seconds=options.timeout_seconds,
-                poll_seconds=options.poll_seconds,
-                runner=command_runner,
-            )
+            if resume_phase == "agent_child_job_wait":
+                assert state.agent_child_job_id is not None
+                child_job_id = state.agent_child_job_id
+            else:
+                child_job_id = _find_agent_child_job(
+                    options.definition,
+                    agent_job_id,
+                    agent_created_at=str(agent_job["created_at"]),
+                    runner=command_runner,
+                )
+                state.agent_child_job_id = child_job_id
+            try:
+                _wait_for_success(
+                    options.definition,
+                    child_job_id,
+                    timeout_seconds=options.timeout_seconds,
+                    poll_seconds=options.poll_seconds,
+                    runner=command_runner,
+                    pending_phase="agent_child_job_wait",
+                )
+            except _AcceptanceObservationPending as pending:
+                raise _live_acceptance_pending(
+                    options,
+                    state=state,
+                    recorder=recorder,
+                    pending=pending,
+                ) from None
             lines.append(f"acceptance.agent_child_job_id={child_job_id}")
             _verify_completed_job(
                 options.definition,
@@ -840,8 +1513,10 @@ def _run_live_acceptance(
             )
 
     lines.append("live acceptance passed")
-    expected_transport_cleanups = sum(
-        [verify_transport, verify_direct_transport, options.verify_ssh_transport]
+    expected_transport_cleanups = (
+        0
+        if resume_checkpoint is not None
+        else sum([verify_transport, verify_direct_transport, options.verify_ssh_transport])
     )
     observed_transport_cleanups = lines.count("transport.cleanup=passed")
     if observed_transport_cleanups < expected_transport_cleanups:
@@ -1388,30 +2063,51 @@ def _verify_secure_runtime_acceptance(
             while True:
                 remaining = query_deadline - time.monotonic()
                 if remaining <= 0:
-                    raise RelayError(
+                    raise _AcceptanceObservationPending(
                         "timed out waiting for one ready JARVIS service runtime binding: "
-                        f"{execution_id}"
+                        f"{execution_id}",
+                        phase="secure_runtime_query",
+                        identifiers={
+                            "pipeline_id": pipeline_id,
+                            "execution_id": execution_id,
+                        },
                     )
                 query_attempt += 1
-                query_session = run_packaged_mcp_stdio_session(
-                    profile="user",
-                    tool="jarvis_get_execution",
-                    arguments={
-                        "cluster": options.cluster,
-                        "pipeline_id": pipeline_id,
-                        "execution_id": execution_id,
-                        "include_service_runtimes": True,
-                        "wait_for_terminal": True,
-                        "wait_timeout_seconds": remaining,
-                        "poll_seconds": options.poll_seconds,
-                    },
-                    timeout_seconds=remaining + 30.0,
-                    require_enforceable_containment=True,
-                )
+                try:
+                    query_session = run_packaged_mcp_stdio_session(
+                        profile="user",
+                        tool="jarvis_get_execution",
+                        arguments={
+                            "cluster": options.cluster,
+                            "pipeline_id": pipeline_id,
+                            "execution_id": execution_id,
+                            "include_service_runtimes": True,
+                            "wait_for_terminal": True,
+                            "wait_timeout_seconds": remaining,
+                            "poll_seconds": options.poll_seconds,
+                        },
+                        timeout_seconds=remaining + 30.0,
+                        require_enforceable_containment=True,
+                    )
+                except (ObservationTimeoutError, TimeoutError):
+                    raise _AcceptanceObservationPending(
+                        "timed out observing one ready JARVIS service runtime binding: "
+                        f"{execution_id}",
+                        phase="secure_runtime_query",
+                        identifiers={
+                            "pipeline_id": pipeline_id,
+                            "execution_id": execution_id,
+                        },
+                    ) from None
                 if time.monotonic() >= query_deadline:
-                    raise RelayError(
+                    raise _AcceptanceObservationPending(
                         "timed out waiting for one ready JARVIS service runtime binding: "
-                        f"{execution_id}"
+                        f"{execution_id}",
+                        phase="secure_runtime_query",
+                        identifiers={
+                            "pipeline_id": pipeline_id,
+                            "execution_id": execution_id,
+                        },
                     )
                 query_result = _packaged_mcp_structured_result(
                     query_session,
@@ -1453,9 +2149,14 @@ def _verify_secure_runtime_acceptance(
                 )
                 remaining = query_deadline - time.monotonic()
                 if remaining <= 0:
-                    raise RelayError(
+                    raise _AcceptanceObservationPending(
                         "timed out waiting for one ready JARVIS service runtime binding: "
-                        f"{execution_id}"
+                        f"{execution_id}",
+                        phase="secure_runtime_query",
+                        identifiers={
+                            "pipeline_id": pipeline_id,
+                            "execution_id": execution_id,
+                        },
                     )
                 time.sleep(min(options.poll_seconds, remaining))
 
@@ -1527,18 +2228,31 @@ def _verify_secure_runtime_acceptance(
                 "resolve exact private authority and bind authenticated relay connectors",
                 forbidden_values=forbidden_values,
             ) as evidence:
-                bind_session = run_packaged_mcp_stdio_session(
-                    profile="user",
-                    tool="relay_bind_jarvis_runtime",
-                    arguments={
-                        "binding": handoff.model_dump(mode="json"),
-                        "readiness_timeout_seconds": options.timeout_seconds,
-                        "poll_seconds": options.poll_seconds,
-                    },
-                    timeout_seconds=options.timeout_seconds + 30.0,
-                    extra_environment=runtime_child_environment,
-                    require_enforceable_containment=True,
-                )
+                try:
+                    bind_session = run_packaged_mcp_stdio_session(
+                        profile="user",
+                        tool="relay_bind_jarvis_runtime",
+                        arguments={
+                            "binding": handoff.model_dump(mode="json"),
+                            "readiness_timeout_seconds": options.timeout_seconds,
+                            "poll_seconds": options.poll_seconds,
+                        },
+                        timeout_seconds=options.timeout_seconds + 30.0,
+                        extra_environment=runtime_child_environment,
+                        require_enforceable_containment=True,
+                    )
+                except (ObservationTimeoutError, TimeoutError):
+                    raise _AcceptanceObservationPending(
+                        "timed out observing the exact secure runtime bind",
+                        phase="secure_runtime_bind",
+                        identifiers={
+                            "pipeline_id": pipeline_id,
+                            "execution_id": execution_id,
+                            "source_job_id": handoff.source_job_id,
+                            "source_artifact_id": handoff.source_artifact_id,
+                            "service_instance_id": handoff.service_instance_id,
+                        },
+                    ) from None
                 bind_result = _packaged_mcp_structured_result(
                     bind_session,
                     expected_tool="relay_bind_jarvis_runtime",
@@ -1556,6 +2270,23 @@ def _verify_secure_runtime_acceptance(
                 ):
                     raise RelayError("packaged MCP identity changed between query and bind")
                 public_documents.append(bind_result)
+                if bind_result.get("outcome") == "pending":
+                    gateway_session_id = _validated_secure_runtime_pending_bind(
+                        bind_result,
+                        handoff=handoff,
+                    )
+                    raise _AcceptanceObservationPending(
+                        "secure runtime bind remained pending at the observation boundary",
+                        phase="secure_runtime_bind",
+                        identifiers={
+                            "pipeline_id": pipeline_id,
+                            "execution_id": execution_id,
+                            "source_job_id": handoff.source_job_id,
+                            "source_artifact_id": handoff.source_artifact_id,
+                            "service_instance_id": handoff.service_instance_id,
+                            "gateway_session_id": gateway_session_id,
+                        },
+                    )
                 gateway_session_id = _secure_runtime_cleanup_candidate(
                     bind_result,
                     handoff=handoff,
@@ -2094,7 +2825,12 @@ def _verify_secure_runtime_acceptance(
                         "secure runtime cleanup discovery: "
                         + _redacted_error_text(cleanup_discovery_exc, forbidden_values)
                     )
-        if supervisor is not None and cleanup_session_ids and not teardown_complete:
+        if (
+            supervisor is not None
+            and cleanup_session_ids
+            and not teardown_complete
+            and not isinstance(primary_error, _AcceptanceObservationPending)
+        ):
             cleanup_errors: list[str] = []
             if active_attachment is not None and gateway_session_id is not None:
                 try:
@@ -2474,6 +3210,50 @@ def _gateway_sessions_for_acceptance(
         if next_cursor <= cursor:
             raise RelayError("secure runtime acceptance gateway pagination did not advance")
         cursor = next_cursor
+
+
+def _validated_secure_runtime_pending_bind(
+    bind_result: dict[str, Any],
+    *,
+    handoff: JarvisServiceRuntimeHandoff,
+) -> str:
+    """Validate a durable bind observation without treating it as a ready endpoint."""
+    if (
+        bind_result.get("outcome") != "pending"
+        or bind_result.get("scheduler_cancel_requested") is not False
+        or bind_result.get("scheduler_action") != "none"
+        or bind_result.get("relay_action") != "none"
+    ):
+        raise RelayError("secure runtime pending bind changed its no-action contract")
+    gateway_session_id = _secure_runtime_cleanup_candidate(bind_result, handoff=handoff)
+    gateway = cast(dict[str, Any], bind_result["gateway_session"])
+    if gateway.get("state") not in {"created", "pending", "allocated", "starting", "degraded"}:
+        raise RelayError("secure runtime pending bind reported an invalid gateway state")
+    retry_selector = bind_result.get("retry_selector")
+    if not isinstance(retry_selector, dict):
+        raise RelayError("secure runtime pending bind omitted its retry selector")
+    typed_selector = cast(dict[str, object], retry_selector)
+    if (
+        typed_selector.get("cluster") != handoff.cluster
+        or typed_selector.get("gateway_session_id") != gateway_session_id
+    ):
+        raise RelayError("secure runtime pending bind changed its retry identity")
+    for key in (
+        "connect_url",
+        "health_url",
+        "stream_url",
+        "events_url",
+        "state_url",
+        "command_url",
+    ):
+        if bind_result.get(key) is not None:
+            raise RelayError(f"secure runtime pending bind exposed unverified {key}")
+    _assert_secret_free_document(
+        bind_result,
+        forbidden_values=set(),
+        label="secure runtime pending bind",
+    )
+    return gateway_session_id
 
 
 def _validated_secure_runtime_bind(
@@ -3500,8 +4280,12 @@ def _wait_for_live_structured_runtime_metadata(
                 if job.state is not JobState.RUNNING:
                     if time.monotonic() >= deadline:
                         lines.append(f"{line_prefix}.job_state={job.state.value}")
-                        raise RelayError(
-                            f"timed out waiting for the secure runtime source job to run: {job_id}"
+                        raise _AcceptanceObservationPending(
+                            "timed out waiting for the secure runtime source job to run; "
+                            "the bounded observation expired while the retained job remained "
+                            f"{job.state.value}: {job_id}",
+                            phase="secure_runtime_metadata",
+                            identifiers={"primary_job_id": job_id},
                         )
                     time.sleep(poll_seconds)
                     continue
@@ -3518,9 +4302,11 @@ def _wait_for_live_structured_runtime_metadata(
 
         if time.monotonic() >= deadline:
             lines.append(f"{line_prefix}.job_state={job.state.value}")
-            raise RelayError(
-                "timed out waiting for structured runtime metadata from secure runtime "
-                f"source job: {job_id}"
+            raise _AcceptanceObservationPending(
+                "timed out waiting for structured runtime metadata from secure runtime source "
+                f"job; the bounded observation expired without changing the workload: {job_id}",
+                phase="secure_runtime_metadata",
+                identifiers={"primary_job_id": job_id},
             )
         time.sleep(poll_seconds)
 
@@ -3532,6 +4318,11 @@ def _wait_for_success(
     timeout_seconds: float,
     poll_seconds: float,
     runner: CommandRunner,
+    pending_phase: Literal[
+        "primary_job_wait",
+        "agent_job_wait",
+        "agent_child_job_wait",
+    ] = "primary_job_wait",
 ) -> dict[str, Any]:
     job = _remote_clio_json(
         definition,
@@ -3546,10 +4337,30 @@ def _wait_for_success(
         ],
         runner=runner,
     )
+    if not isinstance(job, dict):
+        raise RelayError("acceptance job wait did not return a JSON object")
     typed = cast(dict[str, Any], job)
-    if typed["state"] != "succeeded":
-        raise RelayError(f"acceptance job did not succeed: {typed['state']}")
-    return typed
+    observed_job_id = typed.get("job_id")
+    state = typed.get("state")
+    if observed_job_id != job_id or not isinstance(state, str):
+        raise RelayError("acceptance job wait changed or omitted its durable identity")
+    if state == "succeeded":
+        return typed
+    if state in {"failed", "canceled"}:
+        raise RelayError(f"acceptance job did not succeed: {state}")
+    raise _AcceptanceObservationPending(
+        f"bounded observation expired while acceptance job remained {state}: {job_id}",
+        phase=pending_phase,
+        identifiers={
+            (
+                "primary_job_id"
+                if pending_phase == "primary_job_wait"
+                else "agent_job_id"
+                if pending_phase == "agent_job_wait"
+                else "agent_child_job_id"
+            ): job_id
+        },
+    )
 
 
 def _verify_live_package_progress(
@@ -4256,6 +5067,7 @@ def _stage_acceptance_files(
     pipeline_yaml_text: str,
     run_id: str,
     runner: CommandRunner,
+    write_remote: bool = True,
 ) -> str:
     loaded = cast(object, yaml.safe_load(pipeline_yaml_text))
     if not isinstance(loaded, dict):
@@ -4286,12 +5098,13 @@ def _stage_acceptance_files(
         if not local_path.exists():
             raise ConfigurationError(f"staged acceptance file does not exist: {local_path}")
         remote_path = remote_path_value.format(run_id=run_id)
-        _remote_write_file(
-            definition.ssh_host,
-            remote_path,
-            local_path.read_bytes(),
-            runner=runner,
-        )
+        if write_remote:
+            _remote_write_file(
+                definition.ssh_host,
+                remote_path,
+                local_path.read_bytes(),
+                runner=runner,
+            )
     formatted_document = _format_run_id(document, run_id)
     return yaml.safe_dump(formatted_document, sort_keys=False)
 

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -129,7 +129,10 @@ from clio_relay.remote_mcp import (
     unavailable_virtual_remote_mcp_catalog,
 )
 from clio_relay.retention import TerminalRetentionCoordinator
-from clio_relay.service_runtime import ServiceRuntimeSupervisor
+from clio_relay.service_runtime import (
+    ServiceRuntimePendingResult,
+    ServiceRuntimeSupervisor,
+)
 from clio_relay.session_api import (
     OWNED_SESSION_WAIT_RESPONSE_GRACE_SECONDS,
     OwnedSessionApiClient,
@@ -1377,9 +1380,12 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                 "source, and a JARVIS execution_id is not a gateway_session_id. "
                 "Runtime host, paths, scheduler identity, and dataset metadata are read "
                 "only from the durable JARVIS result. The relay allocates the desktop "
-                "loopback port. On success, copy the top-level gateway_session_id "
-                "unchanged into the viewer-opening tool; service_instance_id is not a "
-                "gateway identity."
+                "loopback port. A bounded readiness miss returns outcome=pending with "
+                "nullable URLs and an exact retry_selector; it does not fail, cancel, or "
+                "replace the JARVIS execution or its connectors. Reissue this tool with "
+                "the same binding, name, and policy to resume the same gateway. When "
+                "outcome=ready, copy the top-level gateway_session_id unchanged into the "
+                "viewer-opening tool; service_instance_id is not a gateway identity."
             ),
             "inputSchema": {
                 "type": "object",
@@ -1433,6 +1439,12 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
             "outputSchema": {
                 "type": "object",
                 "properties": {
+                    "outcome": {"type": "string", "enum": ["ready", "pending"]},
+                    "retry_selector": {
+                        "anyOf": [{"type": "object"}, {"type": "null"}],
+                    },
+                    "scheduler_action": {"const": "none"},
+                    "relay_action": {"const": "none"},
                     "gateway_session_id": {
                         **durable_record_id_json_schema(),
                         "pattern": r"^gateway_[0-9a-f]{32}$",
@@ -1442,15 +1454,19 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                         ),
                     },
                     "gateway_session": {"type": "object"},
-                    "connect_url": {"type": "string"},
-                    "health_url": {"type": "string"},
-                    "stream_url": {"type": "string"},
-                    "events_url": {"type": "string"},
-                    "state_url": {"type": "string"},
-                    "command_url": {"type": "string"},
+                    "connect_url": {"type": ["string", "null"]},
+                    "health_url": {"type": ["string", "null"]},
+                    "stream_url": {"type": ["string", "null"]},
+                    "events_url": {"type": ["string", "null"]},
+                    "state_url": {"type": ["string", "null"]},
+                    "command_url": {"type": ["string", "null"]},
                     "scheduler_cancel_requested": {"const": False},
                 },
                 "required": [
+                    "outcome",
+                    "retry_selector",
+                    "scheduler_action",
+                    "relay_action",
                     "gateway_session_id",
                     "gateway_session",
                     "connect_url",
@@ -1460,6 +1476,36 @@ def _all_tool_definitions(*, clusters: list[str] | None = None) -> list[JSON]:
                     "state_url",
                     "command_url",
                     "scheduler_cancel_requested",
+                ],
+                "allOf": [
+                    {
+                        "if": {"properties": {"outcome": {"const": "ready"}}},
+                        "then": {
+                            "properties": {
+                                "retry_selector": {"type": "null"},
+                                "connect_url": {"type": "string"},
+                                "health_url": {"type": "string"},
+                                "stream_url": {"type": "string"},
+                                "events_url": {"type": "string"},
+                                "state_url": {"type": "string"},
+                                "command_url": {"type": "string"},
+                            }
+                        },
+                    },
+                    {
+                        "if": {"properties": {"outcome": {"const": "pending"}}},
+                        "then": {
+                            "properties": {
+                                "retry_selector": {"type": "object"},
+                                "connect_url": {"type": "null"},
+                                "health_url": {"type": "null"},
+                                "stream_url": {"type": "null"},
+                                "events_url": {"type": "null"},
+                                "state_url": {"type": "null"},
+                                "command_url": {"type": "null"},
+                            }
+                        },
+                    },
                 ],
                 "additionalProperties": False,
             },
@@ -4856,6 +4902,39 @@ def _bind_jarvis_runtime(
                 readiness_timeout_seconds=readiness_timeout_seconds,
                 poll_seconds=poll_seconds,
             )
+    gateway_session = public_gateway_session(started.session)
+    gateway_session_id = gateway_session.get("session_id")
+    if gateway_session_id != started.session.session_id:
+        raise ValueError("public gateway session identity did not match the bound runtime")
+    if isinstance(started, ServiceRuntimePendingResult):
+        pending_gateway = dict(gateway_session)
+        nested_gateway = _object(pending_gateway.get("gateway", {}))
+        for key in (
+            "connect_url",
+            "health_url",
+            "stream_url",
+            "events_url",
+            "state_url",
+            "command_url",
+            "compatibility_urls",
+        ):
+            nested_gateway.pop(key, None)
+        pending_gateway["gateway"] = nested_gateway
+        return {
+            "outcome": started.outcome,
+            "retry_selector": started.retry_selector(),
+            "scheduler_action": started.scheduler_action,
+            "relay_action": started.relay_action,
+            "gateway_session_id": gateway_session_id,
+            "gateway_session": pending_gateway,
+            "connect_url": None,
+            "health_url": None,
+            "stream_url": None,
+            "events_url": None,
+            "state_url": None,
+            "command_url": None,
+            "scheduler_cancel_requested": False,
+        }
     if any(
         value is None
         for value in (
@@ -4866,11 +4945,11 @@ def _bind_jarvis_runtime(
         )
     ):
         raise ValueError("verified JARVIS runtime did not produce the complete URL contract")
-    gateway_session = public_gateway_session(started.session)
-    gateway_session_id = gateway_session.get("session_id")
-    if gateway_session_id != started.session.session_id:
-        raise ValueError("public gateway session identity did not match the bound runtime")
     return {
+        "outcome": "ready",
+        "retry_selector": None,
+        "scheduler_action": "none",
+        "relay_action": "none",
         "gateway_session_id": gateway_session_id,
         "gateway_session": gateway_session,
         "connect_url": started.connect_url,

--- a/src/clio_relay/mcp_stdio_validation.py
+++ b/src/clio_relay/mcp_stdio_validation.py
@@ -19,7 +19,7 @@ from typing import Any, BinaryIO, cast
 
 from clio_relay import __version__
 from clio_relay.command_evidence import bounded_error_detail
-from clio_relay.errors import RelayError
+from clio_relay.errors import ObservationTimeoutError, RelayError
 from clio_relay.jarvis_mcp import (
     CLIO_KIT_JARVIS_USER_CONTRACT_ID,
     CLIO_KIT_JARVIS_USER_CONTRACT_SHA256,
@@ -443,7 +443,7 @@ def _run_bounded_process(
         )
     except OwnedProcessSpawnError as exc:
         if monotonic() >= deadline:
-            raise RelayError(
+            raise ObservationTimeoutError(
                 "packaged MCP stdio validation exceeded its total wall-clock deadline"
             ) from None
         cleanup_errors = ",".join(exc.cleanup_errors) or "none"
@@ -454,7 +454,7 @@ def _run_bounded_process(
         ) from None
     except (OSError, RuntimeError) as exc:
         if monotonic() >= deadline:
-            raise RelayError(
+            raise ObservationTimeoutError(
                 "packaged MCP stdio validation exceeded its total wall-clock deadline"
             ) from None
         raise RelayError(
@@ -488,6 +488,7 @@ def _run_bounded_process(
         reader.start()
 
     failure: str | None = None
+    deadline_expired = False
     if staged_mcp:
         try:
             _exchange_staged_mcp(
@@ -501,6 +502,9 @@ def _run_bounded_process(
                 called_tool=cast(str, called_tool),
                 profile=cast(str, profile),
             )
+        except ObservationTimeoutError as exc:
+            failure = str(exc)
+            deadline_expired = True
         except RelayError as exc:
             failure = str(exc)
     while failure is None and process.poll() is None:
@@ -523,6 +527,7 @@ def _run_bounded_process(
         remaining = deadline - monotonic()
         if remaining <= 0:
             failure = "packaged MCP stdio validation exceeded its total wall-clock deadline"
+            deadline_expired = True
             break
         activity.wait(min(_PROCESS_POLL_SECONDS, remaining))
         activity.clear()
@@ -536,6 +541,7 @@ def _run_bounded_process(
         except RuntimeError as exc:
             containment_error = exc
             failure = "packaged MCP child process containment could not be verified"
+            deadline_expired = False
     join_deadline = (
         deadline if failure is None else min(deadline, monotonic() + _PROCESS_POLL_SECONDS)
     )
@@ -545,6 +551,7 @@ def _run_bounded_process(
     stderr, stderr_overflow, stderr_error = stderr_capture.snapshot()
     if failure is None and monotonic() >= deadline:
         failure = "packaged MCP stdio validation exceeded its total wall-clock deadline"
+        deadline_expired = True
     if failure is None and (stdout_overflow or stderr_overflow):
         streams = [
             label
@@ -556,6 +563,7 @@ def _run_bounded_process(
         failure = "packaged MCP stdio validation could not read its child pipes"
     if failure is None and any(reader.is_alive() for reader in readers):
         failure = "packaged MCP stdio validation exceeded its total wall-clock deadline"
+        deadline_expired = True
     if failure is None and any(
         value and value.encode("utf-8") in payload
         for value in private_values
@@ -570,20 +578,24 @@ def _run_bounded_process(
     except RuntimeError as exc:
         containment_error = exc
         failure = "packaged MCP child process containment could not be verified"
+        deadline_expired = False
     finally:
         try:
             release_owned_process(cast(subprocess.Popen[str], cast(object, process)))
         except RuntimeError as exc:
             containment_error = exc
             failure = "packaged MCP child process containment could not be released"
+            deadline_expired = False
     # Provider cleanup is part of a successful acceptance run. Safety cleanup may
     # finish after the deadline, but an over-budget run is never accepted.
     if failure is None and monotonic() >= deadline:
         failure = "packaged MCP stdio validation exceeded its total wall-clock deadline"
+        deadline_expired = True
     if failure is not None:
         detail = _sanitized_diagnostic(stderr, forbidden_values=private_values)
         cause = "" if containment_error is None else f" cause={type(containment_error).__name__}"
-        raise RelayError(
+        error_type = ObservationTimeoutError if deadline_expired else RelayError
+        raise error_type(
             f"{failure}; stdout_bytes={len(stdout)} stderr_bytes={len(stderr)} "
             f"stderr={detail!r}{cause}"
         ) from None
@@ -694,7 +706,9 @@ def _write_mcp_frame(
     )
     writer.start()
     if not completed.wait(max(0.0, deadline - monotonic())):
-        raise RelayError("packaged MCP stdio validation exceeded its total wall-clock deadline")
+        raise ObservationTimeoutError(
+            "packaged MCP stdio validation exceeded its total wall-clock deadline"
+        )
     if errors:
         raise RelayError("packaged MCP stdio validation could not write its request pipe")
 
@@ -743,7 +757,9 @@ def _await_mcp_response(
             raise RelayError(f"packaged MCP exited before correlated response {response_id}")
         remaining = deadline - monotonic()
         if remaining <= 0:
-            raise RelayError("packaged MCP stdio validation exceeded its total wall-clock deadline")
+            raise ObservationTimeoutError(
+                "packaged MCP stdio validation exceeded its total wall-clock deadline"
+            )
         activity.wait(min(_PROCESS_POLL_SECONDS, remaining))
         activity.clear()
 

--- a/src/clio_relay/service_runtime.py
+++ b/src/clio_relay/service_runtime.py
@@ -45,7 +45,7 @@ from clio_relay.cluster_config import (
 )
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
-from clio_relay.errors import ConfigurationError, QueueConflictError, RelayError
+from clio_relay.errors import ConfigurationError, NotFoundError, QueueConflictError, RelayError
 from clio_relay.filesystem_paths import internal_filesystem_path
 from clio_relay.jarvis_service_runtime import (
     JARVIS_SERVICE_RUNTIME_SCHEMA_V1,
@@ -115,10 +115,14 @@ _GATEWAY_DETACH_INTENT_SCHEMA = "clio-relay.gateway-detach-intent.v1"
 _GATEWAY_DETACH_RESULT_SCHEMA = "clio-relay.gateway-detach-result.v1"
 _GATEWAY_TEARDOWN_POLICY_SCHEMA = "clio-relay.gateway-teardown-policy.v1"
 _GATEWAY_TEARDOWN_RESULT_SCHEMA = "clio-relay.gateway-teardown-result.v1"
+_JARVIS_BIND_IDENTITY_SCHEMA = "clio-relay.jarvis-bind-identity.v1"
+_JARVIS_BIND_POLICY_SCHEMA = "clio-relay.jarvis-bind-policy.v1"
+_REMOTE_SUBMISSION_VERIFICATION_SCHEMA = "clio-relay.gateway-submission-verification.v1"
 _REMOTE_RUNTIME_COMMAND_TIMEOUT_SECONDS = 120.0
 _LOCAL_CLEANUP_COMMAND_TIMEOUT_SECONDS = 30.0
 _CONNECTOR_STEP_CLEANUP_TIMEOUT_SECONDS = 30.0
 _CONNECTOR_STEP_CLEANUP_POLL_SECONDS = 0.25
+_RUNTIME_HEALTH_OBSERVATION_TIMEOUT_SECONDS = 5.0
 # Linux assigns these values to both x86-64 and asm-generic syscall ABIs.
 # libc symbols remain the preferred fallback when CPython omits its wrappers.
 _LINUX_PIDFD_SEND_SIGNAL_SYSCALL_NUMBER = 424
@@ -142,6 +146,51 @@ _ACTIVE_RUNTIME_STATES = {
     "running",
 }
 _CANCELED_RUNTIME_STATES = {"canceled", "cancelled"}
+
+
+class _DefinitiveRuntimeObservationError(RelayError):
+    """An observation that proves this runtime cannot safely become ready."""
+
+
+class _AmbiguousRemoteSideEffectError(RelayError):
+    """A remote command may have completed after its transport observation was lost."""
+
+
+class _DefinitiveSubmissionReconciliationError(RelayError):
+    """An exact submission sidecar proves that its submission cannot be resumed."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        evidence: dict[str, object],
+        failure_kind: Literal[
+            "command_failure",
+            "integrity_failure",
+            "response_invalid",
+        ],
+    ) -> None:
+        super().__init__(message)
+        self.evidence = evidence
+        self.failure_kind = failure_kind
+
+    @property
+    def queue_state(self) -> str:
+        """Return a queue state that does not overclaim scheduler disposition."""
+        return {
+            "command_failure": "submission_failed",
+            "integrity_failure": "submission_integrity_failed",
+            "response_invalid": "submission_response_invalid",
+        }[self.failure_kind]
+
+    @property
+    def scheduler_submission_outcome(self) -> str:
+        """Describe only what the durable evidence proves about submission."""
+        return {
+            "command_failure": "submit_command_failed",
+            "integrity_failure": "unknown_due_to_integrity_failure",
+            "response_invalid": "unknown_due_to_invalid_response",
+        }[self.failure_kind]
 
 
 @dataclass(frozen=True)
@@ -474,6 +523,208 @@ class ServiceRuntimeStartResult:
 
 
 @dataclass(frozen=True)
+class ServiceRuntimePendingResult:
+    """Durable, resumable outcome for a submitted runtime not ready yet."""
+
+    session: GatewaySession
+    outcome: Literal["pending"] = "pending"
+    scheduler_action: Literal["none"] = "none"
+    relay_action: Literal["none"] = "none"
+
+    def retry_selector(self) -> dict[str, object]:
+        """Return the exact selector required to advance this submission in place."""
+        scheduler_job_id = self.session.scheduler_job_id
+        selector: dict[str, object] = {
+            "cluster": self.session.cluster,
+            "gateway_session_id": self.session.session_id,
+            "scheduler_provider": self.session.scheduler,
+            "scheduler_job_id": scheduler_job_id,
+        }
+        binding = _object(self.session.gateway.get("jarvis_runtime_binding", {}))
+        if binding:
+            required = {
+                "source_relay_job_id",
+                "source_relay_artifact_id",
+                "package_id",
+                "package_name",
+                "service_instance_id",
+            }
+            if not required.issubset(binding):
+                raise RelayError("pending JARVIS runtime omitted its durable binding identity")
+            selector.update(
+                {
+                    "resume_tool": "relay_bind_jarvis_runtime",
+                    "binding": {
+                        "cluster": self.session.cluster,
+                        "source_job_id": binding["source_relay_job_id"],
+                        "source_artifact_id": binding["source_relay_artifact_id"],
+                        "package_id": binding["package_id"],
+                        "package_name": binding["package_name"],
+                        "service_instance_id": binding["service_instance_id"],
+                    },
+                    "name": self.session.name,
+                }
+            )
+            return selector
+        if scheduler_job_id is not None:
+            return selector
+        intents = _object(self.session.gateway.get("ownership_intents", {}))
+        intent = _object(intents.get("scheduler_submission", {}))
+        submission_id = _optional_str(intent.get("submission_id"))
+        submission_marker = _optional_str(intent.get("submission_marker"))
+        if (
+            intent.get("schema_version") != _OWNERSHIP_INTENT_SCHEMA
+            or intent.get("state") != "starting"
+            or intent.get("scheduler_provider") != self.session.scheduler
+            or submission_id is None
+            or submission_marker is None
+        ):
+            raise RelayError("pending runtime omitted its durable submission identity")
+        selector.update(
+            {
+                "submission_id": submission_id,
+                "submission_marker": submission_marker,
+            }
+        )
+        return selector
+
+    def to_live_validation_report(
+        self,
+        *,
+        launcher: str | None = None,
+        install_source: str | None = None,
+        artifact_sha256: str | None = None,
+    ) -> LiveValidationReport:
+        """Record an honest nonterminal observation that cannot satisfy a release gate."""
+        from clio_relay.validation_report import (
+            EvidenceReference,
+            ValidationCheck,
+            ValidationResource,
+            ValidationStatus,
+            new_live_validation_report,
+        )
+
+        report = new_live_validation_report(
+            scenario="gateway-runtime",
+            cluster=self.session.cluster,
+            launcher=launcher,
+            install_source=install_source,
+            artifact_sha256=artifact_sha256,
+        )
+        observed_at = utc_now()
+        selector = self.retry_selector()
+        scheduler_job_id = self.session.scheduler_job_id
+        jarvis_binding = _object(self.session.gateway.get("jarvis_runtime_binding", {}))
+        unresolved_submission = scheduler_job_id is None and not jarvis_binding
+        summary = (
+            "exact scheduler submission intent is durable; submission outcome is unresolved"
+            if unresolved_submission
+            else (
+                "verified JARVIS runtime binding is durable and its local gateway is not ready yet"
+                if jarvis_binding
+                else "scheduler-backed gateway is durably submitted and not ready yet"
+            )
+        )
+        report.checks.append(
+            ValidationCheck(
+                check_id=RUNTIME_ALLOCATED_CHECK_ID,
+                summary=summary,
+                status=ValidationStatus.PENDING,
+                started_at=report.started_at,
+                completed_at=observed_at,
+                evidence=[
+                    EvidenceReference(
+                        kind="gateway_resume_selector",
+                        excerpt=json.dumps(selector, sort_keys=True),
+                        metadata={
+                            **selector,
+                            "scheduler_action": self.scheduler_action,
+                            "relay_action": self.relay_action,
+                        },
+                    )
+                ],
+            )
+        )
+        report.resources.append(
+            ValidationResource(
+                kind="gateway_session",
+                resource_id=self.session.session_id,
+                cluster=self.session.cluster,
+                state=self.session.state.value,
+                metadata={"retry_selector": selector},
+            )
+        )
+        if jarvis_binding:
+            report.resources.append(
+                ValidationResource(
+                    kind="jarvis_service_runtime",
+                    resource_id=cast(str, jarvis_binding["service_instance_id"]),
+                    cluster=self.session.cluster,
+                    provider=self.session.scheduler,
+                    state=self.session.queue_state,
+                    metadata={
+                        "gateway_session_id": self.session.session_id,
+                        "jarvis_execution_id": jarvis_binding.get("jarvis_execution_id"),
+                        "scheduler_job_id": scheduler_job_id,
+                        "cancel_requested": False,
+                        "resubmit_requested": False,
+                    },
+                )
+            )
+            if scheduler_job_id is not None:
+                report.resources.append(
+                    ValidationResource(
+                        kind="scheduler_job",
+                        resource_id=scheduler_job_id,
+                        cluster=self.session.cluster,
+                        provider=self.session.scheduler,
+                        state=self.session.queue_state,
+                        metadata={
+                            "gateway_session_id": self.session.session_id,
+                            "retained": True,
+                            "cancel_requested": False,
+                            "resubmit_requested": False,
+                        },
+                    )
+                )
+        else:
+            report.resources.append(
+                ValidationResource(
+                    kind=("scheduler_job" if not unresolved_submission else "scheduler_submission"),
+                    resource_id=(scheduler_job_id or cast(str, selector["submission_id"])),
+                    cluster=self.session.cluster,
+                    provider=self.session.scheduler,
+                    state=(
+                        self.session.queue_state if not unresolved_submission else "intent_recorded"
+                    ),
+                    metadata=(
+                        {
+                            "gateway_session_id": self.session.session_id,
+                            "retained": True,
+                            "scheduler_job_id": scheduler_job_id,
+                            "cancel_requested": False,
+                            "resubmit_requested": False,
+                        }
+                        if not unresolved_submission
+                        else {
+                            "gateway_session_id": self.session.session_id,
+                            "scheduler_job_id": None,
+                            "submission_id": selector["submission_id"],
+                            "submission_marker": selector["submission_marker"],
+                            "submission_outcome": "unresolved",
+                            "cancel_requested": False,
+                            "resubmit_requested": False,
+                        }
+                    ),
+                )
+            )
+        report.completed_at = observed_at
+        report.status = ValidationStatus.PENDING
+        report.error = None
+        return report
+
+
+@dataclass(frozen=True)
 class ServiceRuntimeStopResult:
     """Result of stopping owned runtime connector processes."""
 
@@ -571,20 +822,59 @@ class ServiceRuntimeStopResult:
         scheduler_resources = [
             resource for resource in self.resources if resource.kind == "scheduler_job"
         ]
+        scheduler_submission_resources = [
+            resource for resource in self.resources if resource.kind == "scheduler_submission"
+        ]
         gateway_resources = [
             resource for resource in self.resources if resource.kind == "gateway_record"
         ]
         cancellation_requested = any(
             resource.action == "cancel" for resource in scheduler_resources
         )
-        scheduler_identity_exact = (
+        unresolved_submission = bool(
+            self.session.scheduler_job_id is None
+            and self.session.gateway.get("jarvis_runtime_binding") is None
+            and _validated_durable_scheduler_contract(self.session).unresolved_submission
+        )
+        scheduler_identity_exact = bool(
             not scheduler_resources
             if self.session.scheduler_job_id is None
             else len(scheduler_resources) == 1
             and scheduler_resources[0].resource_id == self.session.scheduler_job_id
             and scheduler_resources[0].provider == self.session.scheduler
         )
-        if cancellation_requested:
+        if unresolved_submission:
+            scheduler_intent = _object(
+                _object(self.session.gateway.get("ownership_intents", {})).get(
+                    "scheduler_submission",
+                    {},
+                )
+            )
+            scheduler_submission_exact = (
+                not scheduler_resources
+                and len(scheduler_submission_resources) == 1
+                and scheduler_submission_resources[0].resource_id
+                == scheduler_intent.get("submission_id")
+                and scheduler_submission_resources[0].provider == self.session.scheduler
+                and scheduler_submission_resources[0].action == "retain"
+                and scheduler_submission_resources[0].outcome == "retained"
+                and scheduler_submission_resources[0].observed_state == "intent_recorded"
+                and scheduler_submission_resources[0].ownership_verified
+                and scheduler_submission_resources[0].verified_after_operation
+                and not scheduler_submission_resources[0].residual
+                and scheduler_submission_resources[0].metadata.get("submission_marker")
+                == scheduler_intent.get("submission_marker")
+                and scheduler_submission_resources[0].metadata.get("scheduler_job_id") is None
+                and scheduler_submission_resources[0].metadata.get("cancel_requested") is False
+                and scheduler_submission_resources[0].metadata.get("resubmit_requested") is False
+            )
+            scheduler_check = (
+                RUNTIME_SCHEDULER_RETAINED_CHECK_ID,
+                "exact scheduler submission intent retained; no job, cancellation, or "
+                "resubmission is claimed",
+                scheduler_submission_exact,
+            )
+        elif cancellation_requested:
             scheduler_check = (
                 RUNTIME_SCHEDULER_CANCELED_CHECK_ID,
                 "scheduler cancellation reached an observed canceled state",
@@ -645,11 +935,32 @@ class ServiceRuntimeStopResult:
                 and not resource.residual
                 for resource in remote_connectors
             )
+            no_connector_side_effects = (
+                len(desktop_connectors) == 1
+                and desktop_connectors[0].action == "stop"
+                and desktop_connectors[0].outcome == "missing"
+                and desktop_connectors[0].ownership_verified
+                and desktop_connectors[0].verified_after_operation
+                and not desktop_connectors[0].residual
+                and len(remote_connectors) == 1
+                and remote_connectors[0].action == "retain"
+                and remote_connectors[0].outcome == "missing"
+                and remote_connectors[0].observed_state == "not_created"
+                and remote_connectors[0].ownership_verified
+                and remote_connectors[0].verified_after_operation
+                and not remote_connectors[0].residual
+            )
             check_values = [
                 (
                     RUNTIME_DETACH_CHECK_ID,
-                    "desktop connector stopped and remote connector retained",
-                    desktop_stopped and remote_retained,
+                    (
+                        "connector intents prove no connector side effects were created"
+                        if no_connector_side_effects
+                        else "desktop connector stopped and remote connector retained"
+                    ),
+                    no_connector_side_effects
+                    if no_connector_side_effects
+                    else desktop_stopped and remote_retained,
                 ),
                 scheduler_check,
                 (
@@ -814,7 +1125,7 @@ class ServiceRuntimeSupervisor:
         owner_session_id: str | None = None,
         owner_session_generation_id: str | None = None,
         owner_session_admission_id: str | None = None,
-    ) -> ServiceRuntimeStartResult:
+    ) -> ServiceRuntimeStartResult | ServiceRuntimePendingResult:
         """Start a scheduler-backed remote service and bind it to a desktop port."""
         if spec.deployment_driver == "jarvis-bound":
             raise ConfigurationError("jarvis-bound runtimes must use bind_verified_jarvis_runtime")
@@ -874,8 +1185,7 @@ class ServiceRuntimeSupervisor:
         except BaseException:
             transition_lock.release()
             raise
-        remote_connector: dict[str, object] | None = None
-        local_connector: dict[str, object] | None = None
+        completion_started = False
         try:
             session = self._update(
                 session,
@@ -894,15 +1204,25 @@ class ServiceRuntimeSupervisor:
                     submission_marker=submission_marker,
                 ),
             )
-            submit_output = self._ssh(
-                _submit_script(
-                    submit_command,
-                    session_id=session.session_id,
-                    submission_id=submission_id,
-                    scheduler_provider=spec.scheduler,
-                    submission_marker=submission_marker,
+            try:
+                submit_output = self._ssh(
+                    _submit_script(
+                        submit_command,
+                        session_id=session.session_id,
+                        submission_id=submission_id,
+                        scheduler_provider=spec.scheduler,
+                        submission_marker=submission_marker,
+                    )
                 )
-            )
+            except _AmbiguousRemoteSideEffectError as exc:
+                pending = self._record_runtime_observation_pending(
+                    self.queue.get_gateway_session(session.session_id),
+                    node=None,
+                    error=exc,
+                    provider_status=None,
+                    state=GatewaySessionState.PENDING,
+                )
+                return ServiceRuntimePendingResult(session=pending)
             submission = _parse_runtime_submission(submit_output)
             scheduler_job_id = submission.scheduler_job_id
             session = self._update(
@@ -922,72 +1242,310 @@ class ServiceRuntimeSupervisor:
                     submit_output=submit_output.strip(),
                 ),
             )
-            node = self._wait_for_allocation_and_health(
+            node = self._observe_allocation_and_health_once(
                 session,
                 spec,
                 scheduler_job_id,
                 initial_service_host=submission.service_host,
             )
-            session = self.queue.get_gateway_session(session.session_id)
-            proxy_name = spec.proxy_name or f"{session.session_id}-service"
-            remote_intent = _new_ownership_intent(
-                "starting",
-                owner_token=secrets.token_hex(32),
-                connector_generation_id=secrets.token_hex(16),
-            )
-            session = self._set_ownership_intent(
-                session,
-                "remote_connector",
-                remote_intent,
-            )
-            remote_connector = self._start_remote_connector(
-                session=session,
+            if node is None:
+                return ServiceRuntimePendingResult(
+                    session=self.queue.get_gateway_session(session.session_id)
+                )
+            completion_started = True
+            return self._complete_runtime_start_locked(
+                session_id=session.session_id,
                 spec=spec,
                 node=node,
-                proxy_name=proxy_name,
-                ownership_intent=remote_intent,
             )
-            # Allocation-scoped connector startup may enrich and durably persist
-            # the ownership intent before launching a scheduler step. Reload the
-            # exact revision before publishing the returned connector identity.
-            session = self.queue.get_gateway_session(session.session_id)
+        except Exception as exc:
+            if not completion_started:
+                self._rollback_runtime_start(
+                    session_id=session.session_id,
+                    error=exc,
+                    remote_connector=None,
+                    local_connector=None,
+                )
+            raise
+        finally:
+            transition_lock.release()
+
+    def resume_start(
+        self,
+        *,
+        session_id: str,
+    ) -> ServiceRuntimeStartResult | ServiceRuntimePendingResult:
+        """Advance one exact durable runtime submission without resubmitting it."""
+        self.queue.initialize()
+        with self._gateway_transition_lock(session_id):
+            return self._resume_start_locked(session_id=session_id)
+
+    def _resume_start_locked(
+        self,
+        *,
+        session_id: str,
+    ) -> ServiceRuntimeStartResult | ServiceRuntimePendingResult:
+        """Advance one durable start while the caller holds its transition lock."""
+        session = self.queue.get_gateway_session(session_id)
+        self._validate_gateway_transition_session(session)
+        binding_document = session.gateway.get("jarvis_runtime_binding")
+        if binding_document is not None:
+            try:
+                verified_runtime = reverify_jarvis_service_runtime(
+                    queue=self.queue,
+                    definition=self.definition,
+                    settings=self.settings,
+                    binding_document=binding_document,
+                )
+            except ValueError as exc:
+                raise RelayError(
+                    f"JARVIS service runtime binding re-verification failed: {exc}"
+                ) from exc
+            spec = self._validate_jarvis_binding_session(
+                session=session,
+                verified=verified_runtime,
+            )
+            if session.gateway.get("teardown_intent") is not None:
+                raise ConfigurationError(
+                    f"gateway session {session_id} is committed to teardown and cannot resume"
+                )
+            if session.state is GatewaySessionState.READY:
+                return self._ready_start_result(session)
+            authorization = self._jarvis_runtime_authorization(verified_runtime)
+            return self._resume_jarvis_binding_locked(
+                session_id=session_id,
+                verified=verified_runtime,
+                authorization=authorization,
+                readiness_timeout_seconds=spec.readiness_timeout_seconds,
+                poll_seconds=spec.poll_seconds,
+            )
+        if session.state is GatewaySessionState.READY:
+            return self._ready_start_result(session)
+        if session.gateway.get("teardown_intent") is not None:
+            raise ConfigurationError(
+                f"gateway session {session_id} is committed to teardown and cannot resume"
+            )
+        session = self._reconcile_ownership_intents(session)
+        if session.state is GatewaySessionState.FAILED:
+            scheduler_intent = _object(
+                _object(session.gateway.get("ownership_intents", {})).get(
+                    "scheduler_submission",
+                    {},
+                )
+            )
+            if scheduler_intent.get("reconciliation_outcome") == "definitive_failure":
+                raise RelayError(
+                    _optional_str(scheduler_intent.get("reconciliation_error"))
+                    or "scheduler submission reconciliation failed definitively"
+                )
+        if session.state is GatewaySessionState.DEGRADED:
+            if not self._detached_pending_submission_can_resume(session):
+                raise ConfigurationError(
+                    f"gateway session {session_id} cannot resume start from {session.state.value}"
+                )
+            completed_detach = self._completed_detach_result(session)
+            if completed_detach is None:
+                raise ConfigurationError(
+                    f"gateway session {session_id} has an incomplete detach; retry detach or "
+                    "tear down the runtime"
+                )
+            session = self._consume_completed_detach_for_attach(session)
             session = self._update(
                 session,
-                gateway=self._gateway_with_ownership_intent(
+                state=(
+                    GatewaySessionState.ALLOCATED
+                    if session.node is not None
+                    else GatewaySessionState.PENDING
+                ),
+                metadata={
+                    "cleanup_retryable": None,
+                    "cleanup_errors": [],
+                },
+            )
+        if session.state not in {
+            GatewaySessionState.SUBMITTED,
+            GatewaySessionState.PENDING,
+            GatewaySessionState.ALLOCATED,
+            GatewaySessionState.STARTING,
+        }:
+            raise ConfigurationError(
+                f"gateway session {session_id} cannot resume start from {session.state.value}"
+            )
+        unresolved_connector = self._first_unresolved_connector_role(session)
+        if unresolved_connector is not None:
+            return self._connector_recovery_pending(
+                session,
+                role=unresolved_connector,
+            )
+        try:
+            submission = self._verified_scheduler_submission(session)
+        except RelayError as exc:
+            if (
+                session.scheduler_job_id is None
+                and not self._scheduler_submission_reconciliation_is_pending(session)
+            ):
+                raise
+            pending_session = self._record_runtime_observation_pending(
+                session,
+                node=session.node,
+                error=exc,
+                provider_status=None,
+            )
+            return ServiceRuntimePendingResult(session=pending_session)
+        try:
+            node = self._observe_allocation_and_health_once(
+                session,
+                submission.spec,
+                submission.scheduler_job_id,
+                initial_service_host=session.node,
+            )
+        except _DefinitiveRuntimeObservationError as exc:
+            self._rollback_runtime_start(
+                session_id=session_id,
+                error=exc,
+                remote_connector=None,
+                local_connector=None,
+            )
+            raise
+        if node is None:
+            return ServiceRuntimePendingResult(session=self.queue.get_gateway_session(session_id))
+        return self._complete_runtime_start_locked(
+            session_id=session_id,
+            spec=submission.spec,
+            node=node,
+        )
+
+    def _complete_runtime_start_locked(
+        self,
+        *,
+        session_id: str,
+        spec: ServiceRuntimeSpec,
+        node: str,
+    ) -> ServiceRuntimeStartResult | ServiceRuntimePendingResult:
+        """Create connectors and publish readiness while holding the session transition lock."""
+        session = self._reconcile_ownership_intents(self.queue.get_gateway_session(session_id))
+        remote_connector: dict[str, object] | None = None
+        local_connector: dict[str, object] | None = None
+        try:
+            proxy_name = spec.proxy_name or f"{session.session_id}-service"
+            session = self._update(
+                session,
+                state=GatewaySessionState.STARTING,
+                queue_state="running",
+                node=node,
+            )
+            transport = _object(session.gateway.get("transport", {}))
+            recovered_remote = _object(transport.get("remote_connector", {}))
+            if recovered_remote:
+                if not self._connector_reuse_is_verified(
+                    session,
+                    role="remote_connector",
+                ):
+                    return self._connector_recovery_pending(
+                        session,
+                        role="remote_connector",
+                    )
+                remote_connector = recovered_remote
+            else:
+                if not self._connector_launch_is_authorized(
+                    session,
+                    role="remote_connector",
+                ):
+                    return self._connector_recovery_pending(
+                        session,
+                        role="remote_connector",
+                    )
+                remote_intent = _new_ownership_intent(
+                    "starting",
+                    owner_token=secrets.token_hex(32),
+                    connector_generation_id=secrets.token_hex(16),
+                )
+                session = self._set_ownership_intent(
                     session,
                     "remote_connector",
-                    _new_ownership_intent("recorded", **remote_connector),
-                    transport={
-                        **_object(session.gateway.get("transport", {})),
-                        "remote_connector": remote_connector,
-                    },
-                ),
-            )
-            local_intent = self._local_connector_intent(session)
-            session = self._set_ownership_intent(
-                session,
-                "desktop_connector",
-                local_intent,
-            )
-            local_connector = self._start_local_visitor(
-                session=session,
-                spec=spec,
-                proxy_name=proxy_name,
-                ownership_intent=local_intent,
-            )
-            session = self._update(
-                session,
-                gateway=self._gateway_with_ownership_intent(
+                    remote_intent,
+                )
+                try:
+                    remote_connector = self._start_remote_connector(
+                        session=session,
+                        spec=spec,
+                        node=node,
+                        proxy_name=proxy_name,
+                        ownership_intent=remote_intent,
+                    )
+                except _AmbiguousRemoteSideEffectError as exc:
+                    latest = self.queue.get_gateway_session(session.session_id)
+                    pending = self._record_runtime_observation_pending(
+                        latest,
+                        node=node,
+                        error=exc,
+                        provider_status=None,
+                        state=GatewaySessionState.STARTING,
+                        queue_state=latest.queue_state or "running",
+                        preserve_scheduler_status=True,
+                    )
+                    return ServiceRuntimePendingResult(session=pending)
+                session = self.queue.get_gateway_session(session.session_id)
+                session = self._update(
+                    session,
+                    gateway=self._gateway_with_ownership_intent(
+                        session,
+                        "remote_connector",
+                        _new_ownership_intent("recorded", **remote_connector),
+                        transport={
+                            **_object(session.gateway.get("transport", {})),
+                            "proxy_name": proxy_name,
+                            "remote_connector": remote_connector,
+                        },
+                    ),
+                )
+            transport = _object(session.gateway.get("transport", {}))
+            recovered_local = _object(transport.get("desktop_connector", {}))
+            if recovered_local:
+                if not self._connector_reuse_is_verified(
+                    session,
+                    role="desktop_connector",
+                ):
+                    return self._connector_recovery_pending(
+                        session,
+                        role="desktop_connector",
+                    )
+                local_connector = recovered_local
+            else:
+                if not self._connector_launch_is_authorized(
+                    session,
+                    role="desktop_connector",
+                ):
+                    return self._connector_recovery_pending(
+                        session,
+                        role="desktop_connector",
+                    )
+                local_intent = self._local_connector_intent(session)
+                session = self._set_ownership_intent(
                     session,
                     "desktop_connector",
-                    _new_ownership_intent("recorded", **local_connector),
-                    transport={
-                        **_object(session.gateway.get("transport", {})),
-                        "remote_connector": remote_connector,
-                        "desktop_connector": local_connector,
-                    },
-                ),
-            )
+                    local_intent,
+                )
+                local_connector = self._start_local_visitor(
+                    session=session,
+                    spec=spec,
+                    proxy_name=proxy_name,
+                    ownership_intent=local_intent,
+                )
+                session = self._update(
+                    session,
+                    gateway=self._gateway_with_ownership_intent(
+                        session,
+                        "desktop_connector",
+                        _new_ownership_intent("recorded", **local_connector),
+                        transport={
+                            **_object(session.gateway.get("transport", {})),
+                            "proxy_name": proxy_name,
+                            "remote_connector": remote_connector,
+                            "desktop_connector": local_connector,
+                        },
+                    ),
+                )
             connect_url = spec.connect_url_template.format(
                 bind_addr=spec.desktop_bind_addr,
                 bind_port=spec.desktop_bind_port,
@@ -997,12 +1555,28 @@ class ServiceRuntimeSupervisor:
                 f"{spec.protocol}://{spec.desktop_bind_addr}:"
                 f"{spec.desktop_bind_port}{spec.health_path}"
             )
-            self._wait_for_local_health(
-                health_url,
-                spec.readiness_timeout_seconds,
-                spec.poll_seconds,
-                expected_body=spec.health_expected_body,
-            )
+            try:
+                self._wait_for_local_health(
+                    health_url,
+                    min(
+                        spec.readiness_timeout_seconds,
+                        _RUNTIME_HEALTH_OBSERVATION_TIMEOUT_SECONDS,
+                    ),
+                    spec.poll_seconds,
+                    expected_body=spec.health_expected_body,
+                    max_attempts=1,
+                )
+            except RelayError as exc:
+                pending_session = self._record_runtime_observation_pending(
+                    session,
+                    node=node,
+                    error=exc,
+                    provider_status=None,
+                    state=GatewaySessionState.STARTING,
+                    queue_state=session.queue_state or "running",
+                    preserve_scheduler_status=True,
+                )
+                return ServiceRuntimePendingResult(session=pending_session)
             events_url = (
                 f"{spec.protocol}://{spec.desktop_bind_addr}:"
                 f"{spec.desktop_bind_port}{spec.event_stream_path}"
@@ -1080,76 +1654,209 @@ class ServiceRuntimeSupervisor:
                 command_url=command_url,
             )
         except Exception as exc:
-            cleanup_errors: list[str] = []
-            if remote_connector is None:
-                try:
-                    recovered = self._reconcile_ownership_intents(
-                        self.queue.get_gateway_session(session.session_id)
-                    )
-                    recovered_remote = _object(
-                        _object(recovered.gateway.get("transport", {})).get(
-                            "remote_connector",
-                            {},
-                        )
-                    )
-                    if recovered_remote:
-                        remote_connector = recovered_remote
-                except (ConfigurationError, RelayError) as recovery_exc:
-                    cleanup_errors.append(
-                        f"remote connector rollback reconciliation failed: {recovery_exc}"
-                    )
-            if local_connector is not None:
-                _, local_rollback = self._stop_local_connector(
-                    session_id=session.session_id,
-                    connector=local_connector,
-                    require_record=True,
-                )
-                if local_rollback.residual or not local_rollback.verified_after_operation:
-                    cleanup_errors.append(
-                        local_rollback.detail or "desktop connector rollback was not proven"
-                    )
-            if remote_connector is not None:
-                remote_pid = _optional_int(remote_connector.get("pid"))
-                if remote_pid is None:
-                    cleanup_errors.append("remote connector rollback has no recorded pid")
-                else:
-                    try:
-                        remote_result = _last_json_object(
-                            self._ssh(
-                                _remote_stop_script(
-                                    session_id=session.session_id,
-                                    pid=remote_pid,
-                                )
-                            )
-                        )
-                        if not _remote_cleanup_proven(remote_result):
-                            cleanup_errors.append(
-                                "remote connector rollback did not prove full process-group absence"
-                            )
-                    except RelayError as rollback_exc:
-                        cleanup_errors.append(str(rollback_exc))
-            try:
-                stop_result = self._stop_serialized(
-                    session_id=session.session_id,
-                    cancel_scheduler_job=False,
-                    final_state=GatewaySessionState.FAILED,
-                )
-                cleanup_errors.extend(stop_result.errors)
-            except Exception as cleanup_exc:
-                cleanup_errors.append(str(cleanup_exc))
-            try:
-                self._record_runtime_start_failure(
-                    session_id=session.session_id,
-                    error=exc,
-                    cleanup_errors=cleanup_errors,
-                )
-            except Exception as record_exc:
-                exc.add_note(
-                    f"runtime failure handling could not persist its final record: {record_exc}"
-                )
+            self._rollback_runtime_start(
+                session_id=session_id,
+                error=exc,
+                remote_connector=remote_connector,
+                local_connector=local_connector,
+            )
             raise
-        finally:
-            transition_lock.release()
+
+    def _ready_start_result(self, session: GatewaySession) -> ServiceRuntimeStartResult:
+        """Rehydrate an idempotent ready result from one exact durable gateway record."""
+        gateway = session.gateway
+        connect_url = _optional_str(gateway.get("connect_url"))
+        health_url = _optional_str(gateway.get("health_url"))
+        if connect_url is None or health_url is None:
+            raise RelayError("ready gateway session omitted its durable connection URLs")
+        compatibility_raw = gateway.get("compatibility_urls")
+        compatibility_urls = (
+            {
+                key: value
+                for key, value in cast(dict[object, object], compatibility_raw).items()
+                if isinstance(key, str) and isinstance(value, str)
+            }
+            if isinstance(compatibility_raw, dict)
+            else {}
+        )
+        return ServiceRuntimeStartResult(
+            session=session,
+            connect_url=connect_url,
+            health_url=health_url,
+            stream_url=_optional_str(gateway.get("stream_url")),
+            compatibility_urls=compatibility_urls,
+            events_url=_optional_str(gateway.get("events_url")),
+            state_url=_optional_str(gateway.get("state_url")),
+            command_url=_optional_str(gateway.get("command_url")),
+        )
+
+    @staticmethod
+    def _first_unresolved_connector_role(session: GatewaySession) -> str | None:
+        """Return one connector whose exact durable identity remains ambiguous."""
+        intents = _object(session.gateway.get("ownership_intents", {}))
+        transport = _object(session.gateway.get("transport", {}))
+        for role in ("remote_connector", "desktop_connector"):
+            intent = _object(intents.get(role, {}))
+            record = _object(transport.get(role, {}))
+            if intent.get("reconciliation_error") is not None:
+                return role
+            if intent.get("state") in {"starting", "recorded"} and (
+                not record or intent.get("live_identity_verified") is not True
+            ):
+                return role
+            if record and intent.get("state") != "recorded":
+                return role
+        return None
+
+    @staticmethod
+    def _scheduler_submission_reconciliation_is_pending(session: GatewaySession) -> bool:
+        """Return whether one exact pre-submit identity still awaits sidecar publication."""
+        intents = _object(session.gateway.get("ownership_intents", {}))
+        intent = _object(intents.get("scheduler_submission", {}))
+        return bool(
+            session.scheduler_job_id is None
+            and intent.get("schema_version") == _OWNERSHIP_INTENT_SCHEMA
+            and intent.get("state") == "starting"
+            and _optional_str(intent.get("submission_id")) is not None
+            and _optional_str(intent.get("submission_marker")) is not None
+            and intent.get("scheduler_provider") == session.scheduler
+        )
+
+    @staticmethod
+    def _connector_launch_is_authorized(
+        session: GatewaySession,
+        *,
+        role: str,
+    ) -> bool:
+        """Allow a new generation only after durable non-start or exact absence proof."""
+        intents = _object(session.gateway.get("ownership_intents", {}))
+        intent = _object(intents.get(role, {}))
+        transport = _object(session.gateway.get("transport", {}))
+        return bool(
+            intent.get("schema_version") == _OWNERSHIP_INTENT_SCHEMA
+            and intent.get("state") in {"not_started", "absent_verified"}
+            and not _object(transport.get(role, {}))
+            and intent.get("reconciliation_error") is None
+        )
+
+    @staticmethod
+    def _connector_reuse_is_verified(
+        session: GatewaySession,
+        *,
+        role: str,
+    ) -> bool:
+        """Require fresh live reconciliation before adopting a durable connector record."""
+        intents = _object(session.gateway.get("ownership_intents", {}))
+        intent = _object(intents.get(role, {}))
+        transport = _object(session.gateway.get("transport", {}))
+        return bool(
+            _object(transport.get(role, {}))
+            and intent.get("schema_version") == _OWNERSHIP_INTENT_SCHEMA
+            and intent.get("state") == "recorded"
+            and intent.get("live_identity_verified") is True
+            and intent.get("reconciliation_error") is None
+        )
+
+    def _connector_recovery_pending(
+        self,
+        session: GatewaySession,
+        *,
+        role: str,
+    ) -> ServiceRuntimePendingResult:
+        """Persist an ambiguous connector identity as resumable, without replacement."""
+        intents = _object(session.gateway.get("ownership_intents", {}))
+        intent = _object(intents.get(role, {}))
+        detail = _optional_str(intent.get("reconciliation_error"))
+        error = RelayError(
+            detail or f"{role.replace('_', ' ')} identity has not been proven live for this intent"
+        )
+        pending = self._record_runtime_observation_pending(
+            session,
+            node=session.node,
+            error=error,
+            provider_status=None,
+            state=GatewaySessionState.STARTING,
+            queue_state=session.queue_state or "running",
+            preserve_scheduler_status=True,
+        )
+        return ServiceRuntimePendingResult(session=pending)
+
+    def _rollback_runtime_start(
+        self,
+        *,
+        session_id: str,
+        error: BaseException,
+        remote_connector: dict[str, object] | None,
+        local_connector: dict[str, object] | None,
+    ) -> None:
+        """Roll back owned connectors while retaining the submitted scheduler job."""
+        cleanup_errors: list[str] = []
+        if remote_connector is None:
+            try:
+                recovered = self._reconcile_ownership_intents(
+                    self.queue.get_gateway_session(session_id)
+                )
+                recovered_remote = _object(
+                    _object(recovered.gateway.get("transport", {})).get(
+                        "remote_connector",
+                        {},
+                    )
+                )
+                if recovered_remote:
+                    remote_connector = recovered_remote
+            except (ConfigurationError, RelayError) as recovery_exc:
+                cleanup_errors.append(
+                    f"remote connector rollback reconciliation failed: {recovery_exc}"
+                )
+        if local_connector is not None:
+            _, local_rollback = self._stop_local_connector(
+                session_id=session_id,
+                connector=local_connector,
+                require_record=True,
+            )
+            if local_rollback.residual or not local_rollback.verified_after_operation:
+                cleanup_errors.append(
+                    local_rollback.detail or "desktop connector rollback was not proven"
+                )
+        if remote_connector is not None:
+            remote_pid = _optional_int(remote_connector.get("pid"))
+            if remote_pid is None:
+                cleanup_errors.append("remote connector rollback has no recorded pid")
+            else:
+                try:
+                    remote_result = _last_json_object(
+                        self._ssh(
+                            _remote_stop_script(
+                                session_id=session_id,
+                                pid=remote_pid,
+                            )
+                        )
+                    )
+                    if not _remote_cleanup_proven(remote_result):
+                        cleanup_errors.append(
+                            "remote connector rollback did not prove full process-group absence"
+                        )
+                except RelayError as rollback_exc:
+                    cleanup_errors.append(str(rollback_exc))
+        try:
+            stop_result = self._stop_serialized(
+                session_id=session_id,
+                cancel_scheduler_job=False,
+                final_state=GatewaySessionState.FAILED,
+            )
+            cleanup_errors.extend(stop_result.errors)
+        except Exception as cleanup_exc:
+            cleanup_errors.append(str(cleanup_exc))
+        try:
+            self._record_runtime_start_failure(
+                session_id=session_id,
+                error=error,
+                cleanup_errors=cleanup_errors,
+            )
+        except Exception as record_exc:
+            error.add_note(
+                f"runtime failure handling could not persist its final record: {record_exc}"
+            )
 
     def bind_verified_jarvis_runtime(
         self,
@@ -1163,11 +1870,12 @@ class ServiceRuntimeSupervisor:
         transport_mode: str = "frp-stcp-wss",
         readiness_timeout_seconds: float = 300.0,
         poll_seconds: float = 2.0,
-    ) -> ServiceRuntimeStartResult:
-        """Bind connectors to a ready JARVIS-owned service without submitting work.
+    ) -> ServiceRuntimeStartResult | ServiceRuntimePendingResult:
+        """Bind or resume one exact JARVIS-owned service without submitting work.
 
-        ``desktop_bind_port`` is an internal operator override. Agent-facing calls
-        omit it so the relay allocates a distinct free loopback port.
+        The immutable binding and owner identity derive the gateway ID. Reissuing
+        an identical request therefore resumes the same connector intents; it
+        cannot create a second gateway, scheduler job, or untracked connector.
         """
         runtime = verified.runtime
         binding = verified.binding
@@ -1197,10 +1905,8 @@ class ServiceRuntimeSupervisor:
             )
         if readiness_timeout_seconds <= 0 or poll_seconds <= 0:
             raise ConfigurationError("runtime readiness intervals must be positive")
-        allocation_provider = binding.scheduler_provider
-        allocation_job_id = binding.scheduler_native_id
-        if allocation_job_id is not None:
-            if allocation_provider is None:
+        if binding.scheduler_native_id is not None:
+            if binding.scheduler_provider is None:
                 raise ConfigurationError(
                     "scheduler-backed JARVIS runtime omitted its scheduler provider"
                 )
@@ -1208,13 +1914,171 @@ class ServiceRuntimeSupervisor:
                 raise ConfigurationError(
                     "scheduler-backed JARVIS services must advertise a loopback-only endpoint"
                 )
-        local_port = (
-            _available_loopback_port(exclude={runtime.port})
-            if desktop_bind_port is None
-            else _validated_available_loopback_port(desktop_bind_port)
+
+        owner_identity = self._jarvis_bind_owner_identity(
+            owner_session_id=owner_session_id,
+            owner_session_generation_id=owner_session_generation_id,
+            owner_session_admission_id=owner_session_admission_id,
         )
-        scheduler = binding.scheduler_provider or "external"
-        spec = ServiceRuntimeSpec(
+        session_id, identity_sha256 = self._jarvis_bind_identity(
+            binding=binding,
+            owner_identity=owner_identity,
+        )
+        requested_policy = self._jarvis_bind_policy(
+            name=name,
+            transport_mode=transport_mode,
+            requested_desktop_bind_port=desktop_bind_port,
+        )
+        self.queue.initialize()
+        # The deterministic transition lock is also the binding-creation lock.
+        # No process can race a lookup/create pair for this immutable identity.
+        with self._gateway_transition_lock(session_id):
+            try:
+                session = self.queue.get_gateway_session(session_id)
+            except NotFoundError:
+                # Resolve authenticated authority before creating any durable or
+                # process side effect. Authorization/integrity failures fail closed.
+                authorization = self._jarvis_runtime_authorization(verified)
+                local_port = (
+                    _available_loopback_port(exclude={runtime.port})
+                    if desktop_bind_port is None
+                    else _validated_available_loopback_port(desktop_bind_port)
+                )
+                spec = self._jarvis_runtime_spec(
+                    verified=verified,
+                    local_port=local_port,
+                    transport_mode=transport_mode,
+                    readiness_timeout_seconds=readiness_timeout_seconds,
+                    poll_seconds=poll_seconds,
+                )
+                policy = {
+                    **requested_policy,
+                    "actual_desktop_bind_port": local_port,
+                }
+                owner_metadata: dict[str, object] = {
+                    "owner": "clio-relay",
+                    "runtime_kind": spec.kind,
+                    "binding_source": "jarvis_mcp_result",
+                    "jarvis_bind_identity_sha256": identity_sha256,
+                    "source_relay_job_id": binding.source_relay_job_id,
+                    "source_relay_artifact_id": binding.source_relay_artifact_id,
+                    "jarvis_execution_id": binding.jarvis_execution_id,
+                    **{key: value for key, value in owner_identity.items() if value is not None},
+                }
+                session = self.queue.create_gateway_session(
+                    GatewaySession(
+                        session_id=session_id,
+                        cluster=self.cluster,
+                        name=name,
+                        state=GatewaySessionState.CREATED,
+                        scheduler=binding.scheduler_provider or "external",
+                        scheduler_job_id=binding.scheduler_native_id,
+                        requested_resources={"service_port": runtime.port},
+                        gateway={
+                            "runtime_spec": spec.model_dump(mode="json"),
+                            "jarvis_runtime_binding": binding.model_dump(mode="json"),
+                            "jarvis_bind_policy": policy,
+                            "transport": {"mode": transport_mode},
+                            "ownership_intents": {
+                                "scheduler_submission": _new_ownership_intent(
+                                    "absent_verified",
+                                    source="verified_jarvis_runtime_binding",
+                                ),
+                                "remote_connector": _new_ownership_intent("not_started"),
+                                "desktop_connector": _new_ownership_intent("not_started"),
+                            },
+                        },
+                        metadata=owner_metadata,
+                    )
+                )
+                session = self._runtime_start_session_after_lock(session.session_id)
+            else:
+                self._validate_jarvis_binding_session(
+                    session=session,
+                    verified=verified,
+                    expected_policy=requested_policy,
+                    expected_owner_identity=owner_identity,
+                )
+                if session.gateway.get("teardown_intent") is not None:
+                    raise ConfigurationError(
+                        f"gateway session {session.session_id} is committed to teardown "
+                        "and cannot resume"
+                    )
+                if session.state is GatewaySessionState.READY:
+                    return self._ready_start_result(session)
+                authorization = self._jarvis_runtime_authorization(verified)
+            return self._resume_jarvis_binding_locked(
+                session_id=session.session_id,
+                verified=verified,
+                authorization=authorization,
+                readiness_timeout_seconds=readiness_timeout_seconds,
+                poll_seconds=poll_seconds,
+            )
+
+    @staticmethod
+    def _jarvis_bind_owner_identity(
+        *,
+        owner_session_id: str | None,
+        owner_session_generation_id: str | None,
+        owner_session_admission_id: str | None,
+    ) -> dict[str, object]:
+        """Return the complete owner identity used by deterministic JARVIS binds."""
+        return {
+            "owner_session_id": owner_session_id,
+            "owner_session_generation_id": owner_session_generation_id,
+            "owner_session_admission_id": owner_session_admission_id,
+        }
+
+    def _jarvis_bind_identity(
+        self,
+        *,
+        binding: JarvisServiceRuntimeBinding,
+        owner_identity: dict[str, object],
+    ) -> tuple[str, str]:
+        """Derive one portable gateway ID from immutable binding and owner identity."""
+        document = {
+            "schema_version": _JARVIS_BIND_IDENTITY_SCHEMA,
+            "cluster": self.cluster,
+            "binding": binding.model_dump(mode="json"),
+            "owner_identity": owner_identity,
+        }
+        encoded = json.dumps(
+            document,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+        digest = hashlib.sha256(encoded).hexdigest()
+        return f"gateway_{digest[:32]}", digest
+
+    @staticmethod
+    def _jarvis_bind_policy(
+        *,
+        name: str,
+        transport_mode: str,
+        requested_desktop_bind_port: int | None,
+    ) -> dict[str, object]:
+        """Return side-effect policy that cannot change on an idempotent replay."""
+        return {
+            "schema_version": _JARVIS_BIND_POLICY_SCHEMA,
+            "name": name,
+            "transport_mode": transport_mode,
+            "requested_desktop_bind_port": requested_desktop_bind_port,
+        }
+
+    @staticmethod
+    def _jarvis_runtime_spec(
+        *,
+        verified: VerifiedJarvisServiceRuntime,
+        local_port: int,
+        transport_mode: str,
+        readiness_timeout_seconds: float,
+        poll_seconds: float,
+    ) -> ServiceRuntimeSpec:
+        """Build the generic connector spec from verified JARVIS endpoints only."""
+        runtime = verified.runtime
+        return ServiceRuntimeSpec(
             kind="jarvis-service-runtime",
             submit_command=None,
             deployment_driver="jarvis-bound",
@@ -1231,7 +2095,7 @@ class ServiceRuntimeSupervisor:
             transport_mode=transport_mode,
             readiness_timeout_seconds=readiness_timeout_seconds,
             poll_seconds=poll_seconds,
-            scheduler=scheduler,
+            scheduler=verified.binding.scheduler_provider or "external",
             connect_url_template=f"{runtime.protocol}://{{bind_addr}}:{{bind_port}}",
             metadata={
                 "source": "verified_jarvis_service_runtime",
@@ -1239,57 +2103,122 @@ class ServiceRuntimeSupervisor:
                 "service_revision": runtime.revision,
             },
         )
-        owner_metadata: dict[str, object] = {
-            "owner": "clio-relay",
-            "runtime_kind": spec.kind,
-            "binding_source": "jarvis_mcp_result",
-            "source_relay_job_id": binding.source_relay_job_id,
-            "source_relay_artifact_id": binding.source_relay_artifact_id,
-            "jarvis_execution_id": binding.jarvis_execution_id,
-        }
-        if owner_session_id is not None and owner_session_generation_id is not None:
-            owner_metadata.update(
-                {
-                    "owner_session_id": owner_session_id,
-                    "owner_session_generation_id": owner_session_generation_id,
-                }
+
+    def _validate_jarvis_binding_session(
+        self,
+        *,
+        session: GatewaySession,
+        verified: VerifiedJarvisServiceRuntime,
+        expected_policy: dict[str, object] | None = None,
+        expected_owner_identity: dict[str, object] | None = None,
+    ) -> ServiceRuntimeSpec:
+        """Fail closed if a persisted JARVIS binding or immutable policy changed."""
+        self._validate_gateway_transition_session(session)
+        try:
+            stored_binding = JarvisServiceRuntimeBinding.model_validate(
+                session.gateway.get("jarvis_runtime_binding")
             )
-            if owner_session_admission_id is not None:
-                owner_metadata["owner_session_admission_id"] = owner_session_admission_id
-        self.queue.initialize()
-        session = self.queue.create_gateway_session(
-            GatewaySession(
-                cluster=self.cluster,
-                name=name,
-                state=GatewaySessionState.CREATED,
-                scheduler=scheduler,
-                scheduler_job_id=binding.scheduler_native_id,
-                requested_resources={"service_port": runtime.port},
-                gateway={
-                    "runtime_spec": spec.model_dump(mode="json"),
-                    "jarvis_runtime_binding": binding.model_dump(mode="json"),
-                    "transport": {"mode": transport_mode},
-                    "ownership_intents": {
-                        "scheduler_submission": _new_ownership_intent(
-                            "absent_verified",
-                            source="verified_jarvis_runtime_binding",
-                        ),
-                        "remote_connector": _new_ownership_intent("not_started"),
-                        "desktop_connector": _new_ownership_intent("not_started"),
-                    },
-                },
-                metadata=owner_metadata,
-            )
+            spec = ServiceRuntimeSpec.model_validate(session.gateway.get("runtime_spec"))
+        except ValueError as exc:
+            raise RelayError("JARVIS gateway binding evidence is invalid") from exc
+        if stored_binding != verified.binding:
+            raise ConfigurationError("JARVIS gateway binding identity changed")
+        owner_identity = self._jarvis_bind_owner_identity(
+            owner_session_id=_optional_str(session.metadata.get("owner_session_id")),
+            owner_session_generation_id=_optional_str(
+                session.metadata.get("owner_session_generation_id")
+            ),
+            owner_session_admission_id=_optional_str(
+                session.metadata.get("owner_session_admission_id")
+            ),
         )
-        transition_lock = self._acquire_gateway_transition_lock(session.session_id)
-        try:
-            session = self._runtime_start_session_after_lock(session.session_id)
-        except BaseException:
-            transition_lock.release()
-            raise
-        remote_connector: dict[str, object] | None = None
-        local_connector: dict[str, object] | None = None
-        try:
+        expected_session_id, identity_sha256 = self._jarvis_bind_identity(
+            binding=stored_binding,
+            owner_identity=owner_identity,
+        )
+        if (
+            session.session_id != expected_session_id
+            or session.metadata.get("jarvis_bind_identity_sha256") != identity_sha256
+        ):
+            raise RelayError("JARVIS gateway deterministic binding identity is invalid")
+        if expected_owner_identity is not None and owner_identity != expected_owner_identity:
+            raise ConfigurationError("JARVIS gateway owner identity changed")
+        policy = _object(session.gateway.get("jarvis_bind_policy", {}))
+        actual_port = policy.get("actual_desktop_bind_port")
+        if (
+            policy.get("schema_version") != _JARVIS_BIND_POLICY_SCHEMA
+            or policy.get("name") != session.name
+            or policy.get("transport_mode") != spec.transport_mode
+            or isinstance(actual_port, bool)
+            or not isinstance(actual_port, int)
+            or actual_port != spec.desktop_bind_port
+        ):
+            raise RelayError("JARVIS gateway immutable bind policy is invalid")
+        if expected_policy is not None and any(
+            policy.get(key) != value for key, value in expected_policy.items()
+        ):
+            raise ConfigurationError(
+                "JARVIS runtime is already bound with a different immutable policy"
+            )
+        runtime = verified.runtime
+        expected_scheduler = stored_binding.scheduler_provider or "external"
+        if (
+            spec.deployment_driver != "jarvis-bound"
+            or spec.kind != "jarvis-service-runtime"
+            or session.scheduler != expected_scheduler
+            or session.scheduler_job_id != stored_binding.scheduler_native_id
+            or spec.scheduler != expected_scheduler
+            or spec.service_port != runtime.port
+            or spec.protocol != runtime.protocol
+            or spec.health_path != runtime.health_path
+            or spec.stream_path != runtime.live_data_path
+            or spec.event_stream_path != runtime.events_path
+            or spec.state_path != runtime.state_path
+            or spec.command_path != runtime.command_path
+            or spec.desktop_bind_addr != "127.0.0.1"
+            or spec.transport_mode != policy.get("transport_mode")
+        ):
+            raise RelayError("JARVIS gateway endpoints or scheduler identity changed")
+        return spec
+
+    def _resume_jarvis_binding_locked(
+        self,
+        *,
+        session_id: str,
+        verified: VerifiedJarvisServiceRuntime,
+        authorization: str | None,
+        readiness_timeout_seconds: float,
+        poll_seconds: float,
+    ) -> ServiceRuntimeStartResult | ServiceRuntimePendingResult:
+        """Advance one exact JARVIS binding while holding its transition lock."""
+        session = self.queue.get_gateway_session(session_id)
+        spec = self._validate_jarvis_binding_session(session=session, verified=verified)
+        if session.state is GatewaySessionState.READY:
+            return self._ready_start_result(session)
+        if session.state in {GatewaySessionState.FAILED, GatewaySessionState.CLOSED}:
+            raise ConfigurationError(
+                f"gateway session {session_id} cannot resume from {session.state.value}"
+            )
+        if session.gateway.get("teardown_intent") is not None:
+            raise ConfigurationError(
+                f"gateway session {session_id} is committed to teardown and cannot resume"
+            )
+        if session.state is GatewaySessionState.DEGRADED:
+            return self._attach_serialized(session_id=session_id)
+        if session.state not in {
+            GatewaySessionState.CREATED,
+            GatewaySessionState.SUBMITTED,
+            GatewaySessionState.PENDING,
+            GatewaySessionState.ALLOCATED,
+            GatewaySessionState.STARTING,
+        }:
+            raise ConfigurationError(
+                f"gateway session {session_id} cannot resume from {session.state.value}"
+            )
+        runtime = verified.runtime
+        if runtime.lifecycle != "ready":
+            raise ConfigurationError("JARVIS service runtime is no longer ready")
+        if session.state is GatewaySessionState.CREATED:
             session = self._update(
                 session,
                 state=GatewaySessionState.STARTING,
@@ -1297,27 +2226,89 @@ class ServiceRuntimeSupervisor:
                 node=runtime.host,
                 metadata={"binding_started_at": utc_now().isoformat()},
             )
-            service_authorization = self._jarvis_runtime_authorization(verified)
-            proxy_name = f"{session.session_id}-service"
-            remote_intent = _new_ownership_intent(
-                "starting",
-                owner_token=secrets.token_hex(32),
-                connector_generation_id=secrets.token_hex(16),
+        session = self._reconcile_ownership_intents(session)
+        unresolved_connector = self._first_unresolved_connector_role(session)
+        if unresolved_connector is not None:
+            return self._connector_recovery_pending(session, role=unresolved_connector)
+
+        proxy_name = f"{session.session_id}-service"
+        transport = _object(session.gateway.get("transport", {}))
+        remote_connector = _object(transport.get("remote_connector", {}))
+        if remote_connector:
+            if not self._connector_reuse_is_verified(session, role="remote_connector"):
+                return self._connector_recovery_pending(session, role="remote_connector")
+        else:
+            if not self._connector_launch_is_authorized(session, role="remote_connector"):
+                return self._connector_recovery_pending(session, role="remote_connector")
+            remote_intent = self._jarvis_connector_start_intent(
+                session,
+                role="remote_connector",
             )
             session = self._set_ownership_intent(session, "remote_connector", remote_intent)
-            remote_connector = self._start_remote_connector(
-                session=session,
-                spec=spec,
-                node=runtime.host,
-                proxy_name=proxy_name,
-                ownership_intent=remote_intent,
-                allocation_provider=allocation_provider,
-                allocation_job_id=allocation_job_id,
-            )
-            # ``_start_remote_connector`` persists scheduler placement and its
-            # unique step marker before starting an allocation-scoped process.
-            # Continue from that newer durable revision instead of the stale
-            # pre-placement snapshot.
+            try:
+                remote_connector = self._start_remote_connector(
+                    session=session,
+                    spec=spec,
+                    node=runtime.host,
+                    proxy_name=proxy_name,
+                    ownership_intent=remote_intent,
+                    allocation_provider=verified.binding.scheduler_provider,
+                    allocation_job_id=verified.binding.scheduler_native_id,
+                )
+            except _AmbiguousRemoteSideEffectError as exc:
+                latest = self.queue.get_gateway_session(session.session_id)
+                pending = self._record_runtime_observation_pending(
+                    latest,
+                    node=runtime.host,
+                    error=exc,
+                    provider_status=None,
+                    state=GatewaySessionState.STARTING,
+                    queue_state=runtime.lifecycle,
+                    preserve_scheduler_status=True,
+                )
+                return ServiceRuntimePendingResult(session=pending)
+            except RelayError as exc:
+                provider_status: SchedulerStatus | None = None
+                if (
+                    verified.binding.scheduler_provider is not None
+                    and verified.binding.scheduler_native_id is not None
+                ):
+                    try:
+                        provider_status = self._poll_scheduler_provider(
+                            provider=verified.binding.scheduler_provider,
+                            scheduler_job_id=verified.binding.scheduler_native_id,
+                        )
+                    except RelayError:
+                        provider_status = None
+                if provider_status is not None and provider_status.phase in {
+                    SchedulerPhase.COMPLETED,
+                    SchedulerPhase.FAILED,
+                    SchedulerPhase.CANCELED,
+                }:
+                    definitive = _DefinitiveRuntimeObservationError(
+                        "scheduler job reached a terminal state before its verified JARVIS "
+                        "service could be bound: "
+                        f"job={verified.binding.scheduler_native_id} "
+                        f"state={provider_status.phase.value}"
+                    )
+                    self._rollback_jarvis_binding(session_id=session_id, error=definitive)
+                    raise definitive from exc
+                latest = self.queue.get_gateway_session(session.session_id)
+                pending = self._record_runtime_observation_pending(
+                    latest,
+                    node=runtime.host,
+                    error=exc,
+                    provider_status=provider_status,
+                    state=GatewaySessionState.STARTING,
+                    queue_state=(
+                        provider_status.phase.value
+                        if provider_status is not None
+                        else runtime.lifecycle
+                    ),
+                    preserve_scheduler_status=provider_status is None,
+                )
+                return ServiceRuntimePendingResult(session=pending)
+            # Allocation connector startup can publish placement intent first.
             session = self.queue.get_gateway_session(session.session_id)
             session = self._update(
                 session,
@@ -1327,18 +2318,43 @@ class ServiceRuntimeSupervisor:
                     _new_ownership_intent("recorded", **remote_connector),
                     transport={
                         **_object(session.gateway.get("transport", {})),
+                        "proxy_name": proxy_name,
                         "remote_connector": remote_connector,
                     },
                 ),
             )
-            local_intent = self._local_connector_intent(session)
-            session = self._set_ownership_intent(session, "desktop_connector", local_intent)
-            local_connector = self._start_local_visitor(
-                session=session,
-                spec=spec,
-                proxy_name=proxy_name,
-                ownership_intent=local_intent,
+
+        transport = _object(session.gateway.get("transport", {}))
+        local_connector = _object(transport.get("desktop_connector", {}))
+        if local_connector:
+            if not self._connector_reuse_is_verified(session, role="desktop_connector"):
+                return self._connector_recovery_pending(session, role="desktop_connector")
+        else:
+            if not self._connector_launch_is_authorized(session, role="desktop_connector"):
+                return self._connector_recovery_pending(session, role="desktop_connector")
+            local_intent = self._jarvis_connector_start_intent(
+                session,
+                role="desktop_connector",
             )
+            session = self._set_ownership_intent(session, "desktop_connector", local_intent)
+            try:
+                local_connector = self._start_local_visitor(
+                    session=session,
+                    spec=spec,
+                    proxy_name=proxy_name,
+                    ownership_intent=local_intent,
+                )
+            except (RelayError, OSError, subprocess.SubprocessError) as exc:
+                pending = self._record_runtime_observation_pending(
+                    self.queue.get_gateway_session(session.session_id),
+                    node=runtime.host,
+                    error=RelayError(str(exc)),
+                    provider_status=None,
+                    state=GatewaySessionState.STARTING,
+                    queue_state=runtime.lifecycle,
+                    preserve_scheduler_status=True,
+                )
+                return ServiceRuntimePendingResult(session=pending)
             session = self._update(
                 session,
                 gateway=self._gateway_with_ownership_intent(
@@ -1347,150 +2363,197 @@ class ServiceRuntimeSupervisor:
                     _new_ownership_intent("recorded", **local_connector),
                     transport={
                         **_object(session.gateway.get("transport", {})),
+                        "proxy_name": proxy_name,
                         "remote_connector": remote_connector,
                         "desktop_connector": local_connector,
                     },
                 ),
             )
-            base_url = f"{runtime.protocol}://127.0.0.1:{local_port}"
-            connect_url = base_url
-            health_url = f"{base_url}{runtime.health_path}"
-            stream_url = f"{base_url}{runtime.live_data_path}"
-            events_url = f"{base_url}{runtime.events_path}"
-            state_url = f"{base_url}{runtime.state_path}"
-            command_url = f"{base_url}{runtime.command_path}"
+
+        local_port = spec.desktop_bind_port
+        base_url = f"{runtime.protocol}://127.0.0.1:{local_port}"
+        connect_url = base_url
+        health_url = f"{base_url}{runtime.health_path}"
+        stream_url = f"{base_url}{runtime.live_data_path}"
+        events_url = f"{base_url}{runtime.events_path}"
+        state_url = f"{base_url}{runtime.state_path}"
+        command_url = f"{base_url}{runtime.command_path}"
+        try:
             self._wait_for_jarvis_health(
                 health_url,
-                timeout_seconds=readiness_timeout_seconds,
+                timeout_seconds=min(
+                    readiness_timeout_seconds,
+                    _RUNTIME_HEALTH_OBSERVATION_TIMEOUT_SECONDS,
+                ),
                 poll_seconds=poll_seconds,
                 runtime_schema_version=runtime.schema_version,
-                authorization=service_authorization,
+                authorization=authorization,
+                max_attempts=1,
             )
-            session = self._update(
+        except _DefinitiveRuntimeObservationError as exc:
+            self._rollback_jarvis_binding(session_id=session_id, error=exc)
+            raise
+        except RelayError as exc:
+            pending = self._record_runtime_observation_pending(
                 session,
-                state=GatewaySessionState.READY,
-                queue_state=runtime.lifecycle,
                 node=runtime.host,
-                gateway={
-                    **session.gateway,
-                    "connect_url": connect_url,
-                    "health_url": health_url,
-                    "stream_url": stream_url,
-                    "events_url": events_url,
-                    "state_url": state_url,
-                    "command_url": command_url,
-                    "compatibility_urls": {},
-                    "service": {
-                        "host": runtime.host,
-                        "port": runtime.port,
-                        "protocol": runtime.protocol,
-                        "health_path": runtime.health_path,
-                        "stream_mode": runtime.delivery_mode,
-                        "stream_path": runtime.live_data_path,
-                        "event_stream_path": runtime.events_path,
-                        "state_path": runtime.state_path,
-                        "command_path": runtime.command_path,
-                        "deployment_driver": "jarvis-bound",
-                        "placement": remote_connector.get("placement"),
-                    },
-                    "transport": {
-                        "mode": transport_mode,
-                        "proxy_name": proxy_name,
-                        "remote_connector": remote_connector,
-                        "desktop_connector": local_connector,
-                        "remote_target": f"{runtime.host}:{runtime.port}",
-                        "desktop_bind": f"127.0.0.1:{local_port}",
-                    },
+                error=exc,
+                provider_status=None,
+                state=GatewaySessionState.STARTING,
+                queue_state=runtime.lifecycle,
+                preserve_scheduler_status=True,
+            )
+            return ServiceRuntimePendingResult(session=pending)
+
+        session = self._update(
+            session,
+            state=GatewaySessionState.READY,
+            queue_state=runtime.lifecycle,
+            node=runtime.host,
+            gateway={
+                **session.gateway,
+                "connect_url": connect_url,
+                "health_url": health_url,
+                "stream_url": stream_url,
+                "events_url": events_url,
+                "state_url": state_url,
+                "command_url": command_url,
+                "compatibility_urls": {},
+                "service": {
+                    "host": runtime.host,
+                    "port": runtime.port,
+                    "protocol": runtime.protocol,
+                    "health_path": runtime.health_path,
+                    "stream_mode": runtime.delivery_mode,
+                    "stream_path": runtime.live_data_path,
+                    "event_stream_path": runtime.events_path,
+                    "state_path": runtime.state_path,
+                    "command_path": runtime.command_path,
+                    "deployment_driver": "jarvis-bound",
+                    "placement": remote_connector.get("placement"),
                 },
-                metadata={"ready_at": utc_now().isoformat()},
+                "transport": {
+                    "mode": spec.transport_mode,
+                    "proxy_name": proxy_name,
+                    "remote_connector": remote_connector,
+                    "desktop_connector": local_connector,
+                    "remote_target": f"{runtime.host}:{runtime.port}",
+                    "desktop_bind": f"127.0.0.1:{local_port}",
+                },
+            },
+            metadata={"ready_at": utc_now().isoformat()},
+        )
+        return ServiceRuntimeStartResult(
+            session=session,
+            connect_url=connect_url,
+            health_url=health_url,
+            stream_url=stream_url,
+            compatibility_urls={},
+            events_url=events_url,
+            state_url=state_url,
+            command_url=command_url,
+        )
+
+    def _jarvis_connector_start_intent(
+        self,
+        session: GatewaySession,
+        *,
+        role: Literal["remote_connector", "desktop_connector"],
+    ) -> dict[str, object]:
+        """Reuse an absence-proven generation instead of inventing a retry identity."""
+        intents = _object(session.gateway.get("ownership_intents", {}))
+        previous = _object(intents.get(role, {}))
+        if previous.get("state") != "absent_verified":
+            if role == "desktop_connector":
+                return self._local_connector_intent(session)
+            return _new_ownership_intent(
+                "starting",
+                owner_token=secrets.token_hex(32),
+                connector_generation_id=secrets.token_hex(16),
             )
-            return ServiceRuntimeStartResult(
-                session=session,
-                connect_url=connect_url,
-                health_url=health_url,
-                stream_url=stream_url,
-                compatibility_urls={},
-                events_url=events_url,
-                state_url=state_url,
-                command_url=command_url,
+        identity: dict[str, object] = {
+            "owner_token": _required_intent_str(previous, "owner_token"),
+            "connector_generation_id": _required_intent_str(
+                previous,
+                "connector_generation_id",
+            ),
+        }
+        if role == "desktop_connector":
+            for field in (
+                "config_path",
+                "stdout_path",
+                "stderr_path",
+                "metadata_path",
+            ):
+                identity[field] = _required_intent_str(previous, field)
+        return _new_ownership_intent("starting", **identity)
+
+    def _rollback_jarvis_binding(
+        self,
+        *,
+        session_id: str,
+        error: BaseException,
+    ) -> None:
+        """Fail closed and clean exact connectors after a definitive bind failure."""
+        cleanup_errors: list[str] = []
+        local_connector: dict[str, object] | None = None
+        remote_connector: dict[str, object] | None = None
+        try:
+            recovered = self._reconcile_ownership_intents(
+                self.queue.get_gateway_session(session_id)
             )
-        except Exception as exc:
-            cleanup_errors: list[str] = []
-            if remote_connector is None or local_connector is None:
-                try:
-                    recovered = self._reconcile_ownership_intents(
-                        self.queue.get_gateway_session(session.session_id)
-                    )
-                    recovered_transport = _object(recovered.gateway.get("transport", {}))
-                    if remote_connector is None:
-                        recovered_remote = _object(recovered_transport.get("remote_connector", {}))
-                        if recovered_remote:
-                            remote_connector = recovered_remote
-                    if local_connector is None:
-                        recovered_local = _object(recovered_transport.get("desktop_connector", {}))
-                        if recovered_local:
-                            local_connector = recovered_local
-                except (ConfigurationError, RelayError) as recovery_exc:
-                    cleanup_errors.append(
-                        f"connector rollback reconciliation failed: {recovery_exc}"
-                    )
-            if local_connector is not None:
-                _, local_rollback = self._stop_local_connector(
-                    session_id=session.session_id,
+            transport = _object(recovered.gateway.get("transport", {}))
+            local_connector = _object(transport.get("desktop_connector", {})) or None
+            remote_connector = _object(transport.get("remote_connector", {})) or None
+        except (ConfigurationError, RelayError) as exc:
+            cleanup_errors.append(f"connector rollback reconciliation failed: {exc}")
+        if local_connector is not None:
+            try:
+                _, result = self._stop_local_connector(
+                    session_id=session_id,
                     connector=local_connector,
                     require_record=True,
                 )
-                if local_rollback.residual or not local_rollback.verified_after_operation:
+                if result.residual or not result.verified_after_operation:
                     cleanup_errors.append(
-                        local_rollback.detail or "desktop connector rollback was not proven"
+                        result.detail or "desktop connector rollback was not proven"
                     )
-            if remote_connector is not None:
+            except (ConfigurationError, RelayError) as exc:
+                cleanup_errors.append(str(exc))
+        if remote_connector is not None:
+            try:
                 if remote_connector.get("execution_scope") == "scheduler_allocation":
-                    try:
-                        rollback = self._stop_allocation_connector(
-                            session_id=session.session_id,
-                            connector=remote_connector,
+                    result = self._stop_allocation_connector(
+                        session_id=session_id,
+                        connector=remote_connector,
+                    )
+                    if result.residual or not result.verified_after_operation:
+                        cleanup_errors.append(
+                            result.detail or "allocation connector rollback was not proven"
                         )
-                        if rollback.residual or not rollback.verified_after_operation:
-                            cleanup_errors.append(
-                                rollback.detail
-                                or "allocation connector rollback absence was not proven"
-                            )
-                    except (ConfigurationError, RelayError) as rollback_exc:
-                        cleanup_errors.append(str(rollback_exc))
                 else:
                     remote_pid = _optional_int(remote_connector.get("pid"))
                     if remote_pid is None:
-                        cleanup_errors.append("remote connector rollback has no recorded pid")
-                    else:
-                        try:
-                            result = _last_json_object(
-                                self._ssh(
-                                    _remote_stop_script(
-                                        session_id=session.session_id,
-                                        pid=remote_pid,
-                                    )
-                                )
+                        raise RelayError("remote connector rollback has no recorded pid")
+                    result = _last_json_object(
+                        self._ssh(
+                            _remote_stop_script(
+                                session_id=session_id,
+                                pid=remote_pid,
                             )
-                            if not _remote_cleanup_proven(result):
-                                cleanup_errors.append(
-                                    "remote connector rollback did not prove process-group absence"
-                                )
-                        except RelayError as rollback_exc:
-                            cleanup_errors.append(str(rollback_exc))
-            try:
-                self._record_runtime_start_failure(
-                    session_id=session.session_id,
-                    error=exc,
-                    cleanup_errors=cleanup_errors,
-                )
-            except Exception as record_exc:
-                exc.add_note(
-                    f"runtime failure handling could not persist its final record: {record_exc}"
-                )
-            raise
-        finally:
-            transition_lock.release()
+                        )
+                    )
+                    if not _remote_cleanup_proven(result):
+                        cleanup_errors.append(
+                            "remote connector rollback did not prove process-group absence"
+                        )
+            except (ConfigurationError, RelayError) as exc:
+                cleanup_errors.append(str(exc))
+        self._record_runtime_start_failure(
+            session_id=session_id,
+            error=error,
+            cleanup_errors=cleanup_errors,
+        )
 
     def browser_attach(
         self,
@@ -2343,14 +3406,21 @@ class ServiceRuntimeSupervisor:
         if replay is not None:
             return replay
         session = self._reconcile_ownership_intents(session)
+        pending_without_connectors = self._pending_submission_has_no_connector_side_effects(session)
         scheduler_contract = _validated_durable_scheduler_contract(session, strict=False)
         session, browser_resource, browser_error = self._revoke_browser_for_runtime_cleanup(session)
         transport = _object(session.gateway.get("transport", {}))
         desktop_connector = _object(transport.get("desktop_connector", {}))
+        ownership_intents = _object(session.gateway.get("ownership_intents", {}))
+        desktop_absence_verified = _intent_proves_absence(
+            ownership_intents,
+            "desktop_connector",
+        )
         stopped_local_pid, local_resource = self._stop_local_connector(
             session_id=session.session_id,
             connector=desktop_connector,
-            require_record=True,
+            require_record=not (pending_without_connectors or desktop_absence_verified),
+            absence_verified=pending_without_connectors or desktop_absence_verified,
         )
         local_resource = _bind_cleanup_resource_to_gateway(local_resource, session.session_id)
         resources = [local_resource]
@@ -2443,6 +3513,26 @@ class ServiceRuntimeSupervisor:
             )
             if not remote_verified:
                 errors.append(remote_detail)
+        elif pending_without_connectors:
+            resources.append(
+                _bind_cleanup_resource_to_gateway(
+                    CleanupResource(
+                        kind="remote_connector",
+                        resource_id=session.session_id,
+                        location=self.definition.ssh_host,
+                        action="retain",
+                        ownership_verified=True,
+                        outcome="missing",
+                        verified_after_operation=True,
+                        observed_state="not_created",
+                        detail=(
+                            "durable connector intent proves no remote connector side effect "
+                            "was created"
+                        ),
+                    ),
+                    session.session_id,
+                )
+            )
         else:
             errors.append("owned remote connector record is missing during detach")
             resources.append(
@@ -2467,23 +3557,36 @@ class ServiceRuntimeSupervisor:
                     {},
                 )
             )
+            submission_id = _required_intent_str(scheduler_intent, "submission_id")
+            submission_marker = _required_intent_str(
+                scheduler_intent,
+                "submission_marker",
+            )
             scheduler_resource = CleanupResource(
-                kind="scheduler_job",
-                resource_id=str(scheduler_intent.get("submission_id") or session.session_id),
+                kind="scheduler_submission",
+                resource_id=submission_id,
                 location=self.definition.ssh_host,
                 provider=scheduler_contract.provider,
                 action="retain",
-                metadata={"gateway_session_id": session.session_id},
-                ownership_verified=False,
-                outcome="failed",
-                verified_after_operation=False,
-                residual=True,
+                metadata={
+                    "gateway_session_id": session.session_id,
+                    "submission_id": submission_id,
+                    "submission_marker": submission_marker,
+                    "scheduler_job_id": None,
+                    "submission_outcome": "unresolved",
+                    "cancel_requested": False,
+                    "resubmit_requested": False,
+                },
+                ownership_verified=True,
+                outcome="retained",
+                verified_after_operation=True,
+                observed_state="intent_recorded",
+                residual=False,
                 detail=(
-                    "scheduler submission side effect could not be reconciled to an exact job id"
+                    "exact scheduler submission intent retained without claiming a scheduler job"
                 ),
             )
             resources.append(scheduler_resource)
-            errors.append(scheduler_resource.detail or "scheduler submission is unresolved")
         elif session.scheduler_job_id is not None:
             try:
                 verified_submission = self._verified_scheduler_submission(session)
@@ -2583,14 +3686,22 @@ class ServiceRuntimeSupervisor:
             errors=errors,
         )
 
-    def attach(self, *, session_id: str) -> ServiceRuntimeStartResult:
+    def attach(
+        self,
+        *,
+        session_id: str,
+    ) -> ServiceRuntimeStartResult | ServiceRuntimePendingResult:
         """Serialize attachment against detach and teardown for this gateway."""
         session = self.queue.get_gateway_session(session_id)
         self._validate_gateway_transition_session(session)
         with self._gateway_transition_lock(session_id):
             return self._attach_serialized(session_id=session_id)
 
-    def _attach_serialized(self, *, session_id: str) -> ServiceRuntimeStartResult:
+    def _attach_serialized(
+        self,
+        *,
+        session_id: str,
+    ) -> ServiceRuntimeStartResult | ServiceRuntimePendingResult:
         """Recreate the desktop connector while holding the gateway transition lock."""
         session = self.queue.get_gateway_session(session_id)
         self._validate_gateway_transition_session(session)
@@ -2600,6 +3711,10 @@ class ServiceRuntimeSupervisor:
             raise ConfigurationError(
                 f"gateway session {session_id} is committed to teardown and cannot attach"
             )
+        if self._detached_pending_submission_can_resume(
+            session
+        ) or self._pre_ready_submission_can_resume(session):
+            return self._resume_start_locked(session_id=session_id)
         if session.gateway.get("detach_intent") is not None:
             completed_detach = self._completed_detach_result(session)
             if completed_detach is None:
@@ -2641,6 +3756,15 @@ class ServiceRuntimeSupervisor:
                 raise RelayError("detached JARVIS runtime endpoints changed before reattachment")
             service_authorization = self._jarvis_runtime_authorization(verified_runtime)
         transport = _object(session.gateway.get("transport", {}))
+        remote_connector = _object(transport.get("remote_connector", {}))
+        if not remote_connector or not self._connector_reuse_is_verified(
+            session,
+            role="remote_connector",
+        ):
+            return self._connector_recovery_pending(
+                session,
+                role="remote_connector",
+            )
         proxy_name = _optional_str(transport.get("proxy_name"))
         if proxy_name is None:
             raise ConfigurationError("gateway session has no recorded transport proxy name")
@@ -2655,13 +3779,25 @@ class ServiceRuntimeSupervisor:
         created_connector = False
         local_connector: dict[str, object] | None = None
         try:
-            if (
-                existing_pid is not None
-                and existing_owned
-                and _local_connector_identity_status(existing)[0] == "owned"
-            ):
+            if existing_pid is not None and existing_owned:
+                if not self._connector_reuse_is_verified(
+                    session,
+                    role="desktop_connector",
+                ):
+                    return self._connector_recovery_pending(
+                        session,
+                        role="desktop_connector",
+                    )
                 local_connector = existing
             else:
+                if not self._connector_launch_is_authorized(
+                    session,
+                    role="desktop_connector",
+                ):
+                    return self._connector_recovery_pending(
+                        session,
+                        role="desktop_connector",
+                    )
                 local_intent = self._local_connector_intent(session)
                 session = self._set_ownership_intent(
                     session,
@@ -2696,21 +3832,44 @@ class ServiceRuntimeSupervisor:
                 f"{spec.protocol}://{spec.desktop_bind_addr}:"
                 f"{spec.desktop_bind_port}{spec.health_path}"
             )
-            if verified_runtime is None:
-                self._wait_for_local_health(
-                    health_url,
-                    spec.readiness_timeout_seconds,
-                    spec.poll_seconds,
-                    expected_body=spec.health_expected_body,
+            try:
+                if verified_runtime is None:
+                    self._wait_for_local_health(
+                        health_url,
+                        min(
+                            spec.readiness_timeout_seconds,
+                            _RUNTIME_HEALTH_OBSERVATION_TIMEOUT_SECONDS,
+                        ),
+                        spec.poll_seconds,
+                        expected_body=spec.health_expected_body,
+                        max_attempts=1,
+                    )
+                else:
+                    self._wait_for_jarvis_health(
+                        health_url,
+                        timeout_seconds=min(
+                            spec.readiness_timeout_seconds,
+                            _RUNTIME_HEALTH_OBSERVATION_TIMEOUT_SECONDS,
+                        ),
+                        poll_seconds=spec.poll_seconds,
+                        runtime_schema_version=verified_runtime.runtime.schema_version,
+                        authorization=service_authorization,
+                        max_attempts=1,
+                    )
+            except _DefinitiveRuntimeObservationError as exc:
+                self._rollback_jarvis_binding(session_id=session_id, error=exc)
+                raise
+            except RelayError as exc:
+                pending = self._record_runtime_observation_pending(
+                    session,
+                    node=session.node,
+                    error=exc,
+                    provider_status=None,
+                    state=GatewaySessionState.STARTING,
+                    queue_state=session.queue_state or "running",
+                    preserve_scheduler_status=True,
                 )
-            else:
-                self._wait_for_jarvis_health(
-                    health_url,
-                    timeout_seconds=spec.readiness_timeout_seconds,
-                    poll_seconds=spec.poll_seconds,
-                    runtime_schema_version=verified_runtime.runtime.schema_version,
-                    authorization=service_authorization,
-                )
+                return ServiceRuntimePendingResult(session=pending)
         except Exception as exc:
             cleanup_error: str | None = None
             if not created_connector:
@@ -2969,6 +4128,76 @@ class ServiceRuntimeSupervisor:
                 "detach_errors": [],
             },
             gateway=gateway,
+        )
+
+    def _pending_submission_has_no_connector_side_effects(
+        self,
+        session: GatewaySession,
+    ) -> bool:
+        """Prove a not-yet-ready submission has never launched either connector."""
+
+        if session.state not in {
+            GatewaySessionState.SUBMITTED,
+            GatewaySessionState.PENDING,
+            GatewaySessionState.ALLOCATED,
+            GatewaySessionState.STARTING,
+            GatewaySessionState.DEGRADED,
+        }:
+            return False
+        if "service" in session.gateway:
+            return False
+        transport = _object(session.gateway.get("transport", {}))
+        if _object(transport.get("remote_connector", {})) or _object(
+            transport.get("desktop_connector", {})
+        ):
+            return False
+        intents = _object(session.gateway.get("ownership_intents", {}))
+        scheduler_intent = _object(intents.get("scheduler_submission", {}))
+        scheduler_identity_exact = (
+            self._scheduler_submission_reconciliation_is_pending(session)
+            if session.scheduler_job_id is None
+            else scheduler_intent.get("schema_version") == _OWNERSHIP_INTENT_SCHEMA
+            and scheduler_intent.get("state") == "recorded"
+            and scheduler_intent.get("scheduler_provider") == session.scheduler
+            and scheduler_intent.get("scheduler_job_id") == session.scheduler_job_id
+        )
+        return scheduler_identity_exact and all(
+            _object(intents.get(role, {})).get("schema_version") == _OWNERSHIP_INTENT_SCHEMA
+            and _object(intents.get(role, {})).get("state") in {"not_started", "absent_verified"}
+            for role in ("remote_connector", "desktop_connector")
+        )
+
+    def _detached_pending_submission_can_resume(self, session: GatewaySession) -> bool:
+        """Return whether a detached pre-ready submission can safely advance again."""
+
+        if (
+            session.state is not GatewaySessionState.DEGRADED
+            or session.gateway.get("detach_intent") is None
+            or "service" in session.gateway
+        ):
+            return False
+        intents = _object(session.gateway.get("ownership_intents", {}))
+        scheduler_intent = _object(intents.get("scheduler_submission", {}))
+        return bool(
+            self._scheduler_submission_reconciliation_is_pending(session)
+            if session.scheduler_job_id is None
+            else scheduler_intent.get("schema_version") == _OWNERSHIP_INTENT_SCHEMA
+            and scheduler_intent.get("state") == "recorded"
+            and scheduler_intent.get("scheduler_job_id") == session.scheduler_job_id
+        )
+
+    def _pre_ready_submission_can_resume(self, session: GatewaySession) -> bool:
+        """Return whether attach should advance an existing pre-ready start in place."""
+        return bool(
+            session.state
+            in {
+                GatewaySessionState.SUBMITTED,
+                GatewaySessionState.PENDING,
+                GatewaySessionState.ALLOCATED,
+                GatewaySessionState.STARTING,
+            }
+            and session.gateway.get("teardown_intent") is None
+            and "service" not in session.gateway
         )
 
     def _prepare_teardown_intent(
@@ -3271,6 +4500,143 @@ class ServiceRuntimeSupervisor:
             metadata_path=str(runtime_dir / "desktop-frpc-owner.json"),
         )
 
+    def _validate_remote_connector_intent_binding(
+        self,
+        *,
+        session_id: str,
+        intent: dict[str, object],
+        connector: dict[str, object],
+    ) -> None:
+        """Require a complete remote connector identity bound to one durable intent."""
+        if (
+            intent.get("schema_version") != _OWNERSHIP_INTENT_SCHEMA
+            or intent.get("state") not in {"starting", "recorded"}
+            or connector.get("owner") != "clio-relay"
+            or connector.get("session_id") != session_id
+            or connector.get("owner_token") != _required_intent_str(intent, "owner_token")
+            or connector.get("connector_generation_id")
+            != _required_intent_str(intent, "connector_generation_id")
+        ):
+            raise RelayError("remote connector record does not match its durable intent")
+        common_fields = (
+            "owner",
+            "session_id",
+            "owner_token",
+            "connector_generation_id",
+        )
+        if intent.get("state") == "recorded" and any(
+            intent.get(field) != connector.get(field) for field in common_fields
+        ):
+            raise RelayError("recorded remote connector identity changed after publication")
+        if connector.get("execution_scope") == "scheduler_allocation":
+            self._allocation_connector_identity(
+                session_id=session_id,
+                connector=connector,
+            )
+            allocation_fields = (
+                "execution_scope",
+                "scheduler_provider",
+                "scheduler_native_id",
+                "scheduler_step_id",
+                "scheduler_step_marker",
+                "scheduler_step",
+                "placement",
+                "config_path",
+                "log_path",
+            )
+            if intent.get("state") == "recorded" and any(
+                intent.get(field) != connector.get(field) for field in allocation_fields
+            ):
+                raise RelayError("recorded allocation connector identity changed after publication")
+            return
+        pid = _optional_int(connector.get("pid"))
+        process_group_id = _optional_int(connector.get("process_group_id"))
+        config_path = _optional_str(connector.get("config_path"))
+        log_path = _optional_str(connector.get("log_path"))
+        if pid is None or process_group_id != pid or config_path is None or log_path is None:
+            raise RelayError("remote connector record has incomplete process identity")
+        validated_config = _validated_remote_session_file(
+            config_path,
+            session_id=session_id,
+            filename="remote-frpc.toml",
+        )
+        validated_log = _validated_remote_session_file(
+            log_path,
+            session_id=session_id,
+            filename="remote-frpc.log",
+        )
+        if validated_config.parent != validated_log.parent:
+            raise RelayError("remote connector paths do not belong to one owned session")
+        process_fields = (
+            "pid",
+            "process_group_id",
+            "config_path",
+            "log_path",
+        )
+        if intent.get("state") == "recorded" and any(
+            intent.get(field) != connector.get(field) for field in process_fields
+        ):
+            raise RelayError("recorded remote connector process identity changed after publication")
+
+    def _validate_local_connector_intent_binding(
+        self,
+        *,
+        session_id: str,
+        intent: dict[str, object],
+        connector: dict[str, object],
+    ) -> None:
+        """Require a complete desktop connector identity bound to one durable intent."""
+        if (
+            intent.get("schema_version") != _OWNERSHIP_INTENT_SCHEMA
+            or intent.get("state") not in {"starting", "recorded"}
+            or connector.get("owner") != "clio-relay"
+            or connector.get("session_id") != session_id
+            or connector.get("owner_token") != _required_intent_str(intent, "owner_token")
+            or connector.get("connector_generation_id")
+            != _required_intent_str(intent, "connector_generation_id")
+        ):
+            raise RelayError("desktop connector record does not match its durable intent")
+        pid = _optional_int(connector.get("pid"))
+        process_group_id = _optional_int(connector.get("process_group_id"))
+        start_marker = _optional_str(connector.get("process_start_marker"))
+        if pid is None or process_group_id is None or start_marker is None:
+            raise RelayError("desktop connector record has incomplete process identity")
+        runtime_dir = (self.settings.core_dir.parent / "runtime-sessions" / session_id).resolve()
+        path_fields = (
+            "config_path",
+            "stdout_path",
+            "stderr_path",
+            "metadata_path",
+        )
+        for field in path_fields:
+            value = _optional_str(connector.get(field))
+            if value is None or Path(value).resolve().parent != runtime_dir:
+                raise RelayError("desktop connector record escaped its owned runtime directory")
+        identity_fields = (
+            "owner",
+            "session_id",
+            "pid",
+            "process_group_id",
+            "process_start_marker",
+            "owner_token",
+            "connector_generation_id",
+            *path_fields,
+        )
+        if intent.get("state") == "recorded" and any(
+            intent.get(field) != connector.get(field) for field in identity_fields
+        ):
+            raise RelayError("recorded desktop connector identity changed after publication")
+
+    @staticmethod
+    def _connector_records_match(
+        first: dict[str, object],
+        second: dict[str, object],
+        *,
+        fields: Sequence[str],
+    ) -> bool:
+        """Return whether two records name the same complete connector generation."""
+        return all(first.get(field) == second.get(field) for field in fields)
+
     def _reconcile_ownership_intents(self, session: GatewaySession) -> GatewaySession:
         """Recover scheduler and connector identities written before a hard exit."""
         gateway = dict(session.gateway)
@@ -3280,6 +4646,7 @@ class ServiceRuntimeSupervisor:
         transport = _object(gateway.get("transport", {}))
         changed = False
         scheduler_job_id = session.scheduler_job_id
+        definitive_submission_failure: _DefinitiveSubmissionReconciliationError | None = None
 
         scheduler_intent = _object(intents.get("scheduler_submission", {}))
         if scheduler_job_id is None and scheduler_intent.get("state") == "recorded":
@@ -3287,7 +4654,11 @@ class ServiceRuntimeSupervisor:
             if recorded_scheduler_job_id is not None:
                 scheduler_job_id = recorded_scheduler_job_id
                 changed = True
-        if scheduler_job_id is None and scheduler_intent.get("state") == "starting":
+        if (
+            scheduler_job_id is None
+            and scheduler_intent.get("state") == "starting"
+            and scheduler_intent.get("reconciliation_outcome") != "definitive_failure"
+        ):
             submission_id = _optional_str(scheduler_intent.get("submission_id"))
             scheduler_provider = _optional_str(scheduler_intent.get("scheduler_provider"))
             submission_marker = _optional_str(scheduler_intent.get("submission_marker"))
@@ -3307,6 +4678,30 @@ class ServiceRuntimeSupervisor:
                             )
                         )
                     )
+                    if (
+                        record.get("schema_version") == _REMOTE_SUBMISSION_VERIFICATION_SCHEMA
+                        and record.get("verification_outcome") == "definitive_invalid"
+                    ):
+                        reported_error = _optional_str(record.get("error"))
+                        message = (
+                            reported_error[:1024]
+                            if reported_error is not None
+                            else "scheduler submission sidecar failed integrity verification"
+                        )
+                        failure_kind: Literal["integrity_failure"] = "integrity_failure"
+                        raise _DefinitiveSubmissionReconciliationError(
+                            message,
+                            evidence=_submission_reconciliation_failure_evidence(
+                                session_id=session.session_id,
+                                submission_id=submission_id,
+                                scheduler_provider=scheduler_provider,
+                                submission_marker=submission_marker,
+                                record=record,
+                                error=message,
+                                failure_kind=failure_kind,
+                            ),
+                            failure_kind=failure_kind,
+                        )
                     if record.get("present") is True:
                         output = record.get("output")
                         if (
@@ -3314,11 +4709,87 @@ class ServiceRuntimeSupervisor:
                             or record.get("submission_id") != submission_id
                             or record.get("scheduler_provider") != scheduler_provider
                             or record.get("submission_marker") != submission_marker
-                            or record.get("returncode") != 0
-                            or not isinstance(output, str)
                         ):
-                            raise RelayError("scheduler submission sidecar identity is invalid")
-                        submission = _parse_runtime_submission(output)
+                            message = "scheduler submission sidecar identity is invalid"
+                            raise _DefinitiveSubmissionReconciliationError(
+                                message,
+                                evidence=_submission_reconciliation_failure_evidence(
+                                    session_id=session.session_id,
+                                    submission_id=submission_id,
+                                    scheduler_provider=scheduler_provider,
+                                    submission_marker=submission_marker,
+                                    record=record,
+                                    error=message,
+                                    failure_kind="integrity_failure",
+                                ),
+                                failure_kind="integrity_failure",
+                            )
+                        returncode = record.get("returncode")
+                        if isinstance(returncode, bool) or not isinstance(returncode, int):
+                            message = "scheduler submission sidecar return code is invalid"
+                            raise _DefinitiveSubmissionReconciliationError(
+                                message,
+                                evidence=_submission_reconciliation_failure_evidence(
+                                    session_id=session.session_id,
+                                    submission_id=submission_id,
+                                    scheduler_provider=scheduler_provider,
+                                    submission_marker=submission_marker,
+                                    record=record,
+                                    error=message,
+                                    failure_kind="integrity_failure",
+                                ),
+                                failure_kind="integrity_failure",
+                            )
+                        if returncode != 0:
+                            message = (
+                                "scheduler submission command completed unsuccessfully: "
+                                f"returncode={returncode}"
+                            )
+                            raise _DefinitiveSubmissionReconciliationError(
+                                message,
+                                evidence=_submission_reconciliation_failure_evidence(
+                                    session_id=session.session_id,
+                                    submission_id=submission_id,
+                                    scheduler_provider=scheduler_provider,
+                                    submission_marker=submission_marker,
+                                    record=record,
+                                    error=message,
+                                    failure_kind="command_failure",
+                                ),
+                                failure_kind="command_failure",
+                            )
+                        if not isinstance(output, str):
+                            message = "scheduler submission sidecar output is invalid"
+                            raise _DefinitiveSubmissionReconciliationError(
+                                message,
+                                evidence=_submission_reconciliation_failure_evidence(
+                                    session_id=session.session_id,
+                                    submission_id=submission_id,
+                                    scheduler_provider=scheduler_provider,
+                                    submission_marker=submission_marker,
+                                    record=record,
+                                    error=message,
+                                    failure_kind="integrity_failure",
+                                ),
+                                failure_kind="integrity_failure",
+                            )
+                        try:
+                            submission = _parse_runtime_submission(output)
+                        except RelayError as exc:
+                            message = f"scheduler submission sidecar output is invalid: {exc}"
+                            raise _DefinitiveSubmissionReconciliationError(
+                                message,
+                                evidence=_submission_reconciliation_failure_evidence(
+                                    session_id=session.session_id,
+                                    submission_id=submission_id,
+                                    scheduler_provider=scheduler_provider,
+                                    submission_marker=submission_marker,
+                                    record=record,
+                                    error=message,
+                                    failure_kind="response_invalid",
+                                ),
+                                failure_kind="response_invalid",
+                            ) from exc
                         scheduler_job_id = submission.scheduler_job_id
                         intents["scheduler_submission"] = _new_ownership_intent(
                             "recorded",
@@ -3330,158 +4801,262 @@ class ServiceRuntimeSupervisor:
                         )
                         gateway["submit_output"] = output.strip()
                         changed = True
+                except _DefinitiveSubmissionReconciliationError as exc:
+                    failed_intent = dict(scheduler_intent)
+                    failed_intent["reconciliation_error"] = str(exc)
+                    failed_intent["reconciliation_outcome"] = "definitive_failure"
+                    failed_intent["reconciliation_failure_kind"] = exc.failure_kind
+                    failed_intent["failure_evidence"] = exc.evidence
+                    intents["scheduler_submission"] = failed_intent
+                    definitive_submission_failure = exc
+                    changed = True
                 except RelayError as exc:
-                    scheduler_intent["reconciliation_error"] = str(exc)
-                    intents["scheduler_submission"] = scheduler_intent
+                    unresolved_intent = dict(scheduler_intent)
+                    unresolved_intent["reconciliation_error"] = str(exc)
+                    unresolved_intent["reconciliation_outcome"] = "observation_unknown"
+                    intents["scheduler_submission"] = unresolved_intent
                     changed = True
 
         remote_intent = _object(intents.get("remote_connector", {}))
-        if not _object(transport.get("remote_connector", {})) and remote_intent.get("state") in {
-            "starting",
-            "recorded",
-        }:
-            owner_token = _optional_str(remote_intent.get("owner_token"))
-            generation_id = _optional_str(remote_intent.get("connector_generation_id"))
-            if owner_token is not None and generation_id is not None:
-                try:
-                    allocation_placement = _object(remote_intent.get("placement", {}))
-                    result = _last_json_object(
-                        self._ssh(
-                            _remote_connector_discovery_script(
-                                session_id=session.session_id,
-                                owner_token=owner_token,
-                                connector_generation_id=generation_id,
-                                allocation_provider=_optional_str(
-                                    remote_intent.get("scheduler_provider")
-                                ),
-                                allocation_job_id=_optional_str(
-                                    remote_intent.get("scheduler_native_id")
-                                ),
-                                allocation_step_marker=_optional_str(
-                                    remote_intent.get("scheduler_step_marker")
-                                ),
-                                allocation_placement_host=_optional_str(
-                                    allocation_placement.get("placement_host")
-                                ),
-                            )
-                        )
+        remote_record = _object(transport.get("remote_connector", {}))
+        if remote_intent.get("state") in {"starting", "recorded"}:
+            try:
+                if remote_record:
+                    self._validate_remote_connector_intent_binding(
+                        session_id=session.session_id,
+                        intent=remote_intent,
+                        connector=remote_record,
                     )
-                    connector = result.get("connector")
-                    if remote_intent.get("execution_scope") == "scheduler_allocation":
-                        if result.get("ownership_verified") is not True:
-                            detail = result.get("error")
-                            raise RelayError(
-                                detail
-                                if isinstance(detail, str)
-                                else "allocation connector sidecar could not be verified"
-                            )
-                        typed_connector, absence_verified = (
-                            self._reconcile_allocation_connector_intent(
-                                session_id=session.session_id,
-                                intent=remote_intent,
-                                connector_base=(
-                                    cast(dict[str, object], connector)
-                                    if isinstance(connector, dict)
-                                    else None
-                                ),
-                            )
-                        )
-                        if typed_connector is not None:
-                            transport["remote_connector"] = typed_connector
-                            intents["remote_connector"] = _new_ownership_intent(
-                                "recorded",
-                                reconciled=True,
-                                **typed_connector,
-                            )
-                            changed = True
-                        elif absence_verified:
-                            intents["remote_connector"] = _new_ownership_intent(
-                                "absent_verified",
-                                owner_token=owner_token,
-                                connector_generation_id=generation_id,
-                                execution_scope="scheduler_allocation",
-                                scheduler_provider=remote_intent.get("scheduler_provider"),
-                                scheduler_native_id=remote_intent.get("scheduler_native_id"),
-                                scheduler_step_marker=remote_intent.get("scheduler_step_marker"),
-                                placement=remote_intent.get("placement"),
-                                reconciled=True,
-                            )
-                            changed = True
-                    elif (
-                        result.get("ownership_verified") is True
-                        and result.get("present") is True
-                        and isinstance(connector, dict)
-                    ):
-                        typed_connector = cast(dict[str, object], connector)
-                        transport["remote_connector"] = typed_connector
-                        intents["remote_connector"] = _new_ownership_intent(
-                            "recorded",
-                            reconciled=True,
-                            **typed_connector,
-                        )
-                        changed = True
-                    elif (
-                        result.get("ownership_verified") is True
-                        and result.get("present") is False
-                        and result.get("matching_pids") == []
-                    ):
-                        intents["remote_connector"] = _new_ownership_intent(
-                            "absent_verified",
+                owner_token = _required_intent_str(remote_intent, "owner_token")
+                generation_id = _required_intent_str(
+                    remote_intent,
+                    "connector_generation_id",
+                )
+                allocation_placement = _object(remote_intent.get("placement", {}))
+                result = _last_json_object(
+                    self._ssh(
+                        _remote_connector_discovery_script(
+                            session_id=session.session_id,
                             owner_token=owner_token,
                             connector_generation_id=generation_id,
-                            reconciled=True,
+                            allocation_provider=_optional_str(
+                                remote_intent.get("scheduler_provider")
+                            ),
+                            allocation_job_id=_optional_str(
+                                remote_intent.get("scheduler_native_id")
+                            ),
+                            allocation_step_marker=_optional_str(
+                                remote_intent.get("scheduler_step_marker")
+                            ),
+                            allocation_placement_host=_optional_str(
+                                allocation_placement.get("placement_host")
+                            ),
                         )
-                        changed = True
-                    elif result.get("ownership_verified") is False:
+                    )
+                )
+                connector = result.get("connector")
+                verified_connector: dict[str, object] | None = None
+                absence_verified = False
+                if remote_intent.get("execution_scope") == "scheduler_allocation":
+                    if result.get("ownership_verified") is not True:
                         detail = result.get("error")
-                        remote_intent["reconciliation_error"] = (
+                        raise RelayError(
                             detail
                             if isinstance(detail, str)
-                            else "remote connector ownership observation was incomplete"
+                            else "allocation connector sidecar could not be verified"
                         )
-                        intents["remote_connector"] = remote_intent
-                        changed = True
-                except RelayError as exc:
-                    remote_intent["reconciliation_error"] = str(exc)
-                    intents["remote_connector"] = remote_intent
+                    verified_connector, absence_verified = (
+                        self._reconcile_allocation_connector_intent(
+                            session_id=session.session_id,
+                            intent=remote_intent,
+                            connector_base=(
+                                cast(dict[str, object], connector)
+                                if isinstance(connector, dict)
+                                else None
+                            ),
+                        )
+                    )
+                elif (
+                    result.get("ownership_verified") is True
+                    and result.get("present") is True
+                    and isinstance(connector, dict)
+                ):
+                    verified_connector = cast(dict[str, object], connector)
+                elif (
+                    result.get("ownership_verified") is True
+                    and result.get("present") is False
+                    and result.get("matching_pids") == []
+                ):
+                    absence_verified = True
+                else:
+                    detail = result.get("error")
+                    raise RelayError(
+                        detail
+                        if isinstance(detail, str)
+                        else "remote connector ownership observation was incomplete"
+                    )
+                if verified_connector is not None:
+                    self._validate_remote_connector_intent_binding(
+                        session_id=session.session_id,
+                        intent=remote_intent,
+                        connector=verified_connector,
+                    )
+                    remote_fields = (
+                        "owner",
+                        "session_id",
+                        "pid",
+                        "process_group_id",
+                        "execution_scope",
+                        "scheduler_provider",
+                        "scheduler_native_id",
+                        "scheduler_step_id",
+                        "scheduler_step_marker",
+                        "scheduler_step",
+                        "connector_generation_id",
+                        "owner_token",
+                        "config_path",
+                        "log_path",
+                        "placement",
+                    )
+                    if remote_record and not self._connector_records_match(
+                        remote_record,
+                        verified_connector,
+                        fields=remote_fields,
+                    ):
+                        raise RelayError(
+                            "remote connector record disagrees with its live sidecar identity"
+                        )
+                    transport["remote_connector"] = verified_connector
+                    intents["remote_connector"] = _new_ownership_intent(
+                        "recorded",
+                        reconciled=True,
+                        live_identity_verified=True,
+                        **verified_connector,
+                    )
                     changed = True
+                elif absence_verified:
+                    transport.pop("remote_connector", None)
+                    intents["remote_connector"] = _new_ownership_intent(
+                        "absent_verified",
+                        owner_token=owner_token,
+                        connector_generation_id=generation_id,
+                        execution_scope=remote_intent.get("execution_scope"),
+                        scheduler_provider=remote_intent.get("scheduler_provider"),
+                        scheduler_native_id=remote_intent.get("scheduler_native_id"),
+                        scheduler_step_marker=remote_intent.get("scheduler_step_marker"),
+                        placement=remote_intent.get("placement"),
+                        reconciled=True,
+                    )
+                    changed = True
+            except RelayError as exc:
+                unresolved_remote = dict(remote_intent)
+                unresolved_remote.pop("live_identity_verified", None)
+                unresolved_remote["reconciliation_error"] = str(exc)
+                intents["remote_connector"] = unresolved_remote
+                changed = True
+        elif remote_record:
+            unresolved_remote = dict(remote_intent)
+            unresolved_remote["reconciliation_error"] = (
+                "remote connector record has no matching starting or recorded durable intent"
+            )
+            intents["remote_connector"] = unresolved_remote
+            changed = True
 
         local_intent = _object(intents.get("desktop_connector", {}))
-        if not _object(transport.get("desktop_connector", {})) and local_intent.get("state") in {
-            "starting",
-            "recorded",
-        }:
+        local_record = _object(transport.get("desktop_connector", {}))
+        if local_intent.get("state") in {"starting", "recorded"}:
             try:
+                if local_record:
+                    self._validate_local_connector_intent_binding(
+                        session_id=session.session_id,
+                        intent=local_intent,
+                        connector=local_record,
+                    )
                 connector, absence_verified = _discover_local_connector(
                     local_intent,
                     session_id=session.session_id,
                 )
                 if connector is not None:
+                    self._validate_local_connector_intent_binding(
+                        session_id=session.session_id,
+                        intent=local_intent,
+                        connector=connector,
+                    )
+                    local_fields = (
+                        "owner",
+                        "session_id",
+                        "pid",
+                        "process_group_id",
+                        "process_start_marker",
+                        "owner_token",
+                        "connector_generation_id",
+                        "config_path",
+                        "stdout_path",
+                        "stderr_path",
+                        "metadata_path",
+                    )
+                    if local_record and not self._connector_records_match(
+                        local_record,
+                        connector,
+                        fields=local_fields,
+                    ):
+                        raise RelayError(
+                            "desktop connector record disagrees with its live sidecar identity"
+                        )
                     transport["desktop_connector"] = connector
                     intents["desktop_connector"] = _new_ownership_intent(
                         "recorded",
                         reconciled=True,
+                        live_identity_verified=True,
                         **connector,
                     )
                     changed = True
                 elif absence_verified:
+                    transport.pop("desktop_connector", None)
                     intents["desktop_connector"] = _new_ownership_intent(
                         "absent_verified",
                         owner_token=local_intent.get("owner_token"),
                         connector_generation_id=local_intent.get("connector_generation_id"),
                         config_path=local_intent.get("config_path"),
+                        stdout_path=local_intent.get("stdout_path"),
+                        stderr_path=local_intent.get("stderr_path"),
+                        metadata_path=local_intent.get("metadata_path"),
                         reconciled=True,
                     )
                     changed = True
             except RelayError as exc:
-                local_intent["reconciliation_error"] = str(exc)
-                intents["desktop_connector"] = local_intent
+                unresolved_local = dict(local_intent)
+                unresolved_local.pop("live_identity_verified", None)
+                unresolved_local["reconciliation_error"] = str(exc)
+                intents["desktop_connector"] = unresolved_local
                 changed = True
+        elif local_record:
+            unresolved_local = dict(local_intent)
+            unresolved_local["reconciliation_error"] = (
+                "desktop connector record has no matching starting or recorded durable intent"
+            )
+            intents["desktop_connector"] = unresolved_local
+            changed = True
 
         if not changed:
             return session
         gateway["ownership_intents"] = intents
         gateway["transport"] = transport
+        if definitive_submission_failure is not None:
+            return self._update(
+                session,
+                state=GatewaySessionState.FAILED,
+                queue_state=definitive_submission_failure.queue_state,
+                gateway=gateway,
+                metadata={
+                    "failed_at": utc_now().isoformat(),
+                    "last_error": str(definitive_submission_failure),
+                    "runtime_observation_error": str(definitive_submission_failure),
+                    "scheduler_submission_outcome": (
+                        definitive_submission_failure.scheduler_submission_outcome
+                    ),
+                },
+            )
         if scheduler_job_id is not None:
             return self._update(
                 session,
@@ -3894,17 +5469,18 @@ class ServiceRuntimeSupervisor:
         except OSError as exc:
             raise RelayError("could not remove unpublished desktop connector files") from exc
 
-    def _wait_for_allocation_and_health(
+    def _observe_allocation_and_health_once(
         self,
         session: GatewaySession,
         spec: ServiceRuntimeSpec,
         scheduler_job_id: str,
         initial_service_host: str | None = None,
-    ) -> str:
-        deadline = time.time() + spec.readiness_timeout_seconds
-        last_status = ""
+    ) -> str | None:
+        """Make one bounded scheduler/runtime/health observation without waiting."""
+
         current_session = session
-        while time.time() < deadline:
+        provider_status: SchedulerStatus | None = None
+        try:
             provider_status = (
                 self._poll_scheduler_provider(
                     provider=spec.scheduler,
@@ -3913,6 +5489,58 @@ class ServiceRuntimeSupervisor:
                 if provider_for_scheduler(spec.scheduler).name != "external"
                 else None
             )
+        except ConfigurationError:
+            raise
+        except RelayError as exc:
+            self._record_runtime_observation_pending(
+                current_session,
+                node=initial_service_host or current_session.node,
+                error=exc,
+                provider_status=None,
+            )
+            return None
+        if provider_status is not None:
+            provider_state = provider_status.phase.value
+            if provider_state in _TERMINAL_RUNTIME_STATES:
+                raise _DefinitiveRuntimeObservationError(
+                    "scheduler job reached a terminal state before the service became ready: "
+                    f"job={scheduler_job_id} state={provider_state}"
+                )
+            if provider_status.phase is SchedulerPhase.UNKNOWN:
+                self._record_runtime_observation_pending(
+                    current_session,
+                    node=initial_service_host or current_session.node,
+                    error=RelayError(
+                        "scheduler provider could not observe a current or terminal record for "
+                        f"submitted job {scheduler_job_id}; absence is not terminal proof"
+                    ),
+                    provider_status=provider_status,
+                )
+                return None
+            if provider_status.phase in {SchedulerPhase.SUBMITTED, SchedulerPhase.PENDING}:
+                observed_gateway = dict(current_session.gateway)
+                observed_gateway.pop("runtime_observation", None)
+                self._update(
+                    current_session,
+                    state=GatewaySessionState.PENDING,
+                    queue_state=provider_state,
+                    node=None,
+                    metadata={
+                        "runtime_observation_error": None,
+                        "runtime_observed_at": utc_now().isoformat(),
+                    },
+                    gateway={
+                        **observed_gateway,
+                        "scheduler_status": {
+                            "raw": provider_status.model_dump_json(),
+                            "state": provider_state,
+                            "reason": provider_status.reason,
+                            "provider": provider_status.model_dump(mode="json"),
+                        },
+                    },
+                )
+                return None
+        try:
             if initial_service_host is not None:
                 scheduler_state = (
                     provider_status.phase.value if provider_status is not None else "allocated"
@@ -3949,45 +5577,130 @@ class ServiceRuntimeSupervisor:
                     else status.reason
                 )
                 runtime_events = status.events
-            last_status = status_text.strip()
-            state = (
-                GatewaySessionState.ALLOCATED if node is not None else GatewaySessionState.PENDING
-            )
-            current_session = self._update(
+        except ConfigurationError:
+            raise
+        except RelayError as exc:
+            self._record_runtime_observation_pending(
                 current_session,
-                state=state,
-                queue_state=scheduler_state.lower() if scheduler_state else None,
-                node=node,
-                gateway={
-                    **current_session.gateway,
-                    "scheduler_status": {
-                        "raw": last_status,
-                        "state": scheduler_state,
-                        "reason": reason,
-                        "provider": (
-                            provider_status.model_dump(mode="json")
-                            if provider_status is not None
-                            else None
-                        ),
-                    },
-                    "runtime_events": runtime_events or [],
-                },
+                node=initial_service_host or current_session.node,
+                error=exc,
+                provider_status=provider_status,
             )
-            if node is not None:
-                health = self._ssh(
-                    _remote_http_probe_script(
-                        node,
-                        spec.service_port,
-                        spec.health_path,
-                        expected_body=spec.health_expected_body,
-                    )
+            return None
+
+        last_status = status_text.strip()
+        normalized_scheduler_state = (
+            scheduler_state.strip().lower() if scheduler_state else "unknown"
+        )
+        if normalized_scheduler_state in _TERMINAL_RUNTIME_STATES:
+            raise _DefinitiveRuntimeObservationError(
+                "scheduler job reached a terminal state before the service became ready: "
+                f"job={scheduler_job_id} state={normalized_scheduler_state}"
+            )
+        state = GatewaySessionState.ALLOCATED if node is not None else GatewaySessionState.PENDING
+        observed_gateway = dict(current_session.gateway)
+        observed_gateway.pop("runtime_observation", None)
+        current_session = self._update(
+            current_session,
+            state=state,
+            queue_state=normalized_scheduler_state,
+            node=node,
+            metadata={
+                "runtime_observation_error": None,
+                "runtime_observed_at": utc_now().isoformat(),
+            },
+            gateway={
+                **observed_gateway,
+                "scheduler_status": {
+                    "raw": last_status,
+                    "state": scheduler_state,
+                    "reason": reason,
+                    "provider": (
+                        provider_status.model_dump(mode="json")
+                        if provider_status is not None
+                        else None
+                    ),
+                },
+                "runtime_events": runtime_events or [],
+            },
+        )
+        if node is None:
+            return None
+        try:
+            health = self._ssh(
+                _remote_http_probe_script(
+                    node,
+                    spec.service_port,
+                    spec.health_path,
+                    expected_body=spec.health_expected_body,
                 )
-                if "service_health=ok" in health:
-                    return node
-            self.sleep(spec.poll_seconds)
-        raise RelayError(
-            f"service did not become healthy before timeout; job={scheduler_job_id} "
-            f"last_status={last_status!r}"
+            )
+        except RelayError as exc:
+            self._record_runtime_observation_pending(
+                current_session,
+                node=node,
+                error=exc,
+                provider_status=provider_status,
+            )
+            return None
+        if "service_health=ok" in health:
+            return node
+        self._record_runtime_observation_pending(
+            current_session,
+            node=node,
+            error=RelayError(
+                "service health observation was not ready: "
+                f"job={scheduler_job_id} output={health.strip()!r}"
+            ),
+            provider_status=provider_status,
+        )
+        return None
+
+    def _record_runtime_observation_pending(
+        self,
+        session: GatewaySession,
+        *,
+        node: str | None,
+        error: RelayError,
+        provider_status: SchedulerStatus | None,
+        state: GatewaySessionState | None = None,
+        queue_state: str = "observation_unknown",
+        preserve_scheduler_status: bool = False,
+    ) -> GatewaySession:
+        """Persist an inconclusive observation without failing the owned submission."""
+
+        previous_status = _object(session.gateway.get("scheduler_status", {}))
+        observed_at = utc_now().isoformat()
+        gateway = {
+            **session.gateway,
+            "runtime_observation": {
+                "state": "not_ready",
+                "error": str(error),
+                "observed_at": observed_at,
+            },
+        }
+        if not preserve_scheduler_status:
+            gateway["scheduler_status"] = {
+                "raw": previous_status.get("raw", ""),
+                "state": "observation_unknown",
+                "reason": str(error),
+                "provider": (
+                    provider_status.model_dump(mode="json")
+                    if provider_status is not None
+                    else previous_status.get("provider")
+                ),
+            }
+        return self._update(
+            session,
+            state=state
+            or (GatewaySessionState.ALLOCATED if node is not None else GatewaySessionState.PENDING),
+            queue_state=queue_state,
+            node=node,
+            metadata={
+                "runtime_observation_error": str(error),
+                "runtime_observed_at": observed_at,
+            },
+            gateway=gateway,
         )
 
     def _retained_scheduler_resource(
@@ -4011,31 +5724,6 @@ class ServiceRuntimeSupervisor:
                     provider=provider.name,
                     scheduler_job_id=scheduler_job_id,
                 )
-                if (
-                    provider_status.phase is SchedulerPhase.UNKNOWN
-                    and provider_status.active_record_found is False
-                ):
-                    return CleanupResource(
-                        kind="scheduler_job",
-                        resource_id=scheduler_job_id,
-                        location=self.definition.ssh_host,
-                        provider=session.scheduler,
-                        action="retain",
-                        metadata={
-                            "gateway_session_id": session.session_id,
-                            "scheduler_status": provider_status.model_dump(mode="json"),
-                        },
-                        ownership_verified=True,
-                        outcome="missing",
-                        verified_after_operation=True,
-                        observed_state="missing",
-                        residual=False,
-                        detail=(
-                            "scheduler cancellation was not requested; the provider proved "
-                            "that no active scheduler record remained; no completed or "
-                            "canceled state is claimed"
-                        ),
-                    )
                 observed_state = provider_status.phase.value
         except RelayError as exc:
             return CleanupResource(
@@ -4826,21 +6514,26 @@ class ServiceRuntimeSupervisor:
         poll_seconds: float,
         runtime_schema_version: Literal["jarvis.service-runtime.v1", "jarvis.service-runtime.v2"],
         authorization: str | None,
+        max_attempts: int | None = None,
     ) -> None:
         """Prove the versioned JARVIS HTTP authorization boundary is live."""
         if runtime_schema_version == JARVIS_SERVICE_RUNTIME_SCHEMA_V1:
             if authorization is not None:
-                raise RelayError(
+                raise _DefinitiveRuntimeObservationError(
                     "legacy JARVIS service runtime unexpectedly resolved authorization"
                 )
         elif runtime_schema_version == JARVIS_SERVICE_RUNTIME_SCHEMA_V2:
             if authorization is None:
-                raise RelayError("authenticated JARVIS service runtime omitted authorization")
+                raise _DefinitiveRuntimeObservationError(
+                    "authenticated JARVIS service runtime omitted authorization"
+                )
         else:
-            raise RelayError("JARVIS service runtime schema is unsupported")
+            raise _DefinitiveRuntimeObservationError("JARVIS service runtime schema is unsupported")
         deadline = time.monotonic() + timeout_seconds
         last_error = "no response"
+        attempts = 0
         while time.monotonic() < deadline:
+            attempts += 1
             try:
                 anonymous = _read_bounded_http_response(
                     health_url,
@@ -4854,7 +6547,7 @@ class ServiceRuntimeSupervisor:
                     last_error = f"legacy anonymous health status={anonymous.status_code}"
                 else:
                     if 200 <= anonymous.status_code < 300:
-                        raise RelayError(
+                        raise _DefinitiveRuntimeObservationError(
                             "authenticated JARVIS service health accepted an anonymous request"
                         )
                     if anonymous.status_code != 401:
@@ -4868,9 +6561,15 @@ class ServiceRuntimeSupervisor:
                         )
                         if 200 <= authenticated.status_code < 300:
                             return
+                        if authenticated.status_code in {401, 403}:
+                            raise _DefinitiveRuntimeObservationError(
+                                "authenticated JARVIS service rejected its verified authority"
+                            )
                         last_error = f"authenticated health status={authenticated.status_code}"
             except httpx.HTTPError:
                 last_error = "HTTP transport failed"
+            if max_attempts is not None and attempts >= max_attempts:
+                break
             _sleep_before_deadline(self.sleep, poll_seconds, deadline)
         raise RelayError(f"JARVIS service health boundary was not ready: {last_error}")
 
@@ -4913,10 +6612,13 @@ class ServiceRuntimeSupervisor:
         poll_seconds: float,
         *,
         expected_body: str | None = None,
+        max_attempts: int | None = None,
     ) -> None:
         deadline = time.monotonic() + timeout_seconds
         last_error: str | None = None
+        attempts = 0
         while time.monotonic() < deadline:
+            attempts += 1
             try:
                 response = _read_bounded_http_response(
                     health_url,
@@ -4932,6 +6634,8 @@ class ServiceRuntimeSupervisor:
                     last_error = f"HTTP {response.status_code}"
             except httpx.HTTPError as exc:
                 last_error = str(exc)
+            if max_attempts is not None and attempts >= max_attempts:
+                break
             _sleep_before_deadline(self.sleep, poll_seconds, deadline)
         raise RelayError(f"local service health probe failed: {health_url}: {last_error}")
 
@@ -5026,12 +6730,16 @@ class ServiceRuntimeSupervisor:
                 timeout_seconds=_REMOTE_RUNTIME_COMMAND_TIMEOUT_SECONDS,
             )
         except subprocess.TimeoutExpired as exc:
-            raise RelayError(
+            raise _AmbiguousRemoteSideEffectError(
                 "remote service runtime command timed out after "
                 f"{_REMOTE_RUNTIME_COMMAND_TIMEOUT_SECONDS:g} seconds"
             ) from exc
         if result.returncode != 0:
             detail = result.stderr.strip() or result.stdout.strip()
+            if result.returncode == 255:
+                raise _AmbiguousRemoteSideEffectError(
+                    f"remote service runtime transport failed: {detail}"
+                )
             raise RelayError(f"remote service runtime command failed: {detail}")
         return result.stdout
 
@@ -5573,22 +7281,106 @@ from pathlib import Path
 ) = sys.argv[1:]
 maximum = int(maximum_raw)
 
-def read_private(path_raw, maximum_bytes):
+verification_schema = {_REMOTE_SUBMISSION_VERIFICATION_SCHEMA!r}
+identity_fields = (
+    "schema_version",
+    "session_id",
+    "submission_id",
+    "scheduler_provider",
+    "submission_marker",
+    "returncode",
+    "output_truncated",
+)
+
+def bounded_scalar(value, maximum_characters=256):
+    if isinstance(value, str):
+        return value[:maximum_characters]
+    if isinstance(value, (int, bool)):
+        return value
+    return None
+
+def emit_retryable(error_code, *, anchored=False):
+    print(json.dumps({{
+        "schema_version": verification_schema,
+        "present": False,
+        "anchored": anchored,
+        "verification_outcome": "retryable",
+        "error_code": error_code,
+    }}, sort_keys=True))
+    raise SystemExit(0)
+
+def emit_invalid(
+    error_code,
+    error,
+    component,
+    *,
+    observed=None,
+    observed_output=None,
+    recorded_output_sha256=None,
+):
+    observed_mapping = observed if isinstance(observed, dict) else {{}}
+    payload = {{
+        "schema_version": verification_schema,
+        "present": True,
+        "verification_outcome": "definitive_invalid",
+        "failure_kind": "relay_integrity_failure",
+        "error_code": error_code,
+        "error": error[:1024],
+        "invalid_component": component,
+        "observed_identity": {{
+            field: bounded_scalar(observed_mapping.get(field))
+            for field in identity_fields
+        }},
+    }}
+    if isinstance(recorded_output_sha256, str):
+        payload["output_sha256"] = recorded_output_sha256[:128]
+    if isinstance(observed_output, bytes):
+        payload["observed_output_sha256"] = hashlib.sha256(observed_output).hexdigest()
+        payload["output_size"] = len(observed_output)
+    print(json.dumps(payload, sort_keys=True))
+    raise SystemExit(0)
+
+def read_private(path_raw, maximum_bytes, component):
     path = Path(path_raw)
-    before = os.lstat(path)
+    try:
+        before = os.lstat(path)
+    except FileNotFoundError:
+        emit_retryable(component + "_disappeared", anchored=True)
     if not stat.S_ISREG(before.st_mode) or before.st_nlink != 1 or before.st_mode & 0o077:
-        raise RuntimeError(f"submission sidecar is not a private regular file: {{path}}")
+        emit_invalid(
+            component + "_unsafe_file",
+            "scheduler submission " + component + " is not a private regular file",
+            component,
+        )
     if before.st_size > maximum_bytes:
-        raise RuntimeError(f"submission sidecar exceeds its bound: {{path}}")
-    data = path.read_bytes()
-    after = os.lstat(path)
+        emit_invalid(
+            component + "_oversized",
+            "scheduler submission " + component + " exceeds its size bound",
+            component,
+        )
+    try:
+        data = path.read_bytes()
+        after = os.lstat(path)
+    except FileNotFoundError:
+        emit_retryable(component + "_disappeared", anchored=True)
     if (before.st_ino, before.st_size, before.st_mtime_ns) != (
         after.st_ino,
         after.st_size,
         after.st_mtime_ns,
     ):
-        raise RuntimeError(f"submission sidecar changed while reading: {{path}}")
+        emit_retryable(component + "_changed_while_reading", anchored=True)
     return data
+
+def read_json_private(path_raw, maximum_bytes, component):
+    data = read_private(path_raw, maximum_bytes, component)
+    try:
+        return json.loads(data)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        emit_invalid(
+            component + "_json_invalid",
+            "scheduler submission " + component + " JSON is invalid",
+            component,
+        )
 
 expected = {{
     "session_id": session_id,
@@ -5598,42 +7390,81 @@ expected = {{
 }}
 intent_path = Path(intent_raw)
 if not intent_path.exists():
-    print(json.dumps({{"present": False}}))
-    raise SystemExit(0)
-intent = json.loads(read_private(intent_raw, 65536))
+    emit_retryable("intent_absent")
+intent = read_json_private(intent_raw, 65536, "intent")
 if (
+    not isinstance(intent, dict)
+    or
     intent.get("schema_version") != "clio-relay.gateway-submission-intent.v1"
     or any(intent.get(k) != v for k, v in expected.items())
 ):
-    raise RuntimeError("scheduler submission intent identity mismatch")
+    emit_invalid(
+        "intent_identity_mismatch",
+        "scheduler submission intent identity mismatch",
+        "intent",
+        observed=intent,
+    )
 record_path = Path(record_raw)
 if record_path.exists():
-    record = json.loads(read_private(record_raw, maximum + 65536))
+    record = read_json_private(record_raw, maximum + 65536, "record")
 else:
     output_exists = Path(output_raw).exists()
     meta_exists = Path(meta_raw).exists()
     if not output_exists and not meta_exists:
-        print(json.dumps({{"present": False, "anchored": True}}))
-        raise SystemExit(0)
+        emit_retryable("output_absent", anchored=True)
     if output_exists != meta_exists:
-        raise RuntimeError("scheduler submission output is incomplete or ambiguous")
-    output = read_private(output_raw, maximum + 1)
-    meta = json.loads(read_private(meta_raw, 65536))
+        emit_retryable("output_incomplete", anchored=True)
+    output = read_private(output_raw, maximum + 1, "output")
+    meta = read_json_private(meta_raw, 65536, "output_metadata")
     if (
+        not isinstance(meta, dict)
+        or
         meta.get("schema_version") != "clio-relay.gateway-submission-output.v1"
         or any(meta.get(k) != v for k, v in expected.items())
     ):
-        raise RuntimeError("scheduler submission output identity mismatch")
+        emit_invalid(
+            "output_identity_mismatch",
+            "scheduler submission output identity mismatch",
+            "output_metadata",
+            observed=meta,
+            observed_output=output,
+        )
     if (
         meta.get("output_sha256") != hashlib.sha256(output).hexdigest()
         or meta.get("output_size") != len(output)
     ):
-        raise RuntimeError("scheduler submission output digest mismatch")
+        emit_invalid(
+            "output_digest_mismatch",
+            "scheduler submission output digest mismatch",
+            "output_metadata",
+            observed=meta,
+            observed_output=output,
+            recorded_output_sha256=meta.get("output_sha256"),
+        )
+    returncode = meta.get("returncode")
+    if isinstance(returncode, bool) or not isinstance(returncode, int):
+        emit_invalid(
+            "output_returncode_invalid",
+            "scheduler submission output return code is invalid",
+            "output_metadata",
+            observed=meta,
+            observed_output=output,
+        )
+    try:
+        decoded_output = output.decode("utf-8")
+    except UnicodeDecodeError:
+        emit_invalid(
+            "output_encoding_invalid",
+            "scheduler submission output is not valid UTF-8",
+            "output",
+            observed=meta,
+            observed_output=output,
+        )
     record = {{
         "schema_version": "clio-relay.gateway-submission-sidecar.v1",
         **expected,
-        "returncode": int(meta["returncode"]),
-        "output": output.decode("utf-8"),
+        "returncode": returncode,
+        "output": decoded_output,
         "output_sha256": meta["output_sha256"],
         "output_size": len(output),
         "output_truncated": meta.get("output_truncated") is True,
@@ -5652,15 +7483,38 @@ else:
     finally:
         os.close(directory)
 if (
+    not isinstance(record, dict)
+    or
     record.get("schema_version") != "clio-relay.gateway-submission-sidecar.v1"
     or any(record.get(k) != v for k, v in expected.items())
 ):
-    raise RuntimeError("scheduler submission record identity mismatch")
+    emit_invalid(
+        "record_identity_mismatch",
+        "scheduler submission record identity mismatch",
+        "record",
+        observed=record,
+    )
 output = record.get("output")
 if not isinstance(output, str) or len(output.encode("utf-8")) > maximum + 1:
-    raise RuntimeError("scheduler submission record output is invalid")
-if record.get("output_sha256") != hashlib.sha256(output.encode("utf-8")).hexdigest():
-    raise RuntimeError("scheduler submission record output digest mismatch")
+    emit_invalid(
+        "record_output_invalid",
+        "scheduler submission record output is invalid",
+        "record",
+        observed=record,
+    )
+output_bytes = output.encode("utf-8")
+if (
+    record.get("output_sha256") != hashlib.sha256(output_bytes).hexdigest()
+    or record.get("output_size") != len(output_bytes)
+):
+    emit_invalid(
+        "record_output_digest_mismatch",
+        "scheduler submission record output digest mismatch",
+        "record",
+        observed=record,
+        observed_output=output_bytes,
+        recorded_output_sha256=record.get("output_sha256"),
+    )
 record["present"] = True
 print(json.dumps(record))
 __CLIO_READ_SUBMISSION__
@@ -7018,6 +8872,76 @@ def _new_ownership_intent(state: str, **identity: object) -> dict[str, object]:
     }
 
 
+def _submission_reconciliation_failure_evidence(
+    *,
+    session_id: str,
+    submission_id: str,
+    scheduler_provider: str,
+    submission_marker: str,
+    record: dict[str, object],
+    error: str,
+    failure_kind: Literal[
+        "command_failure",
+        "integrity_failure",
+        "response_invalid",
+    ],
+) -> dict[str, object]:
+    """Return bounded evidence for one definitive exact-sidecar failure."""
+
+    def bounded_scalar(value: object, *, maximum: int = 256) -> str | int | bool | None:
+        if isinstance(value, str):
+            return value[:maximum]
+        if isinstance(value, (int, bool)):
+            return value
+        return None
+
+    output = record.get("output")
+    output_bytes = output.encode("utf-8") if isinstance(output, str) else None
+    recorded_digest = _optional_str(
+        record.get("observed_output_sha256") or record.get("output_sha256")
+    )
+    reported_identity = _object(record.get("observed_identity", {}))
+    scheduler_submission_outcome = {
+        "command_failure": "submit_command_failed",
+        "integrity_failure": "unknown_due_to_integrity_failure",
+        "response_invalid": "unknown_due_to_invalid_response",
+    }[failure_kind]
+    return {
+        "schema_version": "clio-relay.gateway-submission-reconciliation-failure.v1",
+        "session_id": session_id,
+        "submission_id": submission_id,
+        "scheduler_provider": scheduler_provider,
+        "submission_marker": submission_marker,
+        "sidecar_present": record.get("present") is True,
+        "failure_kind": failure_kind,
+        "scheduler_submission_outcome": scheduler_submission_outcome,
+        "verification_outcome": bounded_scalar(record.get("verification_outcome")),
+        "error_code": bounded_scalar(record.get("error_code")),
+        "invalid_component": bounded_scalar(record.get("invalid_component")),
+        "observed_identity": {
+            field: bounded_scalar(reported_identity.get(field, record.get(field)))
+            for field in (
+                "schema_version",
+                "session_id",
+                "submission_id",
+                "scheduler_provider",
+                "submission_marker",
+                "returncode",
+                "output_truncated",
+            )
+        },
+        "output_sha256": (recorded_digest[:128] if recorded_digest is not None else None)
+        or (hashlib.sha256(output_bytes).hexdigest() if output_bytes is not None else None),
+        "output_size": (
+            bounded_scalar(record.get("output_size")) if output_bytes is None else len(output_bytes)
+        ),
+        "error": error[:1024],
+        "observed_at": utc_now().isoformat(),
+        "cancel_requested": False,
+        "resubmit_requested": False,
+    }
+
+
 def _validated_durable_scheduler_contract(
     session: GatewaySession,
     *,
@@ -7250,17 +9174,17 @@ def _validate_completed_detach_resources(
     """Require complete ownership and disposition proof for a finished detach."""
     error = "gateway detach evidence is invalid"
     scheduler_contract = _validated_durable_scheduler_contract(session)
-    if scheduler_contract.unresolved_submission:
-        raise RelayError(error)
     allowed_kinds = {
         "browser_proxy",
         "desktop_connector",
         "remote_connector",
         "scheduler_job",
+        "scheduler_submission",
         "gateway_record",
     }
     counts = {kind: sum(item.kind == kind for item in resources) for kind in allowed_kinds}
     expected_scheduler_count = 1 if scheduler_contract.scheduler_job_id is not None else 0
+    expected_submission_count = 1 if scheduler_contract.unresolved_submission else 0
     if (
         any(item.kind not in allowed_kinds for item in resources)
         or counts["desktop_connector"] != 1
@@ -7268,6 +9192,7 @@ def _validate_completed_detach_resources(
         or counts["gateway_record"] != 1
         or counts["browser_proxy"] > 1
         or counts["scheduler_job"] != expected_scheduler_count
+        or counts["scheduler_submission"] != expected_submission_count
         or any(
             not item.resource_id
             or not item.location
@@ -7282,6 +9207,11 @@ def _validate_completed_detach_resources(
     desktop = next(item for item in resources if item.kind == "desktop_connector")
     remote = next(item for item in resources if item.kind == "remote_connector")
     gateway = next(item for item in resources if item.kind == "gateway_record")
+    ownership_intents = _object(session.gateway.get("ownership_intents", {}))
+    remote_absence_proven = _intent_proves_absence(
+        ownership_intents,
+        "remote_connector",
+    )
     if (
         desktop.action != "stop"
         or desktop.outcome not in {"stopped", "missing"}
@@ -7290,9 +9220,10 @@ def _validate_completed_detach_resources(
         or (desktop.outcome == "stopped") != (stopped_local_pid is not None)
         or (stopped_local_pid is not None and desktop.resource_id != str(stopped_local_pid))
         or remote.action != "retain"
-        or remote.outcome != "retained"
+        or remote.outcome != ("missing" if remote_absence_proven else "retained")
         or not remote.ownership_verified
         or not remote.verified_after_operation
+        or (remote_absence_proven and remote.observed_state != "not_created")
         or gateway.resource_id != session.session_id
         or gateway.action != "retain"
         or gateway.outcome != "retained"
@@ -7324,6 +9255,28 @@ def _validate_completed_detach_resources(
             or not item.ownership_verified
             or not item.verified_after_operation
             or not outcome_state_valid
+        ):
+            raise RelayError(error)
+    submissions = [item for item in resources if item.kind == "scheduler_submission"]
+    if submissions:
+        item = submissions[0]
+        intents = _object(session.gateway.get("ownership_intents", {}))
+        scheduler_intent = _object(intents.get("scheduler_submission", {}))
+        if (
+            not scheduler_contract.unresolved_submission
+            or item.resource_id != scheduler_intent.get("submission_id")
+            or item.provider != scheduler_contract.provider
+            or item.action != "retain"
+            or item.outcome != "retained"
+            or item.observed_state != "intent_recorded"
+            or not item.ownership_verified
+            or not item.verified_after_operation
+            or item.metadata.get("submission_id") != scheduler_intent.get("submission_id")
+            or item.metadata.get("submission_marker") != scheduler_intent.get("submission_marker")
+            or item.metadata.get("scheduler_job_id") is not None
+            or item.metadata.get("submission_outcome") != "unresolved"
+            or item.metadata.get("cancel_requested") is not False
+            or item.metadata.get("resubmit_requested") is not False
         ):
             raise RelayError(error)
 
@@ -7618,6 +9571,7 @@ def _discover_local_connector(
             "config_path": config_path,
             "stdout_path": intent.get("stdout_path"),
             "stderr_path": intent.get("stderr_path"),
+            "metadata_path": str(metadata_path),
         }
         _write_local_connector_sidecar(metadata_path, connector)
         return connector, False

--- a/src/clio_relay/validation_report.py
+++ b/src/clio_relay/validation_report.py
@@ -104,10 +104,11 @@ def _utc_now() -> datetime:
 
 
 class ValidationStatus(StrEnum):
-    """Terminal status for a report or one validation check."""
+    """Outcome status for a report or one validation check."""
 
     PASSED = "passed"
     FAILED = "failed"
+    PENDING = "pending"
 
 
 class InstallSourceKind(StrEnum):

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -265,7 +265,11 @@ def test_fresh_bootstrap_loads_packaged_graph_before_explicit_build_fallback() -
     assert "uv tool install --force --python 3.12 --no-config" in script
     assert '--with "$JARVIS_CD_WHEEL" "$RELAY_INSTALL_TARGET"' in script
     assert 'RELAY_EXECUTABLE="$(uv tool dir --bin --no-config)/clio-relay"' in script
-    assert 'RELAY_PROVIDER_PYTHON="$(sed -n' in script
+    assert 'RELAY_PROVIDER_PYTHON="$UV_TOOL_DIR/clio-relay/bin/python"' in script
+    assert 'JARVIS_MCP_PROVIDER_PYTHON="$UV_TOOL_DIR/clio-kit/bin/python"' in script
+    assert 'RELAY_PROVIDER_PYTHON="$BOOTSTRAP_GENERATION/tools/clio-relay/bin/python"' in script
+    assert 'CLIO_KIT_PROVIDER_PYTHON="$BOOTSTRAP_GENERATION/tools/clio-kit/bin/python"' in script
+    assert "sed -n '1{s/^#!//;p;}'" not in script
     assert "relay-venv312" not in script
     assert 'uv pip install --refresh-package clio-relay "$RELAY_INSTALL_TARGET"' not in script
     assert "uv pip install --no-deps --refresh-package jarvis-cd" not in script
@@ -307,6 +311,22 @@ def test_fresh_bootstrap_loads_packaged_graph_before_explicit_build_fallback() -
     assert '"execution": os.environ["CLIO_RELAY_BOOTSTRAP_JARVIS_CD_EXECUTION_PYTHON"]' in script
     assert "native_execution=clio_kit_native_execution" in script
     assert "persistent_tool=persistent_clio_kit_tool" in script
+    assert '"clio-relay.persistent_tool_verified"' in script
+    assert '"clio-kit.persistent_tool_verified"' in script
+    assert '"clio-kit.native_execution_capability_verified"' in script
+    assert '"jarvis-cd.verified"' in script
+    assert '"jarvis-cd.distribution_identity_verified"' in script
+    assert '"jarvis-cd.runtime_artifact_path_verified"' in script
+    assert '"jarvis-cd.artifact_sha256_verified"' in script
+    assert '"jarvis-cd.execution_interpreter_verified"' in script
+    assert '"jarvis-cd.execution_record_closure_verified"' in script
+    assert '"jarvis-cd.native_execution_capability_verified"' in script
+    assert '"jarvis-cd.jarvis_executable_verified"' in script
+    assert '"jarvis-cd.execution_record_closure_error."' in script
+    assert (
+        "failed_checks = sorted(name for name, verified in checks.items() if not verified)"
+        in script
+    )
     assert "native_execution=jarvis_execution_native_execution" in script
     assert "jarvis_cd_entry_points" not in script
     assert 'requested_source=os.environ["CLIO_RELAY_BOOTSTRAP_JARVIS_MCP_SOURCE"]' in script

--- a/tests/test_bootstrap_cluster_paths.py
+++ b/tests/test_bootstrap_cluster_paths.py
@@ -286,6 +286,221 @@ exit 37
         assert "state=inactive" in stderr
 
 
+def test_failed_readiness_repair_restores_previously_active_worker() -> None:
+    """The repair transaction trap composes the worker-fence recovery contract."""
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.fail("bash is required to validate the Linux bootstrap recovery trap")
+    worker_fence, _recheck, _init, _restart = bootstrap._worker_upgrade_fence_script(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        "ares",
+        rendered_core_dir='"$test_root/core"',
+        activation_observation_timeout_seconds=2,
+        activation_poll_seconds=1,
+        activation_progress_seconds=1,
+    )
+    harness = f"""set -euo pipefail
+test_root="$(mktemp -d)"
+mkdir -p "$test_root/bin" "$test_root/home"
+export HOME="$test_root/home"
+export BOOTSTRAP_TEST_STATE="$test_root/worker-state"
+echo active > "$BOOTSTRAP_TEST_STATE"
+cat > "$test_root/bin/python3" <<'__FAKE_PYTHON__'
+#!/usr/bin/env bash
+cat >/dev/null
+__FAKE_PYTHON__
+cat > "$test_root/bin/systemctl" <<'__FAKE_SYSTEMCTL__'
+#!/usr/bin/env bash
+set -u
+case "${{2:-}}" in
+  show)
+    state="$(cat "$BOOTSTRAP_TEST_STATE")"
+    case " $* " in
+      *--property=LoadState*--value*) echo loaded ;;
+      *--property=ActiveState*--value*) echo "$state" ;;
+      *)
+        invocation=old-invocation
+        sub_state=dead
+        if [ "$state" = active ]; then
+          invocation=new-invocation
+          sub_state=running
+        fi
+        printf '%s\n' 'LoadState=loaded' "ActiveState=$state" \
+          "SubState=$sub_state" 'Result=success' 'ControlPID=0' \
+          'ExecMainCode=0' 'ExecMainStatus=0' 'TimeoutStartUSec=5min' \
+          "InvocationID=$invocation"
+        ;;
+    esac
+    ;;
+  list-jobs) ;;
+  stop)
+    echo "fake-systemctl=stop" >&2
+    echo inactive > "$BOOTSTRAP_TEST_STATE"
+    ;;
+  start)
+    echo "fake-systemctl=start" >&2
+    echo active > "$BOOTSTRAP_TEST_STATE"
+    ;;
+  *) exit 2 ;;
+esac
+__FAKE_SYSTEMCTL__
+cat > "$test_root/bin/flock" <<'__FAKE_FLOCK__'
+#!/usr/bin/env bash
+case "${{1:-}}" in --exclusive|--unlock) exit 0 ;; *) exit 2 ;; esac
+__FAKE_FLOCK__
+chmod +x "$test_root/bin/python3" "$test_root/bin/systemctl" "$test_root/bin/flock"
+export PATH="$test_root/bin:$PATH"
+{worker_fence}
+bootstrap_repair_transaction_exit() {{
+  local status=$?
+  trap - EXIT
+  bootstrap_restore_fenced_worker_on_failure "$status"
+  bootstrap_release_worker_lifetime_guard 2>/dev/null || true
+  exit "$status"
+}}
+trap bootstrap_repair_transaction_exit EXIT
+echo "readiness-repair-step=sabotaged" >&2
+exit 37
+"""
+
+    result = subprocess.run(
+        [bash, "-s"],
+        input=harness.encode("utf-8"),
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 37
+    assert "readiness-repair-step=sabotaged" in stderr
+    assert stderr.count("fake-systemctl=stop") == 1
+    assert stderr.count("fake-systemctl=start") == 1
+    assert "worker_recovery=restored" in stderr
+
+
+def test_failed_unmanaged_readiness_repair_preserves_original_status() -> None:
+    """A no-service repair has no-op fence helpers and cannot mask its failure."""
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.fail("bash is required to validate the Linux bootstrap recovery trap")
+    worker_fence, _recheck, _init, _restart = bootstrap._worker_upgrade_fence_script(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        None,
+        rendered_core_dir='"$HOME/.local/share/clio-relay/core"',
+    )
+    harness = f"""set -euo pipefail
+{worker_fence}
+bootstrap_repair_transaction_exit() {{
+  local status=$?
+  trap - EXIT
+  bootstrap_restore_fenced_worker_on_failure "$status"
+  bootstrap_release_worker_lifetime_guard 2>/dev/null || true
+  exit "$status"
+}}
+trap bootstrap_repair_transaction_exit EXIT
+exit 37
+"""
+
+    result = subprocess.run(
+        [bash, "-s"],
+        input=harness.encode("utf-8"),
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 37
+
+
+def test_interrupted_repair_failure_restores_worker_without_masking_error() -> None:
+    """Recovery retains its exact failing status while restoring journaled service state."""
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.fail("bash is required to validate interrupted repair recovery")
+    cluster = "cluster-a"
+    service_name = endpoint_user_service_name(cluster)
+    script = render_linux_user_bootstrap_script(cluster=cluster)
+    start = script.index("bootstrap_recover_interrupted_repair() {")
+    end = script.index("\n}\n\nbootstrap_recover_previous_transaction()", start) + 3
+    helper = script[start:end].replace("\r\n", "\n")
+    harness = f"""set -euo pipefail
+test_root="$(mktemp -d)"
+mkdir -p "$test_root/bin" "$test_root/home"
+export HOME="$test_root/home"
+export BOOTSTRAP_TEST_STATE="$test_root/worker-state"
+echo inactive > "$BOOTSTRAP_TEST_STATE"
+cat > "$test_root/bin/python3" <<'__FAKE_PYTHON__'
+#!/usr/bin/env bash
+cat >/dev/null
+__FAKE_PYTHON__
+cat > "$test_root/bin/systemctl" <<'__FAKE_SYSTEMCTL__'
+#!/usr/bin/env bash
+set -u
+case "${{2:-}}" in
+  show)
+    state="$(cat "$BOOTSTRAP_TEST_STATE")"
+    case " $* " in
+      *--property=LoadState*--value*) echo loaded ;;
+      *--property=ActiveState*--value*) echo "$state" ;;
+      *)
+        invocation=old-invocation
+        sub_state=dead
+        if [ "$state" = active ]; then
+          invocation=new-invocation
+          sub_state=running
+        fi
+        printf '%s\n' 'LoadState=loaded' "ActiveState=$state" \
+          "SubState=$sub_state" 'Result=success' 'ControlPID=0' \
+          'ExecMainCode=0' 'ExecMainStatus=0' 'TimeoutStartUSec=5min' \
+          "InvocationID=$invocation"
+        ;;
+    esac
+    ;;
+  list-jobs) ;;
+  stop)
+    echo "fake-systemctl=stop" >&2
+    echo inactive > "$BOOTSTRAP_TEST_STATE"
+    ;;
+  start)
+    echo "fake-systemctl=start" >&2
+    if {{ true <&8; }} 2>/dev/null; then
+      echo "fake-systemctl=start-with-lifetime-guard" >&2
+      exit 99
+    fi
+    echo active > "$BOOTSTRAP_TEST_STATE"
+    ;;
+  *) exit 2 ;;
+esac
+__FAKE_SYSTEMCTL__
+cat > "$test_root/bin/flock" <<'__FAKE_FLOCK__'
+#!/usr/bin/env bash
+case "${{1:-}}" in --exclusive|--unlock) exit 0 ;; *) exit 2 ;; esac
+__FAKE_FLOCK__
+chmod +x "$test_root/bin/python3" "$test_root/bin/systemctl" "$test_root/bin/flock"
+export PATH="$test_root/bin:$PATH"
+bootstrap_candidate_action() {{
+  echo "candidate-action=$1" >&2
+  return 37
+}}
+bootstrap_cleanup_preparing_root() {{ :; }}
+{helper}
+bootstrap_recover_interrupted_repair 1 {cluster} {service_name}
+"""
+    result = subprocess.run(
+        [bash, "-s"],
+        input=harness.encode("utf-8"),
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 37
+    assert "candidate-action=repair-managed-binding" in stderr
+    assert stderr.count("fake-systemctl=start") == 1
+    assert "fake-systemctl=start-with-lifetime-guard" not in stderr
+    assert "worker_recovery=restored" in stderr
+
+
 def test_standalone_bootstrap_cannot_mutate_legacy_output() -> None:
     """Without a managed cluster identity bootstrap uses the fail-closed ordinary init path."""
     script = render_linux_user_bootstrap_script()

--- a/tests/test_bootstrap_fast_path.py
+++ b/tests/test_bootstrap_fast_path.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import base64
 import copy
 import hashlib
+import inspect
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -29,6 +31,7 @@ from clio_relay.bootstrap_reconcile import (
     BootstrapTransactionJournal,
     BootstrapTransactionState,
     JarvisStateEvidence,
+    execution_environment_identity,
     make_bootstrap_receipt,
 )
 from clio_relay.cluster_config import ClusterDefinition, ClusterRegistry
@@ -61,6 +64,63 @@ def _run_posix_embedded_driver(
     return subprocess.run(
         [*executable, "-I", "-c", launcher],
         input=json.dumps({"driver": driver, "arguments": encoded}),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+    )
+
+
+def _run_posix_project_driver(
+    driver: str,
+    *,
+    timeout_seconds: float = 120,
+) -> subprocess.CompletedProcess[str]:
+    """Run a Linux-only bootstrap integration probe against this checkout's source."""
+    source_root = Path(__file__).resolve().parents[1] / "src"
+    launcher = (
+        "import json,sys; payload=json.load(sys.stdin); "
+        "sys.path.insert(0,payload['source_root']); "
+        "exec(compile(payload['driver'],'<project-driver>','exec'))"
+    )
+    if os.name != "nt":
+        command = [sys.executable, "-c", launcher]
+        posix_source_root = str(source_root)
+    else:
+        converted = subprocess.run(
+            ["wsl.exe", "-e", "wslpath", "-a", str(source_root)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        posix_source_root = converted.stdout.strip()
+        discovered_uv = subprocess.run(
+            ["wsl.exe", "-e", "sh", "-lc", "command -v uv"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        command = [
+            "wsl.exe",
+            "-e",
+            discovered_uv,
+            "run",
+            "--no-project",
+            "--with",
+            "pydantic",
+            "--with",
+            "pyyaml",
+            "--with",
+            "packaging",
+            "--with",
+            "filelock",
+            "python",
+            "-c",
+            launcher,
+        ]
+    return subprocess.run(
+        command,
+        input=json.dumps({"driver": driver, "source_root": posix_source_root}),
         check=False,
         capture_output=True,
         text=True,
@@ -321,7 +381,7 @@ print("swapped-wheel-rejected")
 
 
 def test_candidate_verifier_accepts_pinned_uv_metadata_subset_only() -> None:
-    """Pinned uv metadata may vary by build path, while unknown members fail closed."""
+    """Pinned uv metadata and long-path launchers verify while unknown members fail closed."""
     driver = r"""
 import base64
 import csv
@@ -345,9 +405,14 @@ with tempfile.TemporaryDirectory() as value:
         capture_output=True,
     )
     wheel = next(built.glob("clio_relay-*.whl"))
-    tool_directory = workspace / "tools"
-    tool_bin_directory = workspace / "bin"
-    cache_directory = workspace / "cache"
+    real_home = workspace / "real-home"
+    real_home.mkdir()
+    home_alias = workspace / "home-alias"
+    home_alias.symlink_to(real_home, target_is_directory=True)
+    generation = home_alias / "share/clio-relay/generations" / ("f" * 128)
+    tool_directory = generation / "tools"
+    tool_bin_directory = generation / "bin"
+    cache_directory = generation / "cache"
     python_directory = Path.home() / ".local/share/clio-relay/uv-python"
     arguments = [
         sys.executable,
@@ -367,6 +432,22 @@ with tempfile.TemporaryDirectory() as value:
     accepted = subprocess.run(arguments, check=False, capture_output=True, text=True)
     if accepted.returncode != 0:
         raise SystemExit(accepted.stdout + accepted.stderr)
+
+    internal_launcher = tool_directory / "clio-relay/bin/clio-relay"
+    launcher_lines = internal_launcher.read_bytes().splitlines()
+    if not launcher_lines or launcher_lines[0] != b"#!/bin/sh":
+        raise SystemExit("the long uv tool path did not produce its shell trampoline")
+    provider = tool_directory / "clio-relay/bin/python"
+    subprocess.run(
+        [
+            provider,
+            "-I",
+            "-c",
+            'from importlib.metadata import version; assert version("clio-relay")',
+        ],
+        check=True,
+        capture_output=True,
+    )
 
     site_packages = next((tool_directory / "clio-relay").glob("lib/python*/site-packages"))
     record = next(site_packages.glob("clio_relay-*.dist-info/RECORD"))
@@ -683,7 +764,9 @@ def test_staged_provider_exec_is_hash_bound_sealed_and_venv_aware(tmp_path: Path
     provider = provider_root / "bin/python"
     relay = generation / "bin/clio-relay"
     relay.parent.mkdir(parents=True)
-    relay_payload = f"#!{provider}\n# staged relay launcher\n".encode()
+    relay_payload = (
+        f"#!/bin/sh\n'''exec' '{provider}' \"$0\" \"$@\"\n' '''\n# staged relay launcher\n"
+    ).encode()
     relay.write_bytes(relay_payload)
     relay.chmod(0o755)
     provider_sha256 = hashlib.sha256(provider.resolve(strict=True).read_bytes()).hexdigest()
@@ -787,6 +870,409 @@ def test_staged_provider_exec_is_hash_bound_sealed_and_venv_aware(tmp_path: Path
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "sealed-provider-ok"
     assert preload_marker.read_bytes() == b""
+
+
+def test_active_generation_identity_accepts_lexical_home_alias() -> None:
+    """A managed generation and provider survive a lexical HOME mount alias."""
+    script = bootstrap.render_linux_user_bootstrap_script(cluster="cluster-a")
+    start = script.index("bootstrap_active_generation_identity() {")
+    provider_start = script.index("bootstrap_active_generation_provider() {", start)
+    end = script.index("\n}\n", provider_start) + len("\n}\n")
+    function_source = script[start:end]
+    provider_discovery = script.index(
+        'BOOTSTRAP_CURRENT_PROVIDER="$(bootstrap_active_generation_provider',
+    )
+    assert start < provider_start < provider_discovery
+    driver = r"""
+import base64
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+function_source = base64.b64decode(sys.argv[1]).decode()
+with tempfile.TemporaryDirectory() as value:
+    workspace = Path(value)
+    canonical_home = workspace / "canonical-home"
+    canonical_home.mkdir()
+    lexical_home = workspace / "home-alias"
+    lexical_home.symlink_to(canonical_home, target_is_directory=True)
+    identity = "a" * 64
+    generation = lexical_home / ".local/share/clio-relay/generations" / identity
+    generation.mkdir(parents=True)
+    provider = generation / "tools/clio-relay/bin/python"
+    provider.parent.mkdir(parents=True)
+    provider.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    provider.chmod(0o755)
+    current = lexical_home / ".local/share/clio-relay/current"
+    current.symlink_to(generation, target_is_directory=True)
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            function_source
+            + "\nbootstrap_active_generation_identity"
+            + "\nbootstrap_active_generation_provider",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "HOME": str(lexical_home)},
+    )
+    if result.returncode != 0:
+        raise SystemExit(result.stdout + result.stderr)
+    values = result.stdout.splitlines()
+    if values != [identity, str(provider.resolve())]:
+        raise SystemExit(
+            "active generation identity/provider did not survive the HOME alias: "
+            + repr(values)
+        )
+print("active-generation-alias-ok")
+"""
+    result = _run_posix_embedded_driver(driver, function_source)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == "active-generation-alias-ok"
+
+
+def test_execution_boundary_round_trips_real_uv_venv_through_home_alias() -> None:
+    """A real uv Python symlink remains inside the lexical venv boundary."""
+    function_source = inspect.getsource(execution_environment_identity)
+    driver = r"""
+import base64
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+class ConfigurationError(Exception):
+    pass
+
+def sha256_file(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+def _stat_identity(value):
+    return (
+        value.st_dev,
+        value.st_ino,
+        value.st_mode,
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_ctime_ns,
+    )
+
+source = base64.b64decode(sys.argv[1]).decode()
+exec(compile(source, "<execution-environment-identity>", "exec"), globals())
+uv = shutil.which("uv") or str(Path.home() / ".local/bin/uv")
+if not Path(uv).is_file():
+    raise SystemExit("uv is unavailable in the Linux acceptance runtime")
+with tempfile.TemporaryDirectory() as value:
+    workspace = Path(value)
+    canonical_home = workspace / "canonical-home"
+    canonical_home.mkdir()
+    lexical_home = workspace / "home-alias"
+    lexical_home.symlink_to(canonical_home, target_is_directory=True)
+    root = lexical_home / ".local/share/clio-relay/jarvis-venv"
+    subprocess.run(
+        [uv, "venv", "--python", sys.executable, "--no-project", str(root)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    python = root / "bin/python"
+    if not python.is_symlink() or python.resolve().is_relative_to(root.resolve()):
+        raise SystemExit("uv did not create the required external Python symlink")
+    jarvis = root / "bin/jarvis"
+    jarvis.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    jarvis.chmod(0o755)
+    identity = execution_environment_identity(
+        root,
+        executables={"python": python, "jarvis": jarvis},
+    )
+    executables = identity["executables"]
+    repeated = execution_environment_identity(
+        Path(identity["root"]),
+        executables={
+            "python": Path(executables["python"]["lexical_path"]),
+            "jarvis": Path(executables["jarvis"]["lexical_path"]),
+        },
+    )
+    if repeated != identity:
+        raise SystemExit("aliased uv execution identity did not round trip")
+    if not identity["root"].startswith(str(lexical_home)):
+        raise SystemExit("execution identity discarded the lexical HOME alias")
+print("uv-venv-alias-ok")
+"""
+    result = _run_posix_embedded_driver(driver, function_source, timeout_seconds=120)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == "uv-venv-alias-ok"
+
+
+def test_aliased_home_generation_activation_reaches_exact_noop() -> None:
+    """Real Linux links activate once and then inspect as an exact warm no-op."""
+    driver = r"""
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+from clio_relay.bootstrap_reconcile import (
+    BootstrapActivationPath,
+    BootstrapDesiredState,
+    BootstrapReconcilePlan,
+    execution_environment_identity,
+    inspect_exact_bootstrap_noop,
+    reconcile_managed_jarvis_repository,
+    reconcile_staged_activation_links,
+    write_jarvis_wrapper,
+)
+
+def digest(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+with tempfile.TemporaryDirectory() as value:
+    workspace = Path(value)
+    canonical_home = workspace / "canonical-home"
+    canonical_home.mkdir()
+    home = workspace / "home-alias"
+    home.symlink_to(canonical_home, target_is_directory=True)
+    local_bin = home / ".local/bin"
+    local_bin.mkdir(parents=True)
+    binaries = {}
+    for name, payload in {
+        "uv": b"#!/bin/sh\necho 'uv 0.11.28'\n",
+        "frpc": b"#!/bin/sh\nexit 0\n",
+        "frps": b"#!/bin/sh\nexit 0\n",
+    }.items():
+        path = local_bin / name
+        path.write_bytes(payload)
+        path.chmod(0o755)
+        binaries[name] = path
+    desired = BootstrapDesiredState(
+        cluster="cluster-a",
+        core_dir="~/.local/share/clio-relay/core",
+        spool_dir="~/.local/share/clio-relay/spool",
+        worker_service="clio-relay-endpoint-cluster-a.service",
+        relay_install_spec="clio-relay==1.5.0",
+        relay_artifact_sha256="a" * 64,
+        relay_source_identity="wheel:sha256:" + "a" * 64,
+        frp_version="0.69.1",
+        frpc_sha256=digest(binaries["frpc"]),
+        frps_sha256=digest(binaries["frps"]),
+        uv_version="0.11.28",
+        uv_sha256=digest(binaries["uv"]),
+        jarvis_util_commit="commit",
+        jarvis_cd_version="1.4.4",
+        jarvis_cd_wheel_url="https://example.test/jarvis.whl",
+        jarvis_cd_wheel_sha256="c" * 64,
+        clio_kit_install_spec="https://example.test/clio-kit.whl",
+        clio_kit_version="2.3.1",
+        clio_kit_artifact_sha256="d" * 64,
+        agent_adapter="exec",
+    )
+    generation = home / ".local/share/clio-relay/generations" / desired.fingerprint
+    execution_root = generation / "jarvis-venv"
+    execution_bin = execution_root / "bin"
+    execution_bin.mkdir(parents=True)
+    execution_python = execution_bin / "python"
+    execution_python.symlink_to(sys.executable)
+    execution_jarvis = execution_bin / "jarvis"
+    execution_jarvis.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    execution_jarvis.chmod(0o755)
+    execution_identity = execution_environment_identity(
+        execution_root,
+        executables={"python": execution_python, "jarvis": execution_jarvis},
+    )
+    generation_bin = generation / "bin"
+    generation_bin.mkdir()
+    relay = generation_bin / "clio-relay"
+    relay.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    relay.chmod(0o755)
+    wrapper = write_jarvis_wrapper(generation_bin / "jarvis", execution_python)
+    (generation / "source/jarvis-packages/clio_relay").mkdir(parents=True)
+    receipt = generation / "install-receipt.json"
+    receipt.write_text("{}\n", encoding="utf-8")
+    activation_paths = {
+        "current": BootstrapActivationPath(
+            path=str(home / ".local/share/clio-relay/current"), kind="symlink"
+        ),
+        "install_receipt": BootstrapActivationPath(
+            path=str(home / ".local/share/clio-relay/install-receipt.json"),
+            kind="file_or_symlink",
+        ),
+        "relay_launcher": BootstrapActivationPath(
+            path=str(home / ".local/bin/clio-relay"), kind="file_or_symlink"
+        ),
+        "jarvis_launcher": BootstrapActivationPath(
+            path=str(home / ".local/bin/jarvis"), kind="file_or_symlink"
+        ),
+        "managed_repo": BootstrapActivationPath(
+            path=str(home / ".local/share/clio-relay/managed-jarvis-repo"),
+            kind="symlink",
+        ),
+    }
+    plan = BootstrapReconcilePlan(
+        mode="component-upgrade",
+        desired_fingerprint=desired.fingerprint,
+        component_actions={"clio-relay": "replace"},
+        activation_paths=activation_paths,
+    )
+    manifest = {
+        "schema_version": "clio-relay.bootstrap-generation.v1",
+        "fingerprint": desired.fingerprint,
+        "plan": plan.model_dump(mode="json"),
+        "legacy_execution_identity": execution_identity,
+        "active_execution_identity": execution_identity,
+        "jarvis_wrapper_sha256": wrapper["sha256"],
+        "install_receipt": str(receipt),
+        "install_receipt_sha256": digest(receipt),
+    }
+    (generation / "manifest.json").write_text(
+        json.dumps(manifest, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    first_activation = reconcile_staged_activation_links(
+        plan, generation=generation, home=home
+    )
+    jarvis_root = home / ".ppi-jarvis"
+    jarvis_root.mkdir()
+    roots = {}
+    for name in ("jarvis-config", "jarvis-private", "jarvis-shared"):
+        path = home / ".local/share/clio-relay" / name
+        path.mkdir(parents=True)
+        roots[name] = str(path.resolve())
+    (jarvis_root / "jarvis_config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "config_dir": roots["jarvis-config"],
+                "private_dir": roots["jarvis-private"],
+                "shared_dir": roots["jarvis-shared"],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    previous_repo = home / ".local/src/clio-relay/jarvis-packages/clio_relay"
+    previous_repo.mkdir(parents=True)
+    repos_file = jarvis_root / "repos.yaml"
+    repos_file.write_text(
+        yaml.safe_dump({"repos": [str(previous_repo), "/operator/clio_relay"]}),
+        encoding="utf-8",
+    )
+    (jarvis_root / "resource_graph.yaml").write_text(
+        "storage:\n  nvme:\n    capacity: 100\n", encoding="utf-8"
+    )
+    managed_repo = home / ".local/share/clio-relay/managed-jarvis-repo"
+    first_repository = reconcile_managed_jarvis_repository(
+        repos_file,
+        managed_repo,
+        previous_managed_repos=(previous_repo,),
+        exchange_identity=desired.fingerprint,
+    )
+    installation = {
+        "schema_version": "clio-relay.installation-info.v1",
+        "receipt_matches_install": True,
+        "receipt": {
+            "install_spec": desired.relay_install_spec,
+            "artifact_sha256": desired.relay_artifact_sha256,
+            "deployment_fingerprint": desired.fingerprint,
+            "deployment_manifest": desired.model_dump(mode="json"),
+            "generation": desired.fingerprint,
+            "components": {
+                "clio-relay": "1.5.0",
+                "clio-kit": desired.clio_kit_version,
+                "jarvis-cd": desired.jarvis_cd_version,
+                "jarvis-util": desired.jarvis_util_commit,
+            },
+            "component_artifacts": {
+                "jarvis-cd": {
+                    "runtime_interpreters": {"execution": str(execution_python)}
+                }
+            },
+        },
+        "component_runtime": {
+            "clio-relay": {"persistent_tool_verified": True},
+            "clio-kit": {
+                "artifact_identity_verified": True,
+                "command_matches_receipt": True,
+                "locked_server_runtime_verified": True,
+                "native_execution_capability_verified": True,
+                "persistent_tool_verified": True,
+            },
+            "jarvis-cd": {"verified": True},
+        },
+    }
+    queue = {
+        "schema_version": "clio-relay.queue-readiness.v1",
+        "complete": True,
+        "sealed": True,
+        "repair_required": False,
+    }
+    worker = {
+        "schema_version": "clio-relay.worker-readiness.v1",
+        "cluster": "cluster-a",
+        "fresh": True,
+        "process_running": True,
+        "identity_matches_current": True,
+        "running": True,
+    }
+    first = inspect_exact_bootstrap_noop(
+        desired,
+        home=home,
+        service_was_active=True,
+        service_was_enabled=True,
+        queue_evidence=queue,
+        worker_evidence=worker,
+        installation_snapshot=installation,
+    )
+    second_activation = reconcile_staged_activation_links(
+        plan, generation=generation, home=home
+    )
+    second_repository = reconcile_managed_jarvis_repository(
+        repos_file,
+        managed_repo,
+        previous_managed_repos=(previous_repo,),
+        exchange_identity=desired.fingerprint,
+    )
+    second = inspect_exact_bootstrap_noop(
+        desired,
+        home=home,
+        service_was_active=True,
+        service_was_enabled=True,
+        queue_evidence=queue,
+        worker_evidence=worker,
+        installation_snapshot=installation,
+    )
+    if not first.exact_match or not second.exact_match:
+        raise SystemExit("exact inspection failed: " + repr(first.reasons + second.reasons))
+    if set(first_activation["actions"].values()) != {"created"}:
+        raise SystemExit("first activation did not create the stable paths")
+    if set(second_activation["actions"].values()) != {"reused"}:
+        raise SystemExit("warm activation was not a no-op")
+    if first_repository["action"] != "updated" or second_repository["action"] != "reused":
+        raise SystemExit("repository alias did not converge exactly once")
+    canonical_managed = str(
+        canonical_home / ".local/share/clio-relay/managed-jarvis-repo"
+    )
+    if yaml.safe_load(repos_file.read_text(encoding="utf-8"))["repos"] != [
+        canonical_managed,
+        "/operator/clio_relay",
+    ]:
+        raise SystemExit("repository registration did not retain one canonical stable path")
+print("aliased-activation-noop-ok")
+"""
+    result = _run_posix_project_driver(driver, timeout_seconds=180)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == "aliased-activation-noop-ok"
 
 
 def test_exact_remote_bootstrap_never_reads_or_builds_payload(
@@ -1033,6 +1519,196 @@ print("legacy-preflight-ok")
     execution = _run_posix_embedded_driver(execution_driver, remote_script)
     assert execution.returncode == 0, execution.stdout + execution.stderr
     assert execution.stdout.strip() == "legacy-preflight-ok"
+
+
+def test_preflight_allows_only_exact_repairable_queue_permission_report(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A current provider may defer one exact owner-repairable queue-root audit."""
+    identity = bootstrap.bootstrap_relay_identity(
+        source_root=tmp_path / "release",
+        relay_wheel=None,
+        relay_artifact_sha256="a" * 64,
+    )
+    desired = bootstrap._bootstrap_desired_state(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        identity=identity,
+        cluster="ares",
+        core_dir=bootstrap.DEFAULT_REMOTE_CORE_DIR,
+        spool_dir=bootstrap.DEFAULT_REMOTE_SPOOL_DIR,
+        frp_version=bootstrap.FRP_VERSION,
+        clio_kit_install_spec=bootstrap.CLIO_KIT_JARVIS_MCP_WHEEL_URL,
+        clio_kit_artifact_sha256=bootstrap.CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
+        agent_adapter="exec",
+        agent_npm_package=None,
+        agent_npm_bin=None,
+        agent_args=[],
+        jarvis_resource_graph_profile="ares",
+    )
+    observed: list[list[str]] = []
+
+    def run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        observed.append(command)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            "bootstrap_preflight_unsupported=repairable_queue_permissions\n",
+            "",
+        )
+
+    monkeypatch.setattr(bootstrap, "_run", run)
+    result = bootstrap._bootstrap_preflight_over_ssh(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        ssh_host="ares",
+        invocation_id="bootstrap_test",
+        desired=desired,
+        core_dir=bootstrap.DEFAULT_REMOTE_CORE_DIR,
+        spool_dir=bootstrap.DEFAULT_REMOTE_SPOOL_DIR,
+        repair=False,
+        timeout_seconds=30,
+    )
+
+    assert result.action == "payload_required"
+    assert len(observed) == 1
+    remote_script = observed[0][-1]
+    execution_driver = r"""
+import base64
+import json
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+script = base64.b64decode(sys.argv[1]).decode()
+expected = {
+    "schema_version": "clio-relay.legacy-state-audit.v1",
+    "family": "root",
+    "reason": "queue directory is readable or writable by another user",
+    "action": (
+        "move the unsafe state aside or export records with portable durable IDs "
+        "before retrying"
+    ),
+}
+
+
+def execute(report_path, *, action=None):
+    with tempfile.TemporaryDirectory() as value:
+        home = Path(value)
+        core = home / ".local/share/clio-relay/core"
+        core.mkdir(parents=True)
+        relay = home / ".local/bin/clio-relay"
+        relay.parent.mkdir(parents=True)
+        report = {**expected, "path": str(report_path(home, core))}
+        if action is not None:
+            report["action"] = action
+        output = "error: " + json.dumps(report, sort_keys=True, separators=(",", ":"))
+        relay.write_text(
+            "#!/bin/sh\nprintf '%s\\n' " + shlex.quote(output) + " >&2\nexit 1\n",
+            encoding="utf-8",
+        )
+        relay.chmod(0o700)
+        receipt = home / ".local/share/clio-relay/install-receipt.json"
+        receipt.parent.mkdir(parents=True, exist_ok=True)
+        receipt.write_text(
+            json.dumps(
+                {
+                    "component_artifacts": {
+                        "clio-relay": {"persistent_tool": {"kind": "uv-tool"}}
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        environment = {**os.environ, "HOME": str(home)}
+        return subprocess.run(
+            ["bash"],
+            input=script,
+            text=True,
+            capture_output=True,
+            env=environment,
+            check=False,
+        )
+
+
+accepted = execute(lambda _home, core: core)
+if accepted.returncode != 0:
+    raise SystemExit(accepted.stdout + accepted.stderr)
+if accepted.stdout.strip() != (
+    "bootstrap_preflight_unsupported=repairable_queue_permissions"
+):
+    raise SystemExit("exact repairable audit did not select the candidate payload path")
+
+wrong_path = execute(lambda home, _core: home / ".local/share/clio-relay/not-core")
+if wrong_path.returncode == 0 or "repairable_queue_permissions" in wrong_path.stdout:
+    raise SystemExit("a mismatched queue-root path was classified as repairable")
+
+wrong_action = execute(lambda _home, core: core, action="repair it automatically")
+if wrong_action.returncode == 0 or "repairable_queue_permissions" in wrong_action.stdout:
+    raise SystemExit("a non-contract audit action was classified as repairable")
+
+print("repairable-preflight-ok")
+"""
+    execution = _run_posix_embedded_driver(execution_driver, remote_script)
+    assert execution.returncode == 0, execution.stdout + execution.stderr
+    assert execution.stdout.strip() == "repairable-preflight-ok"
+
+
+def test_locked_recovery_privatizes_legacy_cursor_directory_on_posix() -> None:
+    """Recovery repairs the fixed legacy-only cursor family before auditing it."""
+    driver = r"""
+import stat
+import tempfile
+from pathlib import Path
+
+from clio_relay.bootstrap_reconcile import repair_legacy_cursor_permissions_for_upgrade
+from clio_relay.core_queue import ClioCoreQueue
+from clio_relay.errors import ConfigurationError
+from clio_relay.worker_lifetime_lock import exclusive_migration_lifetime
+
+with tempfile.TemporaryDirectory() as value:
+    core = Path(value) / "core"
+    core.mkdir(mode=0o755)
+    cursors = core / "cursors"
+    cursors.mkdir(mode=0o755)
+    with exclusive_migration_lifetime(core) as locked_core:
+        ClioCoreQueue(core).initialize(locked_core=locked_core)
+    if stat.S_IMODE(core.stat().st_mode) != 0o700:
+        raise SystemExit("queue root was not privatized")
+    if stat.S_IMODE(cursors.stat().st_mode) != 0o700:
+        raise SystemExit("legacy cursor directory was not privatized")
+    if not (core / "migrations/legacy-record-audit-v1.json").is_file():
+        raise SystemExit("legacy audit seal was not written")
+
+    compatibility_core = Path(value) / "compatibility-core"
+    compatibility_core.mkdir(mode=0o700)
+    compatibility_cursor = compatibility_core / "cursors"
+    compatibility_cursor.mkdir(mode=0o755)
+    repair = repair_legacy_cursor_permissions_for_upgrade(compatibility_core)
+    if repair.get("action") != "repaired":
+        raise SystemExit("compatibility repair did not report its mutation")
+    if stat.S_IMODE(compatibility_cursor.stat().st_mode) != 0o700:
+        raise SystemExit("compatibility repair did not privatize cursors")
+
+    unsafe_core = Path(value) / "unsafe-core"
+    unsafe_core.mkdir(mode=0o700)
+    outside = Path(value) / "outside"
+    outside.mkdir(mode=0o755)
+    (unsafe_core / "cursors").symlink_to(outside, target_is_directory=True)
+    try:
+        repair_legacy_cursor_permissions_for_upgrade(unsafe_core)
+    except ConfigurationError:
+        pass
+    else:
+        raise SystemExit("compatibility repair followed a cursor symlink")
+    if stat.S_IMODE(outside.stat().st_mode) != 0o755:
+        raise SystemExit("compatibility repair changed the symlink target")
+print("legacy-cursor-permissions-ok")
+"""
+    result = _run_posix_project_driver(driver)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == "legacy-cursor-permissions-ok"
 
 
 def test_public_cluster_bootstrap_noop_never_touches_nonexistent_wheel(
@@ -1905,6 +2581,10 @@ def test_staged_upgrade_uses_journal_bound_idempotent_forward_activation() -> No
     recovery = script[script.index("bootstrap_recover_previous_transaction()") : activation]
 
     assert "bootstrap_use_staged_provider()" in script
+    assert 'if os.environ.get("BOOTSTRAP_STAGED_GENERATION"):' in script
+    assert "from clio_relay import bootstrap_reconcile as module" in script
+    assert 'receipt_document.get("deployment_manifest")' in script
+    assert "staged install receipt omitted its desired state" in script
     assert "journal-phase prepared_manifest" in script
     assert provider_function.index("compgen -e") < provider_function.index("exec python3 -I -c")
     assert 'LD_*|PYTHON*|BASH_ENV|ENV) unset "$bootstrap_environment_name"' in provider_function
@@ -1912,6 +2592,22 @@ def test_staged_upgrade_uses_journal_bound_idempotent_forward_activation() -> No
     assert "bootstrap_candidate_action finish-activation" in recovery
     assert "phase_identities" in recovery
     assert "sha256sum --check --strict -" in recovery
+    assert "WORKER_LIFETIME_GUARD_FD=8" in recovery
+    assert 'CLIO_RELAY_WORKER_LIFETIME_GUARD_FD="$WORKER_LIFETIME_GUARD_FD"' in recovery
+    cursor_repair = recovery.index("bootstrap_candidate_action repair-legacy-cursors")
+    recovery_fence = recovery.index('bootstrap_fence_recovered_service "$service_name"')
+    recovery_lock = recovery.index("exec 8<>")
+    queue_init = recovery.index('"$HOME/.local/bin/clio-relay" init --migrate-legacy-output')
+    assert recovery_fence < recovery_lock < cursor_repair < queue_init
+    cursor_repair_prefix = recovery[max(0, cursor_repair - 160) : cursor_repair]
+    assert 'CLIO_RELAY_WORKER_LIFETIME_GUARD_FD="$WORKER_LIFETIME_GUARD_FD"' in (
+        cursor_repair_prefix
+    )
+    assert 'action != "repair-legacy-cursors"' in script
+    assert "export recovery_worker" not in recovery
+    assert "printf '%s\\n' \"$recovery_worker\" | python3 -c" in recovery
+    assert script.count("endpoint worker-info") == 6
+    assert script.count("--readiness-only") == 4
     assert "printf '%s\\n' \"bootstrap_reconcile_plan=$BOOTSTRAP_PLAN_JSON\" >&2" in script
     assert 'mv -Tf "$HOME/.local/share/clio-relay/.current.' not in script
     assert 'readlink "$HOME/.local/share/clio-relay/current"' not in script
@@ -1920,6 +2616,151 @@ def test_staged_upgrade_uses_journal_bound_idempotent_forward_activation() -> No
         'source/jarvis-packages/clio_relay"'
     ) in script
     assert "scancel" not in script
+
+
+def test_forward_recovery_fence_is_idempotent_after_prior_restart() -> None:
+    """A crash after restart is fenced again before forward migration resumes."""
+    script = bootstrap.render_linux_user_bootstrap_script(cluster="cluster-a")
+    start = script.index("bootstrap_fence_recovered_service() {")
+    end = script.index("\n}\n\nbootstrap_recover_interrupted_repair()", start) + 3
+    fence = script[start:end]
+    driver = r"""
+import base64
+import subprocess
+import sys
+
+fence = base64.b64decode(sys.argv[1]).decode()
+harness = r'''set -euo pipefail
+state=active
+stops=0
+systemctl() {
+  case " $* " in
+    *" stop "*) state=inactive; stops=$((stops + 1)) ;;
+    *" --property=LoadState "*) printf '%s\n' loaded ;;
+    *" --property=ActiveState "*) printf '%s\n' "$state" ;;
+    *) return 97 ;;
+  esac
+}
+''' + fence + r'''
+bootstrap_fence_recovered_service clio-relay-endpoint-cluster-a.service
+[ "$state" = inactive ]
+[ "$stops" = 1 ]
+bootstrap_fence_recovered_service clio-relay-endpoint-cluster-a.service
+[ "$stops" = 1 ]
+printf '%s\n' recovery-fence-ok
+'''
+result = subprocess.run(
+    ["bash"],
+    input=harness,
+    text=True,
+    capture_output=True,
+    check=False,
+)
+if result.returncode != 0:
+    raise SystemExit(result.stdout + result.stderr)
+print(result.stdout, end="")
+"""
+    execution = _run_posix_embedded_driver(driver, fence)
+
+    assert execution.returncode == 0, execution.stdout + execution.stderr
+    assert execution.stdout.strip() == "recovery-fence-ok"
+
+
+@pytest.mark.parametrize(
+    "interrupted_state",
+    (
+        BootstrapTransactionState.ACTIVATING,
+        BootstrapTransactionState.ACTIVATED,
+        BootstrapTransactionState.MIGRATION_STARTED,
+        BootstrapTransactionState.MIGRATED,
+        BootstrapTransactionState.STARTING,
+        BootstrapTransactionState.SERVICE_VERIFIED,
+    ),
+)
+def test_interrupted_repair_forward_recovery_does_not_require_staged_evidence(
+    interrupted_state: BootstrapTransactionState,
+) -> None:
+    """Every repair crash boundary dispatches its idempotent non-staged recovery."""
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.fail("bash is required to validate bootstrap repair recovery dispatch")
+    digest = "a" * 64
+    journal = BootstrapTransactionJournal(
+        invocation_id=f"repair-{interrupted_state.value}",
+        desired_fingerprint=digest,
+        mode="repair",
+        state=interrupted_state,
+        prepared_generation=digest,
+        service_name="clio-relay-endpoint-cluster-a.service",
+        service_was_active=True,
+        irreversible_boundary=True,
+    )
+    recovery_payload = journal.model_dump(mode="json")
+    recovery_payload["recovery_mode"] = journal.recovery_mode
+    assert recovery_payload["recovery_mode"] == "forward"
+
+    script = bootstrap.render_linux_user_bootstrap_script(cluster="cluster-a")
+    value_start = script.index("bootstrap_recovery_value() {")
+    value_end = script.index("\n}\n\nbootstrap_recover_service()", value_start) + 3
+    recover_start = script.index("bootstrap_recover_previous_transaction() {")
+    recover_end = script.index("\n}\n\nbootstrap_relay_only_reconcile()", recover_start) + 3
+    functions = (script[value_start:value_end] + script[recover_start:recover_end]).replace(
+        "\r\n", "\n"
+    )
+    harness = f"""set -euo pipefail
+export HOME="$(mktemp -d)"
+export BOOTSTRAP_DESIRED_STATE='{{"cluster":"cluster-a"}}'
+export BOOTSTRAP_TEST_RECOVERY_JSON={shlex.quote(json.dumps(recovery_payload))}
+bootstrap_candidate_action() {{
+  case "$1" in
+    recovery-plan) printf '%s\n' "$BOOTSTRAP_TEST_RECOVERY_JSON" ;;
+    recovery-complete) echo "recovery-complete" ;;
+    *) echo "unexpected-candidate-action=$1" >&2; return 91 ;;
+  esac
+}}
+bootstrap_recover_interrupted_repair() {{
+  echo "repair-recovery=$1:$2:$3"
+  BOOTSTRAP_REPAIR_RECOVERY_ACTIVE=1
+}}
+bootstrap_release_worker_lifetime_guard() {{ echo "lifetime-guard=released"; }}
+{functions}
+bootstrap_recover_previous_transaction
+"""
+    result = subprocess.run(
+        [bash, "-s"],
+        input=harness.encode("utf-8"),
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 0, stderr
+    assert "repair-recovery=1:cluster-a:clio-relay-endpoint-cluster-a.service" in stdout
+    assert stdout.count("recovery-complete") == 1
+    assert stdout.count("lifetime-guard=released") == 1
+    assert "prepared manifest" not in stderr
+
+
+def test_repair_recovery_replays_only_binding_queue_and_readiness_work() -> None:
+    """Repair recovery has no staged generation, download, or scheduler boundary."""
+    script = bootstrap.render_linux_user_bootstrap_script(cluster="cluster-a")
+    start = script.index("bootstrap_recover_interrupted_repair() {")
+    end = script.index("\n}\n\nbootstrap_recover_previous_transaction()", start)
+    recovery = script[start:end]
+    binding = recovery.index("bootstrap_candidate_action repair-managed-binding")
+    queue_check = recovery.index('"$HOME/.local/bin/clio-relay" queue readiness-info')
+    queue_repair = recovery.index("clio-relay init --migrate-legacy-output")
+    restart = recovery.index("if ! bootstrap_bounded_worker_restart", queue_repair)
+
+    assert binding < queue_check < queue_repair < restart
+    assert "bootstrap_require_worker_lifetime_guard" in recovery
+    assert "finish-activation" not in recovery
+    assert "prepared_manifest" not in recovery
+    assert "curl " not in recovery
+    assert "scancel" not in recovery
+    assert "sbatch" not in recovery
 
 
 def test_fresh_jarvis_hardware_graph_commands_are_exact_and_ordered() -> None:

--- a/tests/test_bootstrap_reconcile.py
+++ b/tests/test_bootstrap_reconcile.py
@@ -38,6 +38,7 @@ from clio_relay.bootstrap_reconcile import (
     reconcile_managed_jarvis_repository,
     reconcile_staged_activation_links,
     repair_managed_jarvis_binding,
+    resolve_receipt_bound_jarvis_python,
     validate_jarvis_builtin_result,
     write_jarvis_wrapper,
 )
@@ -48,6 +49,55 @@ from clio_relay.validation_report import sha256_file
 
 def _digest(value: bytes) -> str:
     return hashlib.sha256(value).hexdigest()
+
+
+def _create_directory_alias(alias: Path, target: Path) -> None:
+    """Create an ancestor-path alias on POSIX or unprivileged Windows."""
+    if os.name == "nt":
+        result = subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(alias), str(target)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise AssertionError(result.stdout + result.stderr)
+        return
+    alias.symlink_to(target, target_is_directory=True)
+
+
+def _simulate_file_symlink(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    path: Path,
+    target: Path,
+) -> None:
+    """Expose one file as a symlink without requiring Windows symlink privilege."""
+    details = path.lstat()
+    symlink_details = SimpleNamespace(
+        st_dev=details.st_dev,
+        st_ino=details.st_ino,
+        st_mode=stat.S_IFLNK | 0o777,
+        st_size=len(str(target)),
+        st_mtime_ns=details.st_mtime_ns,
+        st_ctime_ns=details.st_ctime_ns,
+        st_nlink=details.st_nlink,
+    )
+    original_lstat = Path.lstat
+    original_readlink = os.readlink
+
+    def simulated_lstat(candidate: Path) -> os.stat_result:
+        if candidate == path:
+            return cast(os.stat_result, symlink_details)
+        return original_lstat(candidate)
+
+    def simulated_readlink(candidate: Any, *args: Any, **kwargs: Any) -> Any:
+        if Path(candidate) == path:
+            return str(target)
+        return original_readlink(candidate, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "lstat", simulated_lstat)
+    monkeypatch.setattr(os, "readlink", simulated_readlink)
 
 
 def _desired(*, uv_sha256: str, frpc_sha256: str, frps_sha256: str) -> BootstrapDesiredState:
@@ -229,6 +279,66 @@ def test_exact_noop_is_read_only_and_preserves_operator_jarvis_bytes(
     assert {path: (path.read_bytes(), path.stat().st_mtime_ns) for path in before} == before
 
 
+def test_managed_repository_converges_home_alias_to_one_canonical_stable_path(
+    tmp_path: Path,
+) -> None:
+    """Repository migration neither loses nor duplicates a stable path through HOME aliases."""
+    desired = _desired(uv_sha256="a" * 64, frpc_sha256="b" * 64, frps_sha256="c" * 64)
+    canonical_home = tmp_path / "canonical-home"
+    canonical_home.mkdir()
+    lexical_home = tmp_path / "home-alias"
+    _create_directory_alias(lexical_home, canonical_home)
+    root, _config, _graph = _write_jarvis_state(lexical_home, desired)
+    managed = lexical_home / ".local/share/clio-relay/managed-jarvis-repo"
+    previous = lexical_home / ".local/src/clio-relay/jarvis-packages/clio_relay"
+    previous.mkdir(parents=True)
+    operator = "/operator/clio_relay"
+    repos_file = root / "repos.yaml"
+    repos_file.write_text(
+        yaml.safe_dump(
+            {"repos": [str(managed.absolute()), str(previous.absolute()), operator]},
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    evidence = reconcile_managed_jarvis_repository(
+        repos_file,
+        managed,
+        previous_managed_repos=(previous,),
+        exchange_identity=desired.fingerprint,
+    )
+
+    canonical_managed = str(canonical_home / ".local/share/clio-relay/managed-jarvis-repo")
+    canonical_previous = str(canonical_home / ".local/src/clio-relay/jarvis-packages/clio_relay")
+    assert yaml.safe_load(repos_file.read_text(encoding="utf-8"))["repos"] == [
+        canonical_managed,
+        operator,
+    ]
+    assert evidence["managed_repo"] == canonical_managed
+    assert evidence["added_managed_repos"] == [canonical_managed]
+    assert evidence["removed_previous_managed_repos"] == [canonical_previous]
+    assert inspect_jarvis_state(desired, home=lexical_home).managed_repo_registered is True
+
+    repeated = reconcile_managed_jarvis_repository(
+        repos_file,
+        managed,
+        previous_managed_repos=(previous,),
+        exchange_identity=desired.fingerprint,
+    )
+    assert repeated["action"] == "reused"
+
+    repos_file.write_text(
+        yaml.safe_dump(
+            {"repos": [str(managed.absolute()), canonical_managed, operator]},
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigurationError, match="multiple path aliases"):
+        reconcile_managed_jarvis_repository(repos_file, managed)
+
+
 def test_matching_receipt_with_tampered_runtime_is_not_a_noop(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -314,11 +424,48 @@ def test_first_legacy_upgrade_plans_relay_only_and_reuses_verified_components(
     )
     _write_jarvis_state(tmp_path, desired)
     (tmp_path / ".local/share/clio-relay/managed-jarvis-repo").rmdir()
-    legacy_python = (
-        tmp_path
-        / ".local/share/clio-relay/jarvis-venv"
-        / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
-    )
+    managed_generation = "b" * 64 if relay_provider == "staged-candidate" else None
+    execution_root = tmp_path / ".local/share/clio-relay/jarvis-venv"
+    if managed_generation is not None:
+        generation_root = tmp_path / ".local/share/clio-relay/generations" / managed_generation
+        execution_root = generation_root / "jarvis-venv"
+        execution_root.mkdir(parents=True)
+        _create_directory_alias(
+            tmp_path / ".local/share/clio-relay/current",
+            generation_root,
+        )
+
+        def captured_activation_paths(*, home: Path) -> dict[str, BootstrapActivationPath]:
+            assert home == tmp_path
+            return {
+                "current": BootstrapActivationPath(
+                    path=str(home / ".local/share/clio-relay/current"),
+                    kind="symlink",
+                ),
+                "install_receipt": BootstrapActivationPath(
+                    path=str(home / ".local/share/clio-relay/install-receipt.json"),
+                    kind="file_or_symlink",
+                ),
+                "relay_launcher": BootstrapActivationPath(
+                    path=str(home / ".local/bin/clio-relay"),
+                    kind="file_or_symlink",
+                ),
+                "jarvis_launcher": BootstrapActivationPath(
+                    path=str(home / ".local/bin/jarvis"),
+                    kind="file_or_symlink",
+                ),
+                "managed_repo": BootstrapActivationPath(
+                    path=str(home / ".local/share/clio-relay/managed-jarvis-repo"),
+                    kind="symlink",
+                ),
+            }
+
+        monkeypatch.setattr(
+            bootstrap_reconcile_module,
+            "_capture_reconcile_activation_paths",
+            captured_activation_paths,
+        )
+    legacy_python = execution_root / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
     legacy_python.parent.mkdir(parents=True)
     legacy_python.write_bytes(b"python")
     legacy_python.chmod(0o755)
@@ -379,11 +526,19 @@ def test_first_legacy_upgrade_plans_relay_only_and_reuses_verified_components(
             verify_replacement,
         )
     receipt = cast(dict[str, object], info["receipt"])
+    if managed_generation is not None:
+        receipt["generation"] = managed_generation
     receipt.pop("deployment_fingerprint")
     receipt.pop("deployment_manifest")
     receipt["component_artifacts"] = {
         "clio-relay": {
-            "runtime_executables": {"clio-relay": str(bin_dir / "clio-relay")},
+            "runtime_executables": {
+                "clio-relay": (
+                    "/stale/unbound/clio-relay"
+                    if relay_provider == "staged-candidate"
+                    else str(bin_dir / "clio-relay")
+                )
+            },
         },
         "clio-kit": {
             "artifact_sha256": desired.clio_kit_artifact_sha256,
@@ -461,12 +616,13 @@ def test_first_legacy_upgrade_plans_relay_only_and_reuses_verified_components(
         "frp": "reuse",
         "uv": "reuse",
     }
-    assert plan.reusable_paths["jarvis_execution_environment"] == str(
-        (tmp_path / ".local/share/clio-relay/jarvis-venv").resolve()
-    )
+    assert plan.reusable_paths["jarvis_execution_environment"] == str(execution_root.resolve())
     assert plan.activation_paths["current"].before is None
     assert plan.activation_paths["managed_repo"].before is None
-    assert plan.activation_paths["install_receipt"].before is not None
+    if managed_generation is None:
+        assert plan.activation_paths["install_receipt"].before is not None
+    else:
+        assert plan.activation_paths["install_receipt"].before is None
     if relay_provider == "staged-candidate":
         component_runtime = cast(dict[str, object], info["component_runtime"])
         clio_kit_runtime = cast(dict[str, object], component_runtime["clio-kit"])
@@ -478,6 +634,105 @@ def test_first_legacy_upgrade_plans_relay_only_and_reuses_verified_components(
         )
         assert rejected.mode == "full"
         assert rejected.reasons == ["clio-kit live runtime is not reusable"]
+    elif relay_provider == "verified-old":
+        relay_artifact = cast(
+            dict[str, object],
+            cast(dict[str, object], receipt["component_artifacts"])["clio-relay"],
+        )
+        relay_artifact["runtime_executables"] = {"clio-relay": "/stale/unbound/clio-relay"}
+        rejected = plan_bootstrap_reconcile(desired, home=tmp_path)
+        assert rejected.mode == "full"
+        assert rejected.reasons == ["clio-relay launcher is not bound to its install receipt"]
+
+
+def test_active_managed_generation_jarvis_environment_is_reusable(tmp_path: Path) -> None:
+    """A retained generation tool is reusable only while its generation is active."""
+    generation = "a" * 64
+    relay_root = tmp_path / ".local/share/clio-relay"
+    generation_root = relay_root / "generations" / generation
+    environment = generation_root / "jarvis-venv"
+    environment.mkdir(parents=True)
+    current = relay_root / "current"
+    _create_directory_alias(current, generation_root)
+
+    observed = bootstrap_reconcile_module._managed_generation_jarvis_environment(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        {"generation": generation},
+        execution_environment=environment,
+        home=tmp_path,
+    )
+
+    assert observed == environment.resolve(strict=True)
+    assert (
+        bootstrap_reconcile_module._managed_generation_jarvis_environment(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            {"generation": "not-a-generation"},
+            execution_environment=environment,
+            home=tmp_path,
+        )
+        is None
+    )
+
+
+def test_retained_generation_jarvis_environment_is_reusable(tmp_path: Path) -> None:
+    """A relay-only generation may retain a receipt-bound prior JARVIS environment."""
+    active_generation = "a" * 64
+    execution_generation = "b" * 64
+    relay_root = tmp_path / ".local/share/clio-relay"
+    active_root = relay_root / "generations" / active_generation
+    environment = relay_root / "generations" / execution_generation / "jarvis-venv"
+    active_root.mkdir(parents=True)
+    environment.mkdir(parents=True)
+    _create_directory_alias(relay_root / "current", active_root)
+
+    observed = bootstrap_reconcile_module._managed_generation_jarvis_environment(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        {"generation": active_generation},
+        execution_environment=environment,
+        home=tmp_path,
+    )
+
+    assert observed == environment.resolve(strict=True)
+
+
+def test_generation_jarvis_environment_accepts_home_directory_alias(tmp_path: Path) -> None:
+    """Receipt paths may use a lexical home alias that resolves to the managed root."""
+    generation = "a" * 64
+    relay_root = tmp_path / ".local/share/clio-relay"
+    generation_root = relay_root / "generations" / generation
+    environment = generation_root / "jarvis-venv"
+    environment.mkdir(parents=True)
+    _create_directory_alias(relay_root / "current", generation_root)
+    alias = tmp_path / "home-alias"
+    _create_directory_alias(alias, tmp_path)
+
+    observed = bootstrap_reconcile_module._managed_generation_jarvis_environment(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        {"generation": generation},
+        execution_environment=alias
+        / ".local/share/clio-relay/generations"
+        / generation
+        / "jarvis-venv",
+        home=tmp_path,
+    )
+
+    assert observed == environment.resolve(strict=True)
+
+
+def test_generation_jarvis_environment_rejects_unowned_layout(tmp_path: Path) -> None:
+    """A receipt cannot reuse a JARVIS directory outside the managed generation shape."""
+    active_generation = "a" * 64
+    relay_root = tmp_path / ".local/share/clio-relay"
+    active_root = relay_root / "generations" / active_generation
+    active_root.mkdir(parents=True)
+    environment = tmp_path / "jarvis-venv"
+    environment.mkdir()
+    _create_directory_alias(relay_root / "current", active_root)
+
+    assert (
+        bootstrap_reconcile_module._managed_generation_jarvis_environment(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            {"generation": active_generation},
+            execution_environment=environment,
+            home=tmp_path,
+        )
+        is None
+    )
 
 
 def test_replacement_provider_attests_real_private_uv_tool(
@@ -500,7 +755,10 @@ def test_replacement_provider_attests_real_private_uv_tool(
     assert len(wheels) == 1
     version = wheels[0].name.removeprefix("clio_relay-").removesuffix("-py3-none-any.whl")
 
+    canonical_home = tmp_path / "canonical-home"
+    canonical_home.mkdir()
     home = tmp_path / "home"
+    _create_directory_alias(home, canonical_home)
     preparing_parent = home / ".local/share/clio-relay/preparing"
     preparing_root = preparing_parent / "active"
     preparing_root.mkdir(parents=True, mode=0o700)
@@ -710,6 +968,10 @@ def test_existing_jarvis_144_plans_staged_component_upgrade_to_148(
         "error": "uv tool directory is unavailable",
         "persistent_tool_verified": False,
     }
+    component_runtime["jarvis-cd"] = {
+        "error": "installed JARVIS-CD version is stale",
+        "verified": False,
+    }
     component_artifacts: dict[str, object] = {
         "clio-relay": {
             "runtime_executables": {"clio-relay": str(bin_dir / "clio-relay")},
@@ -876,6 +1138,8 @@ def test_managed_repo_reconcile_preserves_same_name_operator_repository(tmp_path
     operator_repo = tmp_path / "operator/clio_relay"
     previous_managed = tmp_path / "legacy/clio_relay"
     managed_repo = tmp_path / "relay/managed-jarvis-repo"
+    previous_managed.parent.mkdir(parents=True)
+    managed_repo.parent.mkdir(parents=True)
     repos_file.write_text(
         yaml.safe_dump(
             {
@@ -914,6 +1178,8 @@ def test_managed_repo_reconcile_refuses_concurrent_operator_edit(
 ) -> None:
     repos_file = tmp_path / "repos.yaml"
     repos_file.write_text("repos:\n  - /operator/original\n", encoding="utf-8")
+    managed_repo = tmp_path / "relay/managed-jarvis-repo"
+    managed_repo.parent.mkdir(parents=True)
     operator_update = b"repos:\n  - /operator/concurrent\n"
     original_read = bootstrap_reconcile_module._read_regular_bounded_with_identity  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
     call_count = 0
@@ -938,7 +1204,7 @@ def test_managed_repo_reconcile_refuses_concurrent_operator_edit(
     with pytest.raises(ConfigurationError, match="changed .*reconciliation"):
         reconcile_managed_jarvis_repository(
             repos_file,
-            tmp_path / "relay/managed-jarvis-repo",
+            managed_repo,
         )
 
     assert repos_file.read_bytes() == operator_update
@@ -2086,6 +2352,203 @@ def test_active_generation_rejects_coordinated_manifest_and_wrapper_tamper(
             generation,
             desired=desired,
             installation=installation,
+        )
+
+
+def test_managed_jarvis_interpreter_is_bound_to_receipt_and_lexical_home(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Managed selection preserves the lexical venv while proving canonical identity."""
+    desired = _desired(uv_sha256="a" * 64, frpc_sha256="b" * 64, frps_sha256="c" * 64)
+    canonical_home = tmp_path / "canonical-home"
+    canonical_home.mkdir()
+    lexical_home = tmp_path / "home-alias"
+    _create_directory_alias(lexical_home, canonical_home)
+
+    generation = lexical_home / ".local/share/clio-relay/generations" / desired.fingerprint
+    execution_root = generation / "jarvis-venv"
+    execution_bin = execution_root / ("Scripts" if os.name == "nt" else "bin")
+    execution_bin.mkdir(parents=True)
+    execution_python = execution_bin / ("python.exe" if os.name == "nt" else "python")
+    execution_jarvis = execution_bin / ("jarvis.exe" if os.name == "nt" else "jarvis")
+    for path in (execution_python, execution_jarvis):
+        path.write_bytes(path.name.encode())
+        path.chmod(0o755)
+    execution_identity = execution_environment_identity(
+        execution_root,
+        executables={"python": execution_python, "jarvis": execution_jarvis},
+    )
+    generation_bin = generation / "bin"
+    generation_bin.mkdir()
+    (lexical_home / ".local/bin").mkdir(parents=True)
+    wrapper = write_jarvis_wrapper(generation_bin / "jarvis", execution_python)
+    receipt_path = generation / "install-receipt.json"
+    receipt_path.write_text("{}\n", encoding="utf-8")
+    manifest = {
+        "schema_version": "clio-relay.bootstrap-generation.v1",
+        "fingerprint": desired.fingerprint,
+        "plan": {
+            "mode": "component-upgrade",
+            "desired_fingerprint": desired.fingerprint,
+            "component_actions": {"jarvis-cd": "replace"},
+        },
+        "legacy_execution_identity": execution_identity,
+        "active_execution_identity": execution_identity,
+        "jarvis_wrapper_sha256": wrapper["sha256"],
+        "install_receipt": str(receipt_path),
+        "install_receipt_sha256": _digest(receipt_path.read_bytes()),
+    }
+    (generation / "manifest.json").write_text(
+        json.dumps(manifest, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    installation = _installation_info(desired)
+    receipt = cast(dict[str, object], installation["receipt"])
+    receipt["component_artifacts"] = {
+        "jarvis-cd": {"runtime_interpreters": {"execution": str(execution_python)}}
+    }
+
+    bootstrap_reconcile_module._verify_active_generation_jarvis_wrapper(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        generation.resolve(strict=True),
+        desired=desired,
+        installation=installation,
+    )
+
+    stable_paths: list[tuple[Path, Path]] = []
+
+    def verify_stable(path: Path, *, expected: Path, label: str) -> Path:
+        del label
+        stable_paths.append((path, expected))
+        return expected.resolve(strict=True)
+
+    def read_installation(path: Path | None = None) -> dict[str, object]:
+        assert path == lexical_home / ".local/share/clio-relay/install-receipt.json"
+        return installation
+
+    def classify_launcher(path: Path, *, lexical_home: Path) -> bool:
+        assert path == lexical_home / ".local/bin/jarvis"
+        assert lexical_home == tmp_path / "home-alias"
+        return True
+
+    monkeypatch.setattr(bootstrap_reconcile_module, "_verify_stable_symlink", verify_stable)
+    monkeypatch.setattr(bootstrap_reconcile_module, "installation_info", read_installation)
+    monkeypatch.setattr(
+        bootstrap_reconcile_module,
+        "_relay_managed_jarvis_launcher_selected",
+        classify_launcher,
+    )
+
+    selected = resolve_receipt_bound_jarvis_python(
+        str(canonical_home / ".local/bin/jarvis"),
+        home=lexical_home,
+    )
+
+    assert selected == str(execution_python)
+    assert len(stable_paths) == 3
+    assert Path(cast(str, selected)).resolve().is_relative_to(canonical_home.resolve())
+    assert cast(str, selected).startswith(str(lexical_home))
+
+
+def test_conventional_home_jarvis_launcher_without_relay_ownership_is_unmanaged(
+    tmp_path: Path,
+) -> None:
+    """A normal user-installed launcher may use the conventional local-bin path."""
+    launcher = tmp_path / ".local/bin/jarvis"
+    launcher.parent.mkdir(parents=True)
+    launcher.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    launcher.chmod(0o755)
+
+    selected = resolve_receipt_bound_jarvis_python(
+        str(launcher),
+        home=tmp_path,
+    )
+
+    assert selected is None
+
+
+def test_conventional_home_jarvis_external_symlink_is_unmanaged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A uv- or pipx-style local-bin symlink remains outside relay ownership."""
+    launcher = tmp_path / ".local/bin/jarvis"
+    launcher.parent.mkdir(parents=True)
+    launcher.write_text("external-link-placeholder\n", encoding="utf-8")
+    external_target = tmp_path / ".local/share/uv/tools/jarvis-cd/bin/jarvis"
+    _simulate_file_symlink(
+        monkeypatch,
+        path=launcher,
+        target=external_target,
+    )
+
+    selected = resolve_receipt_bound_jarvis_python(
+        str(launcher),
+        home=tmp_path,
+    )
+
+    assert selected is None
+
+
+@pytest.mark.parametrize("receipt_payload", [None, "not-json\n"])
+def test_proven_managed_jarvis_launcher_fails_closed_on_missing_or_corrupt_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    receipt_payload: str | None,
+) -> None:
+    """Receipt loss cannot downgrade an already proven relay activation to unmanaged."""
+    launcher = tmp_path / ".local/bin/jarvis"
+    launcher.parent.mkdir(parents=True)
+    launcher.write_text("relay-managed-placeholder\n", encoding="utf-8")
+    receipt = tmp_path / ".local/share/clio-relay/install-receipt.json"
+    receipt.parent.mkdir(parents=True)
+    if receipt_payload is not None:
+        receipt.write_text(receipt_payload, encoding="utf-8")
+    _simulate_file_symlink(
+        monkeypatch,
+        path=launcher,
+        target=tmp_path / ".local/share/clio-relay/current/bin/jarvis",
+    )
+
+    with pytest.raises(ConfigurationError, match="installation receipt is invalid"):
+        resolve_receipt_bound_jarvis_python(
+            str(launcher),
+            home=tmp_path,
+        )
+
+
+def test_managed_jarvis_interpreter_fails_closed_on_unverified_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A managed launcher cannot fall back to ambient Python after receipt failure."""
+    desired = _desired(uv_sha256="a" * 64, frpc_sha256="b" * 64, frps_sha256="c" * 64)
+    installation = _installation_info(desired)
+    runtime = cast(dict[str, object], installation["component_runtime"])
+    runtime["jarvis-cd"] = {"verified": False}
+
+    def read_installation(_path: Path | None = None) -> dict[str, object]:
+        return installation
+
+    monkeypatch.setattr(
+        bootstrap_reconcile_module,
+        "installation_info",
+        read_installation,
+    )
+
+    def classify_launcher(_path: Path, *, lexical_home: Path) -> bool:
+        return lexical_home == tmp_path
+
+    monkeypatch.setattr(
+        bootstrap_reconcile_module,
+        "_relay_managed_jarvis_launcher_selected",
+        classify_launcher,
+    )
+
+    with pytest.raises(ConfigurationError, match="runtime did not verify"):
+        resolve_receipt_bound_jarvis_python(
+            str(tmp_path / ".local/bin/jarvis"),
+            home=tmp_path,
         )
 
 

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1699,7 +1699,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "04525a0c0fe2e944d49e4e40a77b9f746aa51b9725c6e470ed2d3bca4db809c5"
+        "fef11d9506323c61ae505af6e32131a669318c2851d49d31b68f154fb4f4aa4f"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import time
 from contextlib import nullcontext
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from threading import Thread
 from types import SimpleNamespace
@@ -33,7 +33,12 @@ from clio_relay.cluster_config import (
     cluster_route_revision,
 )
 from clio_relay.core_queue import ClioCoreQueue
-from clio_relay.errors import ConfigurationError, QueueConflictError, RelayError
+from clio_relay.errors import (
+    ConfigurationError,
+    ObservationTimeoutError,
+    QueueConflictError,
+    RelayError,
+)
 from clio_relay.jarvis_mcp import (
     CLIO_KIT_JARVIS_MCP_VERSION,
     CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
@@ -41,6 +46,7 @@ from clio_relay.jarvis_mcp import (
     jarvis_cd_lock_binding_expectation,
     jarvis_user_contract,
 )
+from clio_relay.live_acceptance import LiveAcceptanceOptions
 from clio_relay.models import (
     ArtifactRef,
     Cursor,
@@ -61,8 +67,12 @@ from clio_relay.models import (
     SchedulerPhase,
     SchedulerStatus,
 )
+from clio_relay.runtime_metadata import RUNTIME_METADATA_SCHEMA
 from clio_relay.scheduler_providers import SchedulerProvider
-from clio_relay.service_runtime import ServiceRuntimeSupervisor
+from clio_relay.service_runtime import (
+    ServiceRuntimePendingResult,
+    ServiceRuntimeSupervisor,
+)
 from clio_relay.session_lifecycle import (
     CleanupResource,
     OwnedSessionRecoveryStatus,
@@ -74,9 +84,12 @@ from clio_relay.session_lifecycle import (
 from clio_relay.validation_report import (
     EvidenceReference,
     LiveValidationReport,
+    ValidationCheck,
     ValidationRecorder,
     ValidationResource,
+    ValidationStatus,
     new_live_validation_report,
+    write_validation_report,
 )
 from tests.queue_validation_fixtures import (
     DeterministicQueueValidationProvider,
@@ -689,6 +702,44 @@ def test_endpoint_worker_without_explicit_provider_uses_cluster_registry(
     assert captured["closed"] is True
     provider = cast(SchedulerProvider, captured["scheduler_provider"])
     assert provider.name == "slurm"
+
+
+def test_endpoint_worker_info_exposes_bounded_readiness_mode(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Bootstrap can request readiness without exporting detailed installation records."""
+    observed: dict[str, object] = {}
+
+    def worker_info(**kwargs: object) -> dict[str, object]:
+        observed.update(kwargs)
+        return {
+            "schema_version": "clio-relay.worker-readiness.v1",
+            "cluster": kwargs["cluster"],
+            "running": True,
+        }
+
+    monkeypatch.setattr(cli, "worker_runtime_info", worker_info)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "endpoint",
+            "worker-info",
+            "--cluster",
+            "ares",
+            "--freshness-seconds",
+            "90",
+            "--readiness-only",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["schema_version"] == "clio-relay.worker-readiness.v1"
+    assert observed == {
+        "cluster": "ares",
+        "freshness_seconds": 90.0,
+        "readiness_only": True,
+    }
 
 
 def test_cli_lists_artifacts(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
@@ -5761,6 +5812,64 @@ def test_live_test_replaces_stale_success_when_secret_resolution_fails(
     assert "frp token" in (current.error or "")
 
 
+def test_live_test_resume_uses_sibling_report_and_preserves_checkpoint(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The CLI never seeds or overwrites the PENDING report selected for resume."""
+    monkeypatch.chdir(tmp_path)
+    _write_test_cluster(tmp_path)
+    pipeline = tmp_path / "pipeline.yaml"
+    pipeline.write_text("name: generic\npkgs: []\n", encoding="utf-8")
+    source_path = tmp_path / "pending-live-test.json"
+    source = new_live_validation_report(scenario="live-test", cluster="ares")
+    source.status = ValidationStatus.PENDING
+    source.completed_at = datetime.now(UTC)
+    write_validation_report(source, source_path)
+    source_bytes = source_path.read_bytes()
+    captured: list[LiveAcceptanceOptions] = []
+
+    def fake_run(options: LiveAcceptanceOptions) -> list[str]:
+        captured.append(options)
+        report_path = options.report_path
+        assert report_path is not None
+        report_id = options.report_id
+        report = new_live_validation_report(
+            scenario="live-test",
+            cluster="ares",
+            report_id=report_id,
+        )
+        report.status = ValidationStatus.PENDING
+        report.completed_at = datetime.now(UTC)
+        write_validation_report(report, report_path)
+        return ["validation.status=pending", f"validation.report={report_path.resolve()}"]
+
+    monkeypatch.setattr(cli, "run_live_acceptance", fake_run)
+    result = CliRunner().invoke(
+        app,
+        [
+            "live-test",
+            "--cluster",
+            "ares",
+            "--jarvis-yaml",
+            str(pipeline),
+            "--resume-report",
+            str(source_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert source_path.read_bytes() == source_bytes
+    assert len(captured) == 1
+    options = captured[0]
+    assert options.resume_report_path == source_path
+    output_path = options.report_path
+    assert output_path is not None
+    assert output_path != source_path
+    assert output_path.exists()
+    assert output_path.parent == source_path.parent
+
+
 def test_cli_session_teardown_defaults_to_keep_jobs(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -10030,6 +10139,186 @@ def test_cli_gateway_update_closed_session_reports_clean_error(
     assert "Traceback" not in updated.stderr
 
 
+def test_gateway_resume_reenters_exact_owner_session_admission(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Owned pending runtimes cannot resume outside their authoritative generation lock."""
+    core_dir = tmp_path / "core"
+    monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(core_dir))
+    monkeypatch.setenv("CLIO_RELAY_SPOOL_DIR", str(tmp_path / "spool"))
+    queue = ClioCoreQueue(core_dir)
+    queue.initialize()
+    owner_session_id = "desktop-session"
+    owner_generation_id = "generation-1"
+    owner_admission_id = cli._desktop_owner_session_admission_id(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        cluster="test-cluster",
+        session_id=owner_session_id,
+    )
+    queue.mirror_owner_session_generation_open(
+        owner_admission_id,
+        session_generation_id=owner_generation_id,
+    )
+    gateway = queue.create_gateway_session(
+        GatewaySession(
+            cluster="test-cluster",
+            name="pending-runtime",
+            state=GatewaySessionState.PENDING,
+            metadata={
+                "owner": "clio-relay",
+                "owner_session_id": owner_session_id,
+                "owner_session_generation_id": owner_generation_id,
+                "owner_session_admission_id": owner_admission_id,
+            },
+        )
+    )
+    definition = ClusterDefinition(name="test-cluster", ssh_host="test-login")
+    events: list[str] = []
+
+    class FakeResult:
+        def __init__(self, session: GatewaySession) -> None:
+            self.session = session
+
+        def to_live_validation_report(self, **_kwargs: object) -> LiveValidationReport:
+            report = new_live_validation_report(
+                scenario="gateway-runtime",
+                cluster="test-cluster",
+            )
+            recorder = ValidationRecorder(report)
+            with recorder.check("gateway.resume", "resume exact gateway"):
+                pass
+            recorder.finish()
+            return report
+
+    class FakeSupervisor:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        def resume_start(self, *, session_id: str) -> FakeResult:
+            events.append("resume")
+            assert session_id == gateway.session_id
+            return FakeResult(queue.get_gateway_session(session_id))
+
+    def admit(**kwargs: object) -> nullcontext[SimpleNamespace]:
+        events.append("admit")
+        assert kwargs["session_id"] == owner_session_id
+        assert kwargs["session_generation_id"] == owner_generation_id
+        return nullcontext(
+            SimpleNamespace(
+                owner_session_id=owner_session_id,
+                owner_session_generation_id=owner_generation_id,
+                owner_session_admission_id=owner_admission_id,
+            )
+        )
+
+    def require_cluster(_cluster: str) -> ClusterDefinition:
+        return definition
+
+    def selected_queue(_settings: cli.RelaySettings) -> ClioCoreQueue:
+        return queue
+
+    def ignore_verified_report(
+        _report: LiveValidationReport,
+        _definition: ClusterDefinition,
+        _path: Path,
+    ) -> None:
+        return None
+
+    monkeypatch.setattr(cli, "_require_cluster", require_cluster)
+    monkeypatch.setattr(cli, "storage_managed_queue", selected_queue)
+    monkeypatch.setattr(cli, "ServiceRuntimeSupervisor", FakeSupervisor)
+    monkeypatch.setattr(cli, "owner_session_gateway_admission", admit)
+    monkeypatch.setattr(cli, "_write_remote_verified_report", ignore_verified_report)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "gateway",
+            "resume-runtime",
+            gateway.session_id,
+            "--cluster",
+            "test-cluster",
+            "--token",
+            "token",
+            "--secret-key",
+            "secret",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert events == ["admit", "resume"]
+
+
+def test_gateway_attach_runtime_prints_pending_resume_contract(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Attach must not strip a nonterminal gateway's exact retry selector."""
+    monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(tmp_path / "core"))
+    monkeypatch.setenv("CLIO_RELAY_SPOOL_DIR", str(tmp_path / "spool"))
+    definition = ClusterDefinition(name="test-cluster", ssh_host="test-login")
+    gateway = GatewaySession(
+        session_id="gateway_pending_attach",
+        cluster="test-cluster",
+        name="pending-runtime",
+        state=GatewaySessionState.STARTING,
+        scheduler="slurm",
+        scheduler_job_id="12345",
+        gateway={
+            "connect_url": "http://127.0.0.1:28777",
+            "health_url": "http://127.0.0.1:28777/healthz",
+            "stream_url": "http://127.0.0.1:28777/live-data",
+        },
+        metadata={"owner": "clio-relay"},
+    )
+
+    class FakeSupervisor:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        def attach(self, *, session_id: str) -> ServiceRuntimePendingResult:
+            assert session_id == gateway.session_id
+            return ServiceRuntimePendingResult(session=gateway)
+
+    def require_cluster(_cluster: str) -> ClusterDefinition:
+        return definition
+
+    monkeypatch.setattr(cli, "_require_cluster", require_cluster)
+    monkeypatch.setattr(cli, "ServiceRuntimeSupervisor", FakeSupervisor)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "gateway",
+            "attach-runtime",
+            gateway.session_id,
+            "--cluster",
+            definition.name,
+            "--token",
+            "token",
+            "--secret-key",
+            "secret",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["session_id"] == gateway.session_id
+    assert payload["outcome"] == "pending"
+    assert payload["retry_selector"] == {
+        "cluster": definition.name,
+        "gateway_session_id": gateway.session_id,
+        "scheduler_provider": "slurm",
+        "scheduler_job_id": "12345",
+    }
+    assert payload["scheduler_action"] == "none"
+    assert payload["relay_action"] == "none"
+    assert payload["scheduler_cancel_requested"] is False
+    assert "connect_url" not in payload["gateway"]
+    assert "health_url" not in payload["gateway"]
+    assert "stream_url" not in payload["gateway"]
+
+
 def test_cli_remote_agent_run_preserves_posix_prompt_path(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -10192,11 +10481,2156 @@ def test_post_run_execution_query_polls_progress_then_requests_artifacts_once(
 
     assert ["artifacts" in arguments for arguments in calls] == [False, False, True]
     assert all(0 < value <= 60 for value in timeout_values)
+    assert isinstance(result, cli._JarvisExecutionQueryAcceptance)  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
     assert result.call_job_id == "job-query-3"
     assert [item["state"] for item in result.lifecycle_observations] == [
         "running",
         "completed",
+        "completed",
     ]
+
+
+def test_post_run_execution_query_returns_exact_resumable_nonterminal_snapshot(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+    clock = iter((0.0, 0.0, 2.0, 6.0))
+
+    def evidence() -> dict[str, object]:
+        return {"transport": "stdio"}
+
+    session = SimpleNamespace(
+        tools_list_response={"tools": []},
+        tools_call_response={"result": {"structuredContent": {"job_id": "job-query-1"}}},
+        initialize_response={"protocolVersion": "2025-06-18"},
+        evidence=evidence,
+    )
+    mcp_result: dict[str, object] = {
+        "structured_result": {
+            "pipeline_id": "pipeline",
+            "execution_id": "execution",
+            "execution_handle": {
+                "schema_version": "jarvis.execution.handle.v1",
+                "pipeline_id": "pipeline",
+                "execution_id": "execution",
+                "mode": "scheduler",
+                "scheduler_provider": "slurm",
+                "scheduler_native_id": "4242",
+                "cluster": "ares",
+            },
+            "execution_record": {
+                "schema_version": "jarvis.execution.record.v1",
+                "pipeline_id": "pipeline",
+                "execution_id": "execution",
+                "mode": "scheduler",
+                "scheduler_provider": "slurm",
+                "scheduler_native_id": "4242",
+                "cluster": "ares",
+                "state": "submitted",
+                "terminal": False,
+                "return_code": None,
+                "error": None,
+            },
+            "progress": {
+                "schema_version": "jarvis.execution.progress.v1",
+                "pipeline_id": "pipeline",
+                "execution_id": "execution",
+                "execution_state": "submitted",
+                "terminal": False,
+                "packages": [],
+            },
+            "runtime_metadata": None,
+            "artifact_page": None,
+            "service_runtimes": None,
+        }
+    }
+
+    def execute_query(**kwargs: object) -> cli._JarvisExecutionQueryAttempt:  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        calls.append(cast(dict[str, object], kwargs["arguments"]))
+        return cli._JarvisExecutionQueryAttempt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            session=cast(cli.PackagedMcpStdioSession, session),
+            call_job_id="job-query-1",
+            call_status={"job": {"job_id": "job-query-1", "state": "succeeded"}},
+            artifacts=[{"artifact_id": "artifact-query-1"}],
+            mcp_result=cast(dict[str, Any], mcp_result),
+            provenance={"job": {"job_id": "job-query-1"}},
+        )
+
+    def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(cli, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(cli, "_execute_jarvis_execution_query", execute_query)
+    monkeypatch.setattr(cli, "sleep", no_sleep)
+
+    result = cli._run_post_run_jarvis_execution_query(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        cluster="ares",
+        definition=cast(ClusterDefinition, SimpleNamespace()),
+        queue=cast(ClioCoreQueue, SimpleNamespace()),
+        profile="user",
+        pipeline_id="pipeline",
+        execution_id="execution",
+        wait_timeout_seconds=5,
+        poll_seconds=2,
+    )
+
+    assert result.outcome == "observation_unknown"
+    assert calls == [
+        {
+            "cluster": "ares",
+            "pipeline_id": "pipeline",
+            "execution_id": "execution",
+            "include_progress": True,
+        }
+    ]
+    assert result.retry_selector() == {
+        "cluster": "ares",
+        "scheduler_cluster": "ares",
+        "pipeline_id": "pipeline",
+        "execution_id": "execution",
+        "scheduler_provider": "slurm",
+        "scheduler_native_id": "4242",
+        "last_query_job_id": "job-query-1",
+    }
+    assert result.scheduler_action == "none"
+    assert result.relay_action == "none"
+    assert [item["state"] for item in result.lifecycle_observations] == ["submitted"]
+
+
+def test_later_query_observation_timeout_preserves_latest_durable_snapshot(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A later transport deadline cannot discard an already proven execution handle."""
+
+    def evidence() -> dict[str, object]:
+        return {"transport": "stdio"}
+
+    session = SimpleNamespace(
+        tools_list_response={"tools": []},
+        tools_call_response={"result": {"structuredContent": {"job_id": "job-query-1"}}},
+        initialize_response={"protocolVersion": "2025-06-18"},
+        evidence=evidence,
+    )
+    attempt = cli._JarvisExecutionQueryAttempt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        session=cast(cli.PackagedMcpStdioSession, session),
+        call_job_id="job-query-1",
+        call_status={"terminal": True},
+        artifacts=[],
+        mcp_result={},
+        provenance={"job": {"job_id": "job-query-1"}},
+    )
+    calls = 0
+
+    def execute_query(**_kwargs: object) -> cli._JarvisExecutionQueryAttempt:  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return attempt
+        raise ObservationTimeoutError("later query observation expired")
+
+    def submitted_observation(
+        _mcp_result: dict[str, Any] | None,
+        **_kwargs: object,
+    ) -> dict[str, Any]:
+        return {
+            "query_job_id": "job-query-1",
+            "pipeline_id": "pipeline",
+            "execution_id": "execution",
+            "state": "submitted",
+            "terminal": False,
+            "execution_handle": {
+                "schema_version": "jarvis.execution.handle.v1",
+                "pipeline_id": "pipeline",
+                "execution_id": "execution",
+                "mode": "scheduler",
+                "scheduler_provider": "slurm",
+                "scheduler_native_id": "4242",
+                "cluster": "ares",
+            },
+            "execution_record": {
+                "schema_version": "jarvis.execution.record.v1",
+                "pipeline_id": "pipeline",
+                "execution_id": "execution",
+                "mode": "scheduler",
+                "scheduler_provider": "slurm",
+                "scheduler_native_id": "4242",
+                "cluster": "ares",
+                "state": "submitted",
+                "terminal": False,
+                "return_code": None,
+                "error": None,
+            },
+            "progress": {
+                "schema_version": "jarvis.execution.progress.v1",
+                "pipeline_id": "pipeline",
+                "execution_id": "execution",
+                "execution_state": "submitted",
+                "terminal": False,
+                "packages": [],
+            },
+        }
+
+    monkeypatch.setattr(cli, "monotonic", lambda: 0.0)
+    monkeypatch.setattr(cli, "_execute_jarvis_execution_query", execute_query)
+    monkeypatch.setattr(
+        cli,
+        "_jarvis_execution_lifecycle_observation",
+        submitted_observation,
+    )
+
+    def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(cli, "sleep", no_sleep)
+
+    result = cli._run_post_run_jarvis_execution_query(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        cluster="ares",
+        definition=cast(ClusterDefinition, SimpleNamespace()),
+        queue=cast(ClioCoreQueue, SimpleNamespace()),
+        profile="user",
+        pipeline_id="pipeline",
+        execution_id="execution",
+        wait_timeout_seconds=5.0,
+        poll_seconds=1.0,
+    )
+
+    assert calls == 2
+    assert result.outcome == "observation_unknown"
+    assert result.call_job_id == "job-query-1"
+    assert result.retry_selector()["scheduler_native_id"] == "4242"
+    assert [item["state"] for item in result.lifecycle_observations] == ["submitted"]
+
+
+def test_first_query_observation_timeout_returns_exact_query_only_pending(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A first observation timeout retains the known execution instead of failing it."""
+    selector: dict[str, object] = {
+        "cluster": "ares",
+        "scheduler_cluster": "ares",
+        "pipeline_id": "pipeline",
+        "execution_id": "execution",
+        "scheduler_provider": "slurm",
+        "scheduler_native_id": None,
+        "last_query_job_id": None,
+    }
+
+    def timeout(**_kwargs: object) -> None:
+        raise ObservationTimeoutError("first query remains queued")
+
+    monkeypatch.setattr(cli, "_execute_jarvis_execution_query", timeout)
+
+    result = cli._run_post_run_jarvis_execution_query(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        cluster="ares",
+        definition=ClusterDefinition(name="ares", ssh_host="ares"),
+        queue=cast(ClioCoreQueue, SimpleNamespace()),
+        profile="user",
+        pipeline_id="pipeline",
+        execution_id="execution",
+        retry_selector=selector,
+        wait_timeout_seconds=5,
+        poll_seconds=1,
+    )
+
+    assert isinstance(result, cli._JarvisExecutionQueryPending)  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    assert result.outcome == "observation_pending"
+    assert result.lifecycle_observations == ()
+    assert result.retry_selector() == selector
+    assert result.scheduler_action == "none"
+    assert result.relay_action == "retain"
+
+
+def test_terminal_execution_without_artifact_query_time_is_query_only_pending(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A terminal workload is never failed merely because artifact retrieval must resume."""
+    clock = iter((0.0, 0.0, 6.0))
+
+    def evidence() -> dict[str, object]:
+        return {"transport": "stdio"}
+
+    session = SimpleNamespace(
+        tools_list_response={"tools": []},
+        tools_call_response={"result": {"structuredContent": {"job_id": "job-query-1"}}},
+        initialize_response={"protocolVersion": "2025-06-18"},
+        evidence=evidence,
+    )
+    mcp_result: dict[str, Any] = {
+        "structured_result": {
+            "pipeline_id": "pipeline",
+            "execution_id": "execution",
+            "execution_handle": {
+                "schema_version": "jarvis.execution.handle.v1",
+                "pipeline_id": "pipeline",
+                "execution_id": "execution",
+                "mode": "scheduler",
+                "scheduler_provider": "slurm",
+                "scheduler_native_id": "4242",
+                "cluster": "ares",
+            },
+            "execution_record": {
+                "schema_version": "jarvis.execution.record.v1",
+                "pipeline_id": "pipeline",
+                "execution_id": "execution",
+                "mode": "scheduler",
+                "scheduler_provider": "slurm",
+                "scheduler_native_id": "4242",
+                "cluster": "ares",
+                "state": "completed",
+                "terminal": True,
+                "return_code": 0,
+                "error": None,
+            },
+            "progress": {
+                "schema_version": "jarvis.execution.progress.v1",
+                "pipeline_id": "pipeline",
+                "execution_id": "execution",
+                "execution_state": "completed",
+                "terminal": True,
+                "packages": [],
+            },
+            "runtime_metadata": None,
+            "artifact_page": None,
+            "service_runtimes": None,
+        }
+    }
+
+    def execute_query(**_kwargs: object) -> cli._JarvisExecutionQueryAttempt:  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        return cli._JarvisExecutionQueryAttempt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            session=cast(cli.PackagedMcpStdioSession, session),
+            call_job_id="job-query-1",
+            call_status={"terminal": True},
+            artifacts=[],
+            mcp_result=mcp_result,
+            provenance={"job_id": "job-query-1"},
+        )
+
+    monkeypatch.setattr(cli, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(cli, "_execute_jarvis_execution_query", execute_query)
+
+    result = cli._run_post_run_jarvis_execution_query(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        cluster="ares",
+        definition=cast(ClusterDefinition, SimpleNamespace()),
+        queue=cast(ClioCoreQueue, SimpleNamespace()),
+        profile="user",
+        pipeline_id="pipeline",
+        execution_id="execution",
+        wait_timeout_seconds=5,
+        poll_seconds=1,
+    )
+
+    assert result.outcome == "terminal_artifacts_pending"
+    assert result.retry_selector()["scheduler_native_id"] == "4242"
+    assert result.scheduler_action == "none"
+    assert result.relay_action == "none"
+    assert result.lifecycle_observations[-1]["terminal"] is True
+
+
+@pytest.mark.parametrize(
+    ("failure_type", "is_retryable"),
+    [
+        (ObservationTimeoutError, True),
+        (RelayError, False),
+    ],
+)
+def test_terminal_artifact_query_only_defers_typed_observation_timeout(
+    monkeypatch: MonkeyPatch,
+    failure_type: type[RelayError],
+    is_retryable: bool,
+) -> None:
+    """Contract and artifact-integrity failures cannot masquerade as pending work."""
+
+    def evidence() -> dict[str, object]:
+        return {"transport": "stdio"}
+
+    session = SimpleNamespace(
+        tools_list_response={"tools": []},
+        tools_call_response={"result": {"structuredContent": {"job_id": "job-query-1"}}},
+        initialize_response={"protocolVersion": "2025-06-18"},
+        evidence=evidence,
+    )
+    attempt = cli._JarvisExecutionQueryAttempt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        session=cast(cli.PackagedMcpStdioSession, session),
+        call_job_id="job-query-1",
+        call_status={"terminal": True},
+        artifacts=[],
+        mcp_result={},
+        provenance={"job": {"job_id": "job-query-1"}},
+    )
+    calls = 0
+
+    def execute_query(**_kwargs: object) -> cli._JarvisExecutionQueryAttempt:  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return attempt
+        raise failure_type("artifact query failed")
+
+    def terminal_observation(
+        _mcp_result: dict[str, Any] | None,
+        **_kwargs: object,
+    ) -> dict[str, Any]:
+        return {
+            "query_job_id": "job-query-1",
+            "pipeline_id": "pipeline",
+            "execution_id": "execution",
+            "state": "completed",
+            "terminal": True,
+            "execution_handle": {
+                "pipeline_id": "pipeline",
+                "execution_id": "execution",
+                "scheduler_provider": "slurm",
+                "scheduler_native_id": "4242",
+            },
+            "execution_record": {"state": "completed", "return_code": 0, "error": None},
+            "progress": {},
+        }
+
+    monkeypatch.setattr(cli, "monotonic", lambda: 0.0)
+    monkeypatch.setattr(cli, "_execute_jarvis_execution_query", execute_query)
+    monkeypatch.setattr(
+        cli,
+        "_jarvis_execution_lifecycle_observation",
+        terminal_observation,
+    )
+
+    def run_query() -> cli._JarvisExecutionQueryAcceptance:  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        result = cli._run_post_run_jarvis_execution_query(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            cluster="ares",
+            definition=cast(ClusterDefinition, SimpleNamespace()),
+            queue=cast(ClioCoreQueue, SimpleNamespace()),
+            profile="user",
+            pipeline_id="pipeline",
+            execution_id="execution",
+            wait_timeout_seconds=5.0,
+            poll_seconds=1.0,
+        )
+        assert isinstance(result, cli._JarvisExecutionQueryAcceptance)  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        return result
+
+    if is_retryable:
+        result = run_query()
+        assert result.outcome == "terminal_artifacts_pending"
+        assert result.lifecycle_observations[-1]["state"] == "completed"
+    else:
+        with pytest.raises(RelayError, match="artifact query failed"):
+            run_query()
+
+
+def test_nonterminal_jarvis_acceptance_report_is_pending_not_passed_or_failed() -> None:
+    now = datetime.now(UTC)
+    report = new_live_validation_report(scenario="remote-mcp", cluster="ares")
+    report.checks = [
+        ValidationCheck(
+            check_id="remote-mcp.jarvis-call",
+            summary="run dispatch is durable",
+            status=ValidationStatus.PASSED,
+            started_at=now,
+            completed_at=now,
+            evidence=[EvidenceReference(kind="test", excerpt="durable")],
+        ),
+        ValidationCheck(
+            check_id="remote-mcp.jarvis-live-progress",
+            summary="execution lifecycle reached terminal",
+            status=ValidationStatus.FAILED,
+            started_at=now,
+            completed_at=now,
+            evidence=[
+                EvidenceReference(
+                    kind="test",
+                    excerpt="valid nonterminal lifecycle",
+                    metadata={
+                        "assertions": {
+                            "observation_count_bounded": True,
+                            "query_identities_coherent": True,
+                            "scheduler_identity_optional_coherent_and_stable": True,
+                            "lifecycle_prefix_coherent": True,
+                            "package_progress_nonregressing": True,
+                        }
+                    },
+                )
+            ],
+            error="execution remains submitted",
+        ),
+        ValidationCheck(
+            check_id="remote-mcp.jarvis-execution-query",
+            summary="execution query includes final artifacts",
+            status=ValidationStatus.FAILED,
+            started_at=now,
+            completed_at=now,
+            evidence=[
+                EvidenceReference(
+                    kind="test",
+                    excerpt="valid durable query",
+                    metadata={
+                        "assertions": {
+                            "local_query_surface_verified": True,
+                            "server_artifact_binding_verified": True,
+                            "resumable_query_job_verified": True,
+                            "resumable_result_transport_verified": True,
+                            "resumable_result_envelope_verified": True,
+                            "resumable_identity_coherent": True,
+                            "resumable_lifecycle_coherent": True,
+                            "resumable_runner_semantic_validation_verified": True,
+                        }
+                    },
+                )
+            ],
+            error="artifact page is not terminal yet",
+        ),
+    ]
+
+    def evidence() -> dict[str, object]:
+        return {}
+
+    query = cli._JarvisExecutionQueryAcceptance(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        cluster="ares",
+        pipeline_id="pipeline",
+        execution_id="execution",
+        outcome="observation_unknown",
+        tools_list_response={},
+        call_response={},
+        call_job_id="job-query-1",
+        call_status={},
+        artifacts=[],
+        mcp_result=None,
+        provenance=None,
+        initialize_response={},
+        stdio_evidence=evidence(),
+        lifecycle_observations=[
+            {
+                "state": "submitted",
+                "terminal": False,
+                "execution_handle": {
+                    "cluster": "linux",
+                    "scheduler_provider": "slurm",
+                    "scheduler_native_id": "4242",
+                },
+            }
+        ],
+    )
+
+    pending = cli._mark_jarvis_validation_pending(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        report,
+        execution_query=query,
+    )
+
+    assert pending.status is ValidationStatus.PENDING
+    assert pending.error is None
+    assert [check.status for check in pending.checks] == [
+        ValidationStatus.PASSED,
+        ValidationStatus.PENDING,
+        ValidationStatus.PENDING,
+    ]
+    execution_resource = next(
+        resource for resource in pending.resources if resource.kind == "jarvis_execution"
+    )
+    assert execution_resource.resource_id == "execution"
+    assert execution_resource.metadata["retry_selector"] == {
+        "cluster": "ares",
+        "scheduler_cluster": "linux",
+        "pipeline_id": "pipeline",
+        "execution_id": "execution",
+        "scheduler_provider": "slurm",
+        "scheduler_native_id": "4242",
+        "last_query_job_id": "job-query-1",
+    }
+
+
+def test_nonterminal_jarvis_acceptance_does_not_mask_unrelated_failure() -> None:
+    now = datetime.now(UTC)
+    report = new_live_validation_report(scenario="remote-mcp", cluster="ares")
+    report.checks = [
+        ValidationCheck(
+            check_id="remote-mcp.jarvis-remote-contract",
+            summary="contract must match",
+            status=ValidationStatus.FAILED,
+            started_at=now,
+            completed_at=now,
+            error="contract mismatch",
+        )
+    ]
+    query = cli._JarvisExecutionQueryAcceptance(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        cluster="ares",
+        pipeline_id="pipeline",
+        execution_id="execution",
+        outcome="observation_unknown",
+        tools_list_response={},
+        call_response={},
+        call_job_id="job-query-1",
+        call_status={},
+        artifacts=[],
+        mcp_result=None,
+        provenance=None,
+        initialize_response={},
+        stdio_evidence={},
+        lifecycle_observations=[
+            {
+                "state": "submitted",
+                "terminal": False,
+                "execution_handle": {
+                    "cluster": "linux",
+                    "scheduler_provider": "slurm",
+                    "scheduler_native_id": "4242",
+                },
+            }
+        ],
+    )
+
+    unchanged = cli._mark_jarvis_validation_pending(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        report,
+        execution_query=query,
+    )
+
+    assert unchanged.status is ValidationStatus.FAILED
+    assert unchanged.checks[0].status is ValidationStatus.FAILED
+    assert unchanged.resources == []
+
+
+def _jarvis_resume_observation(
+    *,
+    query_job_id: str,
+    state: str,
+    terminal: bool,
+    scheduler_native_id: str | None,
+    scheduler_cluster: str | None = "test-cluster",
+) -> dict[str, Any]:
+    """Build one real-shape native execution observation for resume-loader tests."""
+    handle = {
+        "schema_version": "jarvis.execution.handle.v1",
+        "pipeline_id": "pipeline",
+        "execution_id": "execution",
+        "mode": "scheduler",
+        "scheduler_provider": "slurm",
+        "scheduler_native_id": scheduler_native_id,
+        "cluster": scheduler_cluster,
+    }
+    record = {
+        "schema_version": "jarvis.execution.record.v1",
+        "pipeline_id": "pipeline",
+        "execution_id": "execution",
+        "mode": "scheduler",
+        "scheduler_provider": "slurm",
+        "scheduler_native_id": scheduler_native_id,
+        "cluster": scheduler_cluster,
+        "state": state,
+        "terminal": terminal,
+        "return_code": 0 if terminal else None,
+        "error": None,
+    }
+    progress: dict[str, Any] = {
+        "schema_version": "jarvis.execution.progress.v1",
+        "pipeline_id": "pipeline",
+        "execution_id": "execution",
+        "execution_state": state,
+        "terminal": terminal,
+        "packages": [],
+    }
+    return {
+        "query_job_id": query_job_id,
+        "pipeline_id": "pipeline",
+        "execution_id": "execution",
+        "state": state,
+        "terminal": terminal,
+        "execution_handle": handle,
+        "execution_record": record,
+        "progress": progress,
+        "runtime_metadata": None,
+    }
+
+
+def _jarvis_resume_runtime_metadata(
+    *,
+    state: str,
+    scheduler_native_id: str | None,
+    scheduler_cluster: str | None = "test-cluster",
+) -> dict[str, Any]:
+    """Build the real native authority required by a resumable checkpoint."""
+    submitted = scheduler_native_id is not None
+    handle = {
+        "schema_version": "jarvis.execution.handle.v1",
+        "pipeline_id": "pipeline",
+        "execution_id": "execution",
+        "mode": "scheduler",
+        "scheduler_provider": "slurm",
+        "scheduler_native_id": scheduler_native_id,
+        "cluster": scheduler_cluster,
+    }
+    record = {
+        "schema_version": "jarvis.execution.record.v1",
+        "pipeline_id": "pipeline",
+        "pipeline_name": "pipeline",
+        "execution_id": "execution",
+        "mode": "scheduler",
+        "scheduler_provider": "slurm",
+        "scheduler_native_id": scheduler_native_id,
+        "cluster": scheduler_cluster,
+        "state": state,
+        "submitted": submitted,
+        "terminal": False,
+        "created_at": "2026-07-21T12:00:00Z",
+        "updated_at": "2026-07-21T12:00:01Z",
+        "return_code": None,
+        "error": None,
+        "metadata": {
+            "submission": {
+                "schema_version": "jarvis.scheduler.submission.v1",
+                "execution_id": "execution",
+                "provider": "slurm",
+                "scheduler_job_id": scheduler_native_id,
+                "scheduler_cluster": scheduler_cluster,
+                "submitted": submitted,
+                "identity_source": "scheduler_submit_api" if submitted else None,
+            }
+        },
+    }
+    progress: dict[str, Any] = {
+        "schema_version": "jarvis.execution.progress.v1",
+        "pipeline_id": "pipeline",
+        "execution_id": "execution",
+        "execution_state": state,
+        "terminal": False,
+        "packages": [],
+    }
+    return {
+        "schema_version": RUNTIME_METADATA_SCHEMA,
+        "source": "jarvis_mcp",
+        "pipeline_id": "pipeline",
+        "execution_id": "execution",
+        "scheduler_provider": "slurm",
+        "scheduler_job_id": scheduler_native_id,
+        "terminal": {
+            "state": state,
+            "terminal": False,
+            "returncode": None,
+            "reason": None,
+        },
+        "details": {
+            "native_execution": {
+                "execution_handle": handle,
+                "execution_record": record,
+                "progress": progress,
+            }
+        },
+    }
+
+
+def test_unobserved_query_checkpoint_resumes_after_multiday_delay_without_new_run(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Checkpoint age never turns a queued HPC execution into a failed or duplicate run."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(tmp_path / "core"))
+    monkeypatch.setenv("CLIO_RELAY_SPOOL_DIR", str(tmp_path / "spool"))
+    _write_test_cluster(tmp_path, name="test-cluster")
+    selector: dict[str, object] = {
+        "cluster": "test-cluster",
+        "scheduler_cluster": "test-cluster",
+        "pipeline_id": "pipeline",
+        "execution_id": "execution",
+        "scheduler_provider": "slurm",
+        "scheduler_native_id": "4242",
+        "last_query_job_id": None,
+    }
+    checkpoint: dict[str, Any] = {
+        "schema_version": cli._JARVIS_VALIDATION_RESUME_CHECKPOINT_SCHEMA,  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        "phase": "execution_query",
+        "observation_state": "not_observed",
+        "profile": "user",
+        "retry_selector": selector,
+        "builder_inputs": {
+            "cluster": "test-cluster",
+            "scheduler_cluster": "test-cluster",
+            "tool": "jarvis_run",
+            "runtime_metadata": _jarvis_resume_runtime_metadata(
+                state="submitted",
+                scheduler_native_id="4242",
+            ),
+        },
+        "lifecycle_observations": [],
+    }
+    report = new_live_validation_report(scenario="remote-mcp", cluster="test-cluster")
+    old_time = datetime.now(UTC) - timedelta(days=30)
+    report.started_at = old_time
+    report.completed_at = old_time
+    report.status = ValidationStatus.PENDING
+    report.resources = [
+        ValidationResource(
+            kind="jarvis_execution",
+            resource_id="execution",
+            role="resumable_acceptance_workload",
+            cluster="test-cluster",
+            provider="slurm",
+            state="observation_pending",
+            metadata={
+                "retry_selector": selector,
+                "outcome": "observation_pending",
+                "scheduler_action": "none",
+                "relay_action": "retain",
+                "resume_checkpoint": checkpoint,
+            },
+        )
+    ]
+    resume_path = tmp_path / "multiday-query-pending.json"
+    write_validation_report(report, resume_path)
+    query_calls: list[dict[str, object]] = []
+
+    def still_pending(**kwargs: object) -> cli._JarvisExecutionQueryPending:  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        query_calls.append(dict(kwargs))
+        return cli._JarvisExecutionQueryPending(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            cluster="test-cluster",
+            pipeline_id="pipeline",
+            execution_id="execution",
+            selector=cast(dict[str, object], kwargs["retry_selector"]),
+        )
+
+    def forbid_new_run(**_kwargs: object) -> None:
+        raise AssertionError("query-only resume must not dispatch jarvis_run")
+
+    def execute_locally(_definition: ClusterDefinition) -> bool:
+        return False
+
+    monkeypatch.setattr(cli, "_run_post_run_jarvis_execution_query", still_pending)
+    monkeypatch.setattr(cli, "run_packaged_mcp_stdio_session", forbid_new_run)
+    monkeypatch.setattr(cli, "should_execute_on_cluster", execute_locally)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "jarvis-mcp-validate",
+            "--cluster",
+            "test-cluster",
+            "--resume-report",
+            str(resume_path),
+            "--wait-timeout-seconds",
+            "5",
+            "--poll-seconds",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(query_calls) == 1
+    assert query_calls[0]["pipeline_id"] == "pipeline"
+    assert query_calls[0]["execution_id"] == "execution"
+    persisted = LiveValidationReport.model_validate_json(resume_path.read_text(encoding="utf-8"))
+    assert persisted.status is ValidationStatus.PENDING
+    persisted_selector = persisted.resources[0].metadata["retry_selector"]
+    assert persisted_selector["execution_id"] == "execution"
+    assert persisted.started_at == old_time
+
+
+def test_initial_relay_dispatch_timeout_resumes_exact_job_without_duplicate_run(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Once jarvis_run returns a receipt, resume observes that job and never calls it again."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(tmp_path / "core"))
+    monkeypatch.setenv("CLIO_RELAY_SPOOL_DIR", str(tmp_path / "spool"))
+    _write_test_cluster(tmp_path, name="test-cluster")
+    pending_path = tmp_path / "dispatch-pending.json"
+    stdio_calls: list[dict[str, object]] = []
+    dispatch_calls: list[str] = []
+
+    def discover(**_kwargs: object) -> tuple[str, dict[str, Any], list[dict[str, Any]], bytes]:
+        return "job-discovery", {}, [], b"{}"
+
+    def persist_discovery(**_kwargs: object) -> None:
+        return None
+
+    package_search = cli._JarvisPackageSearchAcceptance(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        tools_list_response={},
+        call_response={},
+        call_job_id="job-search",
+        call_status={},
+        artifacts=[],
+        mcp_result=None,
+        provenance=None,
+        initialize_response={},
+        stdio_evidence={},
+    )
+
+    def search(**_kwargs: object) -> cli._JarvisPackageSearchAcceptance:  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        return package_search
+
+    def run_session(**kwargs: object) -> SimpleNamespace:
+        stdio_calls.append(dict(kwargs))
+        call_response = {"result": {"structuredContent": {"job_id": "job-run"}}}
+        return SimpleNamespace(
+            tools_list_response={},
+            tools_call_response=call_response,
+            initialize_response={},
+            evidence=lambda: {"call_job_id": "job-run", "transport": "stdio"},
+        )
+
+    def complete_dispatch(**kwargs: object) -> dict[str, Any]:
+        checkpoint = cast(dict[str, Any], kwargs["checkpoint"])
+        selector = cast(dict[str, object], checkpoint["retry_selector"])
+        dispatch_calls.append(cast(str, selector["relay_job_id"]))
+        assert selector["relay_job_id"] == "job-run"
+        if len(dispatch_calls) == 1:
+            raise ObservationTimeoutError("relay dispatch remains queued")
+        return {
+            **cast(dict[str, Any], checkpoint["builder_inputs"]),
+            "call_status": {"terminal": True},
+            "runtime_metadata": _jarvis_resume_runtime_metadata(
+                state="submitted",
+                scheduler_native_id="4242",
+            ),
+        }
+
+    def build_report(**kwargs: Any) -> LiveValidationReport:
+        report = new_live_validation_report(
+            scenario="remote-mcp",
+            cluster=cast(str, kwargs["cluster"]),
+        )
+        if kwargs["query_call_job_id"] == "":
+            now = datetime.now(UTC)
+            report.completed_at = now
+            report.status = ValidationStatus.FAILED
+            report.checks = [
+                ValidationCheck(
+                    check_id="remote-mcp.jarvis-call",
+                    summary="relay dispatch reaches terminal observation",
+                    status=ValidationStatus.FAILED,
+                    started_at=report.started_at,
+                    completed_at=now,
+                    error="observation pending",
+                )
+            ]
+            return report
+        recorder = ValidationRecorder(report)
+        with recorder.check("jarvis.complete", "same execution completed") as evidence:
+            evidence.append(EvidenceReference(kind="test", excerpt="same durable execution"))
+        recorder.finish()
+        return report
+
+    def terminal_query(**kwargs: object) -> cli._JarvisExecutionQueryAcceptance:  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        pipeline_id = cast(str, kwargs["pipeline_id"])
+        execution_id = cast(str, kwargs["execution_id"])
+        return cli._JarvisExecutionQueryAcceptance(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            cluster="test-cluster",
+            pipeline_id=pipeline_id,
+            execution_id=execution_id,
+            outcome="terminal",
+            tools_list_response={},
+            call_response={},
+            call_job_id="job-query",
+            call_status={},
+            artifacts=[],
+            mcp_result=None,
+            provenance=None,
+            initialize_response={},
+            stdio_evidence={},
+            lifecycle_observations=[
+                _jarvis_resume_observation(
+                    query_job_id="job-query",
+                    state="completed",
+                    terminal=True,
+                    scheduler_native_id="4242",
+                )
+            ],
+        )
+
+    def execute_locally(_definition: ClusterDefinition) -> bool:
+        return False
+
+    monkeypatch.setattr(cli, "_run_jarvis_remote_contract_discovery", discover)
+    monkeypatch.setattr(cli, "_persist_jarvis_remote_contract_discovery", persist_discovery)
+    monkeypatch.setattr(cli, "_run_jarvis_package_search_query", search)
+    monkeypatch.setattr(cli, "run_packaged_mcp_stdio_session", run_session)
+    monkeypatch.setattr(cli, "_complete_jarvis_run_dispatch", complete_dispatch)
+    monkeypatch.setattr(cli, "_run_post_run_jarvis_execution_query", terminal_query)
+    monkeypatch.setattr(cli, "build_jarvis_mcp_validation_report", build_report)
+    monkeypatch.setattr(cli, "should_execute_on_cluster", execute_locally)
+
+    initial = CliRunner().invoke(
+        app,
+        [
+            "jarvis-mcp-validate",
+            "--cluster",
+            "test-cluster",
+            "--package-search-query",
+            "paraview",
+            "--arguments-json",
+            '{"pipeline_id":"pipeline"}',
+            "--wait-timeout-seconds",
+            "5",
+            "--poll-seconds",
+            "1",
+            "--report",
+            str(pending_path),
+        ],
+    )
+
+    assert initial.exit_code == 0, initial.output
+    assert len(stdio_calls) == 1
+    initial_arguments = cast(dict[str, object], stdio_calls[0]["arguments"])
+    assert isinstance(initial_arguments["idempotency_key"], str)
+    pending = LiveValidationReport.model_validate_json(pending_path.read_text(encoding="utf-8"))
+    checkpoint = pending.resources[-1].metadata["resume_checkpoint"]
+    assert checkpoint["phase"] == "jarvis_run_dispatch"
+    assert checkpoint["retry_selector"]["relay_job_id"] == "job-run"
+
+    resumed = CliRunner().invoke(
+        app,
+        [
+            "jarvis-mcp-validate",
+            "--cluster",
+            "test-cluster",
+            "--resume-report",
+            str(pending_path),
+            "--wait-timeout-seconds",
+            "5",
+            "--poll-seconds",
+            "1",
+        ],
+    )
+
+    assert resumed.exit_code == 0, resumed.output
+    assert len(stdio_calls) == 1
+    assert dispatch_calls == ["job-run", "job-run"]
+    final = LiveValidationReport.model_validate_json(pending_path.read_text(encoding="utf-8"))
+    assert final.status is ValidationStatus.PASSED
+
+
+def test_stdio_receipt_timeout_replays_only_the_same_idempotent_intent(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """An ambiguous stdio boundary may replay its key, but may not mint a new workload key."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(tmp_path / "core"))
+    monkeypatch.setenv("CLIO_RELAY_SPOOL_DIR", str(tmp_path / "spool"))
+    _write_test_cluster(tmp_path, name="test-cluster")
+    pending_path = tmp_path / "intent-pending.json"
+    observed_arguments: list[dict[str, object]] = []
+
+    def discover(
+        **_kwargs: object,
+    ) -> tuple[str, dict[str, Any], list[dict[str, Any]], bytes]:
+        return "job-discovery", {}, [], b"{}"
+
+    def persist_discovery(**_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(cli, "_run_jarvis_remote_contract_discovery", discover)
+    monkeypatch.setattr(cli, "_persist_jarvis_remote_contract_discovery", persist_discovery)
+    package_search = cli._JarvisPackageSearchAcceptance(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        tools_list_response={},
+        call_response={},
+        call_job_id="job-search",
+        call_status={},
+        artifacts=[],
+        mcp_result=None,
+        provenance=None,
+        initialize_response={},
+        stdio_evidence={},
+    )
+
+    def search(**_kwargs: object) -> cli._JarvisPackageSearchAcceptance:  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        return package_search
+
+    monkeypatch.setattr(cli, "_run_jarvis_package_search_query", search)
+
+    def run_session(**kwargs: object) -> SimpleNamespace:
+        observed_arguments.append(cast(dict[str, object], kwargs["arguments"]))
+        if len(observed_arguments) == 1:
+            pre_dispatch = LiveValidationReport.model_validate_json(
+                pending_path.read_text(encoding="utf-8")
+            )
+            assert (
+                pre_dispatch.resources[0].metadata["resume_checkpoint"]["phase"]
+                == "jarvis_run_intent"
+            )
+            raise ObservationTimeoutError("stdio response was not observed")
+        return SimpleNamespace(
+            tools_list_response={},
+            tools_call_response={"result": {"structuredContent": {"job_id": "job-run"}}},
+            initialize_response={},
+            evidence=lambda: {"call_job_id": "job-run", "transport": "stdio"},
+        )
+
+    def still_queued(**_kwargs: object) -> None:
+        raise ObservationTimeoutError("accepted relay job remains queued")
+
+    def build_pending(**kwargs: Any) -> LiveValidationReport:
+        report = new_live_validation_report(
+            scenario="remote-mcp",
+            cluster=cast(str, kwargs["cluster"]),
+        )
+        now = datetime.now(UTC)
+        report.completed_at = now
+        report.status = ValidationStatus.FAILED
+        report.checks = [
+            ValidationCheck(
+                check_id="remote-mcp.jarvis-call",
+                summary="relay dispatch reaches terminal observation",
+                status=ValidationStatus.FAILED,
+                started_at=report.started_at,
+                completed_at=now,
+                error="observation pending",
+            )
+        ]
+        return report
+
+    def execute_locally(_definition: ClusterDefinition) -> bool:
+        return False
+
+    monkeypatch.setattr(cli, "run_packaged_mcp_stdio_session", run_session)
+    monkeypatch.setattr(cli, "_complete_jarvis_run_dispatch", still_queued)
+    monkeypatch.setattr(cli, "build_jarvis_mcp_validation_report", build_pending)
+    monkeypatch.setattr(cli, "should_execute_on_cluster", execute_locally)
+
+    initial = CliRunner().invoke(
+        app,
+        [
+            "jarvis-mcp-validate",
+            "--cluster",
+            "test-cluster",
+            "--package-search-query",
+            "paraview",
+            "--arguments-json",
+            '{"pipeline_id":"pipeline"}',
+            "--wait-timeout-seconds",
+            "5",
+            "--poll-seconds",
+            "1",
+            "--report",
+            str(pending_path),
+        ],
+    )
+    assert initial.exit_code == 0, initial.output
+    first = LiveValidationReport.model_validate_json(pending_path.read_text(encoding="utf-8"))
+    assert first.resources[0].metadata["resume_checkpoint"]["phase"] == "jarvis_run_intent"
+
+    resumed = CliRunner().invoke(
+        app,
+        [
+            "jarvis-mcp-validate",
+            "--cluster",
+            "test-cluster",
+            "--resume-report",
+            str(pending_path),
+            "--wait-timeout-seconds",
+            "5",
+            "--poll-seconds",
+            "1",
+        ],
+    )
+
+    assert resumed.exit_code == 0, resumed.output
+    assert len(observed_arguments) == 2
+    assert observed_arguments[0] == observed_arguments[1]
+    assert observed_arguments[0]["idempotency_key"] == observed_arguments[1]["idempotency_key"]
+    second = LiveValidationReport.model_validate_json(pending_path.read_text(encoding="utf-8"))
+    second_checkpoint = second.resources[-1].metadata["resume_checkpoint"]
+    assert second_checkpoint["phase"] == "jarvis_run_dispatch"
+    assert second_checkpoint["retry_selector"]["relay_job_id"] == "job-run"
+
+
+def test_multiday_dispatch_intent_rejects_tampering_without_expiry(tmp_path: Path) -> None:
+    """Old checkpoints remain valid, while any change to their exact intent remains invalid."""
+    execution_intent = cli._jarvis_run_execution_intent(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        cluster="test-cluster",
+        profile="user",
+        arguments={"pipeline_id": "pipeline"},
+        idempotency_key="validation:jarvis-run:test-cluster:stable-key",
+    )
+    checkpoint = cli._new_jarvis_intent_resume_checkpoint(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        execution_intent=execution_intent,
+        pre_dispatch_inputs={
+            "cluster": "test-cluster",
+            "tool": "jarvis_run",
+            "package_search_query": "paraview",
+            "launcher": None,
+            "install_source": None,
+            "artifact_sha256": None,
+        },
+    )
+    report = cli._new_jarvis_intent_pending_report(checkpoint)  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    old_time = datetime.now(UTC) - timedelta(days=45)
+    report.started_at = old_time
+    report.completed_at = old_time
+    path = tmp_path / "old-intent.json"
+    write_validation_report(report, path)
+
+    loaded = cli._load_jarvis_validation_resume_checkpoint(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        path,
+        cluster="test-cluster",
+    )
+    assert loaded["retry_selector"]["pipeline_id"] == "pipeline"
+
+    tampered = LiveValidationReport.model_validate_json(path.read_text(encoding="utf-8"))
+    resource = tampered.resources[0]
+    tampered_checkpoint = cast(dict[str, Any], resource.metadata["resume_checkpoint"])
+    tampered_intent = cast(dict[str, Any], tampered_checkpoint["execution_intent"])
+    tampered_arguments = cast(dict[str, Any], tampered_intent["arguments"])
+    tampered_arguments["pipeline_id"] = "different-pipeline"
+    tampered_path = tmp_path / "tampered-intent.json"
+    write_validation_report(tampered, tampered_path)
+
+    with pytest.raises(ConfigurationError, match="dispatch identity changed"):
+        cli._load_jarvis_validation_resume_checkpoint(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            tampered_path,
+            cluster="test-cluster",
+        )
+
+
+def test_jarvis_validation_rejects_unresumable_secret_arguments(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """A resume checkpoint never persists credentials needed to replay a workload call."""
+    monkeypatch.chdir(tmp_path)
+    _write_test_cluster(tmp_path, name="test-cluster")
+    report_path = tmp_path / "secret-rejected.json"
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "jarvis-mcp-validate",
+            "--cluster",
+            "test-cluster",
+            "--package-search-query",
+            "paraview",
+            "--arguments-json",
+            '{"pipeline_id":"pipeline","api_token":"must-not-leak"}',
+            "--report",
+            str(report_path),
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "credential-redacted" in result.output
+    assert "must-not-leak" not in result.output
+    assert "must-not-leak" not in report_path.read_text(encoding="utf-8")
+
+
+def test_jarvis_mcp_validate_resume_report_queries_exact_execution_without_new_run(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    cluster_path = tmp_path / ".clio-relay" / "clusters.json"
+    cluster_path.parent.mkdir(parents=True)
+    cluster_path.write_text(
+        json.dumps(
+            {
+                "clusters": {
+                    "test-cluster": ClusterDefinition(
+                        name="test-cluster",
+                        ssh_host="test-login",
+                    ).model_dump(mode="json")
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(tmp_path / "core"))
+    monkeypatch.setenv("CLIO_RELAY_SPOOL_DIR", str(tmp_path / "spool"))
+    resume_path = tmp_path / "jarvis-pending.json"
+    prior_observation = _jarvis_resume_observation(
+        query_job_id="job-query-old",
+        state="submitted",
+        terminal=False,
+        scheduler_native_id="4242",
+    )
+    checkpoint = {
+        "schema_version": cli._JARVIS_VALIDATION_RESUME_CHECKPOINT_SCHEMA,  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        "phase": "execution_query",
+        "observation_state": "observed",
+        "profile": "user",
+        "retry_selector": {
+            "cluster": "test-cluster",
+            "scheduler_cluster": "test-cluster",
+            "pipeline_id": "pipeline",
+            "execution_id": "execution",
+            "scheduler_provider": "slurm",
+            "scheduler_native_id": "4242",
+            "last_query_job_id": "job-query-old",
+        },
+        "builder_inputs": {
+            "cluster": "test-cluster",
+            "scheduler_cluster": "test-cluster",
+            "tool": "jarvis_run",
+            "runtime_metadata": _jarvis_resume_runtime_metadata(
+                state="submitted",
+                scheduler_native_id="4242",
+            ),
+        },
+        "lifecycle_observations": [prior_observation],
+    }
+    pending_report = new_live_validation_report(
+        scenario="remote-mcp",
+        cluster="test-cluster",
+    )
+    pending_report.status = ValidationStatus.PENDING
+    pending_report.completed_at = datetime.now(UTC)
+    pending_report.resources.append(
+        ValidationResource(
+            kind="jarvis_execution",
+            resource_id="execution",
+            role="resumable_acceptance_workload",
+            cluster="test-cluster",
+            provider="slurm",
+            state="submitted",
+            metadata={
+                "retry_selector": checkpoint["retry_selector"],
+                "resume_checkpoint": checkpoint,
+            },
+        )
+    )
+    write_validation_report(pending_report, resume_path)
+    query_calls: list[tuple[str, str, str]] = []
+
+    def query_exact_execution(
+        *,
+        cluster: str,
+        definition: ClusterDefinition,
+        queue: ClioCoreQueue,
+        profile: str,
+        pipeline_id: str,
+        execution_id: str,
+        retry_selector: dict[str, object] | None,
+        wait_timeout_seconds: float,
+        poll_seconds: float,
+    ) -> cli._JarvisExecutionQueryAcceptance:  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        del definition, queue, retry_selector, wait_timeout_seconds, poll_seconds
+        query_calls.append((profile, pipeline_id, execution_id))
+        terminal_observation = _jarvis_resume_observation(
+            query_job_id="job-query-new",
+            state="completed",
+            terminal=True,
+            scheduler_native_id="4242",
+        )
+        return cli._JarvisExecutionQueryAcceptance(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            cluster=cluster,
+            pipeline_id=pipeline_id,
+            execution_id=execution_id,
+            outcome="terminal",
+            tools_list_response={},
+            call_response={},
+            call_job_id="job-query-new",
+            call_status={},
+            artifacts=[],
+            mcp_result=None,
+            provenance=None,
+            initialize_response={},
+            stdio_evidence={},
+            lifecycle_observations=[terminal_observation],
+        )
+
+    builder_calls: list[dict[str, Any]] = []
+
+    def build_report(**kwargs: Any) -> LiveValidationReport:
+        builder_calls.append(kwargs)
+        report = new_live_validation_report(
+            scenario="remote-mcp",
+            cluster="test-cluster",
+        )
+        recorder = ValidationRecorder(report)
+        with recorder.check("jarvis.resume", "resume exact execution") as evidence:
+            evidence.append(EvidenceReference(kind="test", excerpt="same execution"))
+        recorder.finish()
+        return report
+
+    def forbid_new_run(**_kwargs: object) -> None:
+        raise AssertionError("resume must not dispatch jarvis_run")
+
+    def execute_locally(_definition: ClusterDefinition) -> bool:
+        return False
+
+    monkeypatch.setattr(cli, "_run_post_run_jarvis_execution_query", query_exact_execution)
+    monkeypatch.setattr(cli, "build_jarvis_mcp_validation_report", build_report)
+    monkeypatch.setattr(cli, "run_packaged_mcp_stdio_session", forbid_new_run)
+    monkeypatch.setattr(cli, "should_execute_on_cluster", execute_locally)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "jarvis-mcp-validate",
+            "--cluster",
+            "test-cluster",
+            "--resume-report",
+            str(resume_path),
+            "--wait-timeout-seconds",
+            "5",
+            "--poll-seconds",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert query_calls == [("user", "pipeline", "execution")]
+    assert len(builder_calls) == 1
+    assert [
+        observation["state"] for observation in builder_calls[0]["query_lifecycle_observations"]
+    ] == ["submitted", "completed"]
+    completed = LiveValidationReport.model_validate_json(resume_path.read_text(encoding="utf-8"))
+    assert completed.status is ValidationStatus.PASSED
+
+
+def test_jarvis_resume_pending_returns_before_release_provenance_observation(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A durable pending workload survives an ancillary worker-info failure boundary."""
+    cluster_path = tmp_path / ".clio-relay" / "clusters.json"
+    cluster_path.parent.mkdir(parents=True)
+    cluster_path.write_text(
+        json.dumps(
+            {
+                "clusters": {
+                    "test-cluster": ClusterDefinition(
+                        name="test-cluster",
+                        ssh_host="test-login",
+                    ).model_dump(mode="json")
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(tmp_path / "core"))
+    monkeypatch.setenv("CLIO_RELAY_SPOOL_DIR", str(tmp_path / "spool"))
+    resume_path = tmp_path / "jarvis-pending.json"
+    prior_observation = _jarvis_resume_observation(
+        query_job_id="job-query-old",
+        state="submitting",
+        terminal=False,
+        scheduler_native_id=None,
+        scheduler_cluster=None,
+    )
+    selector = {
+        "cluster": "test-cluster",
+        "scheduler_cluster": None,
+        "pipeline_id": "pipeline",
+        "execution_id": "execution",
+        "scheduler_provider": "slurm",
+        "scheduler_native_id": None,
+        "last_query_job_id": "job-query-old",
+    }
+    checkpoint = {
+        "schema_version": cli._JARVIS_VALIDATION_RESUME_CHECKPOINT_SCHEMA,  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        "phase": "execution_query",
+        "observation_state": "observed",
+        "profile": "user",
+        "retry_selector": selector,
+        "builder_inputs": {
+            "cluster": "test-cluster",
+            "scheduler_cluster": None,
+            "tool": "jarvis_run",
+            "runtime_metadata": _jarvis_resume_runtime_metadata(
+                state="submitting",
+                scheduler_native_id=None,
+                scheduler_cluster=None,
+            ),
+        },
+        "lifecycle_observations": [prior_observation],
+    }
+    pending_report = new_live_validation_report(scenario="remote-mcp", cluster="test-cluster")
+    pending_report.status = ValidationStatus.PENDING
+    pending_report.completed_at = datetime.now(UTC)
+    pending_report.resources.append(
+        ValidationResource(
+            kind="jarvis_execution",
+            resource_id="execution",
+            role="resumable_acceptance_workload",
+            cluster="test-cluster",
+            provider="slurm",
+            state="submitting",
+            metadata={"retry_selector": selector, "resume_checkpoint": checkpoint},
+        )
+    )
+    write_validation_report(pending_report, resume_path)
+
+    def query_exact_execution(**kwargs: object) -> cli._JarvisExecutionQueryAcceptance:  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        observation = _jarvis_resume_observation(
+            query_job_id="job-query-new",
+            state="submitted",
+            terminal=False,
+            scheduler_native_id="4242",
+            scheduler_cluster="linux",
+        )
+        return cli._JarvisExecutionQueryAcceptance(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            cluster=cast(str, kwargs["cluster"]),
+            pipeline_id=cast(str, kwargs["pipeline_id"]),
+            execution_id=cast(str, kwargs["execution_id"]),
+            outcome="observation_unknown",
+            tools_list_response={},
+            call_response={},
+            call_job_id="job-query-new",
+            call_status={},
+            artifacts=[],
+            mcp_result=None,
+            provenance=None,
+            initialize_response={},
+            stdio_evidence={},
+            lifecycle_observations=[observation],
+        )
+
+    builder_calls: list[dict[str, Any]] = []
+
+    def build_pending_report(**kwargs: Any) -> LiveValidationReport:
+        builder_calls.append(kwargs)
+        report = new_live_validation_report(scenario="remote-mcp", cluster="test-cluster")
+        now = datetime.now(UTC)
+        report.status = ValidationStatus.FAILED
+        report.completed_at = now
+        report.checks = [
+            ValidationCheck(
+                check_id="remote-mcp.jarvis-live-progress",
+                summary="execution lifecycle remains nonterminal",
+                status=ValidationStatus.FAILED,
+                started_at=now,
+                completed_at=now,
+                evidence=[
+                    EvidenceReference(
+                        kind="test",
+                        excerpt="coherent pending lifecycle",
+                        metadata={
+                            "assertions": {
+                                "observation_count_bounded": True,
+                                "query_identities_coherent": True,
+                                "scheduler_identity_optional_coherent_and_stable": True,
+                                "lifecycle_prefix_coherent": True,
+                                "package_progress_nonregressing": True,
+                            }
+                        },
+                    )
+                ],
+                error="execution remains submitted",
+            ),
+            ValidationCheck(
+                check_id="remote-mcp.jarvis-execution-query",
+                summary="execution query remains resumable",
+                status=ValidationStatus.FAILED,
+                started_at=now,
+                completed_at=now,
+                evidence=[
+                    EvidenceReference(
+                        kind="test",
+                        excerpt="coherent resumable query",
+                        metadata={
+                            "assertions": {
+                                "local_query_surface_verified": True,
+                                "server_artifact_binding_verified": True,
+                                "resumable_query_job_verified": True,
+                                "resumable_result_transport_verified": True,
+                                "resumable_result_envelope_verified": True,
+                                "resumable_identity_coherent": True,
+                                "resumable_lifecycle_coherent": True,
+                                "resumable_runner_semantic_validation_verified": True,
+                            }
+                        },
+                    )
+                ],
+                error="artifact page is not terminal yet",
+            ),
+        ]
+        return report
+
+    worker_info_calls: list[str] = []
+
+    def fail_worker_info(_definition: ClusterDefinition) -> dict[str, object]:
+        worker_info_calls.append("called")
+        raise AssertionError("pending resume must not require release provenance")
+
+    def execute_remotely(_definition: ClusterDefinition) -> bool:
+        return True
+
+    def forbid_new_run(**_kwargs: object) -> None:
+        raise AssertionError("resume must not submit")
+
+    monkeypatch.setattr(cli, "_run_post_run_jarvis_execution_query", query_exact_execution)
+    monkeypatch.setattr(cli, "build_jarvis_mcp_validation_report", build_pending_report)
+    monkeypatch.setattr(cli, "should_execute_on_cluster", execute_remotely)
+    monkeypatch.setattr(cli, "_remote_worker_info", fail_worker_info)
+    monkeypatch.setattr(cli, "run_packaged_mcp_stdio_session", forbid_new_run)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "jarvis-mcp-validate",
+            "--cluster",
+            "test-cluster",
+            "--resume-report",
+            str(resume_path),
+            "--wait-timeout-seconds",
+            "5",
+            "--poll-seconds",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert worker_info_calls == []
+    assert len(builder_calls) == 1
+    assert builder_calls[0]["scheduler_cluster"] == "linux"
+    assert [
+        observation["state"] for observation in builder_calls[0]["query_lifecycle_observations"]
+    ] == ["submitting", "submitted"]
+    persisted = LiveValidationReport.model_validate_json(resume_path.read_text(encoding="utf-8"))
+    assert persisted.status is ValidationStatus.PENDING
+    resource = next(item for item in persisted.resources if item.kind == "jarvis_execution")
+    persisted_checkpoint = cast(dict[str, Any], resource.metadata["resume_checkpoint"])
+    assert persisted_checkpoint["retry_selector"]["cluster"] == "test-cluster"
+    assert persisted_checkpoint["retry_selector"]["scheduler_cluster"] == "linux"
+    assert persisted_checkpoint["builder_inputs"]["scheduler_cluster"] == "linux"
+
+
+def test_jarvis_resume_query_failure_preserves_pending_checkpoint(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A transient resume failure writes separate evidence and preserves its selector."""
+    cluster_path = tmp_path / ".clio-relay" / "clusters.json"
+    cluster_path.parent.mkdir(parents=True)
+    cluster_path.write_text(
+        json.dumps(
+            {
+                "clusters": {
+                    "test-cluster": ClusterDefinition(
+                        name="test-cluster",
+                        ssh_host="test-login",
+                    ).model_dump(mode="json")
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(tmp_path / "core"))
+    monkeypatch.setenv("CLIO_RELAY_SPOOL_DIR", str(tmp_path / "spool"))
+    resume_path = tmp_path / "jarvis-pending.json"
+    checkpoint = {
+        "schema_version": cli._JARVIS_VALIDATION_RESUME_CHECKPOINT_SCHEMA,  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        "phase": "execution_query",
+        "observation_state": "observed",
+        "profile": "user",
+        "retry_selector": {
+            "cluster": "test-cluster",
+            "scheduler_cluster": "test-cluster",
+            "pipeline_id": "pipeline",
+            "execution_id": "execution",
+            "scheduler_provider": "slurm",
+            "scheduler_native_id": "4242",
+            "last_query_job_id": "job-query-old",
+        },
+        "builder_inputs": {
+            "cluster": "test-cluster",
+            "scheduler_cluster": "test-cluster",
+            "tool": "jarvis_run",
+            "runtime_metadata": _jarvis_resume_runtime_metadata(
+                state="submitted",
+                scheduler_native_id="4242",
+            ),
+        },
+        "lifecycle_observations": [
+            _jarvis_resume_observation(
+                query_job_id="job-query-old",
+                state="submitted",
+                terminal=False,
+                scheduler_native_id="4242",
+            )
+        ],
+    }
+    pending_report = new_live_validation_report(
+        scenario="remote-mcp",
+        cluster="test-cluster",
+    )
+    pending_report.status = ValidationStatus.PENDING
+    pending_report.completed_at = datetime.now(UTC)
+    pending_report.resources.append(
+        ValidationResource(
+            kind="jarvis_execution",
+            resource_id="execution",
+            role="resumable_acceptance_workload",
+            cluster="test-cluster",
+            provider="slurm",
+            state="submitted",
+            metadata={
+                "retry_selector": checkpoint["retry_selector"],
+                "resume_checkpoint": checkpoint,
+            },
+        )
+    )
+    write_validation_report(pending_report, resume_path)
+    original = resume_path.read_bytes()
+
+    def fail_query(**_kwargs: object) -> None:
+        raise TimeoutError("temporary relay observation timeout")
+
+    monkeypatch.setattr(cli, "_run_post_run_jarvis_execution_query", fail_query)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "jarvis-mcp-validate",
+            "--cluster",
+            "test-cluster",
+            "--resume-report",
+            str(resume_path),
+            "--wait-timeout-seconds",
+            "5",
+            "--poll-seconds",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert resume_path.read_bytes() == original
+    failure_paths = list(tmp_path.glob("jarvis-pending.resume-failure-*.json"))
+    assert len(failure_paths) == 1
+    failure = LiveValidationReport.model_validate_json(failure_paths[0].read_text(encoding="utf-8"))
+    assert failure.status is ValidationStatus.FAILED
+    loaded = cli._load_jarvis_validation_resume_checkpoint(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        resume_path,
+        cluster="test-cluster",
+    )
+    assert loaded["retry_selector"]["scheduler_native_id"] == "4242"
+
+    tampered_path = tmp_path / "jarvis-tampered.json"
+    tampered = LiveValidationReport.model_validate_json(original)
+    resource = tampered.resources[0]
+    resource.metadata["retry_selector"]["execution_id"] = "different-execution"
+    resource.metadata["resume_checkpoint"]["retry_selector"]["execution_id"] = "different-execution"
+    write_validation_report(tampered, tampered_path)
+    with pytest.raises(
+        ConfigurationError,
+        match="resume identity is invalid|observation identity changed",
+    ):
+        cli._load_jarvis_validation_resume_checkpoint(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            tampered_path,
+            cluster="test-cluster",
+        )
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "missing_record",
+        "record_identity",
+        "state",
+        "terminal",
+        "return_code",
+        "missing_progress",
+        "progress_identity",
+        "integrity_marker",
+        "gap_marker",
+        "coordinated_cluster",
+        "coordinated_mode",
+        "coordinated_provider",
+        "coordinated_pipeline",
+        "coordinated_execution",
+        "runtime_missing_native_execution",
+        "runtime_missing_handle",
+        "runtime_missing_record",
+        "runtime_missing_progress",
+        "runtime_handle_schema",
+        "runtime_handle_native_id",
+        "runtime_record_native_id",
+        "runtime_progress_execution",
+        "runtime_progress_schema",
+        "runtime_terminal_state",
+    ],
+)
+def test_jarvis_resume_rejects_tampered_checkpoint_before_remote_query(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    mutation: str,
+) -> None:
+    """Checkpoint-native documents are an admission boundary, not later report evidence."""
+    cluster_path = tmp_path / ".clio-relay" / "clusters.json"
+    cluster_path.parent.mkdir(parents=True)
+    cluster_path.write_text(
+        json.dumps(
+            {
+                "clusters": {
+                    "test-cluster": ClusterDefinition(
+                        name="test-cluster",
+                        ssh_host="test-login",
+                    ).model_dump(mode="json")
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    observation = _jarvis_resume_observation(
+        query_job_id="job-query-old",
+        state="submitted",
+        terminal=False,
+        scheduler_native_id="4242",
+    )
+    if mutation == "missing_record":
+        observation.pop("execution_record")
+    elif mutation == "record_identity":
+        record = cast(dict[str, Any], observation["execution_record"])
+        record["execution_id"] = "different-execution"
+    elif mutation == "state":
+        observation["state"] = "running"
+    elif mutation == "terminal":
+        observation["terminal"] = True
+    elif mutation == "return_code":
+        record = cast(dict[str, Any], observation["execution_record"])
+        record["return_code"] = 1
+    elif mutation == "missing_progress":
+        observation.pop("progress")
+    elif mutation == "progress_identity":
+        progress = cast(dict[str, Any], observation["progress"])
+        progress["execution_id"] = "different-execution"
+    elif mutation == "integrity_marker":
+        observation["relay_query_integrity"] = {}
+    elif mutation == "gap_marker":
+        observation["relay_query_verified_gap"] = {}
+    elif mutation in {"coordinated_cluster", "coordinated_mode", "coordinated_provider"}:
+        field, value = {
+            "coordinated_cluster": ("cluster", "different-cluster"),
+            "coordinated_mode": ("mode", "direct"),
+            "coordinated_provider": ("scheduler_provider", "pbs"),
+        }[mutation]
+        for document_name in ("execution_handle", "execution_record"):
+            document = cast(dict[str, Any], observation[document_name])
+            document[field] = value
+    elif mutation.startswith("runtime_"):
+        pass
+    else:
+        field = "pipeline_id" if mutation == "coordinated_pipeline" else "execution_id"
+        value = (
+            "different-pipeline" if mutation == "coordinated_pipeline" else "different-execution"
+        )
+        observation[field] = value
+        for document_name in ("execution_handle", "execution_record", "progress"):
+            document = cast(dict[str, Any], observation[document_name])
+            document[field] = value
+    selector = {
+        "cluster": "test-cluster",
+        "scheduler_cluster": "test-cluster",
+        "pipeline_id": "pipeline",
+        "execution_id": "execution",
+        "scheduler_provider": "slurm",
+        "scheduler_native_id": "4242",
+        "last_query_job_id": "job-query-old",
+    }
+    checkpoint = {
+        "schema_version": cli._JARVIS_VALIDATION_RESUME_CHECKPOINT_SCHEMA,  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        "phase": "execution_query",
+        "observation_state": "observed",
+        "profile": "user",
+        "retry_selector": selector,
+        "builder_inputs": {
+            "cluster": "test-cluster",
+            "scheduler_cluster": "test-cluster",
+            "tool": "jarvis_run",
+            "runtime_metadata": _jarvis_resume_runtime_metadata(
+                state="submitted",
+                scheduler_native_id="4242",
+            ),
+        },
+        "lifecycle_observations": [observation],
+    }
+    if mutation.startswith("runtime_"):
+        builder = cast(dict[str, Any], checkpoint["builder_inputs"])
+        runtime = cast(dict[str, Any], builder["runtime_metadata"])
+        details = cast(dict[str, Any], runtime["details"])
+        native = cast(dict[str, Any], details["native_execution"])
+        if mutation == "runtime_missing_native_execution":
+            details.pop("native_execution")
+        elif mutation in {
+            "runtime_missing_handle",
+            "runtime_missing_record",
+            "runtime_missing_progress",
+        }:
+            native.pop(
+                {
+                    "runtime_missing_handle": "execution_handle",
+                    "runtime_missing_record": "execution_record",
+                    "runtime_missing_progress": "progress",
+                }[mutation]
+            )
+        elif mutation == "runtime_terminal_state":
+            terminal = cast(dict[str, Any], runtime["terminal"])
+            terminal["state"] = "running"
+        else:
+            document_name, field, value = {
+                "runtime_handle_schema": (
+                    "execution_handle",
+                    "schema_version",
+                    "jarvis.execution.handle.v0",
+                ),
+                "runtime_handle_native_id": (
+                    "execution_handle",
+                    "scheduler_native_id",
+                    "9999",
+                ),
+                "runtime_record_native_id": (
+                    "execution_record",
+                    "scheduler_native_id",
+                    "9999",
+                ),
+                "runtime_progress_execution": (
+                    "progress",
+                    "execution_id",
+                    "different-execution",
+                ),
+                "runtime_progress_schema": (
+                    "progress",
+                    "schema_version",
+                    "jarvis.execution.progress.v0",
+                ),
+            }[mutation]
+            document = cast(dict[str, Any], native[document_name])
+            document[field] = value
+    pending_report = new_live_validation_report(
+        scenario="remote-mcp",
+        cluster="test-cluster",
+    )
+    pending_report.status = ValidationStatus.PENDING
+    pending_report.completed_at = datetime.now(UTC)
+    pending_report.resources.append(
+        ValidationResource(
+            kind="jarvis_execution",
+            resource_id="execution",
+            role="resumable_acceptance_workload",
+            cluster="test-cluster",
+            provider="slurm",
+            state=str(observation.get("state")),
+            metadata={"retry_selector": selector, "resume_checkpoint": checkpoint},
+        )
+    )
+    resume_path = tmp_path / f"tampered-{mutation}.json"
+    write_validation_report(pending_report, resume_path)
+    query_calls: list[str] = []
+
+    def forbid_query(**_kwargs: object) -> None:
+        query_calls.append("called")
+        raise AssertionError("tampered checkpoint reached a remote query")
+
+    monkeypatch.setattr(cli, "_run_post_run_jarvis_execution_query", forbid_query)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "jarvis-mcp-validate",
+            "--cluster",
+            "test-cluster",
+            "--resume-report",
+            str(resume_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert query_calls == []
+
+
+def test_jarvis_resume_checkpoint_accepts_only_monotonic_scheduler_id_assignment(
+    tmp_path: Path,
+) -> None:
+    """A persisted checkpoint remains resumable after its scheduler ID first appears."""
+    selector: dict[str, object] = {
+        "cluster": "test-cluster",
+        "scheduler_cluster": "test-cluster",
+        "pipeline_id": "pipeline",
+        "execution_id": "execution",
+        "scheduler_provider": "slurm",
+        "scheduler_native_id": "4242",
+        "last_query_job_id": "job-query-assigned",
+    }
+    observations: list[dict[str, object]] = [
+        _jarvis_resume_observation(
+            query_job_id="job-query-before-assignment",
+            state="submitting",
+            terminal=False,
+            scheduler_native_id=None,
+            scheduler_cluster=None,
+        ),
+        _jarvis_resume_observation(
+            query_job_id="job-query-assigned",
+            state="submitted",
+            terminal=False,
+            scheduler_native_id="4242",
+        ),
+    ]
+    checkpoint: dict[str, object] = {
+        "schema_version": cli._JARVIS_VALIDATION_RESUME_CHECKPOINT_SCHEMA,  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        "phase": "execution_query",
+        "observation_state": "observed",
+        "profile": "user",
+        "retry_selector": selector,
+        "builder_inputs": {
+            "cluster": "test-cluster",
+            "scheduler_cluster": "test-cluster",
+            "tool": "jarvis_run",
+            "runtime_metadata": _jarvis_resume_runtime_metadata(
+                state="submitting",
+                scheduler_native_id=None,
+                scheduler_cluster=None,
+            ),
+        },
+        "lifecycle_observations": observations,
+    }
+    report = new_live_validation_report(scenario="remote-mcp", cluster="test-cluster")
+    report.status = ValidationStatus.PENDING
+    report.completed_at = datetime.now(UTC)
+    report.resources.append(
+        ValidationResource(
+            kind="jarvis_execution",
+            resource_id="execution",
+            role="resumable_acceptance_workload",
+            cluster="test-cluster",
+            provider="slurm",
+            state="submitted",
+            metadata={"retry_selector": selector, "resume_checkpoint": checkpoint},
+        )
+    )
+    checkpoint_path = tmp_path / "scheduler-id-assigned.json"
+    write_validation_report(report, checkpoint_path)
+
+    loaded = cli._load_jarvis_validation_resume_checkpoint(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        checkpoint_path,
+        cluster="test-cluster",
+    )
+    assert loaded["retry_selector"]["scheduler_native_id"] == "4242"
+
+    stable_unknown_cluster = LiveValidationReport.model_validate_json(
+        checkpoint_path.read_text(encoding="utf-8")
+    )
+    stable_resource = stable_unknown_cluster.resources[0]
+    stable_checkpoint = cast(dict[str, Any], stable_resource.metadata["resume_checkpoint"])
+    stable_selector = cast(dict[str, Any], stable_checkpoint["retry_selector"])
+    stable_selector["scheduler_cluster"] = None
+    stable_builder = cast(dict[str, Any], stable_checkpoint["builder_inputs"])
+    stable_builder["scheduler_cluster"] = None
+    for stable_observation in cast(
+        list[dict[str, Any]], stable_checkpoint["lifecycle_observations"]
+    ):
+        for document_name in ("execution_handle", "execution_record"):
+            stable_document = cast(dict[str, Any], stable_observation[document_name])
+            stable_document["cluster"] = None
+    stable_resource.metadata["retry_selector"] = stable_selector
+    stable_path = tmp_path / "scheduler-cluster-unavailable.json"
+    write_validation_report(stable_unknown_cluster, stable_path)
+    stable_loaded = cli._load_jarvis_validation_resume_checkpoint(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        stable_path,
+        cluster="test-cluster",
+    )
+    assert stable_loaded["retry_selector"]["scheduler_cluster"] is None
+
+    for mutation, changed_cluster in (
+        ("reverted", None),
+        ("changed", "different-cluster"),
+    ):
+        cluster_tampered = LiveValidationReport.model_validate_json(
+            checkpoint_path.read_text(encoding="utf-8")
+        )
+        cluster_resource = cluster_tampered.resources[0]
+        cluster_checkpoint = cast(dict[str, Any], cluster_resource.metadata["resume_checkpoint"])
+        cluster_observations = cast(
+            list[dict[str, Any]], cluster_checkpoint["lifecycle_observations"]
+        )
+        cluster_observations.append(
+            _jarvis_resume_observation(
+                query_job_id=f"job-query-cluster-{mutation}",
+                state="submitted",
+                terminal=False,
+                scheduler_native_id="4242",
+                scheduler_cluster=changed_cluster,
+            )
+        )
+        cluster_selector = cast(dict[str, Any], cluster_checkpoint["retry_selector"])
+        cluster_selector["last_query_job_id"] = f"job-query-cluster-{mutation}"
+        cluster_resource.metadata["retry_selector"] = cluster_selector
+        cluster_path = tmp_path / f"scheduler-cluster-{mutation}.json"
+        write_validation_report(cluster_tampered, cluster_path)
+        with pytest.raises(ConfigurationError, match="observation identity changed"):
+            cli._load_jarvis_validation_resume_checkpoint(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+                cluster_path,
+                cluster="test-cluster",
+            )
+
+    for mutation in (
+        "missing_runtime",
+        "non_object_runtime",
+        "pipeline",
+        "execution",
+        "provider",
+        "native_id",
+    ):
+        tampered_runtime_report = LiveValidationReport.model_validate_json(
+            checkpoint_path.read_text(encoding="utf-8")
+        )
+        tampered_resource = tampered_runtime_report.resources[0]
+        tampered_checkpoint = cast(dict[str, Any], tampered_resource.metadata["resume_checkpoint"])
+        tampered_builder = cast(dict[str, Any], tampered_checkpoint["builder_inputs"])
+        if mutation == "missing_runtime":
+            tampered_builder.pop("runtime_metadata")
+        elif mutation == "non_object_runtime":
+            tampered_builder["runtime_metadata"] = []
+        else:
+            tampered_runtime = cast(dict[str, Any], tampered_builder["runtime_metadata"])
+            field, value = {
+                "pipeline": ("pipeline_id", "different-pipeline"),
+                "execution": ("execution_id", "different-execution"),
+                "provider": ("scheduler_provider", "different-provider"),
+                "native_id": ("scheduler_job_id", "different-job"),
+            }[mutation]
+            tampered_runtime[field] = value
+        tampered_runtime_path = tmp_path / f"runtime-{mutation}.json"
+        write_validation_report(tampered_runtime_report, tampered_runtime_path)
+        with pytest.raises(
+            ConfigurationError,
+            match="resume checkpoint is invalid|runtime identity changed",
+        ):
+            cli._load_jarvis_validation_resume_checkpoint(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+                tampered_runtime_path,
+                cluster="test-cluster",
+            )
+
+    empty_query_report = LiveValidationReport.model_validate_json(
+        checkpoint_path.read_text(encoding="utf-8")
+    )
+    empty_query_resource = empty_query_report.resources[0]
+    empty_query_checkpoint = cast(
+        dict[str, Any], empty_query_resource.metadata["resume_checkpoint"]
+    )
+    empty_query_observations = cast(
+        list[dict[str, Any]], empty_query_checkpoint["lifecycle_observations"]
+    )
+    empty_query_observations[-1]["query_job_id"] = ""
+    empty_query_path = tmp_path / "empty-query-job-id.json"
+    write_validation_report(empty_query_report, empty_query_path)
+    with pytest.raises(ConfigurationError, match="observation identity changed"):
+        cli._load_jarvis_validation_resume_checkpoint(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            empty_query_path,
+            cluster="test-cluster",
+        )
+
+    tampered = LiveValidationReport.model_validate_json(checkpoint_path.read_text(encoding="utf-8"))
+    resource = tampered.resources[0]
+    stored_checkpoint = cast(dict[str, Any], resource.metadata["resume_checkpoint"])
+    stored_observations = cast(list[dict[str, Any]], stored_checkpoint["lifecycle_observations"])
+    stored_observations.append(
+        _jarvis_resume_observation(
+            query_job_id="job-query-reverted",
+            state="submitted",
+            terminal=False,
+            scheduler_native_id=None,
+        )
+    )
+    stored_selector = cast(dict[str, Any], stored_checkpoint["retry_selector"])
+    stored_selector["last_query_job_id"] = "job-query-reverted"
+    resource.metadata["retry_selector"] = stored_selector
+    tampered_path = tmp_path / "scheduler-id-reverted.json"
+    write_validation_report(tampered, tampered_path)
+
+    with pytest.raises(ConfigurationError, match="observation identity changed"):
+        cli._load_jarvis_validation_resume_checkpoint(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            tampered_path,
+            cluster="test-cluster",
+        )
 
 
 def test_execution_query_remote_boundaries_share_one_deadline(

--- a/tests/test_clio_kit_mcp_contracts.py
+++ b/tests/test_clio_kit_mcp_contracts.py
@@ -689,7 +689,10 @@ def test_real_uv_tool_install_binds_external_launcher_to_receipt_and_record(
             )
         },
     )
-    runtime_identity = jarvis_mcp_runtime_identity(install_receipt)
+    with monkeypatch.context() as unrelated_environment:
+        unrelated_environment.setenv("UV_TOOL_DIR", str(tmp_path / "unrelated-tools"))
+        unrelated_environment.setenv("UV_TOOL_BIN_DIR", str(tmp_path / "unrelated-bin"))
+        runtime_identity = jarvis_mcp_runtime_identity(install_receipt)
     assert runtime_identity["persistent_tool_verified"] is True
     assert runtime_identity["artifact_identity_verified"] is True
 

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -144,6 +144,88 @@ def test_worker_failure_persists_only_logical_windows_paths(tmp_path: Path) -> N
     assert str(logical_failure_path) in failed.last_error
 
 
+def test_worker_provider_uses_receipt_bound_jarvis_interpreter(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Cluster workers pass the managed execution boundary into their provider."""
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        jarvis_bin=str(tmp_path / ".local/bin/jarvis"),
+    )
+    execution_python = tmp_path / "generation/jarvis-venv/bin/python"
+    calls: list[str] = []
+
+    def resolve(jarvis_bin: str) -> str:
+        calls.append(jarvis_bin)
+        return str(execution_python)
+
+    monkeypatch.setattr(endpoint_module, "resolve_receipt_bound_jarvis_python", resolve)
+    worker = EndpointWorker(
+        role=EndpointRole.WORKER,
+        settings=settings,
+        cluster="ares",
+        queue=ClioCoreQueue(settings.core_dir),
+    )
+    try:
+        pipeline = tmp_path / "pipeline.yaml"
+        pipeline.write_text("name: direct\npkgs: []\n", encoding="utf-8")
+
+        command = worker.provider.pipeline_command(pipeline)
+
+        assert calls == [settings.jarvis_bin]
+        assert command[0] == str(execution_python)
+    finally:
+        worker.close()
+
+
+def test_worker_provider_keeps_unmanaged_conventional_jarvis_fallback(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A manual local-bin JARVIS install does not require a relay receipt."""
+    home = tmp_path / "operator-home"
+    local_bin = home / ".local/bin"
+    local_bin.mkdir(parents=True)
+    jarvis = local_bin / "jarvis"
+    jarvis.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    jarvis.chmod(0o755)
+    unmanaged_python = local_bin / "python"
+    unmanaged_python.write_text("unmanaged interpreter placeholder\n", encoding="utf-8")
+    unmanaged_python.chmod(0o755)
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        jarvis_bin=str(jarvis),
+    )
+    resolver = endpoint_module.resolve_receipt_bound_jarvis_python
+
+    def resolve_from_operator_home(jarvis_bin: str) -> str | None:
+        return resolver(jarvis_bin, home=home)
+
+    monkeypatch.setattr(
+        endpoint_module,
+        "resolve_receipt_bound_jarvis_python",
+        resolve_from_operator_home,
+    )
+    worker = EndpointWorker(
+        role=EndpointRole.WORKER,
+        settings=settings,
+        cluster="configured-target",
+        queue=ClioCoreQueue(settings.core_dir),
+    )
+    try:
+        pipeline = tmp_path / "pipeline.yaml"
+        pipeline.write_text("name: direct\npkgs: []\n", encoding="utf-8")
+
+        command = worker.provider.pipeline_command(pipeline)
+
+        assert command[0] == str(unmanaged_python)
+    finally:
+        worker.close()
+
+
 def test_replacement_worker_reconciles_owned_process_before_cancel_acknowledgment(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -317,6 +317,228 @@ def test_native_jarvis_runtime_accepts_canonical_source_aliases(
     assert substituted["verified"] is False
 
 
+def _record_row(relative: str, payload: bytes) -> str:
+    digest = urlsafe_b64encode(hashlib.sha256(payload).digest()).rstrip(b"=").decode()
+    return f"{relative},sha256={digest},{len(payload)}"
+
+
+def _bound_python_script_header(executable: str, *, posix_launcher: str = "uv") -> bytes:
+    if os.name == "nt":
+        return f"#!{executable}\n".encode()
+    if posix_launcher == "uv":
+        provider = "'" + executable.replace("'", "'\"'\"'") + "'"
+    elif posix_launcher == "pip":
+        provider = executable
+    else:
+        raise AssertionError(f"unsupported fixture launcher: {posix_launcher}")
+    return f"#!/bin/sh\n'''exec' {provider} \"$0\" \"$@\"\n' '''\n".encode()
+
+
+def _create_wheel_scripts_fixture(
+    tmp_path: Path,
+    *,
+    posix_launcher: str = "uv",
+) -> tuple[Path, str, Path, dict[str, Path], dict[str, str]]:
+    environment = tmp_path / "environment"
+    venv.EnvBuilder(with_pip=False, symlinks=os.name != "nt").create(environment)
+    invoked_python = environment / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    completed = subprocess.run(
+        [
+            str(invoked_python),
+            "-I",
+            "-c",
+            (
+                "import json, sys, sysconfig; "
+                "print(json.dumps({'executable': sys.executable, "
+                "'paths': sysconfig.get_paths()}))"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    runtime = cast(dict[str, object], json.loads(completed.stdout))
+    executable = cast(str, runtime["executable"])
+    paths = cast(dict[str, str], runtime["paths"])
+    site_packages = Path(paths["purelib"])
+    scripts_root = Path(paths["scripts"])
+    scripts_root.mkdir(parents=True, exist_ok=True)
+
+    metadata_root = "fixture_jarvis-1.0.dist-info"
+    record_name = f"{metadata_root}/RECORD"
+    entry_points = b"[console_scripts]\nfixture-jarvis = fixture_jarvis.cli:main\n"
+    installed_members = {
+        "fixture_jarvis/__init__.py": b'"""Fixture package."""\n',
+        "fixture_jarvis/cli.py": b"def main() -> None:\n    return None\n",
+        f"{metadata_root}/METADATA": (
+            b"Metadata-Version: 2.1\nName: fixture-jarvis\nVersion: 1.0\n\n"
+        ),
+        f"{metadata_root}/WHEEL": (
+            b"Wheel-Version: 1.0\nGenerator: test\nRoot-Is-Purelib: true\nTag: py3-none-any\n\n"
+        ),
+        f"{metadata_root}/entry_points.txt": entry_points,
+    }
+    for relative, payload in installed_members.items():
+        destination = site_packages / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(payload)
+
+    source_scripts = {
+        "fixture-jarvis": b"#!python\nprint('wheel console body')\n",
+        "fixture-resource": b"#!python\nprint('wheel resource body')\n",
+    }
+    header = _bound_python_script_header(executable, posix_launcher=posix_launcher)
+    installed_scripts = {
+        "fixture-jarvis": scripts_root / "fixture-jarvis",
+        "fixture-resource": scripts_root / "fixture-resource",
+    }
+    installed_scripts["fixture-jarvis"].write_bytes(
+        header
+        + b"import sys\n"
+        + b"from fixture_jarvis.cli import main\n"
+        + b"if __name__ == '__main__':\n"
+        + b"    sys.argv[0] = sys.argv[0].removesuffix('.exe')\n"
+        + b"    sys.exit(main())\n"
+    )
+    installed_scripts["fixture-resource"].write_bytes(header + b"print('wheel resource body')\n")
+    if os.name != "nt":
+        for script in installed_scripts.values():
+            script.chmod(0o755)
+
+    installed_record_rows = [
+        _record_row(relative, payload) for relative, payload in sorted(installed_members.items())
+    ]
+    record_members: dict[str, str] = {}
+    for script_name, script in sorted(installed_scripts.items()):
+        relative = os.path.relpath(script, site_packages).replace("\\", "/")
+        record_members[script_name] = relative
+        installed_record_rows.append(_record_row(relative, script.read_bytes()))
+    installed_record_rows.append(f"{record_name},,")
+    installed_record = site_packages / record_name
+    installed_record.write_text("\n".join(installed_record_rows) + "\n", encoding="utf-8")
+
+    wheel_members = dict(installed_members)
+    for script_name, payload in source_scripts.items():
+        wheel_members[f"fixture_jarvis-1.0.data/scripts/{script_name}"] = payload
+    wheel_record_rows = [
+        _record_row(relative, payload) for relative, payload in sorted(wheel_members.items())
+    ]
+    wheel_record_rows.append(f"{record_name},,")
+    wheel_record = ("\n".join(wheel_record_rows) + "\n").encode()
+    wheel = tmp_path / "fixture_jarvis-1.0-py3-none-any.whl"
+    with zipfile.ZipFile(wheel, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for relative, payload in wheel_members.items():
+            archive.writestr(relative, payload)
+        archive.writestr(record_name, wheel_record)
+    return invoked_python, executable, wheel, installed_scripts, record_members
+
+
+def _refresh_installed_record_member(
+    python: Path,
+    distribution_name: str,
+    relative: str,
+    payload: bytes,
+) -> None:
+    completed = subprocess.run(
+        [
+            str(python),
+            "-I",
+            "-c",
+            (
+                "from importlib import metadata; "
+                "print(metadata.distribution('"
+                + distribution_name
+                + "').locate_file('fixture_jarvis-1.0.dist-info/RECORD'))"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    record = Path(completed.stdout.strip())
+    replacement = _record_row(relative, payload)
+    rows = record.read_text(encoding="utf-8").splitlines()
+    matching = [index for index, row in enumerate(rows) if row.startswith(relative + ",")]
+    assert len(matching) == 1
+    rows[matching[0]] = replacement
+    record.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+
+@pytest.mark.parametrize("posix_launcher", ["uv", "pip"])
+def test_native_jarvis_record_closure_verifies_standard_wheel_scripts(
+    tmp_path: Path,
+    posix_launcher: str,
+) -> None:
+    python, _, wheel, _, _ = _create_wheel_scripts_fixture(
+        tmp_path,
+        posix_launcher=posix_launcher,
+    )
+    probe = installation_module._probe_python_distribution_record_closure  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+
+    verified = probe(str(python), "fixture-jarvis", wheel)
+
+    assert verified["verified"] is True
+    assert verified["wheel_script_transform_count"] == 2
+    transforms = {
+        cast(str, item["member"]): item
+        for item in cast(list[dict[str, object]], verified["wheel_script_transforms"])
+    }
+    console = transforms["fixture_jarvis-1.0.data/scripts/fixture-jarvis"]
+    resource = transforms["fixture_jarvis-1.0.data/scripts/fixture-resource"]
+    assert console["transform"] == "declared-console-wrapper"
+    assert console["entry_point"] == "fixture_jarvis.cli:main"
+    assert resource["transform"] == "interpreter-shebang"
+    assert resource["entry_point"] is None
+    expected_launcher = (
+        "direct-interpreter" if os.name == "nt" else f"{posix_launcher}-posix-trampoline"
+    )
+    assert console["launcher"] == expected_launcher
+    assert resource["launcher"] == expected_launcher
+
+
+@pytest.mark.parametrize("tamper", ["resource-body", "console-wrapper", "trampoline"])
+def test_native_jarvis_record_closure_rejects_arbitrary_script_transforms(
+    tmp_path: Path,
+    tamper: str,
+) -> None:
+    python, executable, wheel, scripts, record_members = _create_wheel_scripts_fixture(tmp_path)
+    script_name = "fixture-resource" if tamper != "console-wrapper" else "fixture-jarvis"
+    script = scripts[script_name]
+    payload = script.read_bytes()
+    if tamper == "resource-body":
+        payload = _bound_python_script_header(executable) + b"print('substituted body')\n"
+        expected_error = "body does not match"
+    elif tamper == "console-wrapper":
+        payload += b"print('injected statement')\n"
+        expected_error = "not a canonical declared wrapper"
+    else:
+        if os.name == "nt":
+            payload = payload.replace(
+                f"#!{executable}\n".encode(),
+                f"#!{executable} -I\n".encode(),
+                1,
+            )
+        else:
+            payload = payload.replace(b' "$0" "$@"\n', b' "$0" "$@"; echo injected\n', 1)
+        expected_error = "not bound" if os.name == "nt" else "invalid POSIX shell trampoline"
+    script.write_bytes(payload)
+    if os.name != "nt":
+        script.chmod(0o755)
+    _refresh_installed_record_member(
+        python,
+        "fixture-jarvis",
+        record_members[script_name],
+        payload,
+    )
+    probe = installation_module._probe_python_distribution_record_closure  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+
+    rejected = probe(str(python), "fixture-jarvis", wheel)
+
+    assert rejected["verified"] is False
+    assert expected_error in str(rejected["error"])
+    assert rejected["error_code"] != "unclassified-record-closure-error"
+
+
 def test_native_jarvis_record_closure_rejects_a_tampered_installed_member(
     tmp_path: Path,
 ) -> None:
@@ -939,6 +1161,17 @@ def test_worker_runtime_info_reads_only_the_sealed_fresh_endpoint_index(
     assert result["running"] is True
     assert result["identity_matches_current"] is True
     assert cast(dict[str, object], result["endpoint"])["endpoint_id"] == endpoint.endpoint_id
+
+    readiness = worker_runtime_info(
+        cluster="ares",
+        freshness_seconds=120,
+        readiness_only=True,
+    )
+    assert readiness["schema_version"] == "clio-relay.worker-readiness.v1"
+    assert readiness["running"] is True
+    assert "endpoint" not in readiness
+    assert "installation" not in readiness
+    assert "endpoint_installation" not in readiness
 
 
 def test_cleanup_report_accepts_exact_pypi_worker_for_wheel_operator() -> None:

--- a/tests/test_jarvis_mcp_validation.py
+++ b/tests/test_jarvis_mcp_validation.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
+from copy import deepcopy
+from pathlib import Path
 from typing import Any, cast
 
 import pytest
 
+import clio_relay.cli as relay_cli
 import clio_relay.jarvis_mcp_validation as jarvis_validation
 from clio_relay.jarvis_mcp import (
     CLIO_KIT_JARVIS_MCP_VERSION,
@@ -25,7 +28,7 @@ from clio_relay.jarvis_mcp import (
 from clio_relay.jarvis_mcp_validation import build_jarvis_mcp_validation_report
 from clio_relay.remote_mcp import remote_mcp_server_artifact_digest
 from clio_relay.runtime_metadata import RUNTIME_METADATA_SCHEMA
-from clio_relay.validation_report import ValidationStatus
+from clio_relay.validation_report import ValidationStatus, write_validation_report
 
 
 @pytest.fixture(autouse=True)
@@ -165,6 +168,12 @@ def test_jarvis_mcp_validation_accepts_structured_durable_run() -> None:
         "pagination_coherent": True,
         "artifact_filters_coherent": True,
         "runner_semantic_validation_verified": True,
+        "resumable_query_job_verified": True,
+        "resumable_result_transport_verified": True,
+        "resumable_result_envelope_verified": True,
+        "resumable_identity_coherent": True,
+        "resumable_lifecycle_coherent": True,
+        "resumable_runner_semantic_validation_verified": True,
     }
     execution_id = "jarvis-execution-acceptance"
     for check_id in {
@@ -184,6 +193,309 @@ def test_jarvis_mcp_validation_accepts_structured_durable_run() -> None:
     assert {resource.metadata.get("execution_id") for resource in execution_scoped} == {
         execution_id
     }
+
+
+@pytest.mark.parametrize(
+    ("outcome", "state", "terminal"),
+    [
+        ("observation_unknown", "submitted", False),
+        ("terminal_artifacts_pending", "completed", True),
+    ],
+)
+def test_progress_only_execution_query_is_strictly_resumable_but_not_passed(
+    outcome: str,
+    state: str,
+    terminal: bool,
+) -> None:
+    """Real progress-only evidence can resume but cannot satisfy artifact acceptance."""
+    inputs = _acceptance_inputs()
+    _make_progress_only_execution_query(inputs, state=state, terminal=terminal)
+
+    report = build_jarvis_mcp_validation_report(**inputs)
+    query_check = next(
+        check for check in report.checks if check.check_id == "remote-mcp.jarvis-execution-query"
+    )
+    assertions = query_check.evidence[0].metadata["assertions"]
+    assert query_check.status is ValidationStatus.FAILED
+    assert assertions["durable_query_job_verified"] is False
+    assert assertions["terminal_success_verified"] is False
+    assert assertions["resumable_query_job_verified"] is True
+    assert assertions["resumable_result_transport_verified"] is True
+    assert assertions["resumable_result_envelope_verified"] is True
+    assert assertions["resumable_identity_coherent"] is True
+    assert assertions["resumable_lifecycle_coherent"] is True
+    assert assertions["resumable_runner_semantic_validation_verified"] is True
+
+    observation = _query_lifecycle_observation(
+        state,
+        sequence=2,
+        terminal=terminal,
+    )
+    query = relay_cli._JarvisExecutionQueryAcceptance(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        cluster="ares",
+        pipeline_id="acceptance",
+        execution_id="jarvis-execution-acceptance",
+        outcome=cast(Any, outcome),
+        tools_list_response=cast(dict[str, Any], inputs["query_tools_list_response"]),
+        call_response=cast(dict[str, Any], inputs["query_call_response"]),
+        call_job_id=cast(str, inputs["query_call_job_id"]),
+        call_status=cast(dict[str, Any], inputs["query_call_status"]),
+        artifacts=cast(list[dict[str, Any]], inputs["query_artifacts"]),
+        mcp_result=cast(dict[str, Any], inputs["query_mcp_result"]),
+        provenance=cast(dict[str, Any], inputs["query_provenance"]),
+        initialize_response={},
+        stdio_evidence={},
+        lifecycle_observations=[observation],
+    )
+
+    pending = relay_cli._mark_jarvis_validation_pending(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        report,
+        execution_query=query,
+    )
+
+    assert pending.status is ValidationStatus.PENDING
+    assert all(check.status is not ValidationStatus.FAILED for check in pending.checks)
+
+
+def test_real_builder_pending_checkpoints_round_trip_across_resumes(tmp_path: Path) -> None:
+    """Every checkpoint produced by the real builder is accepted by the strict loader."""
+
+    def set_initial_runtime_pre_assignment(inputs: dict[str, Any]) -> None:
+        runtime = cast(dict[str, Any], inputs["runtime_metadata"])
+        runtime["scheduler_job_id"] = None
+        runtime["scheduler_phase"] = "submitting"
+        terminal = cast(dict[str, Any], runtime["terminal"])
+        terminal.update({"state": "submitting", "terminal": False, "returncode": None})
+        details = cast(dict[str, Any], runtime["details"])
+        native = cast(dict[str, Any], details["native_execution"])
+        handle = cast(dict[str, Any], native["execution_handle"])
+        record = cast(dict[str, Any], native["execution_record"])
+        progress = cast(dict[str, Any], native["progress"])
+        handle["scheduler_native_id"] = None
+        handle["cluster"] = None
+        record.update(
+            {
+                "scheduler_native_id": None,
+                "cluster": None,
+                "state": "submitting",
+                "submitted": False,
+                "terminal": False,
+                "return_code": None,
+                "error": None,
+            }
+        )
+        metadata = cast(dict[str, Any], record["metadata"])
+        submission = cast(dict[str, Any], metadata["submission"])
+        submission.update(
+            {
+                "scheduler_job_id": None,
+                "scheduler_cluster": None,
+                "submitted": False,
+                "identity_source": None,
+            }
+        )
+        progress.update({"execution_state": "submitting", "terminal": False})
+
+    def set_query_job_id(inputs: dict[str, Any], job_id: str) -> None:
+        response = cast(dict[str, Any], inputs["query_call_response"])
+        response_result = cast(dict[str, Any], response["result"])
+        structured_content = cast(dict[str, Any], response_result["structuredContent"])
+        structured_content["job_id"] = job_id
+        inputs["query_call_job_id"] = job_id
+        status = cast(dict[str, Any], inputs["query_call_status"])
+        status_job = cast(dict[str, Any], status["job"])
+        status_job["job_id"] = job_id
+        provenance = cast(dict[str, Any], inputs["query_provenance"])
+        provenance_job = cast(dict[str, Any], provenance["job"])
+        provenance_job["job_id"] = job_id
+
+    def query_acceptance(
+        inputs: dict[str, Any],
+        observation: dict[str, Any],
+        lifecycle: list[dict[str, Any]],
+    ) -> relay_cli._JarvisExecutionQueryAcceptance:  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        return relay_cli._JarvisExecutionQueryAcceptance(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            cluster="ares",
+            pipeline_id="acceptance",
+            execution_id="jarvis-execution-acceptance",
+            outcome="observation_unknown",
+            tools_list_response=cast(dict[str, Any], inputs["query_tools_list_response"]),
+            call_response=cast(dict[str, Any], inputs["query_call_response"]),
+            call_job_id=cast(str, inputs["query_call_job_id"]),
+            call_status=cast(dict[str, Any], inputs["query_call_status"]),
+            artifacts=cast(list[dict[str, Any]], inputs["query_artifacts"]),
+            mcp_result=cast(dict[str, Any], inputs["query_mcp_result"]),
+            provenance=cast(dict[str, Any], inputs["query_provenance"]),
+            initialize_response={},
+            stdio_evidence={},
+            lifecycle_observations=[*lifecycle, observation],
+        )
+
+    first_inputs = _acceptance_inputs()
+    set_initial_runtime_pre_assignment(first_inputs)
+    _make_progress_only_execution_query(
+        first_inputs,
+        state="submitting",
+        terminal=False,
+    )
+    first_observation = _query_lifecycle_observation(
+        "submitting",
+        sequence=1,
+        terminal=False,
+    )
+    _set_scheduler_native_id(first_observation, None)
+    _set_scheduler_cluster(first_observation, None)
+    first_result = cast(dict[str, Any], first_inputs["query_mcp_result"])
+    first_structured = cast(dict[str, Any], first_result["structured_result"])
+    for key in ("execution_handle", "execution_record"):
+        document = cast(dict[str, Any], first_structured[key])
+        document["scheduler_native_id"] = None
+        document["cluster"] = None
+    first_observation["query_job_id"] = first_inputs["query_call_job_id"]
+    first_inputs["query_lifecycle_observations"] = [first_observation]
+    first_inputs["scheduler_cluster"] = None
+    first_report = build_jarvis_mcp_validation_report(**first_inputs)
+    first_query = query_acceptance(first_inputs, first_observation, [])
+    builder_inputs = {
+        key: deepcopy(value) for key, value in first_inputs.items() if not key.startswith("query_")
+    }
+    first_checkpoint = {
+        "schema_version": relay_cli._JARVIS_VALIDATION_RESUME_CHECKPOINT_SCHEMA,  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        "phase": "execution_query",
+        "observation_state": "observed",
+        "profile": "user",
+        "retry_selector": first_query.retry_selector(),
+        "builder_inputs": builder_inputs,
+        "lifecycle_observations": first_query.lifecycle_observations,
+    }
+    first_pending = relay_cli._mark_jarvis_validation_pending(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        first_report,
+        execution_query=first_query,
+        resume_checkpoint=first_checkpoint,
+    )
+    first_path = tmp_path / "first-pending.json"
+    write_validation_report(first_pending, first_path)
+
+    first_loaded = relay_cli._load_jarvis_validation_resume_checkpoint(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        first_path,
+        cluster="ares",
+    )
+    assert first_pending.status is ValidationStatus.PENDING
+    assert first_loaded["retry_selector"] == first_query.retry_selector()
+    assert first_loaded["retry_selector"]["scheduler_native_id"] is None
+    assert first_loaded["retry_selector"]["cluster"] == "ares"
+    assert first_loaded["retry_selector"]["scheduler_cluster"] is None
+
+    second_inputs = _acceptance_inputs()
+    set_initial_runtime_pre_assignment(second_inputs)
+    _make_progress_only_execution_query(
+        second_inputs,
+        state="running",
+        terminal=False,
+    )
+    set_query_job_id(second_inputs, "job-jarvis-query-resume")
+    second_observation = _query_lifecycle_observation(
+        "running",
+        sequence=2,
+        terminal=False,
+    )
+    second_observation["query_job_id"] = second_inputs["query_call_job_id"]
+    lifecycle = [first_observation]
+    second_inputs["query_lifecycle_observations"] = [*lifecycle, second_observation]
+    second_inputs["scheduler_cluster"] = "linux"
+    second_report = build_jarvis_mcp_validation_report(**second_inputs)
+    second_query = query_acceptance(second_inputs, second_observation, lifecycle)
+    second_checkpoint = {
+        **first_loaded,
+        "retry_selector": second_query.retry_selector(),
+        "builder_inputs": {
+            **cast(dict[str, Any], first_loaded["builder_inputs"]),
+            "scheduler_cluster": "linux",
+        },
+        "lifecycle_observations": second_query.lifecycle_observations,
+    }
+    second_pending = relay_cli._mark_jarvis_validation_pending(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        second_report,
+        execution_query=second_query,
+        resume_checkpoint=second_checkpoint,
+    )
+    second_path = tmp_path / "second-pending.json"
+    write_validation_report(second_pending, second_path)
+
+    second_loaded = relay_cli._load_jarvis_validation_resume_checkpoint(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        second_path,
+        cluster="ares",
+    )
+    assert second_pending.status is ValidationStatus.PENDING
+    assert second_loaded["retry_selector"] == second_query.retry_selector()
+    assert second_loaded["retry_selector"]["scheduler_native_id"] == "12345"
+    assert second_loaded["retry_selector"]["cluster"] == "ares"
+    assert second_loaded["retry_selector"]["scheduler_cluster"] == "linux"
+    assert [observation["state"] for observation in second_loaded["lifecycle_observations"]] == [
+        "submitting",
+        "running",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("state", "return_code", "error"),
+    [
+        ("failed", 1, "workload failed"),
+        ("canceled", None, "workload canceled"),
+        ("completed", 1, None),
+    ],
+)
+def test_terminal_artifacts_pending_never_masks_terminal_workload_failure(
+    state: str,
+    return_code: int | None,
+    error: str | None,
+) -> None:
+    """Only a proven successful terminal execution may defer artifact collection."""
+    inputs = _acceptance_inputs()
+    _make_progress_only_execution_query(inputs, state=state, terminal=True)
+    result = cast(dict[str, Any], inputs["query_mcp_result"])
+    structured = cast(dict[str, Any], result["structured_result"])
+    record = cast(dict[str, Any], structured["execution_record"])
+    record["return_code"] = return_code
+    record["error"] = error
+    observations = [
+        _query_lifecycle_observation("submitted", sequence=1, terminal=False),
+        _query_lifecycle_observation("running", sequence=2, terminal=False),
+        _query_lifecycle_observation(state, sequence=3, terminal=True),
+    ]
+    terminal_record = cast(dict[str, Any], observations[-1]["execution_record"])
+    terminal_record["return_code"] = return_code
+    terminal_record["error"] = error
+    inputs["query_lifecycle_observations"] = observations
+    report = build_jarvis_mcp_validation_report(**inputs)
+    query = relay_cli._JarvisExecutionQueryAcceptance(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        cluster="ares",
+        pipeline_id="acceptance",
+        execution_id="jarvis-execution-acceptance",
+        outcome="terminal_artifacts_pending",
+        tools_list_response=cast(dict[str, Any], inputs["query_tools_list_response"]),
+        call_response=cast(dict[str, Any], inputs["query_call_response"]),
+        call_job_id=cast(str, inputs["query_call_job_id"]),
+        call_status=cast(dict[str, Any], inputs["query_call_status"]),
+        artifacts=cast(list[dict[str, Any]], inputs["query_artifacts"]),
+        mcp_result=cast(dict[str, Any], inputs["query_mcp_result"]),
+        provenance=cast(dict[str, Any], inputs["query_provenance"]),
+        initialize_response={},
+        stdio_evidence={},
+        lifecycle_observations=observations,
+    )
+
+    unchanged = relay_cli._mark_jarvis_validation_pending(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        report,
+        execution_query=query,
+    )
+    query_check = next(
+        check for check in report.checks if check.check_id == "remote-mcp.jarvis-execution-query"
+    )
+
+    assert report.status is ValidationStatus.FAILED
+    assert unchanged.status is ValidationStatus.FAILED
+    assert query_check.evidence[0].metadata["assertions"]["resumable_lifecycle_coherent"] is False
 
 
 def test_jarvis_mcp_validation_does_not_require_spack_for_non_spack_run() -> None:
@@ -504,6 +816,7 @@ def test_query_lifecycle_accepts_running_progress_and_no_scheduler_identity() ->
             document["mode"] = "direct"
             document["scheduler_provider"] = None
             document["scheduler_native_id"] = None
+            document["cluster"] = None
 
     evidence, passed, resource = jarvis_validation._jarvis_query_lifecycle_progress_evidence(
         observations=observations,
@@ -517,7 +830,8 @@ def test_query_lifecycle_accepts_running_progress_and_no_scheduler_identity() ->
         "observation_count_bounded": True,
         "query_identities_coherent": True,
         "scheduler_identity_optional_coherent_and_stable": True,
-        "lifecycle_monotonic_and_completed": True,
+        "lifecycle_prefix_coherent": True,
+        "terminal_success_verified": True,
         "in_flight_package_progress_observed": True,
         "package_progress_nonregressing": True,
         "terminal_package_progress_bound": True,
@@ -542,6 +856,322 @@ def test_query_lifecycle_accepts_one_way_scheduler_native_id_assignment() -> Non
     assert passed is True
     assert resource is not None
     assert evidence["assertions"]["scheduler_identity_optional_coherent_and_stable"] is True
+
+
+@pytest.mark.parametrize(
+    ("clusters", "expected"),
+    [
+        ([None, None, None, None], True),
+        ([None, "linux", "linux", "linux"], True),
+        ([None, "linux", None, None], False),
+        ([None, "linux", "different", "different"], False),
+    ],
+)
+def test_query_lifecycle_scheduler_cluster_is_optional_one_way_identity(
+    clusters: list[str | None],
+    expected: bool,
+) -> None:
+    """The scheduler-native cluster may appear once, but never revert or change."""
+    observations = [
+        _query_lifecycle_observation("submitting", sequence=1, terminal=False),
+        _query_lifecycle_observation("submitted", sequence=2, terminal=False),
+        _query_lifecycle_observation("running", sequence=3, terminal=False),
+        _query_lifecycle_observation("completed", sequence=4, terminal=True),
+    ]
+    for observation, cluster in zip(observations, clusters, strict=True):
+        _set_scheduler_cluster(observation, cluster)
+
+    evidence, _passed, _resource = jarvis_validation._jarvis_query_lifecycle_progress_evidence(
+        observations=observations,
+        pipeline_id="acceptance",
+        execution_id="jarvis-execution-acceptance",
+    )
+
+    assert evidence["assertions"]["scheduler_identity_optional_coherent_and_stable"] is expected
+
+
+def _query_lifecycle_with_repeated_terminal_snapshot() -> list[dict[str, Any]]:
+    observations = [
+        _query_lifecycle_observation("submitted", sequence=1, terminal=False),
+        _query_lifecycle_observation("running", sequence=2, terminal=False),
+        _query_lifecycle_observation("completed", sequence=3, terminal=True),
+    ]
+    repeated = deepcopy(observations[-1])
+    repeated["query_job_id"] = "job-query-artifact-resume"
+    observations.append(repeated)
+    return observations
+
+
+def test_real_builder_accepts_immutable_terminal_snapshot_after_artifact_resume() -> None:
+    """A query-only terminal checkpoint can be followed by its artifact-bearing snapshot."""
+    inputs = _acceptance_inputs()
+    inputs["query_lifecycle_observations"] = _query_lifecycle_with_repeated_terminal_snapshot()
+
+    report = build_jarvis_mcp_validation_report(**inputs)
+
+    lifecycle = next(
+        check for check in report.checks if check.check_id == "remote-mcp.jarvis-live-progress"
+    )
+    assertions = lifecycle.evidence[0].metadata["assertions"]
+    assert report.status is ValidationStatus.PASSED
+    assert assertions["lifecycle_prefix_coherent"] is True
+    assert assertions["terminal_success_verified"] is True
+
+
+@pytest.mark.parametrize(
+    ("mutation", "field", "value", "failed_assertion"),
+    [
+        (
+            "cluster",
+            "cluster",
+            "different-cluster",
+            "scheduler_identity_optional_coherent_and_stable",
+        ),
+        ("mode", "mode", "direct", "query_identities_coherent"),
+        ("provider", "scheduler_provider", "pbs", "query_identities_coherent"),
+    ],
+)
+def test_real_builder_anchors_native_execution_identity(
+    mutation: str,
+    field: str,
+    value: str,
+    failed_assertion: str,
+) -> None:
+    """Coordinated native-document drift cannot escape its durable identity."""
+    inputs = _acceptance_inputs()
+    observations = _query_lifecycle_with_repeated_terminal_snapshot()
+    inputs["query_lifecycle_observations"] = observations
+    for observation in observations:
+        for document_name in ("execution_handle", "execution_record"):
+            document = cast(dict[str, Any], observation[document_name])
+            document[field] = value
+        if mutation == "mode":
+            for document_name in ("execution_handle", "execution_record"):
+                document = cast(dict[str, Any], observation[document_name])
+                document["scheduler_provider"] = None
+                document["scheduler_native_id"] = None
+
+    report = build_jarvis_mcp_validation_report(**inputs)
+
+    lifecycle = next(
+        check for check in report.checks if check.check_id == "remote-mcp.jarvis-live-progress"
+    )
+    assertions = lifecycle.evidence[0].metadata["assertions"]
+    assert report.status is ValidationStatus.FAILED
+    assert assertions[failed_assertion] is False
+
+
+@pytest.mark.parametrize(
+    ("mutation", "failed_assertion"),
+    [
+        ("identity", "scheduler_identity_optional_coherent_and_stable"),
+        ("state", "lifecycle_prefix_coherent"),
+        ("result", "lifecycle_prefix_coherent"),
+    ],
+)
+def test_repeated_terminal_snapshot_must_be_immutable(
+    mutation: str,
+    failed_assertion: str,
+) -> None:
+    observations = _query_lifecycle_with_repeated_terminal_snapshot()
+    repeated = observations[-1]
+    record = cast(dict[str, Any], repeated["execution_record"])
+    if mutation == "identity":
+        _set_scheduler_native_id(repeated, "different-job")
+    elif mutation == "state":
+        repeated["state"] = "failed"
+        record["state"] = "failed"
+        record["return_code"] = 1
+        record["error"] = "failed"
+        progress = cast(dict[str, Any], repeated["progress"])
+        progress["execution_state"] = "failed"
+    else:
+        record["return_code"] = 1
+
+    evidence, passed, _resource = jarvis_validation._jarvis_query_lifecycle_progress_evidence(
+        observations=observations,
+        pipeline_id="acceptance",
+        execution_id="jarvis-execution-acceptance",
+    )
+
+    assert passed is False
+    assert evidence["assertions"][failed_assertion] is False
+
+
+def test_query_lifecycle_rejects_running_to_submitted_regression() -> None:
+    observations = [
+        _query_lifecycle_observation("submitted", sequence=1, terminal=False),
+        _query_lifecycle_observation("running", sequence=2, terminal=False),
+        _query_lifecycle_observation("submitted", sequence=3, terminal=False),
+    ]
+
+    evidence, passed, _resource = jarvis_validation._jarvis_query_lifecycle_progress_evidence(
+        observations=observations,
+        pipeline_id="acceptance",
+        execution_id="jarvis-execution-acceptance",
+    )
+
+    assert passed is False
+    assert evidence["assertions"]["lifecycle_prefix_coherent"] is False
+
+
+def test_compaction_persists_lifecycle_regression_beyond_observation_bound() -> None:
+    """Sampling cannot erase a transition violation observed days earlier."""
+    observations: list[dict[str, Any]] = []
+    for sequence in range(1, 521):
+        if sequence == 1 or sequence == 3:
+            state, terminal = "submitted", False
+        elif sequence == 520:
+            state, terminal = "completed", True
+        else:
+            state, terminal = "running", False
+        relay_cli._append_bounded_jarvis_execution_query_observation(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            observations,
+            _query_lifecycle_observation(state, sequence=sequence, terminal=terminal),
+        )
+
+    evidence, passed, _resource = jarvis_validation._jarvis_query_lifecycle_progress_evidence(
+        observations=observations,
+        pipeline_id="acceptance",
+        execution_id="jarvis-execution-acceptance",
+    )
+
+    assert len(observations) <= 512
+    assert any("relay_query_integrity" in observation for observation in observations)
+    assert passed is False
+    assert evidence["assertions"]["lifecycle_prefix_coherent"] is False
+    assert evidence["query_integrity_violations"] == [
+        {
+            "schema_version": "clio-relay.jarvis-query-integrity.v1",
+            "valid": False,
+            "reason": "state_regression",
+            "previous_state": "running",
+            "current_state": "submitted",
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("mutation", "reason"),
+    [
+        ("identity", "scheduler_cluster_changed"),
+        ("scheduler", "scheduler_native_id_changed"),
+        ("progress", "package_progress_regressed"),
+        ("progress_execution", "package_progress_invalid"),
+        ("return_code", "nonterminal_result_present"),
+        ("error", "nonterminal_result_present"),
+        ("query_id", "query_identity_changed"),
+        ("marker", "integrity_marker_invalid"),
+        ("gap_marker", "verified_gap_invalid"),
+    ],
+)
+def test_compaction_persists_every_query_integrity_violation(
+    mutation: str,
+    reason: str,
+) -> None:
+    """Identity and progress corruption cannot vanish from a multi-day sampled run."""
+    observations: list[dict[str, Any]] = []
+    for sequence in range(1, 521):
+        state = "submitted" if sequence == 1 else "running"
+        terminal = False
+        if sequence == 520:
+            state, terminal = "completed", True
+        observation = _query_lifecycle_observation(
+            state,
+            sequence=sequence,
+            terminal=terminal,
+        )
+        if sequence == 3 and mutation == "identity":
+            for key in ("execution_handle", "execution_record"):
+                document = cast(dict[str, Any], observation[key])
+                document["cluster"] = "different-cluster"
+        elif sequence == 3 and mutation == "scheduler":
+            _set_scheduler_native_id(observation, "different-job")
+        elif sequence == 3 and mutation == "progress":
+            progress = cast(dict[str, Any], observation["progress"])
+            package = cast(dict[str, Any], cast(list[object], progress["packages"])[0])
+            package["event_count"] = 1
+            _query_progress_latest(observation)["sequence"] = 1
+        elif sequence == 3 and mutation == "progress_execution":
+            _query_progress_latest(observation)["execution_id"] = "different-execution"
+        elif sequence == 3 and mutation == "return_code":
+            record = cast(dict[str, Any], observation["execution_record"])
+            record["return_code"] = 1
+        elif sequence == 3 and mutation == "error":
+            record = cast(dict[str, Any], observation["execution_record"])
+            record["error"] = "oops"
+        elif sequence == 3 and mutation == "query_id":
+            observation["query_job_id"] = ""
+        elif sequence == 3 and mutation == "marker":
+            observation["relay_query_integrity"] = {}
+        elif sequence == 3 and mutation == "gap_marker":
+            observation["relay_query_verified_gap"] = {}
+        relay_cli._append_bounded_jarvis_execution_query_observation(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            observations,
+            observation,
+        )
+
+    evidence, passed, _resource = jarvis_validation._jarvis_query_lifecycle_progress_evidence(
+        observations=observations,
+        pipeline_id="acceptance",
+        execution_id="jarvis-execution-acceptance",
+    )
+
+    assert len(observations) <= 512
+    assert passed is False
+    assert evidence["assertions"]["lifecycle_prefix_coherent"] is False
+    violations = cast(list[dict[str, Any]], evidence["query_integrity_violations"])
+    assert len(violations) == 1
+    assert violations[0]["reason"] == reason
+
+
+def test_compaction_preserves_healthy_multi_phase_progress_semantics() -> None:
+    """Verified sampled gaps prevent false adjacency across a discarded short phase."""
+    observations: list[dict[str, Any]] = []
+    for sequence in range(1, 601):
+        state = "submitted" if sequence == 1 else "running"
+        terminal = False
+        if sequence == 600:
+            state, terminal = "completed", True
+        observation = _query_lifecycle_observation(
+            state,
+            sequence=sequence,
+            terminal=terminal,
+        )
+        latest = _query_progress_latest(observation)
+        latest["total"] = 1_000.0
+        if sequence <= 9:
+            latest["label"] = "phase-a"
+            latest["current"] = float(sequence)
+        elif sequence == 10:
+            latest["label"] = "phase-b"
+            latest["current"] = 0.0
+        else:
+            latest["label"] = "phase-a"
+            latest["current"] = float(sequence - 10)
+        relay_cli._append_bounded_jarvis_execution_query_observation(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            observations,
+            observation,
+        )
+
+    observations = relay_cli._merge_jarvis_execution_query_observations(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        observations,
+        [],
+    )
+
+    evidence, passed, resource = jarvis_validation._jarvis_query_lifecycle_progress_evidence(
+        observations=observations,
+        pipeline_id="acceptance",
+        execution_id="jarvis-execution-acceptance",
+    )
+
+    assert len(observations) <= 512
+    assert passed is True
+    assert resource is not None
+    assert evidence["verified_gap_count"] > 0
+    assert evidence["invalid_verified_gaps"] == []
+    assert evidence["query_integrity_violations"] == []
+    assert evidence["assertions"]["package_progress_nonregressing"] is True
 
 
 @pytest.mark.parametrize("mutation", ["removed_after_assignment", "changed_after_assignment"])
@@ -678,7 +1308,7 @@ def _change_terminal_handle_scheduler_identity(
         ),
         (
             _set_terminal_return_code_failure,
-            "lifecycle_monotonic_and_completed",
+            "terminal_success_verified",
         ),
         (
             _regress_terminal_progress_sequence,
@@ -1221,6 +1851,36 @@ def _execution_query_mcp_result(
     }
 
 
+def _make_progress_only_execution_query(
+    inputs: dict[str, Any],
+    *,
+    state: str,
+    terminal: bool,
+) -> None:
+    """Replace terminal artifact-query evidence with one exact progress-only query."""
+    status = cast(dict[str, Any], inputs["query_call_status"])
+    job = cast(dict[str, Any], status["job"])
+    spec = cast(dict[str, Any], job["spec"])
+    arguments = cast(dict[str, Any], spec["arguments"])
+    arguments.pop("artifacts")
+    result = cast(dict[str, Any], inputs["query_mcp_result"])
+    structured = cast(dict[str, Any], result["structured_result"])
+    structured["artifact_page"] = None
+    record = cast(dict[str, Any], structured["execution_record"])
+    record["state"] = state
+    record["terminal"] = terminal
+    record["return_code"] = 0 if terminal else None
+    record["error"] = None
+    progress = cast(dict[str, Any], structured["progress"])
+    progress["execution_state"] = state
+    progress["terminal"] = terminal
+    validation = cast(dict[str, Any], result["result_validation"])
+    validation["artifacts_requested"] = False
+    validation["artifact_filters"] = {}
+    validation["returned_artifact_count"] = 0
+    validation["next_cursor_present"] = False
+
+
 def _native_execution_documents(execution_id: str) -> dict[str, object]:
     return {
         "execution_handle": {
@@ -1248,7 +1908,17 @@ def _native_execution_documents(execution_id: str) -> dict[str, object]:
             "error": None,
             "created_at": "2026-07-11T10:00:00Z",
             "updated_at": "2026-07-11T10:00:02Z",
-            "metadata": {},
+            "metadata": {
+                "submission": {
+                    "schema_version": "jarvis.scheduler.submission.v1",
+                    "execution_id": execution_id,
+                    "provider": "slurm",
+                    "scheduler_job_id": "12345",
+                    "scheduler_cluster": "linux",
+                    "submitted": True,
+                    "identity_source": "scheduler_submit_api",
+                }
+            },
         },
         "progress": {
             "schema_version": "jarvis.execution.progress.v1",
@@ -1320,6 +1990,12 @@ def _set_scheduler_native_id(observation: dict[str, Any], native_id: str | None)
     for key in ("execution_handle", "execution_record"):
         document = cast(dict[str, Any], observation[key])
         document["scheduler_native_id"] = native_id
+
+
+def _set_scheduler_cluster(observation: dict[str, Any], cluster: str | None) -> None:
+    for key in ("execution_handle", "execution_record"):
+        document = cast(dict[str, Any], observation[key])
+        document["cluster"] = cluster
 
 
 def _query_progress_latest(observation: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_jarvis_provider.py
+++ b/tests/test_jarvis_provider.py
@@ -810,3 +810,27 @@ def test_scheduled_pipeline_uses_wrapper_shebang_when_sibling_python_is_missing(
     command = provider.pipeline_command(pipeline)
 
     assert command[0] == "/opt/clio-relay/jarvis-venv/bin/python"
+
+
+def test_receipt_bound_python_bypasses_unmanaged_sibling_discovery(tmp_path: Path) -> None:
+    """A managed provider must never select an unrelated sibling interpreter."""
+    pipeline = tmp_path / "pipeline.yaml"
+    pipeline.write_text("name: direct\npkgs: []\n", encoding="utf-8")
+    stable_bin = tmp_path / ".local/bin"
+    stable_bin.mkdir(parents=True)
+    jarvis = stable_bin / "jarvis"
+    jarvis.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    unrelated_python = stable_bin / "python"
+    unrelated_python.write_text("unrelated", encoding="utf-8")
+    execution_python = tmp_path / "generation/jarvis-venv/bin/python"
+    execution_python.parent.mkdir(parents=True)
+    execution_python.write_text("managed", encoding="utf-8")
+    provider = JarvisCdProvider(
+        jarvis_bin=str(jarvis),
+        execution_python=str(execution_python),
+    )
+
+    command = provider.pipeline_command(pipeline)
+
+    assert command[0] == str(execution_python)
+    assert command[0] != str(unrelated_python)

--- a/tests/test_jarvis_service_runtime.py
+++ b/tests/test_jarvis_service_runtime.py
@@ -57,10 +57,16 @@ from clio_relay.models import (
     McpCallSpec,
     RelayJob,
     SchedulerConnectorStepIdentity,
+    SchedulerPhase,
+    SchedulerStatus,
     ServiceRuntimeSpec,
 )
 from clio_relay.remote_mcp import remote_mcp_server_artifact_digest
-from clio_relay.service_runtime import ServiceRuntimeStopResult, ServiceRuntimeSupervisor
+from clio_relay.service_runtime import (
+    ServiceRuntimePendingResult,
+    ServiceRuntimeStopResult,
+    ServiceRuntimeSupervisor,
+)
 from clio_relay.session_lifecycle import CleanupResource
 from tests.jarvis_mcp_fakes import verified_jarvis_server_artifact
 
@@ -1988,6 +1994,10 @@ def test_agent_bind_persists_urls_and_rejects_runtime_commands(
 
     assert response is not None and "error" not in response
     result = cast(dict[str, Any], response["result"]["structuredContent"])
+    assert result["outcome"] == "ready"
+    assert result["retry_selector"] is None
+    assert result["scheduler_action"] == "none"
+    assert result["relay_action"] == "none"
     connect_url = cast(str, result["connect_url"])
     local_port = urllib.parse.urlparse(connect_url).port
     assert local_port is not None
@@ -2131,6 +2141,221 @@ def test_agent_bind_persists_urls_and_rejects_runtime_commands(
     assert closed is not None
     assert "must be closed with stop-runtime" in closed["error"]["message"]
     assert queue.get_gateway_session(gateway["session_id"]).gateway["jarvis_runtime_binding"]
+
+
+def test_agent_bind_pending_replays_same_gateway_and_connector_intents(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A health observation miss is a successful checkpoint, not another bind."""
+    queue, definition, job, artifact, envelope = _source_result(tmp_path)
+    registry_path = tmp_path / "clusters.json"
+    ClusterRegistry(clusters={definition.name: definition}).save(registry_path)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+    monkeypatch.setenv("CLIO_RELAY_FRP_TOKEN", "token")
+    monkeypatch.setenv("CLIO_RELAY_STCP_SECRET", "secret")
+    monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
+    launches = {"remote": 0, "desktop": 0}
+
+    def start_remote(
+        _self: ServiceRuntimeSupervisor,
+        *,
+        session: GatewaySession,
+        spec: ServiceRuntimeSpec,
+        node: str,
+        proxy_name: str,
+        ownership_intent: dict[str, object],
+        allocation_provider: str | None = None,
+        allocation_job_id: str | None = None,
+    ) -> dict[str, object]:
+        del spec, node, proxy_name, allocation_provider, allocation_job_id
+        launches["remote"] += 1
+        return {
+            "owner": "clio-relay",
+            "session_id": session.session_id,
+            "pid": 444,
+            "process_group_id": 444,
+            "connector_generation_id": ownership_intent["connector_generation_id"],
+            "owner_token": ownership_intent["owner_token"],
+            "config_path": "/runtime/remote-frpc.toml",
+            "log_path": "/runtime/remote-frpc.log",
+        }
+
+    def start_local(
+        _self: ServiceRuntimeSupervisor,
+        *,
+        session: GatewaySession,
+        spec: ServiceRuntimeSpec,
+        proxy_name: str,
+        ownership_intent: dict[str, object],
+    ) -> dict[str, object]:
+        del spec, proxy_name
+        launches["desktop"] += 1
+        return {
+            "owner": "clio-relay",
+            "session_id": session.session_id,
+            "pid": 555,
+            "process_group_id": 555,
+            "process_start_marker": "start-555",
+            "connector_generation_id": ownership_intent["connector_generation_id"],
+            "owner_token": ownership_intent["owner_token"],
+            "config_path": ownership_intent["config_path"],
+            "stdout_path": ownership_intent["stdout_path"],
+            "stderr_path": ownership_intent["stderr_path"],
+            "metadata_path": ownership_intent["metadata_path"],
+        }
+
+    health_observations = 0
+
+    def observe_health(*_args: object, **_kwargs: object) -> None:
+        nonlocal health_observations
+        health_observations += 1
+        if health_observations == 1:
+            raise RelayError("bounded health observation did not become ready")
+
+    def reconcile(
+        self: ServiceRuntimeSupervisor,
+        session: GatewaySession,
+    ) -> GatewaySession:
+        transport = cast(dict[str, object], session.gateway.get("transport", {}))
+        roles = ("remote_connector", "desktop_connector")
+        if not all(isinstance(transport.get(role), dict) for role in roles):
+            return session
+        gateway = dict(session.gateway)
+        intents = dict(cast(dict[str, object], gateway["ownership_intents"]))
+        for role in roles:
+            intent = dict(cast(dict[str, object], intents[role]))
+            intent["live_identity_verified"] = True
+            intent.pop("reconciliation_error", None)
+            intents[role] = intent
+        gateway["ownership_intents"] = intents
+        return self.queue.update_gateway_session(
+            session.session_id,
+            gateway=gateway,
+            expected_updated_at=session.updated_at,
+        )
+
+    monkeypatch.setattr(ServiceRuntimeSupervisor, "_start_remote_connector", start_remote)
+    monkeypatch.setattr(ServiceRuntimeSupervisor, "_start_local_visitor", start_local)
+    monkeypatch.setattr(ServiceRuntimeSupervisor, "_wait_for_jarvis_health", observe_health)
+    monkeypatch.setattr(ServiceRuntimeSupervisor, "_reconcile_ownership_intents", reconcile)
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        frpc_bin="frpc-test",
+    )
+    arguments = {
+        "cluster": definition.name,
+        "source_job_id": job.job_id,
+        "source_artifact_id": artifact.artifact_id,
+        "package_id": "paraview-1",
+        "package_name": "builtin.paraview",
+    }
+
+    first_response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "relay_bind_jarvis_runtime", "arguments": arguments},
+        },
+        queue=queue,
+        settings=settings,
+        profile="user",
+    )
+    second_response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "relay_bind_jarvis_runtime", "arguments": arguments},
+        },
+        queue=queue,
+        settings=settings,
+        profile="user",
+    )
+
+    assert first_response is not None and "error" not in first_response, first_response
+    assert second_response is not None and "error" not in second_response, second_response
+    first = cast(dict[str, Any], first_response["result"]["structuredContent"])
+    second = cast(dict[str, Any], second_response["result"]["structuredContent"])
+    assert first["outcome"] == "pending"
+    assert first["scheduler_action"] == "none"
+    assert first["relay_action"] == "none"
+    assert first["scheduler_cancel_requested"] is False
+    assert all(
+        first[key] is None
+        for key in (
+            "connect_url",
+            "health_url",
+            "stream_url",
+            "events_url",
+            "state_url",
+            "command_url",
+        )
+    )
+    retry = cast(dict[str, Any], first["retry_selector"])
+    assert retry["resume_tool"] == "relay_bind_jarvis_runtime"
+    assert retry["binding"]["source_job_id"] == job.job_id
+    pending_report = ServiceRuntimePendingResult(
+        session=GatewaySession.model_validate(first["gateway_session"])
+    ).to_live_validation_report()
+    assert pending_report.status.value == "pending"
+    assert {resource.kind for resource in pending_report.resources} == {
+        "gateway_session",
+        "jarvis_service_runtime",
+        "scheduler_job",
+    }
+    assert second["outcome"] == "ready"
+    assert second["retry_selector"] is None
+    assert second["gateway_session_id"] == first["gateway_session_id"]
+    assert launches == {"remote": 1, "desktop": 1}
+    assert health_observations == 2
+    assert len(queue.list_gateway_sessions(cluster=definition.name)) == 1
+
+
+def test_pending_direct_jarvis_binding_does_not_invent_scheduler_submission() -> None:
+    """A direct JARVIS service resumes by binding identity with no fake job handle."""
+    session = GatewaySession(
+        session_id="gateway_direct_jarvis_pending",
+        cluster="direct-cluster",
+        name="direct-paraview",
+        state=GatewaySessionState.STARTING,
+        scheduler="external",
+        scheduler_job_id=None,
+        queue_state="ready",
+        gateway={
+            "jarvis_runtime_binding": {
+                "source_relay_job_id": "job_source",
+                "source_relay_artifact_id": "artifact_source",
+                "jarvis_execution_id": "execution-1",
+                "package_id": "paraview-1",
+                "package_name": "builtin.paraview",
+                "service_instance_id": "paraview-live-1",
+            }
+        },
+        metadata={"owner": "clio-relay"},
+    )
+    pending = ServiceRuntimePendingResult(session=session)
+
+    selector = pending.retry_selector()
+    report = pending.to_live_validation_report()
+
+    assert selector["scheduler_job_id"] is None
+    assert selector["resume_tool"] == "relay_bind_jarvis_runtime"
+    assert selector["binding"] == {
+        "cluster": "direct-cluster",
+        "source_job_id": "job_source",
+        "source_artifact_id": "artifact_source",
+        "package_id": "paraview-1",
+        "package_name": "builtin.paraview",
+        "service_instance_id": "paraview-live-1",
+    }
+    assert [resource.kind for resource in report.resources] == [
+        "gateway_session",
+        "jarvis_service_runtime",
+    ]
+    assert all(resource.kind != "scheduler_submission" for resource in report.resources)
 
 
 def test_owned_agent_bind_uses_shared_cluster_scoped_gateway_admission(
@@ -3374,11 +3599,11 @@ def test_public_jarvis_bind_uses_the_durable_allocation_connector_revision(
     assert remote_intent["state"] == "recorded"
 
 
-def test_jarvis_bind_recovers_and_stops_allocation_connector_after_lost_start_response(
+def test_jarvis_bind_preserves_and_resumes_allocation_connector_after_lost_start_response(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A lost SSH response cannot orphan its already-started scheduler step."""
+    """A lost SSH response stays pending and adopts the exact scheduler step on replay."""
     queue, definition, job, artifact, envelope = _source_result(tmp_path)
     monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
     verified = resolve_jarvis_service_runtime(
@@ -3455,7 +3680,9 @@ def test_jarvis_bind_recovers_and_stops_allocation_connector_after_lost_start_re
             )
         if "__CLIO_WRITE_ALLOCATION_FRPC__" in script:
             events.append("start-side-effect")
-            raise RelayError("lost allocation connector start response")
+            raise service_runtime_module._AmbiguousRemoteSideEffectError(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+                "lost allocation connector start response"
+            )
         _session, intent, connector, step = allocation_context()
         if "__CLIO_DISCOVER_CONNECTOR__" in script:
             events.append("discover")
@@ -3513,34 +3740,82 @@ def test_jarvis_bind_recovers_and_stops_allocation_connector_after_lost_start_re
         raise AssertionError("unexpected remote connector script")
 
     monkeypatch.setattr(supervisor, "_ssh", ssh)
+    first = supervisor.bind_verified_jarvis_runtime(
+        name="paraview-lost-allocation-response",
+        verified=verified,
+        desktop_bind_port=28777,
+    )
 
-    with pytest.raises(RelayError, match="lost allocation connector start response"):
-        supervisor.bind_verified_jarvis_runtime(
-            name="paraview-lost-allocation-response",
-            verified=verified,
-            desktop_bind_port=28777,
-        )
+    assert isinstance(first, ServiceRuntimePendingResult)
+    assert first.session.state is GatewaySessionState.STARTING
+    assert first.scheduler_action == "none"
+    assert first.relay_action == "none"
+    assert events == ["placement", "start-side-effect"]
+    assert "cancel-step" not in events
+    remote_intent = cast(
+        dict[str, object],
+        cast(dict[str, object], first.session.gateway["ownership_intents"])["remote_connector"],
+    )
+    assert remote_intent["state"] == "starting"
+    assert remote_intent["scheduler_native_id"] == "12345"
 
-    persisted = queue.list_gateway_sessions(cluster=definition.name)[0]
-    assert persisted.state is GatewaySessionState.FAILED
+    def start_local(
+        *,
+        session: GatewaySession,
+        spec: ServiceRuntimeSpec,
+        proxy_name: str,
+        ownership_intent: dict[str, object],
+    ) -> dict[str, object]:
+        del spec, proxy_name
+        return {
+            "owner": "clio-relay",
+            "session_id": session.session_id,
+            "pid": 555,
+            "process_group_id": 555,
+            "process_start_marker": "start-555",
+            "connector_generation_id": ownership_intent["connector_generation_id"],
+            "owner_token": ownership_intent["owner_token"],
+            "config_path": ownership_intent["config_path"],
+            "stdout_path": ownership_intent["stdout_path"],
+            "stderr_path": ownership_intent["stderr_path"],
+            "metadata_path": ownership_intent["metadata_path"],
+        }
+
+    monkeypatch.setattr(supervisor, "_start_local_visitor", start_local)
+
+    def health_ready(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        supervisor,
+        "_wait_for_jarvis_health",
+        health_ready,
+    )
+    resumed = supervisor.bind_verified_jarvis_runtime(
+        name="paraview-lost-allocation-response",
+        verified=verified,
+        desktop_bind_port=28777,
+    )
+
+    assert not isinstance(resumed, ServiceRuntimePendingResult)
+    assert resumed.session.session_id == first.session.session_id
+    assert resumed.session.state is GatewaySessionState.READY
+    assert len(queue.list_gateway_sessions(cluster=definition.name)) == 1
     assert events == [
         "placement",
         "start-side-effect",
         "discover",
         "reconcile-step",
         "status-active",
-        "status-active",
-        "cancel-step",
-        "status-absent",
     ]
-    assert persisted.metadata["cleanup_error"] is None
+    assert "cancel-step" not in events
 
 
-def test_jarvis_bind_recovers_and_stops_local_connector_after_lost_start_response(
+def test_jarvis_bind_preserves_local_connector_intent_after_lost_start_response(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A local sidecar recovers a visitor whose successful response was lost."""
+    """A local sidecar and intent survive ambiguity without cleanup or replacement."""
     queue, definition, job, artifact, envelope = _source_result(tmp_path)
     monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
     _patch_connector_start(monkeypatch)
@@ -3620,17 +3895,141 @@ def test_jarvis_bind_recovers_and_stops_local_connector_after_lost_start_respons
     monkeypatch.setattr(supervisor, "_stop_local_connector", stop_local)
     monkeypatch.setattr(supervisor, "_ssh", _fake_connector_ssh)
 
-    with pytest.raises(RelayError, match="lost desktop connector start response"):
+    pending = supervisor.bind_verified_jarvis_runtime(
+        name="paraview-lost-desktop-response",
+        verified=verified,
+        desktop_bind_port=28777,
+    )
+
+    assert isinstance(pending, ServiceRuntimePendingResult)
+    persisted = queue.get_gateway_session(pending.session.session_id)
+    assert persisted.state is GatewaySessionState.STARTING
+    assert stopped == []
+    local_intent = cast(
+        dict[str, object],
+        cast(dict[str, object], persisted.gateway["ownership_intents"])["desktop_connector"],
+    )
+    assert local_intent["state"] == "starting"
+    assert Path(str(local_intent["metadata_path"])).exists()
+    assert persisted.metadata["runtime_observation_error"] == (
+        "lost desktop connector start response"
+    )
+
+
+def test_jarvis_bind_rejects_policy_change_without_creating_another_gateway(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retry may change observation bounds, but not connector side-effect policy."""
+    queue, definition, job, artifact, envelope = _source_result(tmp_path)
+    monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
+    _patch_connector_start(monkeypatch)
+    verified = resolve_jarvis_service_runtime(
+        queue=queue,
+        definition=definition,
+        source_job_id=job.job_id,
+        source_artifact_id=artifact.artifact_id,
+        package_id="paraview-1",
+        package_name="builtin.paraview",
+    )
+    supervisor = ServiceRuntimeSupervisor(
+        settings=RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool"),
+        queue=queue,
+        cluster=definition.name,
+        definition=definition,
+        token="token",
+        secret_key="secret",
+        sleep=lambda _seconds: None,
+    )
+
+    def not_ready(*_args: object, **_kwargs: object) -> None:
+        raise RelayError("health observation expired")
+
+    monkeypatch.setattr(supervisor, "_wait_for_jarvis_health", not_ready)
+    first = supervisor.bind_verified_jarvis_runtime(
+        name="paraview-live",
+        verified=verified,
+        desktop_bind_port=28777,
+        readiness_timeout_seconds=1,
+    )
+    assert isinstance(first, ServiceRuntimePendingResult)
+
+    with pytest.raises(
+        ConfigurationError,
+        match="already bound with a different immutable policy",
+    ):
         supervisor.bind_verified_jarvis_runtime(
-            name="paraview-lost-desktop-response",
+            name="renamed-paraview-live",
+            verified=verified,
+            desktop_bind_port=28777,
+            # Observation policy is deliberately different and remains mutable.
+            readiness_timeout_seconds=5,
+        )
+
+    sessions = queue.list_gateway_sessions(cluster=definition.name)
+    assert [session.session_id for session in sessions] == [first.session.session_id]
+    assert sessions[0].name == "paraview-live"
+    assert sessions[0].state is GatewaySessionState.STARTING
+
+
+def test_jarvis_bind_fails_closed_on_definitive_scheduler_terminal_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A proven terminal allocation is failure evidence, not a pending observation."""
+    queue, definition, job, artifact, envelope = _source_result(tmp_path)
+    monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
+    verified = resolve_jarvis_service_runtime(
+        queue=queue,
+        definition=definition,
+        source_job_id=job.job_id,
+        source_artifact_id=artifact.artifact_id,
+        package_id="paraview-1",
+        package_name="builtin.paraview",
+    )
+    supervisor = ServiceRuntimeSupervisor(
+        settings=RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool"),
+        queue=queue,
+        cluster=definition.name,
+        definition=definition,
+        token="token",
+        secret_key="secret",
+        sleep=lambda _seconds: None,
+    )
+
+    def fail_connector(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise RelayError("scheduler connector placement is unavailable")
+
+    def completed_status(**_kwargs: object) -> SchedulerStatus:
+        return SchedulerStatus(
+            scheduler="slurm",
+            scheduler_job_id="12345",
+            phase=SchedulerPhase.COMPLETED,
+            record_found=True,
+            active_record_found=False,
+        )
+
+    def no_connectors(session: GatewaySession) -> GatewaySession:
+        return session
+
+    monkeypatch.setattr(supervisor, "_start_remote_connector", fail_connector)
+    monkeypatch.setattr(supervisor, "_poll_scheduler_provider", completed_status)
+    monkeypatch.setattr(supervisor, "_reconcile_ownership_intents", no_connectors)
+
+    with pytest.raises(
+        RelayError,
+        match="scheduler job reached a terminal state before its verified JARVIS service",
+    ):
+        supervisor.bind_verified_jarvis_runtime(
+            name="paraview-terminal",
             verified=verified,
             desktop_bind_port=28777,
         )
 
     persisted = queue.list_gateway_sessions(cluster=definition.name)[0]
     assert persisted.state is GatewaySessionState.FAILED
-    assert stopped == [555]
-    assert persisted.metadata["cleanup_error"] is None
+    assert persisted.scheduler_job_id == "12345"
+    assert "terminal state" in str(persisted.metadata["last_error"])
 
 
 @pytest.mark.parametrize("operation", ["stop", "detach"])

--- a/tests/test_live_acceptance.py
+++ b/tests/test_live_acceptance.py
@@ -17,12 +17,14 @@ from pytest import MonkeyPatch
 from clio_relay.browser_gateway import BrowserAttachmentGrant, BrowserDetachmentResult
 from clio_relay.cluster_config import ClusterDefinition, LiveTestConfig
 from clio_relay.errors import ConfigurationError, RelayError
+from clio_relay.jarvis_service_runtime import JarvisServiceRuntimeHandoff
 from clio_relay.live_acceptance import (
     CommandRunner,
     LiveAcceptanceOptions,
     SecureRuntimeHttpEvidence,
     SecureRuntimeProbeConfig,
     SecureRuntimeProtocolAdapter,
+    _AcceptanceObservationPending,  # pyright: ignore[reportPrivateUsage]
     _assert_progress_adapter,  # pyright: ignore[reportPrivateUsage]
     _assert_secret_free_document,  # pyright: ignore[reportPrivateUsage]
     _browser_json_observation,  # pyright: ignore[reportPrivateUsage]
@@ -36,6 +38,7 @@ from clio_relay.live_acceptance import (
     _require_secure_runtime_control_capacity,  # pyright: ignore[reportPrivateUsage]
     _secure_runtime_probe_config,  # pyright: ignore[reportPrivateUsage]
     _select_secure_runtime_handoff,  # pyright: ignore[reportPrivateUsage]
+    _validated_secure_runtime_pending_bind,  # pyright: ignore[reportPrivateUsage]
     _verify_cluster_deployment,  # pyright: ignore[reportPrivateUsage]
     _verify_live_package_progress,  # pyright: ignore[reportPrivateUsage]
     _verify_runtime_metadata_artifact,  # pyright: ignore[reportPrivateUsage]
@@ -58,6 +61,7 @@ from clio_relay.validation_report import (
     TransportCleanupResourceEvidence,
     TransportProbeEvidence,
     ValidationRecorder,
+    ValidationStatus,
     load_validation_report,
     new_live_validation_report,
     transport_probe_evidence_line,
@@ -452,7 +456,10 @@ def test_secure_runtime_acceptance_metadata_poll_is_bounded() -> None:
         calls += 1
         return _completed(command, json.dumps(_live_source_status(JobState.RUNNING)))
 
-    with pytest.raises(RelayError, match="timed out waiting for structured runtime metadata"):
+    with pytest.raises(
+        RelayError,
+        match="timed out waiting for structured runtime metadata",
+    ) as pending:
         _wait_for_live_structured_runtime_metadata(
             ClusterDefinition(name="test-cluster", ssh_host="test-host"),
             _LIVE_SOURCE_JOB_ID,
@@ -464,6 +471,9 @@ def test_secure_runtime_acceptance_metadata_poll_is_bounded() -> None:
         )
 
     assert calls == 1
+    pending_observation = cast(_AcceptanceObservationPending, pending.value)
+    assert pending_observation.phase == "secure_runtime_metadata"
+    assert pending_observation.identifiers == {"primary_job_id": _LIVE_SOURCE_JOB_ID}
 
 
 def test_secure_runtime_acceptance_rejects_unsupported_metadata_schema() -> None:
@@ -656,6 +666,152 @@ def test_secure_runtime_orchestration_never_waits_for_outer_job_terminal(
     assert source.state == "running"
     assert source.metadata["retained"] is True
     assert source.metadata["cancel_scheduler_job"] is False
+
+
+def test_secure_runtime_query_pending_report_resumes_exact_execution(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A secure query deadline retains source and execution IDs without resubmission."""
+    pipeline = tmp_path / "secure-runtime.yaml"
+    pipeline.write_text("name: secure-runtime\npkgs: []\n", encoding="utf-8")
+    pending_path = tmp_path / "secure-pending.json"
+    passed_path = tmp_path / "secure-passed.json"
+    submitted = 0
+    remote_calls = 0
+    verifier_calls = 0
+    config = SecureRuntimeProbeConfig(
+        package_name="builtin.paraview",
+        command={"command_id": "view-command-41"},
+        protocol_adapter=_secure_runtime_protocol_adapter(),
+    )
+
+    def fake_runner(
+        command: list[str],
+        *,
+        input: bytes | None = None,
+    ) -> subprocess.CompletedProcess[bytes]:
+        nonlocal submitted, remote_calls
+        del input
+        remote_calls += 1
+        script = command[-1]
+        if "mkdir -p" in script or "cat >" in script:
+            return _completed(command, "")
+        if "worker status --cluster test-cluster" in script:
+            return _completed(
+                command,
+                json.dumps(
+                    {
+                        "configured_workload_concurrency": 2,
+                        "configured_control_query_concurrency": 1,
+                        "control_query_concurrency_consistent": True,
+                        "active_leases_by_mcp_admission_class": {
+                            "workload": 0,
+                            "control_query": 0,
+                        },
+                        "scan_truncated": False,
+                    }
+                ),
+            )
+        if "job submit" in script:
+            submitted += 1
+            return _completed(command, f"{_LIVE_SOURCE_JOB_ID}\n")
+        if f"job status {_LIVE_SOURCE_JOB_ID}" in script:
+            return _completed(
+                command,
+                json.dumps(
+                    _live_source_status(
+                        JobState.RUNNING,
+                        runtime_metadata=_structured_live_runtime_metadata(),
+                    )
+                ),
+            )
+        raise AssertionError(f"unexpected command: {command}")
+
+    def verify_secure_runtime(
+        _options: LiveAcceptanceOptions,
+        *,
+        config: SecureRuntimeProbeConfig,
+        runtime_metadata: dict[str, Any],
+        recorder: ValidationRecorder,
+    ) -> set[str]:
+        nonlocal verifier_calls
+        del config, recorder
+        verifier_calls += 1
+        assert runtime_metadata["pipeline_id"] == "pipeline-live-41"
+        assert runtime_metadata["execution_id"] == "execution-live-41"
+        if verifier_calls == 1:
+            raise _AcceptanceObservationPending(
+                "timed out waiting for one ready JARVIS service runtime binding",
+                phase="secure_runtime_query",
+                identifiers={
+                    "pipeline_id": "pipeline-live-41",
+                    "execution_id": "execution-live-41",
+                },
+            )
+        return set()
+
+    def fake_cluster_doctor(_definition: ClusterDefinition) -> list[str]:
+        return ["cluster: test-cluster"]
+
+    def configured_probe(_pipeline_yaml: str) -> SecureRuntimeProbeConfig:
+        return config
+
+    monkeypatch.setattr(
+        "clio_relay.live_acceptance.run_cluster_doctor",
+        fake_cluster_doctor,
+    )
+    monkeypatch.setattr(
+        "clio_relay.live_acceptance._secure_runtime_probe_config",
+        configured_probe,
+    )
+    monkeypatch.setattr(
+        "clio_relay.live_acceptance._verify_secure_runtime_acceptance",
+        verify_secure_runtime,
+    )
+    definition = ClusterDefinition(name="test-cluster", ssh_host="test-host")
+
+    def acceptance_options(
+        report_path: Path,
+        *,
+        resume_report_path: Path | None = None,
+    ) -> LiveAcceptanceOptions:
+        return LiveAcceptanceOptions(
+            cluster="test-cluster",
+            definition=definition,
+            jarvis_yaml=pipeline,
+            timeout_seconds=1,
+            poll_seconds=0.01,
+            report_path=report_path,
+            resume_report_path=resume_report_path,
+        )
+
+    run_live_acceptance(
+        acceptance_options(pending_path),
+        runner=fake_runner,
+    )
+    pending = load_validation_report(pending_path)
+    checkpoint = next(
+        resource.metadata["checkpoint"]
+        for resource in pending.resources
+        if resource.kind == "live_acceptance_checkpoint"
+    )
+    assert pending.status is ValidationStatus.PENDING
+    assert checkpoint["phase"] == "secure_runtime_query"
+    assert checkpoint["pipeline_id"] == "pipeline-live-41"
+    assert checkpoint["execution_id"] == "execution-live-41"
+    assert checkpoint["primary_job_id"] == _LIVE_SOURCE_JOB_ID
+    first_remote_calls = remote_calls
+
+    run_live_acceptance(
+        acceptance_options(passed_path, resume_report_path=pending_path),
+        runner=fake_runner,
+    )
+    passed = load_validation_report(passed_path)
+    assert passed.status is ValidationStatus.PASSED
+    assert submitted == 1
+    assert verifier_calls == 2
+    assert remote_calls == first_remote_calls
 
 
 def test_secure_runtime_capacity_failure_records_pre_submission_evidence() -> None:
@@ -1893,6 +2049,223 @@ def test_live_acceptance_uses_fresh_idempotency_key_per_run(
     assert "live-test:test-cluster:" in submitted_scripts[1]
 
 
+def test_live_acceptance_pending_wait_resumes_exact_job_without_resubmission(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Repeated bounded observations retain one exact HPC workload indefinitely."""
+    pipeline = tmp_path / "pipeline.yaml"
+    pipeline.write_text("name: generic\npkgs: []\n", encoding="utf-8")
+    first_report_path = tmp_path / "pending.json"
+    second_report_path = tmp_path / "pending-again.json"
+    final_report_path = tmp_path / "passed.json"
+    job_id = "job_11111111111111111111111111111111"
+    submitted = 0
+
+    def fake_cluster_doctor(_definition: ClusterDefinition) -> list[str]:
+        return ["cluster: test-cluster"]
+
+    monkeypatch.setattr(
+        "clio_relay.live_acceptance.run_cluster_doctor",
+        fake_cluster_doctor,
+    )
+
+    def runner_for_state(state: str) -> CommandRunner:
+        def fake_runner(
+            command: list[str],
+            *,
+            input: bytes | None = None,
+        ) -> subprocess.CompletedProcess[bytes]:
+            nonlocal submitted
+            del input
+            script = command[-1]
+            if "mkdir -p" in script or "cat >" in " ".join(command):
+                return _completed(command, "")
+            if "job submit" in script:
+                submitted += 1
+                return _completed(command, f"{job_id}\n")
+            if "job wait" in script:
+                return _completed(command, json.dumps({"job_id": job_id, "state": state}))
+            if "job monitor" in script:
+                return _completed(
+                    command,
+                    json.dumps(
+                        {
+                            "events": [
+                                {"event_type": "job.queued"},
+                                {"event_type": "job.running"},
+                                {"event_type": "jarvis.started"},
+                                {"event_type": "job.succeeded"},
+                            ]
+                        }
+                    ),
+                )
+            if "job tasks" in script:
+                return _completed(
+                    command,
+                    json.dumps([{"task_id": "task_abc", "state": "succeeded"}]),
+                )
+            if "read-log" in script and "--stream stdout" in script:
+                return _completed(command, json.dumps({"next_offset": 12}))
+            if "read-log" in script and "--stream stderr" in script:
+                return _completed(command, json.dumps({"next_offset": 0}))
+            if "list-artifacts" in script:
+                return _completed(
+                    command,
+                    json.dumps(
+                        [
+                            {"artifact_id": "artifact_pipeline", "kind": "jarvis_pipeline"},
+                            {"artifact_id": "artifact_stdout", "kind": "stdout"},
+                            {"artifact_id": "artifact_stderr", "kind": "stderr"},
+                            {"artifact_id": "artifact_provenance", "kind": "provenance"},
+                        ]
+                    ),
+                )
+            if "read-artifact" in script:
+                return _completed(
+                    command,
+                    json.dumps({"encoding": "base64", "data": "aGVsbG8="}),
+                )
+            raise AssertionError(f"unexpected command: {command}")
+
+        return fake_runner
+
+    definition = ClusterDefinition(name="test-cluster", ssh_host="test-host")
+
+    def acceptance_options(
+        report_path: Path,
+        *,
+        resume_report_path: Path | None = None,
+    ) -> LiveAcceptanceOptions:
+        return LiveAcceptanceOptions(
+            cluster="test-cluster",
+            definition=definition,
+            jarvis_yaml=pipeline,
+            timeout_seconds=1,
+            poll_seconds=0.01,
+            report_path=report_path,
+            resume_report_path=resume_report_path,
+        )
+
+    first_lines = run_live_acceptance(
+        acceptance_options(first_report_path),
+        runner=runner_for_state("queued"),
+    )
+    first = load_validation_report(first_report_path)
+    assert first.status is ValidationStatus.PENDING
+    assert "validation.status=pending" in first_lines
+    checkpoint_resource = next(
+        resource for resource in first.resources if resource.kind == "live_acceptance_checkpoint"
+    )
+    first_selector = checkpoint_resource.metadata["retry_selector"]
+    assert first_selector["primary_job_id"] == job_id
+    assert checkpoint_resource.metadata["checkpoint_has_ttl"] is False
+    assert submitted == 1
+
+    second_lines = run_live_acceptance(
+        acceptance_options(second_report_path, resume_report_path=first_report_path),
+        runner=runner_for_state("running"),
+    )
+    second = load_validation_report(second_report_path)
+    second_checkpoint = next(
+        resource for resource in second.resources if resource.kind == "live_acceptance_checkpoint"
+    )
+    assert second.status is ValidationStatus.PENDING
+    assert "validation.status=pending" in second_lines
+    assert second_checkpoint.metadata["retry_selector"] == first_selector
+    assert submitted == 1
+
+    final_lines = run_live_acceptance(
+        acceptance_options(final_report_path, resume_report_path=second_report_path),
+        runner=runner_for_state("succeeded"),
+    )
+    final = load_validation_report(final_report_path)
+    assert final.status is ValidationStatus.PASSED
+    assert "acceptance.job_state=succeeded" in final_lines
+    assert submitted == 1
+    assert not any(resource.kind == "live_acceptance_checkpoint" for resource in final.resources)
+
+
+def test_live_acceptance_rejects_tampered_resume_before_remote_mutation(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Checkpoint identity and integrity are verified before SSH or relay submission."""
+    pipeline = tmp_path / "pipeline.yaml"
+    pipeline.write_text("name: generic\npkgs: []\n", encoding="utf-8")
+    pending_path = tmp_path / "pending.json"
+    tampered_path = tmp_path / "tampered.json"
+    resumed_path = tmp_path / "resume-failure.json"
+    job_id = "job_22222222222222222222222222222222"
+
+    def fake_cluster_doctor(_definition: ClusterDefinition) -> list[str]:
+        return ["cluster: test-cluster"]
+
+    monkeypatch.setattr(
+        "clio_relay.live_acceptance.run_cluster_doctor",
+        fake_cluster_doctor,
+    )
+
+    def initial_runner(
+        command: list[str],
+        *,
+        input: bytes | None = None,
+    ) -> subprocess.CompletedProcess[bytes]:
+        del input
+        script = command[-1]
+        if "mkdir -p" in script or "cat >" in " ".join(command):
+            return _completed(command, "")
+        if "job submit" in script:
+            return _completed(command, f"{job_id}\n")
+        if "job wait" in script:
+            return _completed(command, json.dumps({"job_id": job_id, "state": "queued"}))
+        raise AssertionError(f"unexpected command: {command}")
+
+    options = LiveAcceptanceOptions(
+        cluster="test-cluster",
+        definition=ClusterDefinition(name="test-cluster", ssh_host="test-host"),
+        jarvis_yaml=pipeline,
+        report_path=pending_path,
+        timeout_seconds=1,
+        poll_seconds=0.01,
+    )
+    run_live_acceptance(options, runner=initial_runner)
+    document = json.loads(pending_path.read_text(encoding="utf-8"))
+    checkpoint = next(
+        resource
+        for resource in document["resources"]
+        if resource["kind"] == "live_acceptance_checkpoint"
+    )
+    checkpoint["metadata"]["checkpoint"]["primary_job_id"] = "job_ffffffffffffffffffffffffffffffff"
+    tampered_path.write_text(json.dumps(document), encoding="utf-8")
+    remote_calls = 0
+
+    def forbidden_runner(
+        command: list[str],
+        *,
+        input: bytes | None = None,
+    ) -> subprocess.CompletedProcess[bytes]:
+        nonlocal remote_calls
+        del input
+        remote_calls += 1
+        raise AssertionError(f"resume must fail before remote command: {command}")
+
+    with pytest.raises(ConfigurationError, match="checkpoint is invalid"):
+        run_live_acceptance(
+            LiveAcceptanceOptions(
+                cluster="test-cluster",
+                definition=options.definition,
+                jarvis_yaml=pipeline,
+                report_path=resumed_path,
+                resume_report_path=tampered_path,
+                timeout_seconds=1,
+                poll_seconds=0.01,
+            ),
+            runner=forbidden_runner,
+        )
+    assert remote_calls == 0
+
+
 def test_live_acceptance_requires_agent_child_job_when_mcp_configured(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -3078,7 +3451,7 @@ def test_secure_runtime_ready_binding_wait_is_bounded(
     with pytest.raises(
         RelayError,
         match="timed out waiting for one ready JARVIS service runtime binding",
-    ):
+    ) as pending:
         _verify_secure_runtime_acceptance(
             LiveAcceptanceOptions(
                 cluster=cluster,
@@ -3101,6 +3474,70 @@ def test_secure_runtime_ready_binding_wait_is_bounded(
         )
 
     assert calls == 1
+    pending_observation = cast(_AcceptanceObservationPending, pending.value)
+    assert pending_observation.phase == "secure_runtime_query"
+    assert pending_observation.identifiers == {
+        "pipeline_id": "pipeline-readiness-timeout",
+        "execution_id": "execution-readiness-timeout",
+    }
+
+
+def test_secure_runtime_pending_bind_retains_exact_gateway_without_urls() -> None:
+    """A bind observation boundary exposes only its durable resume identity."""
+    handoff = {
+        "cluster": "operator-pending-bind",
+        "source_job_id": "job_pending_bind",
+        "source_artifact_id": "artifact_pending_bind",
+        "package_id": "paraview-pending",
+        "package_name": "builtin.paraview",
+        "service_instance_id": "visualizer-pending",
+    }
+    gateway_session_id = "gateway_pending_bind"
+    gateway = GatewaySession(
+        session_id=gateway_session_id,
+        cluster=handoff["cluster"],
+        name="pending-viewer",
+        state=GatewaySessionState.STARTING,
+        scheduler="slurm",
+        scheduler_job_id="99123",
+        gateway={
+            "jarvis_runtime_binding": {
+                "source_relay_job_id": handoff["source_job_id"],
+                "source_relay_artifact_id": handoff["source_artifact_id"],
+                "package_id": handoff["package_id"],
+                "package_name": handoff["package_name"],
+                "service_instance_id": handoff["service_instance_id"],
+            }
+        },
+        metadata={"owner": "clio-relay"},
+    )
+    result = {
+        "outcome": "pending",
+        "gateway_session_id": gateway_session_id,
+        "gateway_session": gateway.model_dump(mode="json"),
+        "retry_selector": {
+            "cluster": handoff["cluster"],
+            "gateway_session_id": gateway_session_id,
+            "scheduler_provider": "slurm",
+            "scheduler_job_id": "99123",
+        },
+        "scheduler_action": "none",
+        "relay_action": "none",
+        "scheduler_cancel_requested": False,
+        "connect_url": None,
+        "health_url": None,
+        "stream_url": None,
+        "events_url": None,
+        "state_url": None,
+        "command_url": None,
+    }
+
+    observed = _validated_secure_runtime_pending_bind(
+        result,
+        handoff=JarvisServiceRuntimeHandoff.model_validate(handoff),
+    )
+
+    assert observed == gateway_session_id
 
 
 def test_secure_runtime_late_ready_binding_fails_deadline(

--- a/tests/test_mcp_call_runner.py
+++ b/tests/test_mcp_call_runner.py
@@ -915,6 +915,47 @@ def test_windows_uv_trampoline_fails_closed_on_unsupported_zip(
     )
 
 
+def test_posix_uv_shell_trampoline_resolves_exact_provider() -> None:
+    """Long-path uv launchers bind identity probes to their tool interpreter."""
+    runner = _load_runner()
+    provider = "/home/operator/.local/share/uv/tools/clio-kit/bin/python"
+    launcher = (
+        f"#!/bin/sh\n'''exec' '{provider}' \"$0\" \"$@\"\n' '''\n# -*- coding: utf-8 -*-\n"
+    ).encode()
+
+    shebang = cast(Any, runner)._persistent_tool_launcher_shebang(
+        launcher,
+        executable_name="clio-kit",
+    )
+
+    assert shebang == f"#!{provider}"
+
+
+@mark.parametrize(
+    "execution_line,closing_line",
+    [
+        ("'''exec' '/absolute/python' \"$0\" \"$@\"; echo injected", "' '''"),
+        ('exec \'/absolute/python\' "$0" "$@"', "' '''"),
+        ("'''exec' 'relative/python' \"$0\" \"$@\"", "' '''"),
+        ("'''exec' '/absolute/python' \"$0\"", "' '''"),
+        ("'''exec' '/absolute/python' \"$0\" \"$@\"", "not-the-python-quote-close"),
+    ],
+)
+def test_posix_uv_shell_trampoline_rejects_ambiguous_contracts(
+    execution_line: str,
+    closing_line: str,
+) -> None:
+    """Shell syntax outside uv's exact trampoline form fails closed."""
+    runner = _load_runner()
+    launcher = f"#!/bin/sh\n{execution_line}\n{closing_line}\nprint('never run')\n".encode()
+
+    with raises(ValueError, match="persistent uv shell trampoline"):
+        cast(Any, runner)._persistent_tool_launcher_shebang(
+            launcher,
+            executable_name="clio-kit",
+        )
+
+
 def test_mcp_call_runner_supports_server_arguments(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -294,6 +294,10 @@ def test_mcp_lists_relay_tools(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
         ),
     }
     assert bind_output_schema["required"] == [
+        "outcome",
+        "retry_selector",
+        "scheduler_action",
+        "relay_action",
         "gateway_session_id",
         "gateway_session",
         "connect_url",
@@ -304,8 +308,12 @@ def test_mcp_lists_relay_tools(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
         "command_url",
         "scheduler_cancel_requested",
     ]
+    assert bind_output_schema["properties"]["connect_url"] == {"type": ["string", "null"]}
+    assert bind_output_schema["properties"]["scheduler_action"] == {"const": "none"}
+    assert bind_output_schema["properties"]["relay_action"] == {"const": "none"}
     assert "top-level gateway_session_id" in bind_runtime_tool["description"]
     assert "service_instance_id is not a gateway identity" in bind_runtime_tool["description"]
+    assert "Reissue this tool" in bind_runtime_tool["description"]
     create_pipeline_tool = next(
         tool for tool in response["result"]["tools"] if tool["name"] == "jarvis_create_pipeline"
     )
@@ -511,6 +519,46 @@ def test_user_mcp_schemas_avoid_root_unions_and_preserve_exclusive_forms(
     ):
         with pytest.raises(ValidationError):
             bind_runtime.validate(rejected)
+
+    bind_output = cast(
+        _SchemaValidator,
+        Draft202012Validator(tools["relay_bind_jarvis_runtime"]["outputSchema"]),
+    )
+    base_output: dict[str, object] = {
+        "gateway_session_id": f"gateway_{'a' * 32}",
+        "gateway_session": cast(dict[str, object], {}),
+        "scheduler_action": "none",
+        "relay_action": "none",
+        "scheduler_cancel_requested": False,
+    }
+    ready_output: dict[str, object] = {
+        **base_output,
+        "outcome": "ready",
+        "retry_selector": None,
+        "connect_url": "http://127.0.0.1:28777",
+        "health_url": "http://127.0.0.1:28777/healthz",
+        "stream_url": "http://127.0.0.1:28777/live-data",
+        "events_url": "http://127.0.0.1:28777/events",
+        "state_url": "http://127.0.0.1:28777/state",
+        "command_url": "http://127.0.0.1:28777/commands",
+    }
+    pending_output: dict[str, object] = {
+        **base_output,
+        "outcome": "pending",
+        "retry_selector": {"gateway_session_id": f"gateway_{'a' * 32}"},
+        "connect_url": None,
+        "health_url": None,
+        "stream_url": None,
+        "events_url": None,
+        "state_url": None,
+        "command_url": None,
+    }
+    bind_output.validate(ready_output)
+    bind_output.validate(pending_output)
+    with pytest.raises(ValidationError):
+        bind_output.validate({**pending_output, "connect_url": ready_output["connect_url"]})
+    with pytest.raises(ValidationError):
+        bind_output.validate({**ready_output, "retry_selector": {}})
 
 
 def test_mcp_admin_profile_lists_operational_tools(tmp_path: Path) -> None:

--- a/tests/test_mcp_stdio_validation.py
+++ b/tests/test_mcp_stdio_validation.py
@@ -22,7 +22,7 @@ from clio_relay import __version__
 from clio_relay import mcp_stdio_validation as mcp_stdio_validation_module
 from clio_relay.cluster_config import ClusterDefinition, ClusterRegistry
 from clio_relay.core_queue import ClioCoreQueue
-from clio_relay.errors import RelayError
+from clio_relay.errors import ObservationTimeoutError, RelayError
 from clio_relay.jarvis_mcp import (
     CLIO_KIT_JARVIS_USER_CONTRACT_ID,
     CLIO_KIT_JARVIS_USER_CONTRACT_SHA256,
@@ -388,7 +388,7 @@ time.sleep(10)
     monkeypatch.setenv("CLIO_RELAY_VALIDATION_TOOL_EXECUTABLE", str(executable))
 
     started = time.monotonic()
-    with pytest.raises(RelayError, match="total wall-clock deadline"):
+    with pytest.raises(ObservationTimeoutError, match="total wall-clock deadline"):
         run_packaged_mcp_stdio_session(
             profile="user",
             tool="jarvis_run",

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.20"
+    assert version == "1.4.21"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_service_runtime.py
+++ b/tests/test_service_runtime.py
@@ -5,6 +5,7 @@ import errno
 import gzip
 import hashlib
 import json
+import os
 import shlex
 import signal
 import socket
@@ -40,6 +41,7 @@ from clio_relay.models import (
 from clio_relay.service_runtime import (
     CommandRunner,
     LocalConnectorIdentity,
+    ServiceRuntimePendingResult,
     ServiceRuntimeStartResult,
     ServiceRuntimeStopResult,
     ServiceRuntimeSupervisor,
@@ -58,6 +60,8 @@ from tests.gateway_ownership_crash_fixture import (
 from tests.gateway_ownership_crash_fixture import (
     definition as crash_fixture_definition,
 )
+
+_REAL_OBSERVE_LOCAL_PROCESS = service_runtime._observe_local_process  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
 
 
 class FakeProcess:
@@ -362,6 +366,7 @@ class FakeRunner(CommandRunner):
         self.canceled_jobs: list[str] = []
         self.provider_canceled_jobs: list[str] = []
         self.submission_record: dict[str, object] | None = None
+        self.remote_connector: dict[str, object] | None = None
 
     def run(
         self,
@@ -379,7 +384,18 @@ class FakeRunner(CommandRunner):
         if "remote-frpc.toml" in script and "nohup" in script:
             session_id = _script_assignment(script, "session_id")
             generation_id = _script_assignment(script, "connector_generation_id")
+            owner_token = _script_assignment(script, "owner_token")
             session_root = f"/home/user/.local/share/clio-relay/service-sessions/{session_id}"
+            self.remote_connector = {
+                "owner": "clio-relay",
+                "session_id": session_id,
+                "pid": 444,
+                "process_group_id": 444,
+                "connector_generation_id": generation_id,
+                "owner_token": owner_token,
+                "config_path": f"{session_root}/remote-frpc.toml",
+                "log_path": f"{session_root}/remote-frpc.log",
+            }
             return subprocess.CompletedProcess(
                 command,
                 0,
@@ -395,6 +411,33 @@ class FakeRunner(CommandRunner):
                 + "\n",
                 "",
             )
+        if "__CLIO_DISCOVER_CONNECTOR__" in script:
+            expected_session = _script_assignment(script, "session_id")
+            expected_token = _script_assignment(script, "owner_token")
+            expected_generation = _script_assignment(script, "generation_id")
+            connector = self.remote_connector
+            verified = bool(
+                connector is not None
+                and connector.get("session_id") == expected_session
+                and connector.get("owner_token") == expected_token
+                and connector.get("connector_generation_id") == expected_generation
+            )
+            payload: dict[str, object] = (
+                {
+                    "present": True,
+                    "ownership_verified": True,
+                    "matching_pids": [444],
+                    "connector": connector,
+                }
+                if verified
+                else {
+                    "present": False,
+                    "ownership_verified": connector is None,
+                    "matching_pids": [],
+                    "error": (None if connector is None else "remote connector identity mismatch"),
+                }
+            )
+            return subprocess.CompletedProcess(command, 0, json.dumps(payload) + "\n", "")
         if "__CLIO_CAPTURE_SUBMISSION__" in script:
             output = '{"scheduler_job_id":"12345","service_host":"compute-01"}\n'
             self.submission_record = {
@@ -422,6 +465,7 @@ class FakeRunner(CommandRunner):
                 "",
             )
         if "__CLIO_STOP_CONNECTOR__" in script:
+            self.remote_connector = None
             return subprocess.CompletedProcess(
                 command,
                 0,
@@ -520,6 +564,248 @@ class FakeRunner(CommandRunner):
             process_group_id=pid,
             process_start_marker=f"start-{pid}",
             owner_token=owner_token,
+        )
+
+
+class TransientConnectorDiscoveryRunner(FakeRunner):
+    """Inject a bounded remote discovery outage after one connector is durable."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.fail_remote_discovery = False
+
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        input_text: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        if self.fail_remote_discovery and "__CLIO_DISCOVER_CONNECTOR__" in (input_text or ""):
+            self.commands.append(list(command))
+            self.inputs.append(input_text)
+            return subprocess.CompletedProcess(
+                command,
+                1,
+                "",
+                "temporary remote connector sidecar read failure",
+            )
+        return super().run(
+            command,
+            input_text=input_text,
+            timeout_seconds=timeout_seconds,
+        )
+
+
+class AmbiguousSubmissionRunner(FakeRunner):
+    """Lose the first submit response after optionally publishing its exact sidecar."""
+
+    def __init__(self, *, publish_sidecar: bool) -> None:
+        super().__init__()
+        self.publish_sidecar = publish_sidecar
+        self.submit_attempts = 0
+
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        input_text: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        script = input_text or ""
+        if "__CLIO_CAPTURE_SUBMISSION__" in script:
+            self.commands.append(list(command))
+            self.inputs.append(input_text)
+            self.submit_attempts += 1
+            if self.submit_attempts > 1:
+                pytest.fail("an ambiguous scheduler submission must never be resubmitted")
+            if self.publish_sidecar:
+                output = '{"scheduler_job_id":"12345","service_host":"compute-01"}\n'
+                self.submission_record = {
+                    "schema_version": "clio-relay.gateway-submission-sidecar.v1",
+                    "present": True,
+                    "session_id": _script_assignment(script, "session_id"),
+                    "submission_id": _script_assignment(script, "submission_id"),
+                    "scheduler_provider": _script_assignment(
+                        script,
+                        "scheduler_provider",
+                    ),
+                    "submission_marker": _script_assignment(script, "submission_marker"),
+                    "returncode": 0,
+                    "output": output,
+                    "output_truncated": False,
+                }
+            raise subprocess.TimeoutExpired(command, timeout_seconds or 120.0)
+        return super().run(
+            command,
+            input_text=input_text,
+            timeout_seconds=timeout_seconds,
+        )
+
+
+class ProductionSubmissionVerifierRunner(AmbiguousSubmissionRunner):
+    """Execute the generated verifier against a corrupt or incomplete sidecar set."""
+
+    def __init__(self, *, sidecar_state: str) -> None:
+        if sidecar_state not in {"record_identity_mismatch", "output_incomplete"}:
+            raise ValueError(f"unsupported test sidecar state: {sidecar_state}")
+        super().__init__(publish_sidecar=False)
+        self.sidecar_state = sidecar_state
+        self.verifier_runs = 0
+
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        input_text: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        script = input_text or ""
+        if "__CLIO_READ_SUBMISSION__" not in script:
+            return super().run(
+                command,
+                input_text=input_text,
+                timeout_seconds=timeout_seconds,
+            )
+        self.commands.append(list(command))
+        self.inputs.append(input_text)
+        self.verifier_runs += 1
+        session_id = _script_assignment(script, "session_id")
+        submission_id = _script_assignment(script, "submission_id")
+        scheduler_provider = _script_assignment(script, "scheduler_provider")
+        submission_marker = _script_assignment(script, "submission_marker")
+        expected = {
+            "session_id": session_id,
+            "submission_id": submission_id,
+            "scheduler_provider": scheduler_provider,
+            "submission_marker": submission_marker,
+        }
+        intent = {
+            "schema_version": "clio-relay.gateway-submission-intent.v1",
+            **expected,
+        }
+        output = b'{"scheduler_job_id":"should-not-be-trusted"}\n'
+        record = {
+            "schema_version": "clio-relay.gateway-submission-sidecar.v1",
+            **expected,
+            "session_id": "corrupt-session-identity",
+            "returncode": 0,
+            "output": output.decode(),
+            "output_sha256": hashlib.sha256(output).hexdigest(),
+            "output_size": len(output),
+            "output_truncated": False,
+        }
+        wrapper = f"""set -euo pipefail
+test_home=$(mktemp -d)
+trap 'rm -rf -- "$test_home"' EXIT
+export HOME="$test_home"
+root="$HOME/.local/share/clio-relay/service-sessions/{shlex.quote(session_id)}/submissions"
+mkdir -p "$root"
+python3 - "$root/{shlex.quote(submission_id)}.intent.json" \
+  "$root/{shlex.quote(submission_id)}.json" \
+  "$root/{shlex.quote(submission_id)}.out" \
+  {shlex.quote(json.dumps(intent, sort_keys=True))} \
+  {shlex.quote(json.dumps(record, sort_keys=True))} \
+  {shlex.quote(self.sidecar_state)} <<'__CLIO_TEST_SUBMISSION_SIDECARS__'
+import os
+import sys
+from pathlib import Path
+
+intent_raw, record_raw, output_raw, intent, record, sidecar_state = sys.argv[1:]
+Path(intent_raw).write_text(intent, encoding="utf-8")
+os.chmod(intent_raw, 0o600)
+if sidecar_state == "record_identity_mismatch":
+    Path(record_raw).write_text(record, encoding="utf-8")
+    os.chmod(record_raw, 0o600)
+else:
+    Path(output_raw).write_bytes(b'{{"scheduler_job_id":"in-flight"}}\\n')
+    os.chmod(output_raw, 0o600)
+__CLIO_TEST_SUBMISSION_SIDECARS__
+{script}
+"""
+        if sys.platform == "win32":
+            wsl = Path(os.environ.get("SYSTEMROOT", r"C:\Windows")) / "System32" / "wsl.exe"
+            if not wsl.is_file():
+                return self._emulate_verifier_result(command, script)
+            shell_command = [str(wsl), "-e", "bash", "-s"]
+        else:
+            shell_command = ["bash", "-s"]
+        completed = subprocess.run(  # noqa: S603
+            shell_command,
+            input=wrapper.encode("utf-8"),
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
+        return subprocess.CompletedProcess(
+            command,
+            completed.returncode,
+            completed.stdout.decode("utf-8", errors="replace"),
+            completed.stderr.decode("utf-8", errors="replace"),
+        )
+
+    def _emulate_verifier_result(
+        self,
+        command: Sequence[str],
+        script: str,
+    ) -> subprocess.CompletedProcess[str]:
+        """Preserve the generated verifier contract where no POSIX shell is installed."""
+        assert "scheduler submission record identity mismatch" in script
+        if self.sidecar_state == "output_incomplete":
+            payload: dict[str, object] = {
+                "schema_version": "clio-relay.gateway-submission-verification.v1",
+                "present": False,
+                "anchored": True,
+                "verification_outcome": "retryable",
+                "error_code": "output_incomplete",
+            }
+        else:
+            payload = {
+                "schema_version": "clio-relay.gateway-submission-verification.v1",
+                "present": True,
+                "verification_outcome": "definitive_invalid",
+                "failure_kind": "relay_integrity_failure",
+                "error_code": "record_identity_mismatch",
+                "error": "scheduler submission record identity mismatch",
+                "invalid_component": "record",
+                "observed_identity": {"session_id": "corrupt-session-identity"},
+            }
+        return subprocess.CompletedProcess(command, 0, json.dumps(payload) + "\n", "")
+
+
+class AmbiguousRemoteConnectorStartRunner(FakeRunner):
+    """Lose one remote start response after the owned connector is live."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.lose_remote_start_response = True
+        self.remote_start_attempts = 0
+
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        input_text: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        script = input_text or ""
+        if "remote-frpc.toml" in script and "nohup" in script:
+            self.remote_start_attempts += 1
+            if self.remote_start_attempts > 1:
+                pytest.fail("an ambiguous remote connector start must not be repeated")
+            completed = super().run(
+                command,
+                input_text=input_text,
+                timeout_seconds=timeout_seconds,
+            )
+            if self.lose_remote_start_response:
+                self.lose_remote_start_response = False
+                raise subprocess.TimeoutExpired(command, timeout_seconds or 120.0)
+            return completed
+        return super().run(
+            command,
+            input_text=input_text,
+            timeout_seconds=timeout_seconds,
         )
 
 
@@ -804,6 +1090,113 @@ class DeferredHostRunner(FakeRunner):
         return subprocess.CompletedProcess(command, 1, "", f"unexpected script: {script}")
 
 
+class LongPendingDeferredHostRunner(FakeRunner):
+    """Hold one exact scheduler job pending before reporting its allocation."""
+
+    def __init__(self, *, pending_polls: int) -> None:
+        super().__init__()
+        self.pending_polls = pending_polls
+        self.scheduler_polls = 0
+        self.fail_submission_reads = False
+
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        input_text: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        script = input_text or ""
+        if self.fail_submission_reads and "__CLIO_READ_SUBMISSION__" in script:
+            self.commands.append(list(command))
+            self.inputs.append(input_text)
+            return subprocess.CompletedProcess(
+                command,
+                1,
+                "",
+                "temporary sidecar read failure",
+            )
+        if "__CLIO_CAPTURE_SUBMISSION__" in script:
+            self.commands.append(list(command))
+            self.inputs.append(input_text)
+            output = '{"scheduler_job_id":"12345"}\n'
+            self.submission_record = {
+                "schema_version": "clio-relay.gateway-submission-sidecar.v1",
+                "present": True,
+                "session_id": _script_assignment(script, "session_id"),
+                "submission_id": _script_assignment(script, "submission_id"),
+                "scheduler_provider": _script_assignment(script, "scheduler_provider"),
+                "submission_marker": _script_assignment(script, "submission_marker"),
+                "returncode": 0,
+                "output": output,
+                "output_truncated": False,
+            }
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                output,
+                "",
+            )
+        if "clio-relay scheduler status 12345" in script:
+            self.commands.append(list(command))
+            self.inputs.append(input_text)
+            self.scheduler_polls += 1
+            phase = "pending" if self.scheduler_polls <= self.pending_polls else "running"
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps(
+                    {
+                        "scheduler": "slurm",
+                        "scheduler_job_id": "12345",
+                        "phase": phase,
+                        "raw_state": phase.upper(),
+                    }
+                )
+                + "\n",
+                "",
+            )
+        if "jarvis runtime status 12345" in script:
+            self.commands.append(list(command))
+            self.inputs.append(input_text)
+            status = (
+                {"state": "pending"}
+                if self.scheduler_polls <= self.pending_polls
+                else {"state": "allocated", "service_host": "compute-02"}
+            )
+            return subprocess.CompletedProcess(command, 0, json.dumps(status) + "\n", "")
+        return super().run(command, input_text=input_text, timeout_seconds=timeout_seconds)
+
+
+class NotReadyThenHealthyRunner(LongPendingDeferredHostRunner):
+    """Report an allocated service whose first bounded health observation is not ready."""
+
+    def __init__(self) -> None:
+        super().__init__(pending_polls=0)
+        self.health_observations = 0
+
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        input_text: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        script = input_text or ""
+        if "http.client.HTTPConnection" in script:
+            self.commands.append(list(command))
+            self.inputs.append(input_text)
+            self.health_observations += 1
+            if self.health_observations == 1:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    "service_health=not_ready\nservice_status=503\n",
+                    "",
+                )
+        return super().run(command, input_text=input_text, timeout_seconds=timeout_seconds)
+
+
 def test_service_runtime_supervisor_starts_generic_streaming_service(tmp_path: Path) -> None:
     queue = ClioCoreQueue(tmp_path / "core")
     queue.prepare_owner_session_start(
@@ -837,6 +1230,7 @@ def test_service_runtime_supervisor_starts_generic_streaming_service(tmp_path: P
         owner_session_generation_id="generation-1",
     )
 
+    assert isinstance(result, ServiceRuntimeStartResult)
     session = result.session
     assert session.state == GatewaySessionState.READY
     assert session.scheduler_job_id == "12345"
@@ -939,6 +1333,87 @@ def test_gateway_ownership_hard_exit_reconciles_before_closure(
         assert intents["remote_connector"]["state"] == "recorded"
     if mode == "local":
         assert intents["desktop_connector"]["state"] == "recorded"
+
+
+@pytest.mark.parametrize("mode", ["remote", "local"])
+def test_gateway_connector_hard_exit_resumes_exact_live_sidecar_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+) -> None:
+    """A real process crash is recovered from sidecars without connector relaunch."""
+    state_path = tmp_path / "remote-state.json"
+    crashed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tests.gateway_ownership_crash_fixture",
+            str(tmp_path),
+            str(state_path),
+            mode,
+        ],
+        cwd=Path(__file__).parents[1],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert crashed.returncode == 84, crashed.stderr
+    monkeypatch.setattr(
+        service_runtime,
+        "_observe_local_process",
+        _REAL_OBSERVE_LOCAL_PROCESS,
+    )
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        frpc_bin="fixture-frpc",
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+    session = queue.list_gateway_sessions(cluster="configured-target")[0]
+    before_intents = cast(dict[str, object], session.gateway["ownership_intents"])
+    expected_remote_generation = str(
+        cast(dict[str, object], before_intents["remote_connector"])["connector_generation_id"]
+    )
+    expected_local_generation = (
+        str(cast(dict[str, object], before_intents["desktop_connector"])["connector_generation_id"])
+        if mode == "local"
+        else None
+    )
+    runner = DurableFixtureRunner(state_path)
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="configured-target",
+        definition=crash_fixture_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("crash recovery must not poll or sleep"),
+    )
+    supervisor._wait_for_local_health = lambda *_args, **_kwargs: None  # type: ignore[method-assign]
+
+    resumed = supervisor.resume_start(session_id=session.session_id)
+
+    assert isinstance(resumed, ServiceRuntimeStartResult)
+    assert resumed.session.session_id == session.session_id
+    assert resumed.session.scheduler_job_id == "fixture-job"
+    transport = cast(dict[str, object], resumed.session.gateway["transport"])
+    remote = cast(dict[str, object], transport["remote_connector"])
+    local = cast(dict[str, object], transport["desktop_connector"])
+    assert remote["connector_generation_id"] == expected_remote_generation
+    if expected_local_generation is not None:
+        assert local["connector_generation_id"] == expected_local_generation
+    intents = cast(dict[str, object], resumed.session.gateway["ownership_intents"])
+    assert cast(dict[str, object], intents["remote_connector"])["live_identity_verified"] is True
+    if mode == "local":
+        assert (
+            cast(dict[str, object], intents["desktop_connector"])["live_identity_verified"] is True
+        )
+
+    stopped = supervisor.stop(session_id=session.session_id)
+    assert stopped.errors == []
+    assert stopped.canceled_scheduler_job is None
 
 
 def test_service_runtime_stop_keeps_scheduler_job_by_default(tmp_path: Path) -> None:
@@ -1537,7 +2012,7 @@ def test_service_runtime_uses_explicit_slurm_provider_for_tracking_and_cancel(
     assert scheduler_resource.verified_after_operation is True
 
 
-def test_service_runtime_keep_scheduler_accepts_provider_proven_no_active_record(
+def test_service_runtime_keep_scheduler_rejects_transient_missing_record(
     tmp_path: Path,
 ) -> None:
     runner = ProviderRetentionRunner()
@@ -1572,22 +2047,19 @@ def test_service_runtime_keep_scheduler_accepts_provider_proven_no_active_record
     retention_check = next(
         check for check in report.checks if check.check_id == "gateway.jobs-preserved-default"
     )
-    assert result.session.state is GatewaySessionState.CLOSED
-    assert result.errors == []
+    assert result.session.state is GatewaySessionState.DEGRADED
+    assert result.errors != []
     assert result.canceled_scheduler_job is None
     assert runner.provider_canceled_jobs == []
     assert scheduler.action == "retain"
-    assert scheduler.outcome == "missing"
+    assert scheduler.outcome == "failed"
     assert scheduler.ownership_verified is True
-    assert scheduler.verified_after_operation is True
-    assert scheduler.observed_state == "missing"
-    assert scheduler.residual is False
-    scheduler_status = cast(dict[str, object], scheduler.metadata["scheduler_status"])
-    assert scheduler_status["phase"] == "unknown"
-    assert scheduler_status["active_record_found"] is False
-    assert "no completed or canceled state is claimed" in (scheduler.detail or "")
-    assert retention_check.status is ValidationStatus.PASSED
-    assert report.status is ValidationStatus.PASSED
+    assert scheduler.verified_after_operation is False
+    assert scheduler.observed_state == "unknown"
+    assert scheduler.residual is True
+    assert "verification remained unresolved: unknown" in (scheduler.detail or "")
+    assert retention_check.status is ValidationStatus.FAILED
+    assert report.status is ValidationStatus.FAILED
 
 
 def test_service_runtime_keep_scheduler_rejects_ambiguous_unknown_provider_state(
@@ -2186,6 +2658,108 @@ def test_service_runtime_detach_stops_only_desktop_connector(tmp_path: Path) -> 
     attached = supervisor.attach(session_id=session_id)
     assert attached.session.state == GatewaySessionState.READY
     assert len(runner.popen_commands) == 2
+
+
+def test_detached_starting_runtime_attach_is_single_observation_and_resumable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        frpc_bin="frpc-test",
+    )
+    runner = FakeRunner()
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("one attach observation must not sleep"),
+    )
+
+    def health_pending(*_args: object, **_kwargs: object) -> None:
+        raise RelayError("desktop readiness is still pending")
+
+    supervisor._wait_for_local_health = health_pending  # type: ignore[method-assign]
+    first = supervisor.start(name="detached-starting-runtime", spec=_runtime_spec())
+    assert isinstance(first, ServiceRuntimePendingResult)
+    first_transport = cast(dict[str, object], first.session.gateway["transport"])
+    remote_generation = str(
+        cast(dict[str, object], first_transport["remote_connector"])["connector_generation_id"]
+    )
+    detached = supervisor.detach(session_id=first.session.session_id)
+    assert detached.errors == []
+
+    pending = supervisor.attach(session_id=first.session.session_id)
+
+    assert isinstance(pending, ServiceRuntimePendingResult)
+    assert pending.session.state is GatewaySessionState.STARTING
+    assert pending.session.session_id == first.session.session_id
+    assert pending.session.scheduler_job_id == first.session.scheduler_job_id == "12345"
+    pending_transport = cast(dict[str, object], pending.session.gateway["transport"])
+    pending_remote = cast(dict[str, object], pending_transport["remote_connector"])
+    pending_local = cast(dict[str, object], pending_transport["desktop_connector"])
+    assert pending_remote["connector_generation_id"] == remote_generation
+    local_generation = str(pending_local["connector_generation_id"])
+    assert sum("__CLIO_CAPTURE_SUBMISSION__" in (script or "") for script in runner.inputs) == 1
+    assert (
+        sum(
+            "remote-frpc.toml" in (script or "") and "nohup" in (script or "")
+            for script in runner.inputs
+        )
+        == 1
+    )
+
+    def prove_persisted_fake_connector_live(
+        intent: dict[str, object],
+        *,
+        session_id: str,
+    ) -> tuple[dict[str, object] | None, bool]:
+        metadata_path = Path(str(intent["metadata_path"]))
+        payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+        assert payload["session_id"] == session_id
+        return (
+            {key: value for key, value in payload.items() if key != "schema_version"},
+            False,
+        )
+
+    monkeypatch.setattr(
+        service_runtime,
+        "_discover_local_connector",
+        prove_persisted_fake_connector_live,
+    )
+    observed: list[tuple[str, str, str, str]] = []
+    for _day in range(3):
+        repeated = supervisor.attach(session_id=first.session.session_id)
+        assert isinstance(repeated, ServiceRuntimePendingResult)
+        transport = cast(dict[str, object], repeated.session.gateway["transport"])
+        observed.append(
+            (
+                repeated.session.session_id,
+                str(repeated.session.scheduler_job_id),
+                str(
+                    cast(dict[str, object], transport["remote_connector"])[
+                        "connector_generation_id"
+                    ]
+                ),
+                str(
+                    cast(dict[str, object], transport["desktop_connector"])[
+                        "connector_generation_id"
+                    ]
+                ),
+            )
+        )
+    assert set(observed) == {
+        (first.session.session_id, "12345", remote_generation, local_generation)
+    }
+    assert len(runner.popen_commands) == 2
+    assert runner.canceled_jobs == []
+    assert runner.provider_canceled_jobs == []
 
 
 def test_committed_gateway_teardown_intent_cannot_be_overwritten(tmp_path: Path) -> None:
@@ -3400,7 +3974,7 @@ def test_service_runtime_failure_record_conflict_does_not_mask_original_error(
     )
 
 
-def test_service_runtime_failed_health_cleans_owned_connectors_without_canceling_job(
+def test_service_runtime_local_health_delay_retains_connectors_for_resume(
     tmp_path: Path,
 ) -> None:
     queue = ClioCoreQueue(tmp_path / "core")
@@ -3423,15 +3997,31 @@ def test_service_runtime_failed_health_cleans_owned_connectors_without_canceling
         raise RelayError("desktop health failed")
 
     supervisor._wait_for_local_health = fail_health  # type: ignore[method-assign]
-    with pytest.raises(RelayError, match="desktop health failed"):
-        supervisor.start(name="failed-health", spec=_runtime_spec())
+    pending = supervisor.start(name="delayed-health", spec=_runtime_spec())
 
-    session = queue.list_gateway_sessions(cluster="test-cluster")[0]
-    assert session.state == GatewaySessionState.FAILED
-    assert session.gateway["teardown"]["stopped_remote_pid"] == 444
-    assert session.gateway["teardown"]["canceled_scheduler_job"] is None
+    assert isinstance(pending, ServiceRuntimePendingResult)
+    session = pending.session
+    assert session.state is GatewaySessionState.STARTING
+    assert session.queue_state == "running"
+    assert session.metadata["runtime_observation_error"] == "desktop health failed"
+    assert cast(dict[str, object], session.gateway["scheduler_status"])["state"] == "allocated"
+    assert cast(dict[str, object], session.gateway["runtime_observation"])["state"] == ("not_ready")
+    assert "teardown_intent" not in session.gateway
+    transport = cast(dict[str, object], session.gateway["transport"])
+    assert cast(dict[str, object], transport["remote_connector"])["pid"] == 444
+    assert cast(dict[str, object], transport["desktop_connector"])["pid"] == 555
+    assert not any("__CLIO_STOP_CONNECTOR__" in (script or "") for script in runner.inputs)
     assert runner.canceled_jobs == []
-    assert session.metadata["last_error"] == "desktop health failed"
+
+    supervisor._wait_for_local_health = lambda *_args, **_kwargs: None  # type: ignore[method-assign]
+    resumed = supervisor.resume_start(session_id=session.session_id)
+
+    assert isinstance(resumed, ServiceRuntimeStartResult)
+    assert resumed.session.state is GatewaySessionState.READY
+    assert "runtime_observation" not in resumed.session.gateway
+    # The fake process has no live OS identity. Exact absence authorizes one new
+    # desktop generation; the durable remote connector is still reused.
+    assert len(runner.popen_commands) == 2
 
 
 def test_service_runtime_supports_xtcp_transport_mode(tmp_path: Path) -> None:
@@ -3503,6 +4093,1127 @@ def test_service_runtime_uses_package_status_command_for_deferred_service_host(
     ]
     scripts = "\n".join(script or "" for script in runner.inputs)
     assert "jarvis runtime status 12345" in scripts
+
+
+def test_service_runtime_pending_queue_time_does_not_consume_readiness_deadline(
+    tmp_path: Path,
+) -> None:
+    clock = [0.0]
+
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        frpc_bin="frpc-test",
+    )
+    runner = LongPendingDeferredHostRunner(pending_polls=3)
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("queued runtime observation must not sleep"),
+    )
+    supervisor._wait_for_local_health = lambda *_args, **_kwargs: None  # type: ignore[method-assign]
+    spec = _runtime_spec().model_copy(
+        update={"readiness_timeout_seconds": 1.0, "scheduler": "slurm"}
+    )
+
+    pending = supervisor.start(name="long-queued-service", spec=spec)
+    assert isinstance(pending, ServiceRuntimePendingResult)
+    session_id = pending.session.session_id
+    assert pending.session.state is GatewaySessionState.PENDING
+    assert pending.retry_selector() == {
+        "cluster": "test-cluster",
+        "gateway_session_id": session_id,
+        "scheduler_provider": "slurm",
+        "scheduler_job_id": "12345",
+    }
+
+    for expected_poll in (2, 3):
+        clock[0] += 86_400.0
+        pending = supervisor.resume_start(session_id=session_id)
+        assert isinstance(pending, ServiceRuntimePendingResult)
+        assert pending.session.session_id == session_id
+        assert pending.session.scheduler_job_id == "12345"
+        assert runner.scheduler_polls == expected_poll
+    assert not any("jarvis runtime status 12345" in (script or "") for script in runner.inputs)
+
+    clock[0] += 86_400.0
+    result = supervisor.resume_start(session_id=session_id)
+
+    assert isinstance(result, ServiceRuntimeStartResult)
+    assert clock[0] == 259_200.0
+    assert runner.scheduler_polls == 4
+    assert result.session.state is GatewaySessionState.READY
+    assert result.session.session_id == session_id
+    assert result.session.scheduler_job_id == "12345"
+    assert result.session.node == "compute-02"
+    assert sum("jarvis runtime status 12345" in (script or "") for script in runner.inputs) == 1
+    assert runner.canceled_jobs == []
+    assert runner.provider_canceled_jobs == []
+    assert sum("__CLIO_CAPTURE_SUBMISSION__" in (script or "") for script in runner.inputs) == 1
+    assert not any("__CLIO_STOP_CONNECTOR__" in (script or "") for script in runner.inputs)
+
+
+def test_service_runtime_transient_scheduler_observation_stays_resumable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        frpc_bin="frpc-test",
+    )
+    runner = LongPendingDeferredHostRunner(pending_polls=0)
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("runtime observation must not sleep"),
+    )
+    supervisor._wait_for_local_health = lambda *_args, **_kwargs: None  # type: ignore[method-assign]
+    original_poll = supervisor._poll_scheduler_provider  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    observations = 0
+
+    def transient_poll(*, provider: str, scheduler_job_id: str) -> SchedulerStatus:
+        nonlocal observations
+        observations += 1
+        if observations == 1:
+            raise RelayError("scheduler status transport interrupted")
+        return original_poll(provider=provider, scheduler_job_id=scheduler_job_id)
+
+    monkeypatch.setattr(supervisor, "_poll_scheduler_provider", transient_poll)
+    spec = _runtime_spec().model_copy(update={"scheduler": "slurm"})
+
+    pending = supervisor.start(name="transient-observation", spec=spec)
+
+    assert isinstance(pending, ServiceRuntimePendingResult)
+    assert pending.session.state is GatewaySessionState.PENDING
+    assert pending.session.queue_state == "observation_unknown"
+    assert pending.session.metadata["runtime_observation_error"] == (
+        "scheduler status transport interrupted"
+    )
+    assert "teardown_intent" not in pending.session.gateway
+    assert pending.session.metadata.get("last_error") is None
+
+    resumed = supervisor.resume_start(session_id=pending.session.session_id)
+
+    assert isinstance(resumed, ServiceRuntimeStartResult)
+    assert resumed.session.state is GatewaySessionState.READY
+    assert sum("__CLIO_CAPTURE_SUBMISSION__" in (script or "") for script in runner.inputs) == 1
+    assert runner.canceled_jobs == []
+    assert runner.provider_canceled_jobs == []
+
+
+def test_service_runtime_transient_submission_query_stays_resumable(
+    tmp_path: Path,
+) -> None:
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        frpc_bin="frpc-test",
+    )
+    runner = LongPendingDeferredHostRunner(pending_polls=1)
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("runtime observation must not sleep"),
+    )
+    supervisor._wait_for_local_health = lambda *_args, **_kwargs: None  # type: ignore[method-assign]
+    spec = _runtime_spec().model_copy(update={"scheduler": "slurm"})
+    first = supervisor.start(name="transient-submission-query", spec=spec)
+    assert isinstance(first, ServiceRuntimePendingResult)
+    runner.fail_submission_reads = True
+
+    pending = supervisor.resume_start(session_id=first.session.session_id)
+
+    assert isinstance(pending, ServiceRuntimePendingResult)
+    assert pending.session.state is GatewaySessionState.PENDING
+    assert pending.session.queue_state == "observation_unknown"
+    assert "temporary sidecar read failure" in str(
+        pending.session.metadata["runtime_observation_error"]
+    )
+    assert "teardown_intent" not in pending.session.gateway
+    assert runner.scheduler_polls == 1
+
+    runner.fail_submission_reads = False
+    resumed = supervisor.resume_start(session_id=first.session.session_id)
+
+    assert isinstance(resumed, ServiceRuntimeStartResult)
+    assert resumed.session.state is GatewaySessionState.READY
+    assert sum("__CLIO_CAPTURE_SUBMISSION__" in (script or "") for script in runner.inputs) == 1
+
+
+def test_service_runtime_allocated_but_unhealthy_returns_pending_without_waiting(
+    tmp_path: Path,
+) -> None:
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        frpc_bin="frpc-test",
+    )
+    runner = NotReadyThenHealthyRunner()
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("runtime observation must not sleep"),
+    )
+    supervisor._wait_for_local_health = lambda *_args, **_kwargs: None  # type: ignore[method-assign]
+    spec = _runtime_spec().model_copy(update={"scheduler": "slurm"})
+
+    pending = supervisor.start(name="allocated-not-healthy", spec=spec)
+
+    assert isinstance(pending, ServiceRuntimePendingResult)
+    assert pending.session.state is GatewaySessionState.ALLOCATED
+    assert pending.session.node == "compute-02"
+    assert pending.session.queue_state == "observation_unknown"
+    assert runner.health_observations == 1
+    assert "teardown_intent" not in pending.session.gateway
+
+    resumed = supervisor.resume_start(session_id=pending.session.session_id)
+
+    assert isinstance(resumed, ServiceRuntimeStartResult)
+    assert resumed.session.state is GatewaySessionState.READY
+    assert runner.health_observations == 2
+    assert sum("__CLIO_CAPTURE_SUBMISSION__" in (script or "") for script in runner.inputs) == 1
+
+
+def test_service_runtime_terminal_scheduler_job_is_not_pending(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    runner = FakeRunner()
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("runtime observation must not sleep"),
+    )
+
+    def scheduler_status(*, provider: str, scheduler_job_id: str) -> SchedulerStatus:
+        del provider, scheduler_job_id
+        return SchedulerStatus(
+            scheduler="slurm",
+            scheduler_job_id="12345",
+            phase=SchedulerPhase.FAILED,
+            active_record_found=False,
+        )
+
+    monkeypatch.setattr(supervisor, "_poll_scheduler_provider", scheduler_status)
+
+    with pytest.raises(RelayError, match="terminal state"):
+        supervisor.start(
+            name="terminal-before-ready",
+            spec=_runtime_spec().model_copy(update={"scheduler": "slurm"}),
+        )
+
+    session = queue.list_gateway_sessions(cluster="test-cluster")[0]
+    assert session.state is GatewaySessionState.FAILED
+    assert session.queue_state != "pending"
+    assert runner.canceled_jobs == []
+    assert runner.provider_canceled_jobs == []
+
+
+def test_service_runtime_missing_scheduler_observation_remains_pending(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient scheduler visibility gap cannot terminalize a submitted job."""
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    runner = FakeRunner()
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("runtime observation must not sleep"),
+    )
+
+    def scheduler_status(*, provider: str, scheduler_job_id: str) -> SchedulerStatus:
+        del provider, scheduler_job_id
+        return SchedulerStatus(
+            scheduler="slurm",
+            scheduler_job_id="12345",
+            phase=SchedulerPhase.UNKNOWN,
+            record_found=False,
+            active_record_found=False,
+        )
+
+    monkeypatch.setattr(supervisor, "_poll_scheduler_provider", scheduler_status)
+
+    pending = supervisor.start(
+        name="temporarily-unobservable",
+        spec=_runtime_spec().model_copy(update={"scheduler": "slurm"}),
+    )
+
+    assert isinstance(pending, ServiceRuntimePendingResult)
+    assert pending.session.state is GatewaySessionState.ALLOCATED
+    assert pending.session.queue_state == "observation_unknown"
+    assert pending.session.scheduler_job_id == "12345"
+    assert pending.retry_selector()["scheduler_job_id"] == "12345"
+    assert "absence is not terminal proof" in str(
+        pending.session.metadata["runtime_observation_error"]
+    )
+    assert sum("__CLIO_CAPTURE_SUBMISSION__" in (script or "") for script in runner.inputs) == 1
+    assert runner.canceled_jobs == []
+    assert runner.provider_canceled_jobs == []
+
+
+def test_resume_terminal_scheduler_observation_fails_without_canceling(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    runner = LongPendingDeferredHostRunner(pending_polls=10)
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("runtime observation must not sleep"),
+    )
+    pending = supervisor.start(
+        name="terminal-after-pending",
+        spec=_runtime_spec().model_copy(update={"scheduler": "slurm"}),
+    )
+    assert isinstance(pending, ServiceRuntimePendingResult)
+    terminal = SchedulerStatus(
+        scheduler="slurm",
+        scheduler_job_id="12345",
+        phase=SchedulerPhase.FAILED,
+        active_record_found=False,
+    )
+
+    def terminal_status(*, provider: str, scheduler_job_id: str) -> SchedulerStatus:
+        del provider, scheduler_job_id
+        return terminal
+
+    monkeypatch.setattr(supervisor, "_poll_scheduler_provider", terminal_status)
+
+    with pytest.raises(RelayError, match="terminal state"):
+        supervisor.resume_start(session_id=pending.session.session_id)
+
+    session = queue.get_gateway_session(pending.session.session_id)
+    assert session.state is GatewaySessionState.FAILED
+    assert session.scheduler_job_id == "12345"
+    assert runner.canceled_jobs == []
+    assert runner.provider_canceled_jobs == []
+
+
+def test_resume_recovers_exact_scheduler_job_from_submission_sidecar(
+    tmp_path: Path,
+) -> None:
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    runner = LongPendingDeferredHostRunner(pending_polls=10)
+    spec = _runtime_spec().model_copy(update={"scheduler": "slurm"})
+    submission_id = "submission-after-hard-exit"
+    submission_marker = "marker-after-hard-exit"
+    session = GatewaySession(
+        cluster="test-cluster",
+        name="sidecar-recovery",
+        state=GatewaySessionState.SUBMITTED,
+        scheduler="slurm",
+        gateway={
+            "runtime_spec": spec.model_dump(mode="json"),
+            "transport": {"mode": spec.transport_mode},
+            "ownership_intents": {
+                "scheduler_submission": {
+                    "schema_version": "clio-relay.gateway-ownership-intent.v1",
+                    "state": "starting",
+                    "submission_id": submission_id,
+                    "scheduler_provider": "slurm",
+                    "submission_marker": submission_marker,
+                },
+                "remote_connector": {
+                    "schema_version": "clio-relay.gateway-ownership-intent.v1",
+                    "state": "not_started",
+                },
+                "desktop_connector": {
+                    "schema_version": "clio-relay.gateway-ownership-intent.v1",
+                    "state": "not_started",
+                },
+            },
+        },
+        metadata={"owner": "clio-relay", "runtime_kind": spec.kind},
+    )
+    session = queue.create_gateway_session(session)
+    runner.submission_record = {
+        "schema_version": "clio-relay.gateway-submission-sidecar.v1",
+        "present": True,
+        "session_id": session.session_id,
+        "submission_id": submission_id,
+        "scheduler_provider": "slurm",
+        "submission_marker": submission_marker,
+        "returncode": 0,
+        "output": '{"scheduler_job_id":"12345"}\n',
+        "output_truncated": False,
+    }
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("runtime observation must not sleep"),
+    )
+
+    pending = supervisor.resume_start(session_id=session.session_id)
+
+    assert isinstance(pending, ServiceRuntimePendingResult)
+    assert pending.session.scheduler_job_id == "12345"
+    assert pending.session.state is GatewaySessionState.PENDING
+    scheduler_intent = cast(
+        dict[str, object],
+        cast(dict[str, object], pending.session.gateway["ownership_intents"])[
+            "scheduler_submission"
+        ],
+    )
+    assert scheduler_intent["state"] == "recorded"
+    assert scheduler_intent["scheduler_job_id"] == "12345"
+    assert scheduler_intent["reconciled"] is True
+    assert not any("__CLIO_CAPTURE_SUBMISSION__" in (script or "") for script in runner.inputs)
+
+
+@pytest.mark.parametrize("publish_sidecar", [False, True])
+def test_ambiguous_scheduler_submit_is_query_only_and_resumable(
+    tmp_path: Path,
+    publish_sidecar: bool,
+) -> None:
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        frpc_bin="frpc-test",
+    )
+    runner = AmbiguousSubmissionRunner(publish_sidecar=publish_sidecar)
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("ambiguous submit recovery must not sleep"),
+    )
+    supervisor._wait_for_local_health = lambda *_args, **_kwargs: None  # type: ignore[method-assign]
+
+    pending = supervisor.start(name="ambiguous-submit", spec=_runtime_spec())
+
+    assert isinstance(pending, ServiceRuntimePendingResult)
+    assert pending.session.state is GatewaySessionState.PENDING
+    assert pending.session.scheduler_job_id is None
+    selector = pending.retry_selector()
+    assert selector["gateway_session_id"] == pending.session.session_id
+    assert selector["scheduler_job_id"] is None
+    assert isinstance(selector["submission_id"], str)
+    assert isinstance(selector["submission_marker"], str)
+    report = pending.to_live_validation_report()
+    assert report.status is ValidationStatus.PENDING
+    assert report.checks[0].summary == (
+        "exact scheduler submission intent is durable; submission outcome is unresolved"
+    )
+    rendered_report = report.model_dump_json()
+    assert "durably submitted" not in rendered_report
+    assert "scheduler job preserved" not in rendered_report
+    submission_resource = next(
+        resource for resource in report.resources if resource.kind == "scheduler_submission"
+    )
+    assert submission_resource.resource_id == selector["submission_id"]
+    assert submission_resource.metadata["scheduler_job_id"] is None
+    assert "retained" not in submission_resource.metadata
+    assert submission_resource.metadata["submission_outcome"] == "unresolved"
+    assert submission_resource.metadata["cancel_requested"] is False
+    assert submission_resource.metadata["resubmit_requested"] is False
+    intent = cast(
+        dict[str, object],
+        cast(dict[str, object], pending.session.gateway["ownership_intents"])[
+            "scheduler_submission"
+        ],
+    )
+    assert intent["state"] == "starting"
+    assert runner.submit_attempts == 1
+    assert runner.canceled_jobs == []
+    assert runner.provider_canceled_jobs == []
+
+    if not publish_sidecar:
+        observed: list[dict[str, object]] = []
+        for _day in range(3):
+            still_pending = supervisor.resume_start(session_id=pending.session.session_id)
+            assert isinstance(still_pending, ServiceRuntimePendingResult)
+            observed.append(still_pending.retry_selector())
+        assert observed == [selector, selector, selector]
+        assert runner.submit_attempts == 1
+        runner.publish_sidecar = True
+        output = '{"scheduler_job_id":"12345","service_host":"compute-01"}\n'
+        runner.submission_record = {
+            "schema_version": "clio-relay.gateway-submission-sidecar.v1",
+            "present": True,
+            "session_id": pending.session.session_id,
+            "submission_id": selector["submission_id"],
+            "scheduler_provider": "external",
+            "submission_marker": selector["submission_marker"],
+            "returncode": 0,
+            "output": output,
+            "output_truncated": False,
+        }
+
+    resumed = supervisor.resume_start(session_id=pending.session.session_id)
+
+    assert isinstance(resumed, ServiceRuntimeStartResult)
+    assert resumed.session.session_id == pending.session.session_id
+    assert resumed.session.scheduler_job_id == "12345"
+    assert runner.submit_attempts == 1
+    assert runner.canceled_jobs == []
+    assert runner.provider_canceled_jobs == []
+
+
+@pytest.mark.parametrize("failure_kind", ["nonzero", "identity"])
+def test_exact_failed_submission_sidecar_is_definitive_without_resubmit_or_cancel(
+    tmp_path: Path,
+    failure_kind: str,
+) -> None:
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        frpc_bin="frpc-test",
+    )
+    runner = AmbiguousSubmissionRunner(publish_sidecar=False)
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("definitive reconciliation must not sleep"),
+    )
+    pending = supervisor.start(name="definitive-submit-failure", spec=_runtime_spec())
+    assert isinstance(pending, ServiceRuntimePendingResult)
+    selector = pending.retry_selector()
+    output = (
+        "scheduler rejected the request\n"
+        if failure_kind == "nonzero"
+        else ('{"scheduler_job_id":"unexpected-job"}\n')
+    )
+    runner.submission_record = {
+        "schema_version": "clio-relay.gateway-submission-sidecar.v1",
+        "present": True,
+        "session_id": (
+            pending.session.session_id if failure_kind == "nonzero" else "tampered-session-identity"
+        ),
+        "submission_id": selector["submission_id"],
+        "scheduler_provider": "external",
+        "submission_marker": selector["submission_marker"],
+        "returncode": 64 if failure_kind == "nonzero" else 0,
+        "output": output,
+        "output_truncated": False,
+    }
+
+    with pytest.raises(RelayError, match="sidecar identity|completed unsuccessfully"):
+        supervisor.resume_start(session_id=pending.session.session_id)
+
+    failed = queue.get_gateway_session(pending.session.session_id)
+    assert failed.state is GatewaySessionState.FAILED
+    assert failed.scheduler_job_id is None
+    intents = cast(dict[str, object], failed.gateway["ownership_intents"])
+    intent = cast(dict[str, object], intents["scheduler_submission"])
+    assert intent["state"] == "starting"
+    assert intent["submission_id"] == selector["submission_id"]
+    assert intent["submission_marker"] == selector["submission_marker"]
+    assert intent["reconciliation_outcome"] == "definitive_failure"
+    expected_failure_kind = "command_failure" if failure_kind == "nonzero" else "integrity_failure"
+    expected_queue_state = (
+        "submission_failed" if failure_kind == "nonzero" else "submission_integrity_failed"
+    )
+    expected_submission_outcome = (
+        "submit_command_failed" if failure_kind == "nonzero" else "unknown_due_to_integrity_failure"
+    )
+    assert intent["reconciliation_failure_kind"] == expected_failure_kind
+    assert failed.queue_state == expected_queue_state
+    assert failed.metadata["scheduler_submission_outcome"] == expected_submission_outcome
+    evidence = cast(dict[str, object], intent["failure_evidence"])
+    assert evidence["sidecar_present"] is True
+    assert evidence["failure_kind"] == expected_failure_kind
+    assert evidence["scheduler_submission_outcome"] == expected_submission_outcome
+    assert evidence["cancel_requested"] is False
+    assert evidence["resubmit_requested"] is False
+    assert runner.submit_attempts == 1
+    assert runner.canceled_jobs == []
+    assert runner.provider_canceled_jobs == []
+    assert not runner.popen_commands
+
+
+def test_production_submission_verifier_mismatch_is_integrity_failure(
+    tmp_path: Path,
+) -> None:
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        frpc_bin="frpc-test",
+    )
+    runner = ProductionSubmissionVerifierRunner(
+        sidecar_state="record_identity_mismatch",
+    )
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("integrity reconciliation must not sleep"),
+    )
+    pending = supervisor.start(name="production-verifier-corruption", spec=_runtime_spec())
+    assert isinstance(pending, ServiceRuntimePendingResult)
+
+    with pytest.raises(RelayError, match="scheduler submission record identity mismatch"):
+        supervisor.resume_start(session_id=pending.session.session_id)
+
+    failed = queue.get_gateway_session(pending.session.session_id)
+    assert failed.state is GatewaySessionState.FAILED
+    assert failed.queue_state == "submission_integrity_failed"
+    assert failed.scheduler_job_id is None
+    assert failed.metadata["scheduler_submission_outcome"] == "unknown_due_to_integrity_failure"
+    intents = cast(dict[str, object], failed.gateway["ownership_intents"])
+    intent = cast(dict[str, object], intents["scheduler_submission"])
+    assert intent["state"] == "starting"
+    assert intent["reconciliation_outcome"] == "definitive_failure"
+    assert intent["reconciliation_failure_kind"] == "integrity_failure"
+    evidence = cast(dict[str, object], intent["failure_evidence"])
+    assert evidence["failure_kind"] == "integrity_failure"
+    assert evidence["error_code"] == "record_identity_mismatch"
+    assert evidence["invalid_component"] == "record"
+    assert evidence["scheduler_submission_outcome"] == ("unknown_due_to_integrity_failure")
+    assert evidence["cancel_requested"] is False
+    assert evidence["resubmit_requested"] is False
+    assert runner.verifier_runs == 1
+    assert runner.submit_attempts == 1
+    assert runner.canceled_jobs == []
+    assert runner.provider_canceled_jobs == []
+    assert not runner.popen_commands
+
+
+def test_production_submission_verifier_incomplete_output_remains_pending(
+    tmp_path: Path,
+) -> None:
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        frpc_bin="frpc-test",
+    )
+    runner = ProductionSubmissionVerifierRunner(sidecar_state="output_incomplete")
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("in-flight reconciliation must not sleep"),
+    )
+    pending = supervisor.start(name="production-verifier-in-flight", spec=_runtime_spec())
+    assert isinstance(pending, ServiceRuntimePendingResult)
+    selector = pending.retry_selector()
+
+    resumed = supervisor.resume_start(session_id=pending.session.session_id)
+
+    assert isinstance(resumed, ServiceRuntimePendingResult)
+    assert resumed.session.state is GatewaySessionState.PENDING
+    assert resumed.session.scheduler_job_id is None
+    assert resumed.retry_selector() == selector
+    assert resumed.session.metadata.get("scheduler_submission_outcome") != (
+        "unknown_due_to_integrity_failure"
+    )
+    assert runner.verifier_runs == 1
+    assert runner.submit_attempts == 1
+    assert runner.canceled_jobs == []
+    assert runner.provider_canceled_jobs == []
+    assert not runner.popen_commands
+
+
+def test_unresolved_submission_detach_replay_and_three_day_reconnect_are_exact(
+    tmp_path: Path,
+) -> None:
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        frpc_bin="frpc-test",
+    )
+    runner = AmbiguousSubmissionRunner(publish_sidecar=False)
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("detached unresolved submission must not sleep"),
+    )
+    pending = supervisor.start(name="unresolved-detach", spec=_runtime_spec())
+    assert isinstance(pending, ServiceRuntimePendingResult)
+    selector = pending.retry_selector()
+
+    detached = supervisor.detach(session_id=pending.session.session_id)
+
+    assert detached.errors == []
+    assert detached.residual_resources == []
+    assert detached.session.state is GatewaySessionState.DEGRADED
+    assert detached.session.scheduler_job_id is None
+    assert detached.canceled_scheduler_job is None
+    resources = {resource.kind: resource for resource in detached.resources}
+    assert "scheduler_job" not in resources
+    submission = resources["scheduler_submission"]
+    assert submission.resource_id == selector["submission_id"]
+    assert submission.outcome == "retained"
+    assert submission.observed_state == "intent_recorded"
+    assert submission.metadata["scheduler_job_id"] is None
+    assert submission.metadata["cancel_requested"] is False
+    assert submission.metadata["resubmit_requested"] is False
+    assert resources["desktop_connector"].outcome == "missing"
+    assert resources["remote_connector"].outcome == "missing"
+    assert resources["remote_connector"].observed_state == "not_created"
+    report = detached.to_live_validation_report()
+    assert report.status is ValidationStatus.PASSED
+    rendered_report = report.model_dump_json()
+    assert "scheduler job preserved" not in rendered_report
+    assert "remote connector retained" not in rendered_report
+    assert "no job, cancellation, or resubmission is claimed" in rendered_report
+
+    replay = supervisor.detach(session_id=pending.session.session_id)
+    assert replay == detached
+
+    observed: list[dict[str, object]] = []
+    for _day in range(3):
+        reconnected = supervisor.attach(session_id=pending.session.session_id)
+        assert isinstance(reconnected, ServiceRuntimePendingResult)
+        observed.append(reconnected.retry_selector())
+        assert reconnected.session.scheduler_job_id is None
+        intents = cast(dict[str, object], reconnected.session.gateway["ownership_intents"])
+        scheduler_intent = cast(dict[str, object], intents["scheduler_submission"])
+        assert scheduler_intent["state"] == "starting"
+        assert scheduler_intent["submission_id"] == selector["submission_id"]
+        assert scheduler_intent["submission_marker"] == selector["submission_marker"]
+        assert cast(dict[str, object], intents["remote_connector"])["state"] == ("not_started")
+        assert cast(dict[str, object], intents["desktop_connector"])["state"] == ("not_started")
+
+    assert observed == [selector, selector, selector]
+    assert runner.submit_attempts == 1
+    assert runner.canceled_jobs == []
+    assert runner.provider_canceled_jobs == []
+    assert not runner.popen_commands
+
+
+def test_ambiguous_remote_connector_start_recovers_same_generation_without_relaunch(
+    tmp_path: Path,
+) -> None:
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        frpc_bin="frpc-test",
+    )
+    runner = AmbiguousRemoteConnectorStartRunner()
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("connector recovery must not sleep"),
+    )
+    supervisor._wait_for_local_health = lambda *_args, **_kwargs: None  # type: ignore[method-assign]
+
+    pending = supervisor.start(name="ambiguous-remote-connector", spec=_runtime_spec())
+
+    assert isinstance(pending, ServiceRuntimePendingResult)
+    assert pending.session.state is GatewaySessionState.STARTING
+    intent = cast(
+        dict[str, object],
+        cast(dict[str, object], pending.session.gateway["ownership_intents"])["remote_connector"],
+    )
+    generation_id = str(intent["connector_generation_id"])
+    assert intent["state"] == "starting"
+    assert runner.remote_start_attempts == 1
+
+    resumed = supervisor.resume_start(session_id=pending.session.session_id)
+
+    assert isinstance(resumed, ServiceRuntimeStartResult)
+    transport = cast(dict[str, object], resumed.session.gateway["transport"])
+    remote = cast(dict[str, object], transport["remote_connector"])
+    assert remote["connector_generation_id"] == generation_id
+    assert runner.remote_start_attempts == 1
+    assert sum("__CLIO_CAPTURE_SUBMISSION__" in (script or "") for script in runner.inputs) == 1
+    assert runner.canceled_jobs == []
+    assert runner.provider_canceled_jobs == []
+
+
+def test_resume_rejects_incomplete_published_connector_records_without_relaunch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        frpc_bin="frpc-test",
+    )
+    runner = LongPendingDeferredHostRunner(pending_polls=0)
+    spec = _runtime_spec().model_copy(update={"scheduler": "slurm"})
+    submission_id = "connector-sidecar-submission"
+    submission_marker = "connector-sidecar-marker"
+    session = GatewaySession(
+        cluster="test-cluster",
+        name="connector-sidecar-recovery",
+        state=GatewaySessionState.STARTING,
+        scheduler="slurm",
+        scheduler_job_id="12345",
+        queue_state="running",
+        node="compute-02",
+        metadata={"owner": "clio-relay", "runtime_kind": spec.kind},
+    )
+    remote_connector: dict[str, object] = {
+        "owner": "clio-relay",
+        "session_id": session.session_id,
+        "pid": 444,
+        "connector_generation_id": "remote-generation",
+    }
+    desktop_connector: dict[str, object] = {
+        "owner": "clio-relay",
+        "session_id": session.session_id,
+        "pid": 555,
+        "connector_generation_id": "desktop-generation",
+    }
+    session = session.model_copy(
+        update={
+            "gateway": {
+                "runtime_spec": spec.model_dump(mode="json"),
+                "transport": {
+                    "mode": spec.transport_mode,
+                    "proxy_name": "connector-sidecar-recovery",
+                    "remote_connector": remote_connector,
+                    "desktop_connector": desktop_connector,
+                },
+                "ownership_intents": {
+                    "scheduler_submission": {
+                        "schema_version": "clio-relay.gateway-ownership-intent.v1",
+                        "state": "recorded",
+                        "submission_id": submission_id,
+                        "scheduler_provider": "slurm",
+                        "submission_marker": submission_marker,
+                        "scheduler_job_id": "12345",
+                    },
+                    "remote_connector": {
+                        "schema_version": "clio-relay.gateway-ownership-intent.v1",
+                        "state": "recorded",
+                        **remote_connector,
+                    },
+                    "desktop_connector": {
+                        "schema_version": "clio-relay.gateway-ownership-intent.v1",
+                        "state": "recorded",
+                        **desktop_connector,
+                    },
+                },
+            }
+        }
+    )
+    session = queue.create_gateway_session(session)
+    runner.submission_record = {
+        "schema_version": "clio-relay.gateway-submission-sidecar.v1",
+        "present": True,
+        "session_id": session.session_id,
+        "submission_id": submission_id,
+        "scheduler_provider": "slurm",
+        "submission_marker": submission_marker,
+        "returncode": 0,
+        "output": '{"scheduler_job_id":"12345"}\n',
+        "output_truncated": False,
+    }
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("runtime observation must not sleep"),
+    )
+    supervisor._wait_for_local_health = lambda *_args, **_kwargs: None  # type: ignore[method-assign]
+
+    def refuse_relaunch(**_kwargs: object) -> dict[str, object]:
+        pytest.fail("a published connector sidecar must be adopted, not relaunched")
+
+    monkeypatch.setattr(supervisor, "_start_remote_connector", refuse_relaunch)
+    monkeypatch.setattr(supervisor, "_start_local_visitor", refuse_relaunch)
+
+    resumed = supervisor.resume_start(session_id=session.session_id)
+
+    assert isinstance(resumed, ServiceRuntimePendingResult)
+    assert resumed.session.state is GatewaySessionState.STARTING
+    transport = cast(dict[str, object], resumed.session.gateway["transport"])
+    assert transport["remote_connector"] == remote_connector
+    assert transport["desktop_connector"] == desktop_connector
+    assert not runner.popen_commands
+    assert "owner_token" in str(resumed.session.metadata["runtime_observation_error"])
+
+
+@pytest.mark.parametrize("role", ["remote_connector", "desktop_connector"])
+def test_transient_connector_discovery_preserves_exact_intent_and_returns_pending(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    role: str,
+) -> None:
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        frpc_bin="frpc-test",
+    )
+    runner = TransientConnectorDiscoveryRunner()
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("connector recovery must not sleep"),
+    )
+
+    def health_pending(*_args: object, **_kwargs: object) -> None:
+        raise RelayError("desktop health is still starting")
+
+    supervisor._wait_for_local_health = health_pending  # type: ignore[method-assign]
+    first = supervisor.start(name="connector-recovery-pending", spec=_runtime_spec())
+    assert isinstance(first, ServiceRuntimePendingResult)
+    before_intents = cast(dict[str, object], first.session.gateway["ownership_intents"])
+    before_intent = dict(cast(dict[str, object], before_intents[role]))
+    before_transport = cast(dict[str, object], first.session.gateway["transport"])
+    before_connector = dict(cast(dict[str, object], before_transport[role]))
+    remote_starts = sum(
+        "remote-frpc.toml" in (script or "") and "nohup" in (script or "")
+        for script in runner.inputs
+    )
+    local_starts = len(runner.popen_commands)
+
+    if role == "remote_connector":
+        runner.fail_remote_discovery = True
+    else:
+
+        def fail_local_discovery(
+            _intent: dict[str, object],
+            *,
+            session_id: str,
+        ) -> tuple[dict[str, object] | None, bool]:
+            del session_id
+            raise RelayError("temporary desktop connector sidecar read failure")
+
+        monkeypatch.setattr(
+            service_runtime,
+            "_discover_local_connector",
+            fail_local_discovery,
+        )
+
+    observed_ids: list[tuple[str, str, str, str]] = []
+    for _day in range(3):
+        pending = supervisor.resume_start(session_id=first.session.session_id)
+        assert isinstance(pending, ServiceRuntimePendingResult)
+        assert pending.session.state is GatewaySessionState.STARTING
+        intents = cast(dict[str, object], pending.session.gateway["ownership_intents"])
+        intent = cast(dict[str, object], intents[role])
+        transport = cast(dict[str, object], pending.session.gateway["transport"])
+        connector = cast(dict[str, object], transport[role])
+        observed_ids.append(
+            (
+                pending.session.session_id,
+                str(pending.session.scheduler_job_id),
+                str(intent["connector_generation_id"]),
+                str(connector["connector_generation_id"]),
+            )
+        )
+        assert intent["state"] == before_intent["state"] == "recorded"
+        assert intent["owner_token"] == before_intent["owner_token"]
+        assert connector == before_connector
+        assert "temporary" in str(pending.session.metadata["runtime_observation_error"])
+
+    assert len(set(observed_ids)) == 1
+    assert remote_starts == sum(
+        "remote-frpc.toml" in (script or "") and "nohup" in (script or "")
+        for script in runner.inputs
+    )
+    assert len(runner.popen_commands) == local_starts
+    assert sum("__CLIO_CAPTURE_SUBMISSION__" in (script or "") for script in runner.inputs) == 1
+    assert runner.canceled_jobs == []
+    assert runner.provider_canceled_jobs == []
+
+
+@pytest.mark.parametrize("role", ["remote_connector", "desktop_connector"])
+def test_tampered_connector_record_is_not_adopted_or_replaced(
+    tmp_path: Path,
+    role: str,
+) -> None:
+    queue = ClioCoreQueue(tmp_path / "core")
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        frpc_bin="frpc-test",
+    )
+    runner = TransientConnectorDiscoveryRunner()
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("tamper rejection must not sleep"),
+    )
+
+    def health_pending(*_args: object, **_kwargs: object) -> None:
+        raise RelayError("desktop health is still starting")
+
+    supervisor._wait_for_local_health = health_pending  # type: ignore[method-assign]
+    first = supervisor.start(name="connector-record-tamper", spec=_runtime_spec())
+    assert isinstance(first, ServiceRuntimePendingResult)
+    current = queue.get_gateway_session(first.session.session_id)
+    transport = dict(cast(dict[str, object], current.gateway["transport"]))
+    connector = dict(cast(dict[str, object], transport[role]))
+    connector["owner_token"] = "tampered-owner-token"
+    transport[role] = connector
+    queue.update_gateway_session(
+        current.session_id,
+        expected_updated_at=current.updated_at,
+        gateway={**current.gateway, "transport": transport},
+    )
+    remote_starts = sum(
+        "remote-frpc.toml" in (script or "") and "nohup" in (script or "")
+        for script in runner.inputs
+    )
+    local_starts = len(runner.popen_commands)
+
+    pending = supervisor.resume_start(session_id=current.session_id)
+
+    assert isinstance(pending, ServiceRuntimePendingResult)
+    assert pending.session.state is GatewaySessionState.STARTING
+    persisted_transport = cast(dict[str, object], pending.session.gateway["transport"])
+    assert cast(dict[str, object], persisted_transport[role])["owner_token"] == (
+        "tampered-owner-token"
+    )
+    assert "durable intent" in str(pending.session.metadata["runtime_observation_error"])
+    assert remote_starts == sum(
+        "remote-frpc.toml" in (script or "") and "nohup" in (script or "")
+        for script in runner.inputs
+    )
+    assert len(runner.popen_commands) == local_starts
+    assert runner.canceled_jobs == []
+    assert runner.provider_canceled_jobs == []
+
+
+def test_pending_runtime_detach_and_reconnect_resumes_exact_submission(
+    tmp_path: Path,
+) -> None:
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        frpc_bin="frpc-test",
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+    runner = LongPendingDeferredHostRunner(pending_polls=2)
+    spec = _runtime_spec().model_copy(update={"scheduler": "slurm"})
+    supervisor = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=queue,
+        cluster="test-cluster",
+        definition=_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("runtime observation must not sleep"),
+    )
+
+    pending = supervisor.start(name="overnight-queued", spec=spec)
+    assert isinstance(pending, ServiceRuntimePendingResult)
+
+    detached = supervisor.detach(session_id=pending.session.session_id)
+
+    assert detached.session.state is GatewaySessionState.DEGRADED
+    assert detached.errors == []
+    assert detached.residual_resources == []
+    assert detached.session.scheduler_job_id == "12345"
+    assert detached.canceled_scheduler_job is None
+
+    reconnected = ServiceRuntimeSupervisor(
+        settings=settings,
+        queue=ClioCoreQueue(settings.core_dir),
+        cluster="test-cluster",
+        definition=_definition(),
+        token="token",
+        secret_key="secret",
+        runner=runner,
+        sleep=lambda _seconds: pytest.fail("runtime observation must not sleep"),
+    )
+    reconnected._wait_for_local_health = lambda *_args, **_kwargs: None  # type: ignore[method-assign]
+    resumed = reconnected.resume_start(session_id=pending.session.session_id)
+
+    assert isinstance(resumed, ServiceRuntimeStartResult)
+    assert resumed.session.state is GatewaySessionState.READY
+    assert resumed.session.scheduler_job_id == "12345"
+    assert "detach_intent" not in resumed.session.gateway
+    assert "detach" not in resumed.session.gateway
+    assert sum("__CLIO_CAPTURE_SUBMISSION__" in (script or "") for script in runner.inputs) == 1
+    assert runner.canceled_jobs == []
+    assert runner.provider_canceled_jobs == []
 
 
 def test_service_runtime_requires_status_command_for_deferred_service_host(
@@ -3645,6 +5356,136 @@ def test_gateway_start_runtime_cli_uses_service_runtime_spec(
     report = json.loads(validation_report.read_text(encoding="utf-8"))
     assert "worker.artifact-version" in {check["check_id"] for check in report["checks"]}
     assert "relay_worker" in {resource["kind"] for resource in report["resources"]}
+
+
+def test_gateway_start_runtime_cli_returns_resumable_pending_report(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec_path = tmp_path / "runtime.json"
+    spec = _runtime_spec().model_copy(update={"scheduler": "slurm"})
+    spec_path.write_text(spec.model_dump_json(), encoding="utf-8")
+    cluster_path = tmp_path / ".clio-relay" / "clusters.json"
+    cluster_path.parent.mkdir(parents=True)
+    cluster_path.write_text(
+        '{"clusters":{"test-cluster":' + _definition().model_dump_json() + "}}",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(tmp_path / "core"))
+    monkeypatch.setenv("CLIO_RELAY_SPOOL_DIR", str(tmp_path / "spool"))
+    monkeypatch.setenv("CLIO_RELAY_FRP_TOKEN", "token")
+    monkeypatch.setenv("CLIO_RELAY_STCP_SECRET", "secret")
+
+    def fake_start(
+        self: ServiceRuntimeSupervisor,
+        *,
+        name: str,
+        spec: ServiceRuntimeSpec,
+        owner_session_id: str | None = None,
+        owner_session_generation_id: str | None = None,
+        owner_session_admission_id: str | None = None,
+    ) -> ServiceRuntimePendingResult:
+        del owner_session_id, owner_session_generation_id, owner_session_admission_id
+        session = self.queue.create_gateway_session(
+            GatewaySession(
+                cluster="test-cluster",
+                name=name,
+                state=GatewaySessionState.PENDING,
+                scheduler="slurm",
+                scheduler_job_id="998877",
+                queue_state="pending",
+                gateway={"runtime_spec": spec.model_dump(mode="json")},
+                metadata={"owner": "clio-relay", "runtime_kind": spec.kind},
+            )
+        )
+        return ServiceRuntimePendingResult(session=session)
+
+    def forbid_worker_identity(
+        _report: LiveValidationReport,
+        _definition: ClusterDefinition,
+        *,
+        observed_worker_info: dict[str, object] | None = None,
+    ) -> None:
+        del observed_worker_info
+        pytest.fail("pending runtime must return before worker provenance observation")
+
+    monkeypatch.setattr(ServiceRuntimeSupervisor, "start", fake_start)
+    monkeypatch.setattr(relay_cli, "_attach_verified_remote_worker", forbid_worker_identity)
+    report_path = tmp_path / "gateway-pending.json"
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "gateway",
+            "start-runtime",
+            "--cluster",
+            "test-cluster",
+            "--name",
+            "queued-runtime",
+            "--runtime-json-file",
+            str(spec_path),
+            "--validation-report",
+            str(report_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["outcome"] == "pending"
+    assert payload["scheduler_job_id"] == "998877"
+    assert payload["scheduler_action"] == "none"
+    assert payload["relay_action"] == "none"
+    assert payload["retry_selector"] == {
+        "cluster": "test-cluster",
+        "gateway_session_id": payload["session_id"],
+        "scheduler_provider": "slurm",
+        "scheduler_job_id": "998877",
+    }
+    report = LiveValidationReport.model_validate_json(report_path.read_text(encoding="utf-8"))
+    assert report.status is ValidationStatus.PENDING
+    assert report.checks[0].status is ValidationStatus.PENDING
+    assert report.error is None
+    assert any(
+        resource.kind == "scheduler_job"
+        and resource.resource_id == "998877"
+        and resource.metadata["retained"] is True
+        for resource in report.resources
+    )
+
+    resumed_session_ids: list[str] = []
+
+    def fake_resume(
+        self: ServiceRuntimeSupervisor,
+        *,
+        session_id: str,
+    ) -> ServiceRuntimePendingResult:
+        resumed_session_ids.append(session_id)
+        return ServiceRuntimePendingResult(session=self.queue.get_gateway_session(session_id))
+
+    monkeypatch.setattr(ServiceRuntimeSupervisor, "resume_start", fake_resume)
+    resume_report_path = tmp_path / "gateway-resume-pending.json"
+    resumed = CliRunner().invoke(
+        app,
+        [
+            "gateway",
+            "resume-runtime",
+            payload["session_id"],
+            "--cluster",
+            "test-cluster",
+            "--validation-report",
+            str(resume_report_path),
+        ],
+    )
+
+    assert resumed.exit_code == 0, resumed.output
+    assert resumed_session_ids == [payload["session_id"]]
+    resumed_payload = json.loads(resumed.output)
+    assert resumed_payload["retry_selector"] == payload["retry_selector"]
+    resumed_report = LiveValidationReport.model_validate_json(
+        resume_report_path.read_text(encoding="utf-8")
+    )
+    assert resumed_report.status is ValidationStatus.PENDING
 
 
 @pytest.mark.parametrize(

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2009,6 +2009,17 @@ def test_release_gate_rejects_dirty_or_untagged_build() -> None:
     assert "report source tag must be v1.0.0, got None" in reasons
 
 
+def test_release_gate_rejects_resumable_pending_report() -> None:
+    """Durable queue evidence remains useful but can never satisfy acceptance."""
+    report = _report()
+    report.status = ValidationStatus.PENDING
+
+    result = _evaluate(_policy(), [report])
+
+    assert result.passed is False
+    assert "report did not pass" in result.unsatisfied_requirements["remote-mcp-primary"]
+
+
 def test_release_gate_binds_candidate_wheel_reports_to_independent_digest() -> None:
     policy = _policy()
     policy.artifact_stage = "immutable_candidate"
@@ -2343,13 +2354,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.20-py3-none-any.whl",
+            resource_id="clio-relay-1.4.21-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.20.tar.gz",
+            resource_id="clio_relay-1.4.21.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2488,7 +2499,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.20"
+    assert policy.release_version == "1.4.21"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.20"
+version = "1.4.21"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- make owned relay sessions, connectors, gateways, and JARVIS runtime bindings recoverable across desktop disconnects and arbitrarily long scheduler waits without cancelling scheduler jobs by default
- harden cluster bootstrap with crash-safe staged generations, exact wheel/RECORD attestation, legacy queue permission recovery, worker fencing, compact readiness checks, and retained JARVIS execution environments
- persist structured live-acceptance checkpoints and bounded JARVIS execution/artifact evidence so interrupted acceptance runs resume from durable state
- update the 1.4.21 release documentation and validation contracts

## Root cause

Several lifecycle boundaries treated a short observation window, a desktop process exit, or a partially upgraded endpoint as terminal even when the remote session or scheduler work remained valid. Ares also exposed upgrade compatibility gaps around legacy cursor permissions, stale service ownership, receipt-bound generation paths, and `/home` versus `/mnt/common` aliases. The patch separates observation from ownership and makes bootstrap reconciliation validate and preserve the exact retained resources.

## Validation

- Ares candidate wheel `e22c1e225afc8391c34d29855d762aba4c2a5f5ef4b6a222b95d066f2a3daa22`: passed relay-only activation, preserved JARVIS state byte-for-byte, zero scheduler submissions/cancellations
- identical Ares warm bootstrap: `noop_verified` in 7.63 s, zero payload bytes, zero service stops/restarts, worker ready
- focused bootstrap/recovery tests passed
- Ruff check and format check passed for all changed Python files
- Pyright passed with zero errors; `uv lock --check` and `git diff --check` passed