### PR TITLE
fix: restore verified JARVIS execution startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.21` uses a release-first patch process. A maintainer builds the
+> Version `1.4.22` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.21"
+$Version = "1.4.22"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.21"
+release_version: "1.4.22"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: fef11d9506323c61ae505af6e32131a669318c2851d49d31b68f154fb4f4aa4f
+acceptance_matrix_sha256: e54f60dce0caa564a221a48c27b74b604814bb0cd09837da510e9b3d3a87ee9f
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.21"
+$Tag = "v1.4.22"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.21" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.22" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.21",
-  "matrix_sha256": "fef11d9506323c61ae505af6e32131a669318c2851d49d31b68f154fb4f4aa4f",
+  "release_version": "1.4.22",
+  "matrix_sha256": "e54f60dce0caa564a221a48c27b74b604814bb0cd09837da510e9b3d3a87ee9f",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/jarvis-packages/clio_relay/clio_relay/process_containment.py
+++ b/jarvis-packages/clio_relay/clio_relay/process_containment.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import errno
+import hmac
 import json
 import math
 import os
@@ -33,11 +34,31 @@ BROKER_STDIN_MAX_BYTES = 4 * 1024 * 1024
 BROKER_SETUP_MAX_BYTES = 6 * 1024 * 1024
 BROKER_HANDSHAKE_TIMEOUT_SECONDS = 5.0
 BROKER_READY_TIMEOUT_SECONDS = 10.0
+BROKER_STARTUP_RECORD_SCHEMA = "clio-relay.broker-startup.v1"
+BROKER_STARTUP_RECORD_MAX_BYTES = 1024
 DISCOVERY_TIMEOUT_SECONDS = 5.0
 TERMINATION_TIMEOUT_SECONDS = 10.0
 POLL_SECONDS = 0.05
 DISCOVERY_ROUNDS = 3
 SYSTEMCTL_OUTPUT_MAX_BYTES = 64 * 1024
+
+_BROKER_STARTUP_STAGE_CODES: dict[str, frozenset[str]] = {
+    "memory_gate": frozenset({"internal_error"}),
+    "setup_parse": frozenset({"internal_error"}),
+    "child_spawn": frozenset(
+        {
+            "executable_not_found",
+            "executable_not_permitted",
+            "executable_format_invalid",
+            "internal_error",
+        }
+    ),
+    "credential_write": frozenset({"child_exited", "credential_timeout", "internal_error"}),
+    "credential_ack": frozenset({"child_exited", "ack_timeout", "ack_mismatch", "internal_error"}),
+    "readiness_publish": frozenset({"internal_error"}),
+    "stdin_forward": frozenset({"child_exited", "internal_error"}),
+}
+_BROKER_EXCEPTION_TYPE_PATTERN = re.compile(r"[A-Za-z][A-Za-z0-9_]{0,63}")
 
 
 class _ResourceModule(Protocol):
@@ -72,6 +93,36 @@ class OwnedProcessSpawnError(RuntimeError):
             f"pid={process_id} mode={mode} cleanup_verified={self.cleanup_verified} "
             f"cleanup_errors={detail}"
         )
+
+
+@dataclass(frozen=True, slots=True)
+class _BrokerStartupDiagnostic:
+    """Strict, non-sensitive diagnostic published by a containment broker."""
+
+    stage: str
+    code: str
+    exception_type: str | None
+    error_number: int | None
+    child_return_code: int | None
+
+    def safe_message(self) -> str:
+        """Render only allowlisted fields that cannot contain runtime payloads."""
+        fields = [f"stage={self.stage}", f"code={self.code}"]
+        if self.exception_type is not None:
+            fields.append(f"exception_type={self.exception_type}")
+        if self.error_number is not None:
+            fields.append(f"errno={self.error_number}")
+        if self.child_return_code is not None:
+            fields.append(f"child_return_code={self.child_return_code}")
+        return "containment broker startup failed: " + " ".join(fields)
+
+
+@dataclass(frozen=True, slots=True)
+class _BrokerStartupRecord:
+    """Authenticated completion record read from the private readiness channel."""
+
+    ready: bool
+    diagnostic: _BrokerStartupDiagnostic | None
 
 
 def enforce_linux_secret_memory_gate() -> None:
@@ -223,6 +274,7 @@ def _reject_broker_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, 
 _BROKER_SCRIPT = r"""
 import base64
 import binascii
+import errno
 import json
 import os
 import select
@@ -234,9 +286,11 @@ import time
 MAX_CREDENTIAL_BYTES = 16 * 1024
 MAX_STDIN_BYTES = 4 * 1024 * 1024
 MAX_SETUP_BYTES = 6 * 1024 * 1024
+MAX_STARTUP_RECORD_BYTES = 1024
 HANDSHAKE_TIMEOUT_SECONDS = 5.0
 FD_ENV = "CLIO_RELAY_BROKER_CREDENTIAL_FD"
 READY_FD_ENV = "CLIO_RELAY_BROKER_READY_FD"
+STARTUP_RECORD_SCHEMA = "clio-relay.broker-startup.v1"
 
 # Import only the relay's exact stdlib-only containment module before reading
 # the setup pipe. The module root is a non-secret parent-supplied path.
@@ -246,13 +300,35 @@ if not os.path.isabs(module_root) or not os.path.isdir(module_root):
 sys.path.insert(0, module_root)
 try:
     from clio_relay.process_containment import enforce_linux_secret_memory_gate
-except (ImportError, RuntimeError):
-    raise SystemExit(125)
+except BaseException:
+    raise SystemExit(125) from None
 if sys.platform.startswith("linux"):
-    enforce_linux_secret_memory_gate()
+    try:
+        enforce_linux_secret_memory_gate()
+    except BaseException:
+        raise SystemExit(125) from None
 
 
-def publish_ready(token):
+def publish_record(token, ready, diagnostic):
+    record = {
+        "schema_version": STARTUP_RECORD_SCHEMA,
+        "token": token,
+        "complete": True,
+        "ready": ready,
+        "diagnostic": diagnostic,
+    }
+    payload = (
+        json.dumps(
+            record,
+            allow_nan=False,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("ascii")
+        + b"\n"
+    )
+    if not token or len(token) > 128 or len(payload) > MAX_STARTUP_RECORD_BYTES:
+        raise RuntimeError("broker readiness payload was invalid")
     flags = (
         os.O_WRONLY
         | int(getattr(os, "O_CLOEXEC", 0))
@@ -276,15 +352,52 @@ def publish_ready(token):
             or opened.st_nlink != 1
         ):
             raise RuntimeError("broker readiness file identity changed")
-        payload = token.encode("ascii")
-        if not payload or len(payload) > 128:
-            raise RuntimeError("broker readiness payload was invalid")
         os.ftruncate(descriptor, 0)
         if os.write(descriptor, payload) != len(payload):
             raise RuntimeError("broker readiness write was incomplete")
         os.fsync(descriptor)
     finally:
         os.close(descriptor)
+
+
+def safe_exception_type(error):
+    name = type(error).__name__
+    if (
+        not name
+        or len(name) > 64
+        or not name[0].isalpha()
+        or not all(character.isalnum() or character == "_" for character in name)
+    ):
+        return None
+    return name
+
+
+def safe_integer(value, *, minimum, maximum):
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    if value < minimum or value > maximum:
+        return None
+    return value
+
+
+def publish_failure(token, stage, code, error, child_return_code):
+    if token is None:
+        return
+    diagnostic = {
+        "stage": stage,
+        "code": code,
+        "exception_type": safe_exception_type(error),
+        "errno": safe_integer(getattr(error, "errno", None), minimum=0, maximum=65535),
+        "child_return_code": safe_integer(
+            child_return_code,
+            minimum=-(2**31),
+            maximum=2**31 - 1,
+        ),
+    }
+    try:
+        publish_record(token, False, diagnostic)
+    except BaseException:
+        pass
 
 
 def close_fd(descriptor):
@@ -296,56 +409,63 @@ def close_fd(descriptor):
         pass
 
 
-raw_message = sys.stdin.buffer.readline(MAX_SETUP_BYTES + 1)
-if not raw_message.endswith(b"\n") or len(raw_message) > MAX_SETUP_BYTES:
-    raise SystemExit(125)
+readiness_token = None
+startup_stage = "setup_parse"
+startup_code = "internal_error"
 try:
+    raw_message = sys.stdin.buffer.readline(MAX_SETUP_BYTES + 1)
+    if not raw_message.endswith(b"\n") or len(raw_message) > MAX_SETUP_BYTES:
+        raise ValueError
     message = json.loads(raw_message)
+    if not isinstance(message, dict) or message.get("release") is not True:
+        raise ValueError
+    candidate_token = message.get("readiness_token")
+    if (
+        not isinstance(candidate_token, str)
+        or not candidate_token.isascii()
+        or not candidate_token
+        or len(candidate_token) > 128
+    ):
+        raise ValueError
+    readiness_token = candidate_token
     command = json.loads(sys.argv[1])
-except (json.JSONDecodeError, TypeError):
-    raise SystemExit(125)
-if not isinstance(message, dict) or message.get("release") is not True:
-    raise SystemExit(125)
-credential = message.get("credential")
-readiness_token = message.get("readiness_token")
-stdin_payload_encoded = message.get("stdin_payload")
-interactive_stdin = message.get("interactive_stdin")
-target_environment = message.get("target_environment")
-if credential is not None and (os.name == "nt" or not isinstance(credential, str)):
-    raise SystemExit(125)
-if not isinstance(readiness_token, str) or not readiness_token.isascii() or not readiness_token:
-    raise SystemExit(125)
-if stdin_payload_encoded is not None and not isinstance(stdin_payload_encoded, str):
-    raise SystemExit(125)
-if not isinstance(interactive_stdin, bool):
-    raise SystemExit(125)
-if interactive_stdin and stdin_payload_encoded is not None:
-    raise SystemExit(125)
-if target_environment is not None:
-    if os.name != "nt" or credential is not None or not isinstance(target_environment, dict):
-        raise SystemExit(125)
-    if not target_environment:
-        raise SystemExit(125)
-    for environment_name, environment_value in target_environment.items():
-        if (
-            not isinstance(environment_name, str)
-            or not environment_name
-            or "=" in environment_name
-            or "\x00" in environment_name
-            or not isinstance(environment_value, str)
-            or "\x00" in environment_value
-        ):
-            raise SystemExit(125)
-try:
+    credential = message.get("credential")
+    stdin_payload_encoded = message.get("stdin_payload")
+    interactive_stdin = message.get("interactive_stdin")
+    target_environment = message.get("target_environment")
+    if credential is not None and (os.name == "nt" or not isinstance(credential, str)):
+        raise ValueError
+    if stdin_payload_encoded is not None and not isinstance(stdin_payload_encoded, str):
+        raise ValueError
+    if not isinstance(interactive_stdin, bool):
+        raise ValueError
+    if interactive_stdin and stdin_payload_encoded is not None:
+        raise ValueError
+    if target_environment is not None:
+        if os.name != "nt" or credential is not None or not isinstance(target_environment, dict):
+            raise ValueError
+        if not target_environment:
+            raise ValueError
+        for environment_name, environment_value in target_environment.items():
+            if (
+                not isinstance(environment_name, str)
+                or not environment_name
+                or "=" in environment_name
+                or "\x00" in environment_name
+                or not isinstance(environment_value, str)
+                or "\x00" in environment_value
+            ):
+                raise ValueError
     stdin_payload = (
         None
         if stdin_payload_encoded is None
         else base64.b64decode(stdin_payload_encoded.encode("ascii"), validate=True)
     )
-except (UnicodeEncodeError, binascii.Error):
-    raise SystemExit(125)
-if stdin_payload is not None and len(stdin_payload) > MAX_STDIN_BYTES:
-    raise SystemExit(125)
+    if stdin_payload is not None and len(stdin_payload) > MAX_STDIN_BYTES:
+        raise ValueError
+except BaseException as error:
+    publish_failure(readiness_token, startup_stage, startup_code, error, None)
+    raise SystemExit(125) from None
 
 read_fd = None
 write_fd = None
@@ -371,31 +491,49 @@ try:
             "env": child_env,
             "pass_fds": (read_fd, ready_write_fd),
         }
-    process = subprocess.Popen(
-        command,
-        **popen_kwargs,
-        stdin=(
-            subprocess.PIPE
-            if stdin_payload is not None or interactive_stdin
-            else subprocess.DEVNULL
-        ),
-    )
+    startup_stage = "child_spawn"
+    startup_code = "internal_error"
+    try:
+        process = subprocess.Popen(
+            command,
+            **popen_kwargs,
+            stdin=(
+                subprocess.PIPE
+                if stdin_payload is not None or interactive_stdin
+                else subprocess.DEVNULL
+            ),
+        )
+    except FileNotFoundError:
+        startup_code = "executable_not_found"
+        raise
+    except PermissionError:
+        startup_code = "executable_not_permitted"
+        raise
+    except OSError as error:
+        if error.errno == errno.ENOEXEC or getattr(error, "winerror", None) == 193:
+            startup_code = "executable_format_invalid"
+        raise
     close_fd(read_fd)
     read_fd = None
     close_fd(ready_write_fd)
     ready_write_fd = None
     if write_fd is not None:
+        startup_stage = "credential_write"
+        startup_code = "internal_error"
         os.set_blocking(write_fd, False)
         view = memoryview(credential_bytes)
         deadline = time.monotonic() + HANDSHAKE_TIMEOUT_SECONDS
         while view:
             if process.poll() is not None:
+                startup_code = "child_exited"
                 raise RuntimeError("credential consumer exited before broker readiness")
             remaining = deadline - time.monotonic()
             if remaining <= 0:
+                startup_code = "credential_timeout"
                 raise RuntimeError("broker credential write timed out")
             _, writable, _ = select.select([], [write_fd], [], remaining)
             if not writable:
+                startup_code = "credential_timeout"
                 raise RuntimeError("broker credential write timed out")
             try:
                 written = os.write(write_fd, view)
@@ -406,34 +544,49 @@ try:
             view = view[written:]
         close_fd(write_fd)
         write_fd = None
+        startup_stage = "credential_ack"
+        startup_code = "internal_error"
         os.set_blocking(ready_read_fd, False)
         deadline = time.monotonic() + HANDSHAKE_TIMEOUT_SECONDS
         while True:
             if process.poll() is not None:
+                startup_code = "child_exited"
                 raise RuntimeError("credential consumer exited before broker readiness")
             remaining = deadline - time.monotonic()
             if remaining <= 0:
+                startup_code = "ack_timeout"
                 raise RuntimeError("broker readiness acknowledgement timed out")
             readable, _, _ = select.select([ready_read_fd], [], [], remaining)
             if not readable:
+                startup_code = "ack_timeout"
                 raise RuntimeError("broker readiness acknowledgement timed out")
             try:
                 acknowledgement = os.read(ready_read_fd, 2)
             except BlockingIOError:
                 continue
             if acknowledgement != b"1":
+                startup_code = "ack_mismatch"
                 raise RuntimeError("broker readiness acknowledgement did not match")
             break
         close_fd(ready_read_fd)
         ready_read_fd = None
-    publish_ready(readiness_token)
     if stdin_payload is not None:
+        startup_stage = "stdin_forward"
+        startup_code = "internal_error"
         if process.stdin is None:
+            if process.poll() is not None:
+                startup_code = "child_exited"
             raise RuntimeError("stdin consumer did not expose its input pipe")
         process.stdin.write(stdin_payload)
         process.stdin.close()
     elif interactive_stdin:
+        startup_stage = "readiness_publish"
+        startup_code = "internal_error"
+        publish_record(readiness_token, True, None)
+        startup_stage = "stdin_forward"
         if process.stdin is None:
+            if process.poll() is not None:
+                startup_code = "child_exited"
             raise RuntimeError("interactive stdin consumer did not expose its input pipe")
         while True:
             chunk = os.read(sys.stdin.fileno(), 64 * 1024)
@@ -442,16 +595,37 @@ try:
             process.stdin.write(chunk)
             process.stdin.flush()
         process.stdin.close()
-except BaseException:
+    if not interactive_stdin:
+        startup_stage = "readiness_publish"
+        startup_code = "internal_error"
+        publish_record(readiness_token, True, None)
+except BaseException as error:
     close_fd(read_fd)
     close_fd(write_fd)
     close_fd(ready_read_fd)
     close_fd(ready_write_fd)
     if process is not None and process.poll() is None:
-        process.kill()
-        process.wait()
-    raise
-raise SystemExit(process.wait())
+        try:
+            process.kill()
+            process.wait()
+        except BaseException:
+            pass
+    child_return_code = None if process is None else process.poll()
+    if startup_stage == "stdin_forward" and child_return_code is not None:
+        startup_code = "child_exited"
+    publish_failure(
+        readiness_token,
+        startup_stage,
+        startup_code,
+        error,
+        child_return_code,
+    )
+    raise SystemExit(125) from None
+try:
+    return_code = process.wait()
+except BaseException:
+    raise SystemExit(125) from None
+raise SystemExit(return_code)
 """
 
 
@@ -768,6 +942,24 @@ def _cleanup_failed_owned_spawn(
         _remove_broker_readiness(readiness)
     except BaseException as exc:
         errors.append(f"broker readiness cleanup failed: {type(exc).__name__}")
+    errors.extend(_close_failed_broker_streams(process))
+    return errors
+
+
+def _close_failed_broker_streams(process: subprocess.Popen[str]) -> list[str]:
+    """Close broker-owned pipes after startup failure without reading their contents."""
+    errors: list[str] = []
+    closed: set[int] = set()
+    for stream_name in ("stdin", "stdout", "stderr"):
+        stream = getattr(process, stream_name, None)
+        if stream is None or id(stream) in closed:
+            continue
+        closed.add(id(stream))
+        try:
+            stream.close()
+        except BaseException as exc:
+            errors.append(f"broker {stream_name} cleanup failed: {type(exc).__name__}")
+        setattr(process, stream_name, None)
     return errors
 
 
@@ -1270,7 +1462,7 @@ def _release_broker(
     if errors:
         setup_channel.close()
         process.stdin = None
-        raise RuntimeError(f"containment broker setup write failed: {errors[0]}")
+        raise RuntimeError(f"containment broker setup write failed: {type(errors[0]).__name__}")
     if not interactive_stdin:
         setup_channel.close()
         process.stdin = None
@@ -1318,6 +1510,113 @@ def _precreate_broker_readiness() -> _BrokerReadiness:
         raise
 
 
+def _parse_broker_startup_record(
+    payload: bytes,
+    *,
+    expected_token: str,
+) -> _BrokerStartupRecord | None:
+    """Parse one complete authenticated broker record without accepting free-form data."""
+    if not payload:
+        return None
+    if len(payload) > BROKER_STARTUP_RECORD_MAX_BYTES:
+        raise RuntimeError("containment broker readiness payload exceeded its bound")
+    if not payload.endswith(b"\n"):
+        return None
+    if b"\n" in payload[:-1]:
+        raise RuntimeError("containment broker readiness record was invalid")
+    try:
+        decoded = cast(
+            object,
+            json.loads(
+                payload[:-1].decode("ascii"),
+                object_pairs_hook=_reject_broker_duplicate_keys,
+            ),
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError, TypeError):
+        raise RuntimeError("containment broker readiness record was invalid") from None
+    if not isinstance(decoded, dict):
+        raise RuntimeError("containment broker readiness record was invalid")
+    raw_record = cast(dict[object, object], decoded)
+    if set(raw_record) != {
+        "schema_version",
+        "token",
+        "complete",
+        "ready",
+        "diagnostic",
+    }:
+        raise RuntimeError("containment broker readiness record was invalid")
+    record = cast(dict[str, object], raw_record)
+    token = record["token"]
+    if (
+        record["schema_version"] != BROKER_STARTUP_RECORD_SCHEMA
+        or record["complete"] is not True
+        or not isinstance(token, str)
+        or not token.isascii()
+        or not hmac.compare_digest(token, expected_token)
+        or not isinstance(record["ready"], bool)
+    ):
+        raise RuntimeError("containment broker readiness record was invalid")
+    if record["ready"] is True:
+        if record["diagnostic"] is not None:
+            raise RuntimeError("containment broker readiness record was invalid")
+        return _BrokerStartupRecord(ready=True, diagnostic=None)
+    raw_diagnostic = record["diagnostic"]
+    if not isinstance(raw_diagnostic, dict):
+        raise RuntimeError("containment broker readiness record was invalid")
+    diagnostic_record = cast(dict[object, object], raw_diagnostic)
+    if set(diagnostic_record) != {
+        "stage",
+        "code",
+        "exception_type",
+        "errno",
+        "child_return_code",
+    }:
+        raise RuntimeError("containment broker readiness record was invalid")
+    diagnostic_values = cast(dict[str, object], diagnostic_record)
+    stage = diagnostic_values["stage"]
+    code = diagnostic_values["code"]
+    exception_type = diagnostic_values["exception_type"]
+    error_number = diagnostic_values["errno"]
+    child_return_code = diagnostic_values["child_return_code"]
+    if (
+        not isinstance(stage, str)
+        or not isinstance(code, str)
+        or stage not in _BROKER_STARTUP_STAGE_CODES
+        or code not in _BROKER_STARTUP_STAGE_CODES[stage]
+        or (
+            exception_type is not None
+            and (
+                not isinstance(exception_type, str)
+                or _BROKER_EXCEPTION_TYPE_PATTERN.fullmatch(exception_type) is None
+            )
+        )
+        or not _is_bounded_broker_integer(error_number, minimum=0, maximum=65535)
+        or not _is_bounded_broker_integer(
+            child_return_code,
+            minimum=-(2**31),
+            maximum=2**31 - 1,
+        )
+    ):
+        raise RuntimeError("containment broker readiness record was invalid")
+    return _BrokerStartupRecord(
+        ready=False,
+        diagnostic=_BrokerStartupDiagnostic(
+            stage=stage,
+            code=code,
+            exception_type=exception_type,
+            error_number=cast(int | None, error_number),
+            child_return_code=cast(int | None, child_return_code),
+        ),
+    )
+
+
+def _is_bounded_broker_integer(value: object, *, minimum: int, maximum: int) -> bool:
+    """Accept null or a non-boolean integer inside a fixed diagnostic range."""
+    return value is None or (
+        isinstance(value, int) and not isinstance(value, bool) and minimum <= value <= maximum
+    )
+
+
 def _await_broker_readiness(
     process: subprocess.Popen[str],
     readiness: _BrokerReadiness,
@@ -1328,33 +1627,48 @@ def _await_broker_readiness(
     descriptor = readiness.descriptor
     if descriptor is None:
         raise RuntimeError("containment broker readiness channel was already closed")
-    expected = readiness.token.encode("ascii")
     deadline = (
         startup_deadline
         if startup_deadline is not None
         else time.monotonic() + BROKER_READY_TIMEOUT_SECONDS
     )
+
+    def read_record() -> _BrokerStartupRecord | None:
+        try:
+            opened = os.fstat(descriptor)
+            if (
+                int(opened.st_dev) != readiness.device
+                or int(opened.st_ino) != readiness.inode
+                or int(opened.st_uid) != readiness.owner
+                or int(opened.st_nlink) != readiness.link_count
+                or stat_module.S_IMODE(opened.st_mode) != readiness.mode
+            ):
+                raise RuntimeError("containment broker readiness identity changed")
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            observed = os.read(descriptor, BROKER_STARTUP_RECORD_MAX_BYTES + 1)
+        except OSError as exc:
+            raise RuntimeError("containment broker readiness channel failed") from exc
+        return _parse_broker_startup_record(observed, expected_token=readiness.token)
+
+    def accept_record(record: _BrokerStartupRecord | None) -> bool:
+        if record is None:
+            return False
+        if record.ready:
+            return True
+        diagnostic = record.diagnostic
+        if diagnostic is None:
+            raise RuntimeError("containment broker readiness record was invalid")
+        raise RuntimeError(diagnostic.safe_message())
+
     try:
         while time.monotonic() < deadline:
-            try:
-                opened = os.fstat(descriptor)
-                if (
-                    int(opened.st_dev) != readiness.device
-                    or int(opened.st_ino) != readiness.inode
-                    or int(opened.st_uid) != readiness.owner
-                    or int(opened.st_nlink) != readiness.link_count
-                    or stat_module.S_IMODE(opened.st_mode) != readiness.mode
-                ):
-                    raise RuntimeError("containment broker readiness identity changed")
-                os.lseek(descriptor, 0, os.SEEK_SET)
-                observed = os.read(descriptor, len(expected) + 1)
-                if observed == expected:
-                    return
-                if len(observed) > len(expected):
-                    raise RuntimeError("containment broker readiness payload exceeded its bound")
-            except OSError as exc:
-                raise RuntimeError("containment broker readiness channel failed") from exc
+            if accept_record(read_record()):
+                return
             if process.poll() is not None:
+                # The broker can publish its terminal record immediately before
+                # exiting. Re-read after observing exit to close that race.
+                if accept_record(read_record()):
+                    return
                 raise RuntimeError(
                     "containment broker exited before child readiness "
                     f"with return code {process.returncode}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.21"
+version = "1.4.22"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.21"
+__version__ = "1.4.22"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -4398,10 +4398,14 @@ bootstrap_relay_only_reconcile() {{
   JARVIS_MCP_ARTIFACT_SHA256=""
   JARVIS_MCP_ARTIFACT_PATH=""
   CLIO_KIT_PROVIDER_PYTHON=""
+  REUSED_RELAY_ARTIFACT=""
   if [ "$BOOTSTRAP_PLAN_MODE" = "relay-only" ]; then
     JARVIS_CD_WHEEL="$(bootstrap_plan_value reusable_paths.jarvis-cd_artifact)"
     CLIO_KIT_EXECUTABLE="$(
       bootstrap_plan_value reusable_paths.clio-kit_clio-kit_executable
+    )"
+    REUSED_RELAY_ARTIFACT="$(
+      bootstrap_plan_value reusable_paths.clio-relay_artifact
     )"
   else
     JARVIS_CD_WHEEL="$BOOTSTRAP_GENERATION/artifacts/{JARVIS_CD_WHEEL_FILENAME}"
@@ -4481,29 +4485,33 @@ bootstrap_relay_only_reconcile() {{
     RELAY_ARTIFACT_SHA256={rendered_relay_artifact_sha256}
     RELAY_INSTALL_TARGET="$RELAY_INSTALL_SPEC"
     RELAY_ARTIFACT_PATH=""
-    case "$RELAY_INSTALL_SPEC" in
-      clio-relay==*)
-        DOWNLOAD_DIR="$DEST/downloaded-wheels"
-        mkdir -p "$DOWNLOAD_DIR"
-        "$LEGACY_JARVIS_PYTHON" -m pip download --isolated \
-          --disable-pip-version-check --no-cache-dir --index-url https://pypi.org/simple \
-          --no-deps --only-binary=:all: --dest "$DOWNLOAD_DIR" "$RELAY_INSTALL_SPEC"
-        mapfile -t RELAY_WHEELS < <(
-          find "$DOWNLOAD_DIR" -maxdepth 1 -type f -name 'clio_relay-*.whl' -print
-        )
-        if [ "${{#RELAY_WHEELS[@]}}" -ne 1 ]; then
-          echo "expected exactly one downloaded clio-relay wheel" >&2
-          return 1
-        fi
-        RELAY_ARTIFACT_PATH="${{RELAY_WHEELS[0]}}"
-        RELAY_INSTALL_TARGET="$RELAY_ARTIFACT_PATH"
-        BOOTSTRAP_RELAY_DOWNLOAD_COUNT=1
-        if [ -z "$RELAY_ARTIFACT_SHA256" ]; then
-          RELAY_VERSION="${{RELAY_INSTALL_SPEC#clio-relay==}}"
-          RELAY_ARTIFACT_SHA256="$(
-            "$LEGACY_JARVIS_PYTHON" - \
-              "$RELAY_VERSION" "$(basename "$RELAY_ARTIFACT_PATH")" \
-              <<'__CLIO_RELAY_RECONCILE_PYPI_DIGEST__'
+    if [ "$BOOTSTRAP_PLAN_MODE" = "relay-only" ]; then
+      RELAY_ARTIFACT_PATH="$REUSED_RELAY_ARTIFACT"
+      RELAY_INSTALL_TARGET="$RELAY_ARTIFACT_PATH"
+    else
+      case "$RELAY_INSTALL_SPEC" in
+        clio-relay==*)
+          DOWNLOAD_DIR="$DEST/downloaded-wheels"
+          mkdir -p "$DOWNLOAD_DIR"
+          "$LEGACY_JARVIS_PYTHON" -m pip download --isolated \
+            --disable-pip-version-check --no-cache-dir --index-url https://pypi.org/simple \
+            --no-deps --only-binary=:all: --dest "$DOWNLOAD_DIR" "$RELAY_INSTALL_SPEC"
+          mapfile -t RELAY_WHEELS < <(
+            find "$DOWNLOAD_DIR" -maxdepth 1 -type f -name 'clio_relay-*.whl' -print
+          )
+          if [ "${{#RELAY_WHEELS[@]}}" -ne 1 ]; then
+            echo "expected exactly one downloaded clio-relay wheel" >&2
+            return 1
+          fi
+          RELAY_ARTIFACT_PATH="${{RELAY_WHEELS[0]}}"
+          RELAY_INSTALL_TARGET="$RELAY_ARTIFACT_PATH"
+          BOOTSTRAP_RELAY_DOWNLOAD_COUNT=1
+          if [ -z "$RELAY_ARTIFACT_SHA256" ]; then
+            RELAY_VERSION="${{RELAY_INSTALL_SPEC#clio-relay==}}"
+            RELAY_ARTIFACT_SHA256="$(
+              "$LEGACY_JARVIS_PYTHON" - \
+                "$RELAY_VERSION" "$(basename "$RELAY_ARTIFACT_PATH")" \
+                <<'__CLIO_RELAY_RECONCILE_PYPI_DIGEST__'
 import json
 import re
 import sys
@@ -4531,13 +4539,14 @@ if not isinstance(digest, str) or re.fullmatch(r"[0-9a-f]{{64}}", digest) is Non
     raise SystemExit("PyPI clio-relay wheel identity omitted a valid SHA-256")
 print(digest)
 __CLIO_RELAY_RECONCILE_PYPI_DIGEST__
-          )"
-        fi
-        ;;
-      *.whl)
-        RELAY_ARTIFACT_PATH="$RELAY_INSTALL_SPEC"
-        ;;
-    esac
+            )"
+          fi
+          ;;
+        *.whl)
+          RELAY_ARTIFACT_PATH="$RELAY_INSTALL_SPEC"
+          ;;
+      esac
+    fi
     if [ -n "$RELAY_ARTIFACT_PATH" ]; then
       test -n "$RELAY_ARTIFACT_SHA256"
       echo "$RELAY_ARTIFACT_SHA256 *$RELAY_ARTIFACT_PATH" | \
@@ -4551,6 +4560,11 @@ __CLIO_RELAY_RECONCILE_PYPI_DIGEST__
     RELAY_EXECUTABLE="$BOOTSTRAP_GENERATION/bin/clio-relay"
     RELAY_PROVIDER_PYTHON="$BOOTSTRAP_GENERATION/tools/clio-relay/bin/python"
     test -x "$RELAY_EXECUTABLE" -a -x "$RELAY_PROVIDER_PYTHON"
+    if [ "$BOOTSTRAP_PLAN_MODE" = "component-upgrade" ]; then
+      "$HOME/.local/bin/uv" pip install --python "$ACTIVE_JARVIS_PYTHON" \
+        --default-index https://pypi.org/simple \
+        --refresh-package clio-relay "$RELAY_INSTALL_TARGET"
+    fi
     bootstrap_candidate_action jarvis-wrapper \
       "$BOOTSTRAP_GENERATION/bin/jarvis" "$ACTIVE_JARVIS_PYTHON"
     ACTIVE_JARVIS_EXECUTABLE="$ACTIVE_JARVIS_VENV/bin/jarvis"
@@ -4562,8 +4576,12 @@ __CLIO_RELAY_RECONCILE_PYPI_DIGEST__
     if [ "$BOOTSTRAP_PLAN_MODE" = "relay-only" ]; then
       ln -s "$CLIO_KIT_EXECUTABLE" "$BOOTSTRAP_GENERATION/bin/clio-kit"
     fi
-    "$RELAY_PROVIDER_PYTHON" -c \
-      'import clio_relay,jarvis_cd,clio_relay.bounded_command.pkg,clio_relay.mcp_call.pkg'
+    JARVIS_PACKAGE_PROBE='import clio_relay, jarvis_cd; '
+    JARVIS_PACKAGE_PROBE+='import clio_relay.bounded_command.pkg; '
+    JARVIS_PACKAGE_PROBE+='import clio_relay.mcp_call.pkg; '
+    JARVIS_PACKAGE_PROBE+='import clio_relay.remote_agent.pkg'
+    "$RELAY_PROVIDER_PYTHON" -I -c "$JARVIS_PACKAGE_PROBE"
+    "$ACTIVE_JARVIS_PYTHON" -I -c "$JARVIS_PACKAGE_PROBE"
 
     export BOOTSTRAP_GENERATION RELAY_INSTALL_SPEC RELAY_ARTIFACT_PATH
     export RELAY_ARTIFACT_SHA256 RELAY_EXECUTABLE RELAY_PROVIDER_PYTHON
@@ -4626,7 +4644,10 @@ relay_component = ComponentArtifactIdentity(
     artifact_sha256=(sha256_file(relay_artifact) if relay_artifact is not None else None),
     runtime_artifact_path=(str(relay_artifact) if relay_artifact is not None else None),
     runtime_command=[os.environ["RELAY_EXECUTABLE"], "installation-info"],
-    runtime_interpreters={{"provider": os.environ["RELAY_PROVIDER_PYTHON"]}},
+    runtime_interpreters={{
+        "provider": os.environ["RELAY_PROVIDER_PYTHON"],
+        "execution": os.environ["ACTIVE_JARVIS_PYTHON"],
+    }},
     runtime_executables={{
         "clio-relay": os.environ["RELAY_EXECUTABLE"],
         "uv": str(Path.home() / ".local/bin/uv"),
@@ -4734,6 +4755,9 @@ checks = {{
     "receipt_matches_install": info.get("receipt_matches_install") is True,
     "clio-relay.persistent_tool_verified": (
         runtime.get("clio-relay", {{}}).get("persistent_tool_verified") is True
+    ),
+    "clio-relay.execution_runtime_verified": (
+        runtime.get("clio-relay", {{}}).get("execution_runtime_verified") is True
     ),
     "clio-kit.persistent_tool_verified": (
         runtime.get("clio-kit", {{}}).get("persistent_tool_verified") is True
@@ -7261,6 +7285,9 @@ receipt = write_install_receipt(
             ],
             runtime_interpreters={{
                 "provider": os.environ["CLIO_RELAY_BOOTSTRAP_RELAY_PROVIDER_PYTHON"],
+                "execution": os.environ[
+                    "CLIO_RELAY_BOOTSTRAP_JARVIS_CD_EXECUTION_PYTHON"
+                ],
             }},
             runtime_executables={{
                 "clio-relay": os.environ["CLIO_RELAY_BOOTSTRAP_RELAY_EXECUTABLE"],

--- a/src/clio_relay/bootstrap_reconcile.py
+++ b/src/clio_relay/bootstrap_reconcile.py
@@ -1147,6 +1147,7 @@ def inspect_prepared_generation(
     if not (
         isinstance(relay_runtime, dict)
         and cast(dict[str, object], relay_runtime).get("persistent_tool_verified") is True
+        and cast(dict[str, object], relay_runtime).get("execution_runtime_verified") is True
         and isinstance(clio_kit_runtime, dict)
         and cast(dict[str, object], clio_kit_runtime).get("persistent_tool_verified") is True
         and cast(dict[str, object], clio_kit_runtime).get("native_execution_capability_verified")
@@ -1541,6 +1542,7 @@ def plan_bootstrap_reconcile(
     if not replacement_verified and (
         not isinstance(relay_runtime, dict)
         or cast(dict[str, object], relay_runtime).get("persistent_tool_verified") is not True
+        or cast(dict[str, object], relay_runtime).get("execution_runtime_verified") is not True
     ):
         relay_runtime_error = (
             cast(dict[str, object], relay_runtime).get("error")
@@ -1570,6 +1572,38 @@ def plan_bootstrap_reconcile(
         not isinstance(relay_executable, str) or relay_executable != str(expected_relay_executable)
     ):
         return _full_plan(desired, "clio-relay launcher is not bound to its install receipt")
+    relay_execution_reusable = False
+    resolved_relay_artifact: Path | None = None
+    if isinstance(raw_relay_artifact, dict):
+        relay_artifact = cast(dict[str, object], raw_relay_artifact)
+        relay_artifact_path = relay_artifact.get("runtime_artifact_path")
+        relay_artifact_sha256 = relay_artifact.get("artifact_sha256")
+        relay_execution_runtime = runtime.get("clio-relay")
+        if (
+            isinstance(relay_artifact_path, str)
+            and isinstance(relay_artifact_sha256, str)
+            and desired.relay_artifact_sha256 is not None
+            and relay_artifact.get("install_spec") == desired.relay_install_spec
+            and relay_artifact_sha256 == desired.relay_artifact_sha256
+            and isinstance(relay_execution_runtime, dict)
+            and cast(dict[str, object], relay_execution_runtime).get("execution_runtime_verified")
+            is True
+        ):
+            try:
+                lexical_relay_artifact = Path(relay_artifact_path).expanduser()
+                relay_artifact_before = lexical_relay_artifact.lstat()
+                resolved_relay_artifact = lexical_relay_artifact.resolve(strict=True)
+                relay_execution_reusable = (
+                    not lexical_relay_artifact.is_symlink()
+                    and resolved_relay_artifact.is_file()
+                    and sha256_file(resolved_relay_artifact) == relay_artifact_sha256
+                    and _stat_identity(lexical_relay_artifact.lstat())
+                    == _stat_identity(relay_artifact_before)
+                )
+            except (OSError, RuntimeError, ValueError):
+                relay_execution_reusable = False
+            if relay_execution_reusable and resolved_relay_artifact is not None:
+                reusable_paths["clio-relay_artifact"] = str(resolved_relay_artifact)
     expected_components = {
         "clio-kit": (desired.clio_kit_version, desired.clio_kit_artifact_sha256),
         "jarvis-cd": (desired.jarvis_cd_version, desired.jarvis_cd_wheel_sha256),
@@ -1800,6 +1834,22 @@ def plan_bootstrap_reconcile(
         activation_paths = _capture_reconcile_activation_paths(home=lexical_home)
     except (ConfigurationError, OSError, RuntimeError, ValueError) as exc:
         return _full_plan(desired, f"legacy activation boundary is not reusable: {exc}")
+    if not relay_execution_reusable:
+        return BootstrapReconcilePlan(
+            mode="component-upgrade",
+            desired_fingerprint=desired.fingerprint,
+            reasons=["relay JARVIS execution runtime requires a staged replacement"],
+            component_actions={
+                "clio-relay": "replace",
+                "jarvis-cd": "replace",
+                "jarvis-util": "reuse",
+                "clio-kit": "replace",
+                "frp": "reuse",
+                "uv": "reuse",
+            },
+            reusable_paths=reusable_paths,
+            activation_paths=activation_paths,
+        )
     return BootstrapReconcilePlan(
         mode="relay-only",
         desired_fingerprint=desired.fingerprint,
@@ -2738,6 +2788,8 @@ def _inspect_installation_identity(
         or cast(dict[str, object], relay_runtime).get("persistent_tool_verified") is not True
     ):
         reasons.append("clio-relay persistent tool identity did not verify")
+    elif cast(dict[str, object], relay_runtime).get("execution_runtime_verified") is not True:
+        reasons.append("clio-relay JARVIS execution runtime did not verify")
     clio_kit_runtime = runtime.get("clio-kit")
     required_clio_kit = (
         "artifact_identity_verified",
@@ -3071,6 +3123,14 @@ def resolve_receipt_bound_jarvis_python(
         or cast(dict[str, object], jarvis_runtime).get("verified") is not True
     ):
         raise ConfigurationError("relay-managed JARVIS runtime did not verify its receipt")
+    relay_runtime = runtime.get("clio-relay")
+    if (
+        not isinstance(relay_runtime, dict)
+        or cast(dict[str, object], relay_runtime).get("execution_runtime_verified") is not True
+    ):
+        raise ConfigurationError(
+            "relay-managed JARVIS execution runtime did not verify its relay receipt"
+        )
 
     raw_manifest = receipt.get("deployment_manifest")
     fingerprint = receipt.get("deployment_fingerprint")

--- a/src/clio_relay/core_queue.py
+++ b/src/clio_relay/core_queue.py
@@ -102,6 +102,7 @@ OWNER_SESSION_CLOSURE_WRITE_ATTEMPTS = 3
 JOB_INDEX_SCHEMA = "clio-relay.job-index.v1"
 INDEX_MIGRATION_SCHEMA = "clio-relay.index-migration.v1"
 LEASE_OPERATIONAL_INDEX_SCHEMA = "clio-relay.lease-operational-index.v2"
+_LEGACY_LEASE_OPERATIONAL_INDEX_SCHEMA = "clio-relay.lease-operational-index.v1"
 LEASE_CAPACITY_AGGREGATE_SCHEMA = "clio-relay.lease-capacity-aggregate.v1"
 LEASE_CAPACITY_CHECKPOINT_SCHEMA = "clio-relay.lease-capacity-checkpoint.v1"
 LEASE_CAPACITY_AUDIT_SCHEMA = "clio-relay.lease-capacity-audit.v1"
@@ -738,7 +739,11 @@ class ClioCoreQueue:
                 reason="queue directory is readable or writable by another user",
             )
 
-    def _read_legacy_record_audit_marker(self) -> _LegacyOutputAudit | None:
+    def _read_legacy_record_audit_marker(
+        self,
+        *,
+        allow_legacy_lease_schema: bool = False,
+    ) -> _LegacyOutputAudit | None:
         """Return constant-size indexed-era evidence, or ``None`` for bounded repair."""
         marker_path = self._legacy_record_audit_marker_path()
         if _path_lstat(marker_path) is None:
@@ -774,7 +779,7 @@ class ClioCoreQueue:
                 path=marker_path,
                 reason="legacy-record audit marker has an unknown or incomplete contract",
             )
-        self._read_sealed_index_migration_state()
+        self._read_sealed_index_migration_state(allow_legacy_lease_schema=allow_legacy_lease_schema)
         legacy_output = self._read_legacy_output_marker()
         if legacy_output is None:
             raise LegacyQueueStateError(
@@ -884,7 +889,11 @@ class ClioCoreQueue:
         ):
             raise QueueConflictError(f"sealed {label} record count is invalid")
 
-    def _read_sealed_index_migration_state(self) -> dict[str, object]:
+    def _read_sealed_index_migration_state(
+        self,
+        *,
+        allow_legacy_lease_schema: bool = False,
+    ) -> dict[str, object]:
         """Read and strictly validate indexed-era state without repairing or scanning."""
         path = self._storage_root / "migrations" / "index-v1.json"
         try:
@@ -932,11 +941,27 @@ class ClioCoreQueue:
                 label="retention family",
                 families=_RETENTION_INDEX_FAMILIES,
             )
+            raw_operational: object = state.get("operational_families")
+            operational = (
+                cast(dict[str, object], raw_operational)
+                if isinstance(raw_operational, dict)
+                else {}
+            )
+            raw_lease_checkpoint = operational.get("leases")
+            lease_checkpoint = (
+                cast(dict[str, object], raw_lease_checkpoint)
+                if isinstance(raw_lease_checkpoint, dict)
+                else {}
+            )
+            lease_schema = lease_checkpoint.get("schema_version")
+            accepted_lease_schema = LEASE_OPERATIONAL_INDEX_SCHEMA
+            if allow_legacy_lease_schema and lease_schema == _LEGACY_LEASE_OPERATIONAL_INDEX_SCHEMA:
+                accepted_lease_schema = _LEGACY_LEASE_OPERATIONAL_INDEX_SCHEMA
             self._require_sealed_checkpoint_group(
-                state.get("operational_families"),
+                cast(object, raw_operational),
                 label="operational family",
                 families=_OPERATIONAL_INDEX_FAMILIES,
-                schema_by_family={"leases": LEASE_OPERATIONAL_INDEX_SCHEMA},
+                schema_by_family={"leases": accepted_lease_schema},
             )
             raw_repair = state.get("lease_operational_repair")
             if not isinstance(raw_repair, dict):
@@ -949,7 +974,7 @@ class ClioCoreQueue:
                 raise QueueConflictError("sealed lease repair checkpoint has an unknown shape")
             if (
                 not isinstance(repair.get("complete"), bool)
-                or repair.get("schema_version") != LEASE_OPERATIONAL_INDEX_SCHEMA
+                or repair.get("schema_version") != accepted_lease_schema
             ):
                 raise QueueConflictError("sealed lease repair checkpoint is invalid")
             self._require_optional_bounded_record_count(repair, label="lease repair")
@@ -989,6 +1014,34 @@ class ClioCoreQueue:
                 reason=f"sealed index migration state is invalid: {type(error).__name__}",
             ) from error
         return state
+
+    def _upgrade_sealed_lease_operational_schema_unlocked(self) -> None:
+        """Invalidate exact v1 lease indexes so the bounded v2 migration can rebuild them."""
+        if not self._lock.is_locked:
+            raise RuntimeError("sealed lease index upgrade requires the queue lock")
+        state = self._read_sealed_index_migration_state(allow_legacy_lease_schema=True)
+        operational = cast(dict[str, object], state["operational_families"])
+        lease_checkpoint = cast(dict[str, object], operational["leases"])
+        repair = cast(dict[str, object], state["lease_operational_repair"])
+        if lease_checkpoint.get("schema_version") == LEASE_OPERATIONAL_INDEX_SCHEMA:
+            return
+        lease_checkpoint.clear()
+        lease_checkpoint.update(
+            {
+                "cursor": None,
+                "complete": False,
+                "schema_version": LEASE_OPERATIONAL_INDEX_SCHEMA,
+            }
+        )
+        repair.clear()
+        repair.update(
+            {
+                "complete": False,
+                "schema_version": LEASE_OPERATIONAL_INDEX_SCHEMA,
+            }
+        )
+        state["complete"] = False
+        self._write_index_migration_state(state)
 
     def _audit_legacy_state_before_initialization(self) -> _LegacyOutputAudit:
         """Refuse unsafe v0.9 canonical state before creating or changing files."""
@@ -2403,7 +2456,9 @@ class ClioCoreQueue:
         self._prepare_queue_root_for_lock()
         try:
             with self._lock:
-                locked_indexed_audit = self._read_legacy_record_audit_marker()
+                locked_indexed_audit = self._read_legacy_record_audit_marker(
+                    allow_legacy_lease_schema=True
+                )
                 if locked_indexed_audit is None:
                     if not self._migration_lifetime_guarded:
                         raise QueueSealRequiresExclusive(
@@ -2563,6 +2618,7 @@ class ClioCoreQueue:
                 if locked_indexed_audit is None:
                     self._write_legacy_record_audit_marker_unlocked()
                 else:
+                    self._upgrade_sealed_lease_operational_schema_unlocked()
                     self._read_sealed_index_migration_state()
                 self._initialized = True
         except QueueSealRequiresExclusive:

--- a/src/clio_relay/installation.py
+++ b/src/clio_relay/installation.py
@@ -2106,10 +2106,12 @@ def _component_runtime_identity(receipt: InstallReceipt) -> dict[str, object]:
     identities: dict[str, object] = {}
     relay_component = receipt.component_artifacts.get("clio-relay")
     if relay_component is not None and relay_component.persistent_tool is not None:
-        identities["clio-relay"] = persistent_component_runtime_identity(
+        relay_identity = persistent_component_runtime_identity(
             relay_component,
             entry_point="clio-relay",
         )
+        relay_identity.update(_relay_execution_runtime_identity(relay_component))
+        identities["clio-relay"] = relay_identity
     if "clio-kit" in receipt.component_artifacts:
         from clio_relay.jarvis_mcp import jarvis_mcp_runtime_identity
 
@@ -2201,6 +2203,158 @@ def persistent_component_runtime_identity(
         "observed": observed.model_dump(mode="json"),
         "error": None if observed == expected else "persistent uv tool identity changed",
     }
+
+
+def _relay_execution_runtime_identity(
+    component: ComponentArtifactIdentity,
+) -> dict[str, object]:
+    """Verify relay package bytes and imports in the JARVIS execution interpreter."""
+    execution_python = component.runtime_interpreters.get("execution")
+    runtime_path: Path | None = None
+    try:
+        if component.runtime_artifact_path is not None:
+            runtime_path = Path(component.runtime_artifact_path).expanduser().resolve(strict=True)
+    except (OSError, RuntimeError, ValueError):
+        runtime_path = None
+    artifact_sha256_verified = (
+        runtime_path is not None
+        and runtime_path.is_file()
+        and component.artifact_filename == runtime_path.name
+        and component.artifact_sha256 is not None
+        and sha256_file(runtime_path) == component.artifact_sha256
+    )
+    execution = _probe_python_distribution(execution_python, component.distribution)
+    execution_distribution_identity_verified = (
+        execution.get("distribution") is not None
+        and _normalized_distribution_name(str(execution["distribution"]))
+        == _normalized_distribution_name(component.distribution)
+        and execution.get("distribution_version") == component.distribution_version
+    )
+    execution_source_verified = runtime_path is not None and _direct_url_source_matches(
+        execution.get("direct_url"),
+        expected_artifact=runtime_path,
+    )
+    try:
+        execution_interpreter_verified = (
+            execution_python is not None
+            and execution.get("executable") is not None
+            and Path(str(execution["executable"])).resolve(strict=True)
+            == Path(execution_python).expanduser().resolve(strict=True)
+            and execution_distribution_identity_verified
+            and execution_source_verified
+        )
+    except (OSError, RuntimeError, ValueError):
+        execution_interpreter_verified = False
+    execution_record_closure = (
+        _probe_python_distribution_record_closure(
+            execution_python,
+            component.distribution,
+            runtime_path,
+        )
+        if artifact_sha256_verified
+        else {
+            "verified": False,
+            "error": "retained relay wheel artifact identity is not verified",
+            "tree_scanned": False,
+            "tree_copied": False,
+        }
+    )
+    import_probe = _probe_relay_execution_imports(
+        execution_python,
+        expected_version=component.distribution_version,
+    )
+    execution_runtime_verified = (
+        artifact_sha256_verified
+        and execution_interpreter_verified
+        and execution_record_closure.get("verified") is True
+        and import_probe.get("verified") is True
+    )
+    return {
+        "execution_runtime_verified": execution_runtime_verified,
+        "execution_interpreter": execution_python,
+        "execution_interpreter_verified": execution_interpreter_verified,
+        "execution_distribution_identity_verified": (execution_distribution_identity_verified),
+        "execution_source_verified": execution_source_verified,
+        "execution_artifact_sha256_verified": artifact_sha256_verified,
+        "execution_record_closure": execution_record_closure,
+        "execution_record_closure_verified": (execution_record_closure.get("verified") is True),
+        "execution_imports": import_probe,
+        "execution_imports_verified": import_probe.get("verified") is True,
+    }
+
+
+def _probe_relay_execution_imports(
+    python: str | None,
+    *,
+    expected_version: str | None,
+) -> dict[str, object]:
+    """Import the exact relay packages JARVIS executes in one isolated interpreter."""
+    if python is None or expected_version is None:
+        return {
+            "verified": False,
+            "error": "relay execution interpreter or version is not configured",
+        }
+    script = """
+import json
+import sys
+from importlib.metadata import version
+
+import clio_relay
+import clio_relay.bounded_command.pkg
+import clio_relay.mcp_call.pkg
+import clio_relay.remote_agent.pkg
+import jarvis_cd
+
+observed = version("clio-relay")
+print(json.dumps({
+    "executable": sys.executable,
+    "distribution_version": observed,
+    "imports": [
+        "clio_relay",
+        "clio_relay.bounded_command.pkg",
+        "clio_relay.mcp_call.pkg",
+        "clio_relay.remote_agent.pkg",
+        "jarvis_cd",
+    ],
+}, sort_keys=True))
+"""
+    try:
+        completed = run_bounded_process(
+            [python, "-I", "-c", script],
+            timeout_seconds=10,
+            stdout_maximum_bytes=64 * 1024,
+            stderr_maximum_bytes=16 * 1024,
+        )
+    except (OSError, BoundedProcessError) as exc:
+        return {"verified": False, "error": f"{type(exc).__name__}: {exc}"}
+    if completed.returncode != 0:
+        return {
+            "verified": False,
+            "error": completed.stderr.strip() or completed.stdout.strip(),
+        }
+    try:
+        loaded = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        return {"verified": False, "error": f"invalid relay import probe JSON: {exc}"}
+    if not isinstance(loaded, dict):
+        return {"verified": False, "error": "relay import probe was not an object"}
+    result = {str(key): value for key, value in cast(dict[object, object], loaded).items()}
+    expected_imports = [
+        "clio_relay",
+        "clio_relay.bounded_command.pkg",
+        "clio_relay.mcp_call.pkg",
+        "clio_relay.remote_agent.pkg",
+        "jarvis_cd",
+    ]
+    result["verified"] = (
+        result.get("distribution_version") == expected_version
+        and result.get("imports") == expected_imports
+    )
+    if result["verified"] is not True:
+        result["error"] = "relay execution imports did not match the receipt"
+    else:
+        result["error"] = None
+    return result
 
 
 def _native_jarvis_component_runtime_identity(

--- a/src/clio_relay/process_containment.py
+++ b/src/clio_relay/process_containment.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import errno
+import hmac
 import json
 import math
 import os
@@ -33,11 +34,31 @@ BROKER_STDIN_MAX_BYTES = 4 * 1024 * 1024
 BROKER_SETUP_MAX_BYTES = 6 * 1024 * 1024
 BROKER_HANDSHAKE_TIMEOUT_SECONDS = 5.0
 BROKER_READY_TIMEOUT_SECONDS = 10.0
+BROKER_STARTUP_RECORD_SCHEMA = "clio-relay.broker-startup.v1"
+BROKER_STARTUP_RECORD_MAX_BYTES = 1024
 DISCOVERY_TIMEOUT_SECONDS = 5.0
 TERMINATION_TIMEOUT_SECONDS = 10.0
 POLL_SECONDS = 0.05
 DISCOVERY_ROUNDS = 3
 SYSTEMCTL_OUTPUT_MAX_BYTES = 64 * 1024
+
+_BROKER_STARTUP_STAGE_CODES: dict[str, frozenset[str]] = {
+    "memory_gate": frozenset({"internal_error"}),
+    "setup_parse": frozenset({"internal_error"}),
+    "child_spawn": frozenset(
+        {
+            "executable_not_found",
+            "executable_not_permitted",
+            "executable_format_invalid",
+            "internal_error",
+        }
+    ),
+    "credential_write": frozenset({"child_exited", "credential_timeout", "internal_error"}),
+    "credential_ack": frozenset({"child_exited", "ack_timeout", "ack_mismatch", "internal_error"}),
+    "readiness_publish": frozenset({"internal_error"}),
+    "stdin_forward": frozenset({"child_exited", "internal_error"}),
+}
+_BROKER_EXCEPTION_TYPE_PATTERN = re.compile(r"[A-Za-z][A-Za-z0-9_]{0,63}")
 
 
 class _ResourceModule(Protocol):
@@ -72,6 +93,36 @@ class OwnedProcessSpawnError(RuntimeError):
             f"pid={process_id} mode={mode} cleanup_verified={self.cleanup_verified} "
             f"cleanup_errors={detail}"
         )
+
+
+@dataclass(frozen=True, slots=True)
+class _BrokerStartupDiagnostic:
+    """Strict, non-sensitive diagnostic published by a containment broker."""
+
+    stage: str
+    code: str
+    exception_type: str | None
+    error_number: int | None
+    child_return_code: int | None
+
+    def safe_message(self) -> str:
+        """Render only allowlisted fields that cannot contain runtime payloads."""
+        fields = [f"stage={self.stage}", f"code={self.code}"]
+        if self.exception_type is not None:
+            fields.append(f"exception_type={self.exception_type}")
+        if self.error_number is not None:
+            fields.append(f"errno={self.error_number}")
+        if self.child_return_code is not None:
+            fields.append(f"child_return_code={self.child_return_code}")
+        return "containment broker startup failed: " + " ".join(fields)
+
+
+@dataclass(frozen=True, slots=True)
+class _BrokerStartupRecord:
+    """Authenticated completion record read from the private readiness channel."""
+
+    ready: bool
+    diagnostic: _BrokerStartupDiagnostic | None
 
 
 def enforce_linux_secret_memory_gate() -> None:
@@ -223,6 +274,7 @@ def _reject_broker_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, 
 _BROKER_SCRIPT = r"""
 import base64
 import binascii
+import errno
 import json
 import os
 import select
@@ -234,9 +286,11 @@ import time
 MAX_CREDENTIAL_BYTES = 16 * 1024
 MAX_STDIN_BYTES = 4 * 1024 * 1024
 MAX_SETUP_BYTES = 6 * 1024 * 1024
+MAX_STARTUP_RECORD_BYTES = 1024
 HANDSHAKE_TIMEOUT_SECONDS = 5.0
 FD_ENV = "CLIO_RELAY_BROKER_CREDENTIAL_FD"
 READY_FD_ENV = "CLIO_RELAY_BROKER_READY_FD"
+STARTUP_RECORD_SCHEMA = "clio-relay.broker-startup.v1"
 
 # Import only the relay's exact stdlib-only containment module before reading
 # the setup pipe. The module root is a non-secret parent-supplied path.
@@ -246,13 +300,35 @@ if not os.path.isabs(module_root) or not os.path.isdir(module_root):
 sys.path.insert(0, module_root)
 try:
     from clio_relay.process_containment import enforce_linux_secret_memory_gate
-except (ImportError, RuntimeError):
-    raise SystemExit(125)
+except BaseException:
+    raise SystemExit(125) from None
 if sys.platform.startswith("linux"):
-    enforce_linux_secret_memory_gate()
+    try:
+        enforce_linux_secret_memory_gate()
+    except BaseException:
+        raise SystemExit(125) from None
 
 
-def publish_ready(token):
+def publish_record(token, ready, diagnostic):
+    record = {
+        "schema_version": STARTUP_RECORD_SCHEMA,
+        "token": token,
+        "complete": True,
+        "ready": ready,
+        "diagnostic": diagnostic,
+    }
+    payload = (
+        json.dumps(
+            record,
+            allow_nan=False,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("ascii")
+        + b"\n"
+    )
+    if not token or len(token) > 128 or len(payload) > MAX_STARTUP_RECORD_BYTES:
+        raise RuntimeError("broker readiness payload was invalid")
     flags = (
         os.O_WRONLY
         | int(getattr(os, "O_CLOEXEC", 0))
@@ -276,15 +352,52 @@ def publish_ready(token):
             or opened.st_nlink != 1
         ):
             raise RuntimeError("broker readiness file identity changed")
-        payload = token.encode("ascii")
-        if not payload or len(payload) > 128:
-            raise RuntimeError("broker readiness payload was invalid")
         os.ftruncate(descriptor, 0)
         if os.write(descriptor, payload) != len(payload):
             raise RuntimeError("broker readiness write was incomplete")
         os.fsync(descriptor)
     finally:
         os.close(descriptor)
+
+
+def safe_exception_type(error):
+    name = type(error).__name__
+    if (
+        not name
+        or len(name) > 64
+        or not name[0].isalpha()
+        or not all(character.isalnum() or character == "_" for character in name)
+    ):
+        return None
+    return name
+
+
+def safe_integer(value, *, minimum, maximum):
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    if value < minimum or value > maximum:
+        return None
+    return value
+
+
+def publish_failure(token, stage, code, error, child_return_code):
+    if token is None:
+        return
+    diagnostic = {
+        "stage": stage,
+        "code": code,
+        "exception_type": safe_exception_type(error),
+        "errno": safe_integer(getattr(error, "errno", None), minimum=0, maximum=65535),
+        "child_return_code": safe_integer(
+            child_return_code,
+            minimum=-(2**31),
+            maximum=2**31 - 1,
+        ),
+    }
+    try:
+        publish_record(token, False, diagnostic)
+    except BaseException:
+        pass
 
 
 def close_fd(descriptor):
@@ -296,56 +409,63 @@ def close_fd(descriptor):
         pass
 
 
-raw_message = sys.stdin.buffer.readline(MAX_SETUP_BYTES + 1)
-if not raw_message.endswith(b"\n") or len(raw_message) > MAX_SETUP_BYTES:
-    raise SystemExit(125)
+readiness_token = None
+startup_stage = "setup_parse"
+startup_code = "internal_error"
 try:
+    raw_message = sys.stdin.buffer.readline(MAX_SETUP_BYTES + 1)
+    if not raw_message.endswith(b"\n") or len(raw_message) > MAX_SETUP_BYTES:
+        raise ValueError
     message = json.loads(raw_message)
+    if not isinstance(message, dict) or message.get("release") is not True:
+        raise ValueError
+    candidate_token = message.get("readiness_token")
+    if (
+        not isinstance(candidate_token, str)
+        or not candidate_token.isascii()
+        or not candidate_token
+        or len(candidate_token) > 128
+    ):
+        raise ValueError
+    readiness_token = candidate_token
     command = json.loads(sys.argv[1])
-except (json.JSONDecodeError, TypeError):
-    raise SystemExit(125)
-if not isinstance(message, dict) or message.get("release") is not True:
-    raise SystemExit(125)
-credential = message.get("credential")
-readiness_token = message.get("readiness_token")
-stdin_payload_encoded = message.get("stdin_payload")
-interactive_stdin = message.get("interactive_stdin")
-target_environment = message.get("target_environment")
-if credential is not None and (os.name == "nt" or not isinstance(credential, str)):
-    raise SystemExit(125)
-if not isinstance(readiness_token, str) or not readiness_token.isascii() or not readiness_token:
-    raise SystemExit(125)
-if stdin_payload_encoded is not None and not isinstance(stdin_payload_encoded, str):
-    raise SystemExit(125)
-if not isinstance(interactive_stdin, bool):
-    raise SystemExit(125)
-if interactive_stdin and stdin_payload_encoded is not None:
-    raise SystemExit(125)
-if target_environment is not None:
-    if os.name != "nt" or credential is not None or not isinstance(target_environment, dict):
-        raise SystemExit(125)
-    if not target_environment:
-        raise SystemExit(125)
-    for environment_name, environment_value in target_environment.items():
-        if (
-            not isinstance(environment_name, str)
-            or not environment_name
-            or "=" in environment_name
-            or "\x00" in environment_name
-            or not isinstance(environment_value, str)
-            or "\x00" in environment_value
-        ):
-            raise SystemExit(125)
-try:
+    credential = message.get("credential")
+    stdin_payload_encoded = message.get("stdin_payload")
+    interactive_stdin = message.get("interactive_stdin")
+    target_environment = message.get("target_environment")
+    if credential is not None and (os.name == "nt" or not isinstance(credential, str)):
+        raise ValueError
+    if stdin_payload_encoded is not None and not isinstance(stdin_payload_encoded, str):
+        raise ValueError
+    if not isinstance(interactive_stdin, bool):
+        raise ValueError
+    if interactive_stdin and stdin_payload_encoded is not None:
+        raise ValueError
+    if target_environment is not None:
+        if os.name != "nt" or credential is not None or not isinstance(target_environment, dict):
+            raise ValueError
+        if not target_environment:
+            raise ValueError
+        for environment_name, environment_value in target_environment.items():
+            if (
+                not isinstance(environment_name, str)
+                or not environment_name
+                or "=" in environment_name
+                or "\x00" in environment_name
+                or not isinstance(environment_value, str)
+                or "\x00" in environment_value
+            ):
+                raise ValueError
     stdin_payload = (
         None
         if stdin_payload_encoded is None
         else base64.b64decode(stdin_payload_encoded.encode("ascii"), validate=True)
     )
-except (UnicodeEncodeError, binascii.Error):
-    raise SystemExit(125)
-if stdin_payload is not None and len(stdin_payload) > MAX_STDIN_BYTES:
-    raise SystemExit(125)
+    if stdin_payload is not None and len(stdin_payload) > MAX_STDIN_BYTES:
+        raise ValueError
+except BaseException as error:
+    publish_failure(readiness_token, startup_stage, startup_code, error, None)
+    raise SystemExit(125) from None
 
 read_fd = None
 write_fd = None
@@ -371,31 +491,49 @@ try:
             "env": child_env,
             "pass_fds": (read_fd, ready_write_fd),
         }
-    process = subprocess.Popen(
-        command,
-        **popen_kwargs,
-        stdin=(
-            subprocess.PIPE
-            if stdin_payload is not None or interactive_stdin
-            else subprocess.DEVNULL
-        ),
-    )
+    startup_stage = "child_spawn"
+    startup_code = "internal_error"
+    try:
+        process = subprocess.Popen(
+            command,
+            **popen_kwargs,
+            stdin=(
+                subprocess.PIPE
+                if stdin_payload is not None or interactive_stdin
+                else subprocess.DEVNULL
+            ),
+        )
+    except FileNotFoundError:
+        startup_code = "executable_not_found"
+        raise
+    except PermissionError:
+        startup_code = "executable_not_permitted"
+        raise
+    except OSError as error:
+        if error.errno == errno.ENOEXEC or getattr(error, "winerror", None) == 193:
+            startup_code = "executable_format_invalid"
+        raise
     close_fd(read_fd)
     read_fd = None
     close_fd(ready_write_fd)
     ready_write_fd = None
     if write_fd is not None:
+        startup_stage = "credential_write"
+        startup_code = "internal_error"
         os.set_blocking(write_fd, False)
         view = memoryview(credential_bytes)
         deadline = time.monotonic() + HANDSHAKE_TIMEOUT_SECONDS
         while view:
             if process.poll() is not None:
+                startup_code = "child_exited"
                 raise RuntimeError("credential consumer exited before broker readiness")
             remaining = deadline - time.monotonic()
             if remaining <= 0:
+                startup_code = "credential_timeout"
                 raise RuntimeError("broker credential write timed out")
             _, writable, _ = select.select([], [write_fd], [], remaining)
             if not writable:
+                startup_code = "credential_timeout"
                 raise RuntimeError("broker credential write timed out")
             try:
                 written = os.write(write_fd, view)
@@ -406,34 +544,49 @@ try:
             view = view[written:]
         close_fd(write_fd)
         write_fd = None
+        startup_stage = "credential_ack"
+        startup_code = "internal_error"
         os.set_blocking(ready_read_fd, False)
         deadline = time.monotonic() + HANDSHAKE_TIMEOUT_SECONDS
         while True:
             if process.poll() is not None:
+                startup_code = "child_exited"
                 raise RuntimeError("credential consumer exited before broker readiness")
             remaining = deadline - time.monotonic()
             if remaining <= 0:
+                startup_code = "ack_timeout"
                 raise RuntimeError("broker readiness acknowledgement timed out")
             readable, _, _ = select.select([ready_read_fd], [], [], remaining)
             if not readable:
+                startup_code = "ack_timeout"
                 raise RuntimeError("broker readiness acknowledgement timed out")
             try:
                 acknowledgement = os.read(ready_read_fd, 2)
             except BlockingIOError:
                 continue
             if acknowledgement != b"1":
+                startup_code = "ack_mismatch"
                 raise RuntimeError("broker readiness acknowledgement did not match")
             break
         close_fd(ready_read_fd)
         ready_read_fd = None
-    publish_ready(readiness_token)
     if stdin_payload is not None:
+        startup_stage = "stdin_forward"
+        startup_code = "internal_error"
         if process.stdin is None:
+            if process.poll() is not None:
+                startup_code = "child_exited"
             raise RuntimeError("stdin consumer did not expose its input pipe")
         process.stdin.write(stdin_payload)
         process.stdin.close()
     elif interactive_stdin:
+        startup_stage = "readiness_publish"
+        startup_code = "internal_error"
+        publish_record(readiness_token, True, None)
+        startup_stage = "stdin_forward"
         if process.stdin is None:
+            if process.poll() is not None:
+                startup_code = "child_exited"
             raise RuntimeError("interactive stdin consumer did not expose its input pipe")
         while True:
             chunk = os.read(sys.stdin.fileno(), 64 * 1024)
@@ -442,16 +595,37 @@ try:
             process.stdin.write(chunk)
             process.stdin.flush()
         process.stdin.close()
-except BaseException:
+    if not interactive_stdin:
+        startup_stage = "readiness_publish"
+        startup_code = "internal_error"
+        publish_record(readiness_token, True, None)
+except BaseException as error:
     close_fd(read_fd)
     close_fd(write_fd)
     close_fd(ready_read_fd)
     close_fd(ready_write_fd)
     if process is not None and process.poll() is None:
-        process.kill()
-        process.wait()
-    raise
-raise SystemExit(process.wait())
+        try:
+            process.kill()
+            process.wait()
+        except BaseException:
+            pass
+    child_return_code = None if process is None else process.poll()
+    if startup_stage == "stdin_forward" and child_return_code is not None:
+        startup_code = "child_exited"
+    publish_failure(
+        readiness_token,
+        startup_stage,
+        startup_code,
+        error,
+        child_return_code,
+    )
+    raise SystemExit(125) from None
+try:
+    return_code = process.wait()
+except BaseException:
+    raise SystemExit(125) from None
+raise SystemExit(return_code)
 """
 
 
@@ -768,6 +942,24 @@ def _cleanup_failed_owned_spawn(
         _remove_broker_readiness(readiness)
     except BaseException as exc:
         errors.append(f"broker readiness cleanup failed: {type(exc).__name__}")
+    errors.extend(_close_failed_broker_streams(process))
+    return errors
+
+
+def _close_failed_broker_streams(process: subprocess.Popen[str]) -> list[str]:
+    """Close broker-owned pipes after startup failure without reading their contents."""
+    errors: list[str] = []
+    closed: set[int] = set()
+    for stream_name in ("stdin", "stdout", "stderr"):
+        stream = getattr(process, stream_name, None)
+        if stream is None or id(stream) in closed:
+            continue
+        closed.add(id(stream))
+        try:
+            stream.close()
+        except BaseException as exc:
+            errors.append(f"broker {stream_name} cleanup failed: {type(exc).__name__}")
+        setattr(process, stream_name, None)
     return errors
 
 
@@ -1270,7 +1462,7 @@ def _release_broker(
     if errors:
         setup_channel.close()
         process.stdin = None
-        raise RuntimeError(f"containment broker setup write failed: {errors[0]}")
+        raise RuntimeError(f"containment broker setup write failed: {type(errors[0]).__name__}")
     if not interactive_stdin:
         setup_channel.close()
         process.stdin = None
@@ -1318,6 +1510,113 @@ def _precreate_broker_readiness() -> _BrokerReadiness:
         raise
 
 
+def _parse_broker_startup_record(
+    payload: bytes,
+    *,
+    expected_token: str,
+) -> _BrokerStartupRecord | None:
+    """Parse one complete authenticated broker record without accepting free-form data."""
+    if not payload:
+        return None
+    if len(payload) > BROKER_STARTUP_RECORD_MAX_BYTES:
+        raise RuntimeError("containment broker readiness payload exceeded its bound")
+    if not payload.endswith(b"\n"):
+        return None
+    if b"\n" in payload[:-1]:
+        raise RuntimeError("containment broker readiness record was invalid")
+    try:
+        decoded = cast(
+            object,
+            json.loads(
+                payload[:-1].decode("ascii"),
+                object_pairs_hook=_reject_broker_duplicate_keys,
+            ),
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError, TypeError):
+        raise RuntimeError("containment broker readiness record was invalid") from None
+    if not isinstance(decoded, dict):
+        raise RuntimeError("containment broker readiness record was invalid")
+    raw_record = cast(dict[object, object], decoded)
+    if set(raw_record) != {
+        "schema_version",
+        "token",
+        "complete",
+        "ready",
+        "diagnostic",
+    }:
+        raise RuntimeError("containment broker readiness record was invalid")
+    record = cast(dict[str, object], raw_record)
+    token = record["token"]
+    if (
+        record["schema_version"] != BROKER_STARTUP_RECORD_SCHEMA
+        or record["complete"] is not True
+        or not isinstance(token, str)
+        or not token.isascii()
+        or not hmac.compare_digest(token, expected_token)
+        or not isinstance(record["ready"], bool)
+    ):
+        raise RuntimeError("containment broker readiness record was invalid")
+    if record["ready"] is True:
+        if record["diagnostic"] is not None:
+            raise RuntimeError("containment broker readiness record was invalid")
+        return _BrokerStartupRecord(ready=True, diagnostic=None)
+    raw_diagnostic = record["diagnostic"]
+    if not isinstance(raw_diagnostic, dict):
+        raise RuntimeError("containment broker readiness record was invalid")
+    diagnostic_record = cast(dict[object, object], raw_diagnostic)
+    if set(diagnostic_record) != {
+        "stage",
+        "code",
+        "exception_type",
+        "errno",
+        "child_return_code",
+    }:
+        raise RuntimeError("containment broker readiness record was invalid")
+    diagnostic_values = cast(dict[str, object], diagnostic_record)
+    stage = diagnostic_values["stage"]
+    code = diagnostic_values["code"]
+    exception_type = diagnostic_values["exception_type"]
+    error_number = diagnostic_values["errno"]
+    child_return_code = diagnostic_values["child_return_code"]
+    if (
+        not isinstance(stage, str)
+        or not isinstance(code, str)
+        or stage not in _BROKER_STARTUP_STAGE_CODES
+        or code not in _BROKER_STARTUP_STAGE_CODES[stage]
+        or (
+            exception_type is not None
+            and (
+                not isinstance(exception_type, str)
+                or _BROKER_EXCEPTION_TYPE_PATTERN.fullmatch(exception_type) is None
+            )
+        )
+        or not _is_bounded_broker_integer(error_number, minimum=0, maximum=65535)
+        or not _is_bounded_broker_integer(
+            child_return_code,
+            minimum=-(2**31),
+            maximum=2**31 - 1,
+        )
+    ):
+        raise RuntimeError("containment broker readiness record was invalid")
+    return _BrokerStartupRecord(
+        ready=False,
+        diagnostic=_BrokerStartupDiagnostic(
+            stage=stage,
+            code=code,
+            exception_type=exception_type,
+            error_number=cast(int | None, error_number),
+            child_return_code=cast(int | None, child_return_code),
+        ),
+    )
+
+
+def _is_bounded_broker_integer(value: object, *, minimum: int, maximum: int) -> bool:
+    """Accept null or a non-boolean integer inside a fixed diagnostic range."""
+    return value is None or (
+        isinstance(value, int) and not isinstance(value, bool) and minimum <= value <= maximum
+    )
+
+
 def _await_broker_readiness(
     process: subprocess.Popen[str],
     readiness: _BrokerReadiness,
@@ -1328,33 +1627,48 @@ def _await_broker_readiness(
     descriptor = readiness.descriptor
     if descriptor is None:
         raise RuntimeError("containment broker readiness channel was already closed")
-    expected = readiness.token.encode("ascii")
     deadline = (
         startup_deadline
         if startup_deadline is not None
         else time.monotonic() + BROKER_READY_TIMEOUT_SECONDS
     )
+
+    def read_record() -> _BrokerStartupRecord | None:
+        try:
+            opened = os.fstat(descriptor)
+            if (
+                int(opened.st_dev) != readiness.device
+                or int(opened.st_ino) != readiness.inode
+                or int(opened.st_uid) != readiness.owner
+                or int(opened.st_nlink) != readiness.link_count
+                or stat_module.S_IMODE(opened.st_mode) != readiness.mode
+            ):
+                raise RuntimeError("containment broker readiness identity changed")
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            observed = os.read(descriptor, BROKER_STARTUP_RECORD_MAX_BYTES + 1)
+        except OSError as exc:
+            raise RuntimeError("containment broker readiness channel failed") from exc
+        return _parse_broker_startup_record(observed, expected_token=readiness.token)
+
+    def accept_record(record: _BrokerStartupRecord | None) -> bool:
+        if record is None:
+            return False
+        if record.ready:
+            return True
+        diagnostic = record.diagnostic
+        if diagnostic is None:
+            raise RuntimeError("containment broker readiness record was invalid")
+        raise RuntimeError(diagnostic.safe_message())
+
     try:
         while time.monotonic() < deadline:
-            try:
-                opened = os.fstat(descriptor)
-                if (
-                    int(opened.st_dev) != readiness.device
-                    or int(opened.st_ino) != readiness.inode
-                    or int(opened.st_uid) != readiness.owner
-                    or int(opened.st_nlink) != readiness.link_count
-                    or stat_module.S_IMODE(opened.st_mode) != readiness.mode
-                ):
-                    raise RuntimeError("containment broker readiness identity changed")
-                os.lseek(descriptor, 0, os.SEEK_SET)
-                observed = os.read(descriptor, len(expected) + 1)
-                if observed == expected:
-                    return
-                if len(observed) > len(expected):
-                    raise RuntimeError("containment broker readiness payload exceeded its bound")
-            except OSError as exc:
-                raise RuntimeError("containment broker readiness channel failed") from exc
+            if accept_record(read_record()):
+                return
             if process.poll() is not None:
+                # The broker can publish its terminal record immediately before
+                # exiting. Re-read after observing exit to close that race.
+                if accept_record(read_record()):
+                    return
                 raise RuntimeError(
                     "containment broker exited before child readiness "
                     f"with return code {process.returncode}"

--- a/tests/test_acceptance_report_defaults.py
+++ b/tests/test_acceptance_report_defaults.py
@@ -327,6 +327,24 @@ ACCEPTANCE_COMMANDS = (
         scenario="gateway-runtime",
     ),
     AcceptanceCommandCase(
+        name="gateway-resume-runtime",
+        success_command=(
+            "gateway",
+            "resume-runtime",
+            "gateway-owned",
+            "--cluster",
+            "test-cluster",
+        ),
+        failure_command=(
+            "gateway",
+            "resume-runtime",
+            "gateway-owned",
+            "--cluster",
+            "missing",
+        ),
+        scenario="gateway-runtime",
+    ),
+    AcceptanceCommandCase(
         name="gateway-stop-runtime",
         success_command=(
             "gateway",
@@ -536,7 +554,21 @@ def _gateway_session(*, state: GatewaySessionState) -> GatewaySession:
         state=state,
         scheduler="external",
         queue_state="running" if state is not GatewaySessionState.CLOSED else "completed",
-        gateway={"runtime_kind": "test-runtime"},
+        gateway={
+            "runtime_kind": "test-runtime",
+            "runtime_spec": {
+                "kind": "test-runtime",
+                "submit_command": ["runtime-submit"],
+                "service_port": 19010,
+                "desktop_bind_port": 19010,
+            },
+            "ownership_intents": {
+                "scheduler_submission": {
+                    "schema_version": "clio-relay.gateway-ownership-intent.v1",
+                    "state": "absent_verified",
+                }
+            },
+        },
     )
 
 
@@ -786,6 +818,13 @@ def _detach_gateway(
     return _gateway_stop_result(mode="detach")
 
 
+def _resume_gateway(
+    _self: ServiceRuntimeSupervisor,
+    **_kwargs: object,
+) -> ServiceRuntimeStartResult:
+    return _gateway_start_result()
+
+
 def _stop_gateway(
     _self: ServiceRuntimeSupervisor,
     **_kwargs: object,
@@ -803,8 +842,28 @@ def _persist_jarvis_contract(**_kwargs: object) -> None:
     return None
 
 
-def _post_run_jarvis_query(**_kwargs: object) -> SimpleNamespace:
-    return SimpleNamespace(
+class _PostRunJarvisQuery(SimpleNamespace):
+    """Minimal terminal execution query accepted by the CLI report adapter."""
+
+    def retry_selector(self) -> dict[str, object]:
+        """Return the exact identity represented by this test query."""
+        return {
+            "cluster": "test-cluster",
+            "scheduler_cluster": None,
+            "pipeline_id": "pipeline",
+            "execution_id": "execution",
+            "scheduler_provider": None,
+            "scheduler_native_id": None,
+            "last_query_job_id": "query-job",
+        }
+
+
+def _post_run_jarvis_query(**_kwargs: object) -> _PostRunJarvisQuery:
+    return _PostRunJarvisQuery(
+        cluster="test-cluster",
+        pipeline_id="pipeline",
+        execution_id="execution",
+        outcome="terminal",
         tools_list_response={},
         call_response={},
         call_job_id="query-job",
@@ -814,7 +873,44 @@ def _post_run_jarvis_query(**_kwargs: object) -> SimpleNamespace:
         provenance={},
         initialize_response={},
         stdio_evidence={},
+        lifecycle_observations=[{}],
     )
+
+
+def _complete_jarvis_dispatch(
+    *,
+    checkpoint: dict[str, object],
+    **_kwargs: object,
+) -> dict[str, object]:
+    """Complete the acceptance fixture's durable dispatch without remote I/O."""
+    builder_inputs = checkpoint["builder_inputs"]
+    assert isinstance(builder_inputs, dict)
+    return {
+        **builder_inputs,
+        "call_status": {"terminal": True},
+        "artifacts": [],
+        "mcp_result": {},
+        "provenance": {},
+        "runtime_metadata": {
+            "pipeline_id": "pipeline",
+            "execution_id": "execution",
+        },
+        "progress": [],
+        "live_progress_observation": None,
+    }
+
+
+def _jarvis_retry_selector(*_args: object, **_kwargs: object) -> dict[str, object]:
+    """Return the exact execution selector represented by the fixture metadata."""
+    return {
+        "cluster": "test-cluster",
+        "scheduler_cluster": None,
+        "pipeline_id": "pipeline",
+        "execution_id": "execution",
+        "scheduler_provider": None,
+        "scheduler_native_id": None,
+        "last_query_job_id": None,
+    }
 
 
 def _jarvis_package_search(**_kwargs: object) -> SimpleNamespace:
@@ -1002,6 +1098,12 @@ def _install_success_fakes(
     if case.name == "gateway-detach-runtime":
         monkeypatch.setattr(ServiceRuntimeSupervisor, "detach", _detach_gateway)
         return
+    if case.name == "gateway-resume-runtime":
+        ClioCoreQueue(root / "core").create_gateway_session(
+            _gateway_session(state=GatewaySessionState.READY)
+        )
+        monkeypatch.setattr(ServiceRuntimeSupervisor, "resume_start", _resume_gateway)
+        return
     if case.name == "gateway-stop-runtime":
         monkeypatch.setattr(ServiceRuntimeSupervisor, "stop", _stop_gateway)
         return
@@ -1018,19 +1120,12 @@ def _install_success_fakes(
         )
         monkeypatch.setattr(cli, "run_packaged_mcp_stdio_session", _packaged_mcp_session)
         monkeypatch.setattr(cli, "_mcp_response_job_id", _relay_job_id)
-        monkeypatch.setattr(cli, "_wait_for_local_job_terminal", _terminal_job_status)
-        monkeypatch.setattr(cli, "_complete_local_progress_records", _empty_artifacts)
-        monkeypatch.setattr(cli, "_complete_local_artifact_records", _empty_artifacts)
-
-        def read_jarvis_artifact(
-            *_args: object,
-            kind: str,
-        ) -> dict[str, object]:
-            if kind == "runtime_metadata":
-                return {"pipeline_id": "pipeline", "execution_id": "execution"}
-            return {}
-
-        monkeypatch.setattr(cli, "_read_local_json_artifact_kind", read_jarvis_artifact)
+        monkeypatch.setattr(cli, "_complete_jarvis_run_dispatch", _complete_jarvis_dispatch)
+        monkeypatch.setattr(
+            cli,
+            "_jarvis_execution_retry_selector_from_runtime_metadata",
+            _jarvis_retry_selector,
+        )
         monkeypatch.setattr(
             cli,
             "_run_post_run_jarvis_execution_query",

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -269,6 +269,22 @@ def test_fresh_bootstrap_loads_packaged_graph_before_explicit_build_fallback() -
     assert 'JARVIS_MCP_PROVIDER_PYTHON="$UV_TOOL_DIR/clio-kit/bin/python"' in script
     assert 'RELAY_PROVIDER_PYTHON="$BOOTSTRAP_GENERATION/tools/clio-relay/bin/python"' in script
     assert 'CLIO_KIT_PROVIDER_PYTHON="$BOOTSTRAP_GENERATION/tools/clio-kit/bin/python"' in script
+    reconcile_install = (
+        '"$HOME/.local/bin/uv" pip install --python "$ACTIVE_JARVIS_PYTHON" '
+        "        --default-index https://pypi.org/simple "
+        '        --refresh-package clio-relay "$RELAY_INSTALL_TARGET"'
+    )
+    component_guard = 'if [ "$BOOTSTRAP_PLAN_MODE" = "component-upgrade" ]; then'
+    assert script.count(reconcile_install) == 1
+    assert script.rindex(component_guard, 0, script.index(reconcile_install)) < script.index(
+        reconcile_install
+    )
+    assert script.index(reconcile_install) < script.index(
+        '"$ACTIVE_JARVIS_PYTHON" -I -c "$JARVIS_PACKAGE_PROBE"'
+    )
+    assert 'RELAY_ARTIFACT_PATH="$REUSED_RELAY_ARTIFACT"' in script
+    assert '"execution": os.environ["ACTIVE_JARVIS_PYTHON"]' in script
+    assert '"clio-relay.execution_runtime_verified"' in script
     assert "sed -n '1{s/^#!//;p;}'" not in script
     assert "relay-venv312" not in script
     assert 'uv pip install --refresh-package clio-relay "$RELAY_INSTALL_TARGET"' not in script

--- a/tests/test_bootstrap_fast_path.py
+++ b/tests/test_bootstrap_fast_path.py
@@ -1199,7 +1199,10 @@ with tempfile.TemporaryDirectory() as value:
             },
         },
         "component_runtime": {
-            "clio-relay": {"persistent_tool_verified": True},
+            "clio-relay": {
+                "persistent_tool_verified": True,
+                "execution_runtime_verified": True,
+            },
             "clio-kit": {
                 "artifact_identity_verified": True,
                 "command_matches_receipt": True,

--- a/tests/test_bootstrap_reconcile.py
+++ b/tests/test_bootstrap_reconcile.py
@@ -178,7 +178,10 @@ def _installation_info(desired: BootstrapDesiredState) -> dict[str, object]:
             },
         },
         "component_runtime": {
-            "clio-relay": {"persistent_tool_verified": True},
+            "clio-relay": {
+                "persistent_tool_verified": True,
+                "execution_runtime_verified": True,
+            },
             "clio-kit": {
                 "artifact_identity_verified": True,
                 "command_matches_receipt": True,
@@ -396,12 +399,39 @@ def test_matching_receipt_with_tampered_runtime_is_not_a_noop(
     assert "clio-relay persistent tool identity did not verify" in inspection.reasons
     assert "managed endpoint service is inactive" in inspection.reasons
 
+    runtime["clio-relay"] = {
+        "persistent_tool_verified": True,
+        "execution_runtime_verified": False,
+    }
+    execution_mismatch = inspect_exact_bootstrap_noop(
+        desired,
+        home=tmp_path,
+        service_was_active=False,
+        service_was_enabled=True,
+        queue_evidence={
+            "schema_version": "clio-relay.queue-readiness.v1",
+            "complete": True,
+            "sealed": True,
+            "repair_required": False,
+        },
+        worker_evidence=None,
+    )
+
+    assert execution_mismatch.exact_match is False
+    assert "clio-relay JARVIS execution runtime did not verify" in execution_mismatch.reasons
+
 
 @pytest.mark.parametrize(
     "relay_provider",
-    ["verified-old", "unverified-old", "staged-candidate", "tampered-candidate"],
+    [
+        "verified-current-execution",
+        "verified-old",
+        "unverified-old",
+        "staged-candidate",
+        "tampered-candidate",
+    ],
 )
-def test_first_legacy_upgrade_plans_relay_only_and_reuses_verified_components(
+def test_first_legacy_upgrade_stages_an_unbound_relay_execution_runtime(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     relay_provider: str,
@@ -481,16 +511,21 @@ def test_first_legacy_upgrade_plans_relay_only_and_reuses_verified_components(
     receipt_path.write_text("{}\n", encoding="utf-8")
     clio_kit_wheel = tmp_path / "clio-kit.whl"
     jarvis_wheel = tmp_path / "jarvis-cd.whl"
+    relay_wheel = tmp_path / "clio-relay.whl"
     clio_kit_wheel.write_bytes(b"clio-kit")
     jarvis_wheel.write_bytes(b"jarvis")
+    relay_wheel.write_bytes(b"relay-wheel")
+    relay_digest = _digest(b"relay-wheel")
     desired = desired.model_copy(
         update={
+            "relay_artifact_sha256": relay_digest,
+            "relay_source_identity": f"wheel:sha256:{relay_digest}",
             "clio_kit_artifact_sha256": _digest(b"clio-kit"),
             "jarvis_cd_wheel_sha256": _digest(b"jarvis"),
         }
     )
     info = _installation_info(desired)
-    if relay_provider != "verified-old":
+    if relay_provider not in {"verified-current-execution", "verified-old"}:
         component_runtime = cast(dict[str, object], info["component_runtime"])
         component_runtime["clio-relay"] = {
             "persistent_tool_verified": False,
@@ -530,16 +565,26 @@ def test_first_legacy_upgrade_plans_relay_only_and_reuses_verified_components(
         receipt["generation"] = managed_generation
     receipt.pop("deployment_fingerprint")
     receipt.pop("deployment_manifest")
-    receipt["component_artifacts"] = {
-        "clio-relay": {
-            "runtime_executables": {
-                "clio-relay": (
-                    "/stale/unbound/clio-relay"
-                    if relay_provider == "staged-candidate"
-                    else str(bin_dir / "clio-relay")
-                )
-            },
+    relay_component: dict[str, object] = {
+        "runtime_executables": {
+            "clio-relay": (
+                "/stale/unbound/clio-relay"
+                if relay_provider == "staged-candidate"
+                else str(bin_dir / "clio-relay")
+            )
         },
+    }
+    if relay_provider == "verified-current-execution":
+        relay_component.update(
+            {
+                "install_spec": desired.relay_install_spec,
+                "artifact_sha256": desired.relay_artifact_sha256,
+                "runtime_artifact_path": str(relay_wheel),
+                "runtime_interpreters": {"execution": str(legacy_python)},
+            }
+        )
+    receipt["component_artifacts"] = {
+        "clio-relay": relay_component,
         "clio-kit": {
             "artifact_sha256": desired.clio_kit_artifact_sha256,
             "runtime_artifact_path": str(clio_kit_wheel),
@@ -607,16 +652,23 @@ def test_first_legacy_upgrade_plans_relay_only_and_reuses_verified_components(
         ]
         return
 
-    assert plan.mode == "relay-only", plan.reasons
+    expected_mode = (
+        "relay-only" if relay_provider == "verified-current-execution" else "component-upgrade"
+    )
+    assert plan.mode == expected_mode, plan.reasons
     assert plan.component_actions == {
         "clio-relay": "replace",
-        "jarvis-cd": "reuse",
+        "jarvis-cd": "reuse" if expected_mode == "relay-only" else "replace",
         "jarvis-util": "reuse",
-        "clio-kit": "reuse",
+        "clio-kit": "reuse" if expected_mode == "relay-only" else "replace",
         "frp": "reuse",
         "uv": "reuse",
     }
     assert plan.reusable_paths["jarvis_execution_environment"] == str(execution_root.resolve())
+    if expected_mode == "relay-only":
+        assert plan.reusable_paths["clio-relay_artifact"] == str(relay_wheel.resolve())
+    else:
+        assert plan.reasons == ["relay JARVIS execution runtime requires a staged replacement"]
     assert plan.activation_paths["current"].before is None
     assert plan.activation_paths["managed_repo"].before is None
     if managed_generation is None:
@@ -634,7 +686,7 @@ def test_first_legacy_upgrade_plans_relay_only_and_reuses_verified_components(
         )
         assert rejected.mode == "full"
         assert rejected.reasons == ["clio-kit live runtime is not reusable"]
-    elif relay_provider == "verified-old":
+    elif relay_provider in {"verified-current-execution", "verified-old"}:
         relay_artifact = cast(
             dict[str, object],
             cast(dict[str, object], receipt["component_artifacts"])["clio-relay"],
@@ -2546,6 +2598,39 @@ def test_managed_jarvis_interpreter_fails_closed_on_unverified_runtime(
     )
 
     with pytest.raises(ConfigurationError, match="runtime did not verify"):
+        resolve_receipt_bound_jarvis_python(
+            str(tmp_path / ".local/bin/jarvis"),
+            home=tmp_path,
+        )
+
+
+def test_managed_jarvis_interpreter_requires_relay_execution_packages(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Worker selection rejects a JARVIS venv without receipt-bound relay packages."""
+    desired = _desired(uv_sha256="a" * 64, frpc_sha256="b" * 64, frps_sha256="c" * 64)
+    installation = _installation_info(desired)
+    runtime = cast(dict[str, object], installation["component_runtime"])
+    runtime["clio-relay"] = {
+        "persistent_tool_verified": True,
+        "execution_runtime_verified": False,
+    }
+
+    def read_installation(_path: Path | None = None) -> dict[str, object]:
+        return installation
+
+    def classify_launcher(_path: Path, *, lexical_home: Path) -> bool:
+        return lexical_home == tmp_path
+
+    monkeypatch.setattr(bootstrap_reconcile_module, "installation_info", read_installation)
+    monkeypatch.setattr(
+        bootstrap_reconcile_module,
+        "_relay_managed_jarvis_launcher_selected",
+        classify_launcher,
+    )
+
+    with pytest.raises(ConfigurationError, match="execution runtime did not verify"):
         resolve_receipt_bound_jarvis_python(
             str(tmp_path / ".local/bin/jarvis"),
             home=tmp_path,

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1699,7 +1699,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "fef11d9506323c61ae505af6e32131a669318c2851d49d31b68f154fb4f4aa4f"
+        "e54f60dce0caa564a221a48c27b74b604814bb0cd09837da510e9b3d3a87ee9f"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -317,6 +317,85 @@ def test_native_jarvis_runtime_accepts_canonical_source_aliases(
     assert substituted["verified"] is False
 
 
+def test_relay_execution_runtime_requires_exact_wheel_closure_and_imports(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retained JARVIS interpreter must prove the exact relay package runtime."""
+    wheel = tmp_path / "clio_relay-1.5.0-py3-none-any.whl"
+    wheel.write_bytes(b"verified-relay-wheel")
+    import_verified = {"value": True}
+
+    def probe_execution(_python: str | None, _distribution: str) -> dict[str, object]:
+        return {
+            "executable": sys.executable,
+            "distribution": "clio-relay",
+            "distribution_version": "1.5.0",
+            "direct_url": wheel.as_uri(),
+            "entry_points": [],
+        }
+
+    def probe_record_closure(
+        _python: str | None,
+        _distribution_name: str,
+        _expected_artifact: Path | None,
+        *,
+        environment: dict[str, str] | None = None,
+    ) -> dict[str, object]:
+        del environment
+        return {
+            "schema_version": "clio-relay.python-record-closure.v1",
+            "verified": True,
+            "tree_scanned": False,
+            "tree_copied": False,
+        }
+
+    def probe_imports(
+        _python: str | None,
+        *,
+        expected_version: str | None,
+    ) -> dict[str, object]:
+        assert expected_version == "1.5.0"
+        return {"verified": import_verified["value"], "error": None}
+
+    monkeypatch.setattr(installation_module, "_probe_python_distribution", probe_execution)
+    monkeypatch.setattr(
+        installation_module,
+        "_probe_python_distribution_record_closure",
+        probe_record_closure,
+    )
+    monkeypatch.setattr(
+        installation_module,
+        "_probe_relay_execution_imports",
+        probe_imports,
+    )
+    component = ComponentArtifactIdentity(
+        distribution="clio-relay",
+        distribution_version="1.5.0",
+        install_spec=str(wheel),
+        requested_source="wheel",
+        artifact_filename=wheel.name,
+        artifact_sha256=hashlib.sha256(wheel.read_bytes()).hexdigest(),
+        runtime_artifact_path=str(wheel),
+        runtime_interpreters={"provider": sys.executable, "execution": sys.executable},
+    )
+
+    identity = installation_module._relay_execution_runtime_identity(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        component
+    )
+
+    assert identity["execution_runtime_verified"] is True
+    assert identity["execution_record_closure_verified"] is True
+    assert identity["execution_imports_verified"] is True
+
+    import_verified["value"] = False
+    rejected = installation_module._relay_execution_runtime_identity(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        component
+    )
+    assert rejected["execution_runtime_verified"] is False
+    assert rejected["execution_imports_verified"] is False
+
+
 def _record_row(relative: str, payload: bytes) -> str:
     digest = urlsafe_b64encode(hashlib.sha256(payload).digest()).rstrip(b"=").decode()
     return f"{relative},sha256={digest},{len(payload)}"

--- a/tests/test_process_containment.py
+++ b/tests/test_process_containment.py
@@ -1008,6 +1008,44 @@ time.sleep(60)
     assert _wait_until_pid_exits(child_pid, timeout_seconds=3)
 
 
+def _broker_startup_record(
+    token: str,
+    *,
+    ready: bool = False,
+    stage: str = "child_spawn",
+    code: str = "executable_not_found",
+    exception_type: str | None = "FileNotFoundError",
+    error_number: int | None = 2,
+    child_return_code: int | None = None,
+) -> bytes:
+    """Build an exact broker record for readiness protocol tests."""
+    diagnostic: dict[str, object] | None = None
+    if not ready:
+        diagnostic = {
+            "stage": stage,
+            "code": code,
+            "exception_type": exception_type,
+            "errno": error_number,
+            "child_return_code": child_return_code,
+        }
+    return (
+        json.dumps(
+            {
+                "schema_version": "clio-relay.broker-startup.v1",
+                "token": token,
+                "complete": True,
+                "ready": ready,
+                "diagnostic": diagnostic,
+            },
+            allow_nan=False,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("ascii")
+        + b"\n"
+    )
+
+
 @pytest.mark.parametrize(
     ("payload_kind", "error_match"),
     [
@@ -1023,7 +1061,11 @@ def test_broker_readiness_rejects_forged_and_oversized_payloads_boundedly(
     private = cast(Any, process_containment)
     readiness = private._precreate_broker_readiness()
     descriptor = cast(int, readiness.descriptor)
-    payload = b"1" if payload_kind == "forged" else readiness.token.encode("ascii") + b"x"
+    payload = (
+        b"1"
+        if payload_kind == "forged"
+        else b"x" * (process_containment.BROKER_STARTUP_RECORD_MAX_BYTES + 1)
+    )
     os.lseek(descriptor, 0, os.SEEK_SET)
     assert os.write(descriptor, payload) == len(payload)
     os.fsync(descriptor)
@@ -1038,6 +1080,236 @@ def test_broker_readiness_rejects_forged_and_oversized_payloads_boundedly(
     assert time.monotonic() - started < 1
     assert readiness.descriptor is None
     assert not readiness.path.exists()
+
+
+@pytest.mark.parametrize(
+    "payload_kind",
+    ["wrong-token", "duplicate-key", "partial", "forged-code"],
+)
+def test_broker_startup_record_is_strict_and_authenticated(
+    payload_kind: str,
+) -> None:
+    """Only a complete exact record carrying the pinned token is trusted."""
+    private = cast(Any, process_containment)
+    token = "1" * 32
+    if payload_kind == "wrong-token":
+        encoded = _broker_startup_record("0" * len(token))
+    elif payload_kind == "duplicate-key":
+        encoded = (
+            b'{"complete":true,"diagnostic":null,"ready":true,'
+            b'"ready":true,"schema_version":"clio-relay.broker-startup.v1",'
+            + json.dumps("token").encode("ascii")
+            + b":"
+            + json.dumps(token).encode("ascii")
+            + b"}\n"
+        )
+    elif payload_kind == "partial":
+        encoded = _broker_startup_record(token)[:-1]
+    else:
+        encoded = _broker_startup_record(token, code="unbounded-secret-code")
+
+    if not encoded.endswith(b"\n"):
+        assert private._parse_broker_startup_record(encoded, expected_token=token) is None
+        return
+    with pytest.raises(RuntimeError, match="readiness record was invalid"):
+        private._parse_broker_startup_record(encoded, expected_token=token)
+
+
+def test_broker_exit_performs_final_authenticated_record_read() -> None:
+    """A terminal broker record written just before exit wins the poll/read race."""
+    private = cast(Any, process_containment)
+    readiness = private._precreate_broker_readiness()
+    descriptor = cast(int, readiness.descriptor)
+    polls = 0
+
+    def poll() -> int | None:
+        nonlocal polls
+        polls += 1
+        if polls == 1:
+            record = _broker_startup_record(
+                readiness.token,
+                stage="credential_ack",
+                code="child_exited",
+                exception_type="RuntimeError",
+                error_number=None,
+                child_return_code=9,
+            )
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            os.ftruncate(descriptor, 0)
+            assert os.write(descriptor, record) == len(record)
+            os.fsync(descriptor)
+        return 125
+
+    process = SimpleNamespace(poll=poll, returncode=125)
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "stage=credential_ack code=child_exited exception_type=RuntimeError child_return_code=9"
+        ),
+    ):
+        private._await_broker_readiness(process, readiness)
+
+    assert polls == 1
+    assert readiness.descriptor is None
+    assert not readiness.path.exists()
+
+
+def test_missing_executable_reports_only_structured_startup_diagnostic(
+    tmp_path: Path,
+) -> None:
+    """Executable launch errors expose a fixed code without leaking their command path."""
+    secret = "must-not-leak-from-command"
+    missing_executable = tmp_path / secret / "missing-program"
+
+    with pytest.raises(OwnedProcessSpawnError) as failure:
+        process_containment.spawn_owned_process(
+            [str(missing_executable), "also-must-not-leak"],
+            startup_timeout_seconds=5,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    rendered = str(failure.value)
+    assert "stage=child_spawn" in rendered
+    assert "code=executable_not_found" in rendered
+    assert "exception_type=FileNotFoundError" in rendered
+    assert secret not in rendered
+    assert "also-must-not-leak" not in rendered
+    assert str(missing_executable) not in rendered
+
+
+def test_malicious_child_stderr_cannot_enter_startup_diagnostic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Credential-bearing child output is discarded when its startup handshake fails."""
+    if os.name == "nt":
+        private = cast(Any, process_containment)
+        record = private._parse_broker_startup_record(
+            _broker_startup_record(
+                "1" * 32,
+                stage="credential_ack",
+                code="ack_mismatch",
+                exception_type="RuntimeError",
+                error_number=None,
+            ),
+            expected_token="1" * 32,
+        )
+        assert record.diagnostic.safe_message() == (
+            "containment broker startup failed: "
+            "stage=credential_ack code=ack_mismatch exception_type=RuntimeError"
+        )
+        return
+
+    private = cast(Any, process_containment)
+    monkeypatch.setattr(
+        process_containment,
+        "containment_capability",
+        lambda **_kwargs: {
+            "mode": "cooperative_process_group",
+            "enforceable": False,
+            "reason": "focused test",
+        },
+    )
+    secret = "credential-and-stderr-must-not-leak"
+    script = r"""
+import os
+import sys
+import time
+
+credential_fd = int(os.environ["CLIO_RELAY_BROKER_CREDENTIAL_FD"])
+ready_fd = int(os.environ["CLIO_RELAY_BROKER_READY_FD"])
+payload = bytearray()
+while True:
+    chunk = os.read(credential_fd, 4096)
+    if not chunk:
+        break
+    payload.extend(chunk)
+os.close(credential_fd)
+os.close(ready_fd)
+sys.stderr.buffer.write(payload)
+sys.stderr.buffer.flush()
+time.sleep(1)
+"""
+
+    with pytest.raises(OwnedProcessSpawnError) as failure:
+        process_containment.spawn_owned_process(
+            [sys.executable, "-I", "-S", "-c", script],
+            credential_payload=secret,
+            startup_timeout_seconds=5,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    rendered = str(failure.value)
+    assert "stage=credential_ack" in rendered
+    assert "code=ack_mismatch" in rendered
+    assert secret not in rendered
+    assert secret not in repr(failure.value.__cause__)
+
+
+def test_startup_output_flood_fails_boundedly_without_being_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blocked child output pipe cannot make credential startup unbounded."""
+    private = cast(Any, process_containment)
+    if os.name == "nt":
+
+        class CloseOnlyStream:
+            def __init__(self) -> None:
+                self.closed = False
+
+            def close(self) -> None:
+                self.closed = True
+
+        streams = [CloseOnlyStream(), CloseOnlyStream(), CloseOnlyStream()]
+        process = SimpleNamespace(stdin=streams[0], stdout=streams[1], stderr=streams[2])
+        assert private._close_failed_broker_streams(process) == []
+        assert all(stream.closed for stream in streams)
+        assert process.stdin is None and process.stdout is None and process.stderr is None
+        return
+
+    shortened = private._BROKER_SCRIPT.replace(
+        "HANDSHAKE_TIMEOUT_SECONDS = 5.0",
+        "HANDSHAKE_TIMEOUT_SECONDS = 0.2",
+    )
+    monkeypatch.setattr(process_containment, "_BROKER_SCRIPT", shortened)
+    monkeypatch.setattr(
+        process_containment,
+        "containment_capability",
+        lambda **_kwargs: {
+            "mode": "cooperative_process_group",
+            "enforceable": False,
+            "reason": "focused test",
+        },
+    )
+    script = r"""
+import os
+import sys
+
+credential_fd = int(os.environ["CLIO_RELAY_BROKER_CREDENTIAL_FD"])
+while os.read(credential_fd, 4096):
+    pass
+os.close(credential_fd)
+chunk = b"untrusted-output" * 4096
+while True:
+    sys.stderr.buffer.write(chunk)
+    sys.stderr.buffer.flush()
+"""
+    started = time.monotonic()
+    with pytest.raises(OwnedProcessSpawnError) as failure:
+        process_containment.spawn_owned_process(
+            [sys.executable, "-I", "-S", "-c", script],
+            credential_payload="bounded-test-credential",
+            startup_timeout_seconds=3,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    assert time.monotonic() - started < 3
+    rendered = str(failure.value)
+    assert "stage=credential_ack" in rendered
+    assert "code=ack_timeout" in rendered
+    assert "untrusted-output" not in rendered
 
 
 def test_broker_readiness_rejects_replaced_path_and_closes_anchor(
@@ -1124,6 +1396,7 @@ def test_broker_readiness_replacement_is_rejected_without_truncation(tmp_path: P
             timeout=10,
         )
         assert result.returncode != 0
+        assert result.stderr == ""
         assert readiness.path.read_bytes() == replacement
     finally:
         readiness.path.unlink(missing_ok=True)

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.21"
+    assert version == "1.4.22"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -1090,7 +1090,8 @@ def test_executor_replaces_exact_legacy_old_release_session(
         "_current_session_api_release_identity",
         lambda: current_release,
     )
-    monkeypatch.setattr(os, "geteuid", lambda: 0, raising=False)
+    effective_uid = getattr(os, "geteuid", lambda: 0)()
+    monkeypatch.setattr(os, "geteuid", lambda: effective_uid, raising=False)
     inspection_count = 0
 
     def inspect(**_kwargs: object) -> OwnedSessionRecoveryStatus:
@@ -1361,7 +1362,8 @@ def test_old_release_migration_crash_retries_same_replacement_with_real_inspecti
         "_current_session_api_release_identity",
         lambda: current_release,
     )
-    monkeypatch.setattr(os, "geteuid", lambda: 0, raising=False)
+    effective_uid = getattr(os, "geteuid", lambda: 0)()
+    monkeypatch.setattr(os, "geteuid", lambda: effective_uid, raising=False)
     migrate = session_lifecycle._migrate_legacy_start_attempt  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
 
     class MigrationCrash(RuntimeError):
@@ -1407,7 +1409,7 @@ def test_old_release_migration_crash_retries_same_replacement_with_real_inspecti
         core_dir=queue.root,
         home=home,
         proc_root=proc_root,
-        effective_uid=0,
+        effective_uid=effective_uid,
         transaction=cast(session_lifecycle._OwnedSessionTransaction, transaction),  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
         expected_start_operation_id=request.start_operation_id,
         expected_cluster_route_revision=request.cluster_route_revision,

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2354,13 +2354,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.21-py3-none-any.whl",
+            resource_id="clio-relay-1.4.22-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.21.tar.gz",
+            resource_id="clio_relay-1.4.22.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2499,7 +2499,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.21"
+    assert policy.release_version == "1.4.22"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.21"
+version = "1.4.22"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- Repair upgraded-cluster JARVIS execution by installing and proving the exact released relay wheel inside a fresh staged JARVIS environment. Relay-only reconciliation never mutates an active retained environment.
- Make prepared-generation validation, warm no-op inspection, installation receipts, and worker startup fail closed unless the JARVIS interpreter has the exact relay wheel, RECORD closure, source identity, and required package imports.
- Add authenticated, bounded broker startup diagnostics that expose only fixed stage/code metadata and never child output, credentials, commands, paths, or environment values.
- Carry forward the actionable v1.4.21 asynchronous CI fixes: gateway resume acceptance inventory/fixtures, lock-held lease-index v1 to v2 rebuilding, and Linux ownership-correct migration fixtures.
- Bump the release metadata and acceptance matrix to 1.4.22.

## Root cause

v1.4.21 correctly switched workers to the receipt-bound JARVIS interpreter. Fresh bootstrap installed relay's JARVIS packages there, but the component-upgrade path used on Ares did not. The hardened child therefore exited before acknowledging the private broker credential channel, and the old broker protocol discarded the pre-readiness diagnostic.

## Validation

- 16 focused containment tests passed.
- 10 focused bootstrap/runtime-identity tests passed.
- 12 focused acceptance/index/session tests passed.
- 26 focused release-policy/version tests passed.
- Exact packaged containment mirror test passed.
- Ruff and targeted Pyright passed; `uv lock --check` and `git diff --check` passed.

The full regression matrix remains asynchronous on the release tag, per the repository release-first policy.
