### PR TITLE
fix: restore bootstrap MCP repository binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.22` uses a release-first patch process. A maintainer builds the
+> Version `1.4.23` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.22"
+$Version = "1.4.23"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.22"
+release_version: "1.4.23"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: e54f60dce0caa564a221a48c27b74b604814bb0cd09837da510e9b3d3a87ee9f
+acceptance_matrix_sha256: fdea05c380e1d033acced2ce1b0caa7f5e4000e389adb4ef420ac1e5f4830b2d
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.22"
+$Tag = "v1.4.23"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.22" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.23" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.22",
-  "matrix_sha256": "e54f60dce0caa564a221a48c27b74b604814bb0cd09837da510e9b3d3a87ee9f",
+  "release_version": "1.4.23",
+  "matrix_sha256": "fdea05c380e1d033acced2ce1b0caa7f5e4000e389adb4ef420ac1e5f4830b2d",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.22"
+version = "1.4.23"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.22"
+__version__ = "1.4.23"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -30,6 +30,8 @@ from packaging.version import InvalidVersion, Version
 
 from clio_relay import __version__
 from clio_relay.bootstrap_reconcile import (
+    LEGACY_MANAGED_JARVIS_REPO_PATH,
+    MANAGED_JARVIS_REPO_PATH,
     BootstrapDesiredState,
     validate_jarvis_builtin_result,
 )
@@ -3214,7 +3216,7 @@ def _validate_bootstrap_receipt(
             or not _is_sha256_value(typed_generation.get("previous"))
         ):
             raise RelayError("bootstrap managed JARVIS binding repair is invalid")
-        managed_suffix = "/.local/share/clio-relay/managed-jarvis-repo"
+        managed_suffix = MANAGED_JARVIS_REPO_PATH.removeprefix("~")
         if not managed_repo.endswith(managed_suffix):
             raise RelayError("bootstrap managed JARVIS binding repair is invalid")
         remote_home = managed_repo[: -len(managed_suffix)]
@@ -3222,6 +3224,15 @@ def _validate_bootstrap_receipt(
             remote_home + "/.local/share/clio-relay/current/source/jarvis-packages/clio_relay"
         )
         expected_previous = remote_home + "/.local/src/clio-relay/jarvis-packages/clio_relay"
+        expected_legacy = remote_home + LEGACY_MANAGED_JARVIS_REPO_PATH.removeprefix("~")
+        typed_removed_repositories = cast(list[object], removed_repositories)
+        removed_repositories_are_proven = bool(
+            all(isinstance(value, str) for value in typed_removed_repositories)
+            and typed_removed_repositories
+            == sorted(set(cast(list[str], typed_removed_repositories)))
+            and set(cast(list[str], typed_removed_repositories))
+            <= {expected_previous, expected_legacy}
+        )
         repository_action = repository_update.get("action")
         if binding.get("target") != expected_target:
             raise RelayError("bootstrap managed JARVIS binding repair is invalid")
@@ -3236,7 +3247,7 @@ def _validate_bootstrap_receipt(
             if (
                 typed_jarvis_preservation.get("repositories_byte_identical") is not False
                 or added_repositories not in ([], [managed_repo])
-                or removed_repositories not in ([], [expected_previous])
+                or not removed_repositories_are_proven
                 or (not added_repositories and not removed_repositories)
             ):
                 raise RelayError("bootstrap managed JARVIS repository repair is invalid")
@@ -3300,7 +3311,7 @@ def _validate_bootstrap_receipt(
             or binding.get("link") != managed_repo
         ):
             raise RelayError("staged reconcile repository binding is invalid")
-        managed_suffix = "/.local/share/clio-relay/managed-jarvis-repo"
+        managed_suffix = MANAGED_JARVIS_REPO_PATH.removeprefix("~")
         if not managed_repo.endswith(managed_suffix):
             raise RelayError("staged reconcile repository binding is invalid")
         remote_home = managed_repo[: -len(managed_suffix)]
@@ -3308,6 +3319,15 @@ def _validate_bootstrap_receipt(
             remote_home + "/.local/share/clio-relay/current/source/jarvis-packages/clio_relay"
         )
         expected_previous = remote_home + "/.local/src/clio-relay/jarvis-packages/clio_relay"
+        expected_legacy = remote_home + LEGACY_MANAGED_JARVIS_REPO_PATH.removeprefix("~")
+        typed_removed_repositories = cast(list[object], removed_repositories)
+        removed_repositories_are_proven = bool(
+            all(isinstance(value, str) for value in typed_removed_repositories)
+            and typed_removed_repositories
+            == sorted(set(cast(list[str], typed_removed_repositories)))
+            and set(cast(list[str], typed_removed_repositories))
+            <= {expected_previous, expected_legacy}
+        )
         repository_action = repository_update.get("action")
         if (
             binding.get("target") != expected_target
@@ -3326,8 +3346,8 @@ def _validate_bootstrap_receipt(
             if (
                 typed_jarvis_preservation.get("repositories_byte_identical") is not False
                 or added_repositories not in ([], [managed_repo])
-                or removed_repositories not in ([], [expected_previous])
-                or (not added_repositories and removed_repositories != [expected_previous])
+                or not removed_repositories_are_proven
+                or (not added_repositories and not removed_repositories)
             ):
                 raise RelayError("staged reconcile repository migration is invalid")
         else:  # pragma: no cover - rejected by the generic evidence contract above
@@ -3918,7 +3938,7 @@ bootstrap_verify_stable_activation_links() {{
   bootstrap_require_stable_link "$HOME/.local/bin/jarvis" \
     "$HOME/.local/share/clio-relay/current/bin/jarvis"
   bootstrap_require_stable_link \
-    "$HOME/.local/share/clio-relay/managed-jarvis-repo" \
+    "$HOME/.local/share/clio-relay/clio_relay" \
       "$HOME/.local/share/clio-relay/current/source/jarvis-packages/clio_relay"
 }}
 
@@ -6415,19 +6435,19 @@ __CLIO_RELAY_CANDIDATE_WHEEL_PATH__
       )"
       ;;
     clio-relay==*)
-      BOOTSTRAP_CANDIDATE_ARTIFACT="$BOOTSTRAP_PREPARING_ROOT/candidate-relay.whl"
-      timeout --signal=TERM --kill-after=5s 180 \
-        python3 -I - "$BOOTSTRAP_CANDIDATE_INSTALL_SPEC" \
-        "$BOOTSTRAP_CANDIDATE_ARTIFACT_SHA256" \
-        "$BOOTSTRAP_CANDIDATE_ARTIFACT" <<'__CLIO_RELAY_CANDIDATE_PYPI_WHEEL__'
+      BOOTSTRAP_CANDIDATE_ARTIFACT="$(
+        timeout --signal=TERM --kill-after=5s 180 \
+          python3 -I - "$BOOTSTRAP_CANDIDATE_INSTALL_SPEC" \
+          "$BOOTSTRAP_CANDIDATE_ARTIFACT_SHA256" \
+          "$BOOTSTRAP_PREPARING_ROOT" <<'__CLIO_RELAY_CANDIDATE_PYPI_WHEEL__'
 import hashlib
 import json
 import sys
-from pathlib import Path
-from urllib.parse import quote, urlsplit
+from pathlib import Path, PurePosixPath
+from urllib.parse import quote, unquote, urlsplit
 from urllib.request import urlopen
 
-specification, expected_sha256, destination_value = sys.argv[1:]
+specification, expected_sha256, destination_root_value = sys.argv[1:]
 version = specification.removeprefix("clio-relay==")
 if not version or specification != f"clio-relay=={{version}}":
     raise SystemExit("candidate PyPI install spec is not exact")
@@ -6450,6 +6470,14 @@ matches = [
 ]
 if len(matches) != 1:
     raise SystemExit("PyPI did not return the exact digest-pinned relay wheel")
+filename = matches[0].get("filename")
+if (
+    not isinstance(filename, str)
+    or not filename.endswith(".whl")
+    or Path(filename).name != filename
+    or any(character in filename for character in "\\x00\\r\\n")
+):
+    raise SystemExit("PyPI relay wheel filename is unsafe")
 url = matches[0].get("url")
 if not isinstance(url, str):
     raise SystemExit("PyPI relay wheel URL is missing")
@@ -6458,7 +6486,19 @@ if parsed.scheme != "https" or not parsed.hostname or not parsed.hostname.endswi
     ".pythonhosted.org"
 ):
     raise SystemExit("PyPI relay wheel URL has an unsupported origin")
-destination = Path(destination_value)
+if PurePosixPath(unquote(parsed.path)).name != filename:
+    raise SystemExit("PyPI relay wheel URL does not preserve its verified filename")
+destination_root = Path(destination_root_value)
+if (
+    not destination_root.is_absolute()
+    or destination_root.is_symlink()
+    or not destination_root.is_dir()
+):
+    raise SystemExit("candidate relay wheel destination root is unsafe")
+destination_root = destination_root.resolve(strict=True)
+destination = destination_root / filename
+if destination.parent != destination_root:
+    raise SystemExit("candidate relay wheel destination escaped its private root")
 digest = hashlib.sha256()
 size = 0
 with urlopen(url, timeout=60) as response, destination.open("xb") as stream:
@@ -6471,7 +6511,9 @@ with urlopen(url, timeout=60) as response, destination.open("xb") as stream:
 if size < 1 or digest.hexdigest() != expected_sha256:
     destination.unlink(missing_ok=True)
     raise SystemExit("downloaded candidate relay wheel did not match its digest")
+print(destination)
 __CLIO_RELAY_CANDIDATE_PYPI_WHEEL__
+      )"
       ;;
     *)
       echo "retained-state reconcile supports only an exact released relay wheel" >&2
@@ -6756,7 +6798,7 @@ for name, path, kind in (
         home / ".local/share/clio-relay/install-receipt.json",
         "symlink",
     ),
-    ("managed_repo", home / ".local/share/clio-relay/managed-jarvis-repo", "symlink"),
+    ("managed_repo", home / ".local/share/clio-relay/clio_relay", "symlink"),
     ("relay_launcher", home / ".local/bin/clio-relay", "symlink"),
     ("jarvis_launcher", home / ".local/bin/jarvis", "symlink"),
 ):
@@ -7513,7 +7555,7 @@ else
   JARVIS_GRAPH_ACTION="preserved"
   BOOTSTRAP_JARVIS_COMMANDS_JSON='[]'
 fi
-MANAGED_JARVIS_REPO="$HOME/.local/share/clio-relay/managed-jarvis-repo"
+MANAGED_JARVIS_REPO="$HOME/.local/share/clio-relay/clio_relay"
 MANAGED_JARVIS_REPO_TARGET="$HOME/.local/share/clio-relay/current/source/jarvis-packages/clio_relay"
 if [ -L "$MANAGED_JARVIS_REPO" ]; then
   if [ "$(readlink "$MANAGED_JARVIS_REPO")" != "$MANAGED_JARVIS_REPO_TARGET" ]; then
@@ -7529,6 +7571,7 @@ else
 fi
 export MANAGED_JARVIS_REPO JARVIS_REPOS_FILE
 "$RELAY_PROVIDER_PYTHON" - "$DEST/jarvis-packages/clio_relay" \
+  "$HOME/.local/share/clio-relay/managed-jarvis-repo" \
   <<'__CLIO_RELAY_JARVIS_REPO_RECONCILE__'
 import os
 import sys
@@ -7539,7 +7582,7 @@ from clio_relay.bootstrap_reconcile import reconcile_managed_jarvis_repository
 evidence = reconcile_managed_jarvis_repository(
     Path(os.environ["JARVIS_REPOS_FILE"]),
     Path(os.environ["MANAGED_JARVIS_REPO"]),
-    previous_managed_repos=(Path(sys.argv[1]),),
+    previous_managed_repos=(Path(sys.argv[1]), Path(sys.argv[2])),
 )
 print(f"jarvis_managed_repo={{evidence['action']}}")
 __CLIO_RELAY_JARVIS_REPO_RECONCILE__
@@ -7665,7 +7708,7 @@ BOOTSTRAP_ACTIVATION_IDENTITY="$(bootstrap_path_set_identity \
   "$HOME/.local/share/clio-relay/install-receipt.json" \
   "$HOME/.local/bin/clio-relay" \
   "$HOME/.local/bin/jarvis" \
-  "$HOME/.local/share/clio-relay/managed-jarvis-repo")"
+  "$HOME/.local/share/clio-relay/clio_relay")"
 bootstrap_journal_action phase "$BOOTSTRAP_TRANSACTION_JOURNAL" \
   generation_activated "$BOOTSTRAP_ACTIVATION_IDENTITY"
 bootstrap_journal_action advance "$BOOTSTRAP_TRANSACTION_JOURNAL" activated

--- a/src/clio_relay/bootstrap_reconcile.py
+++ b/src/clio_relay/bootstrap_reconcile.py
@@ -45,6 +45,8 @@ from clio_relay.worker_lifetime_lock import (
 BOOTSTRAP_DESIRED_STATE_SCHEMA = "clio-relay.bootstrap-desired-state.v1"
 BOOTSTRAP_RECEIPT_SCHEMA = "clio-relay.bootstrap-receipt.v2"
 BOOTSTRAP_TRANSACTION_SCHEMA = "clio-relay.bootstrap-transaction.v1"
+MANAGED_JARVIS_REPO_PATH = "~/.local/share/clio-relay/clio_relay"
+LEGACY_MANAGED_JARVIS_REPO_PATH = "~/.local/share/clio-relay/managed-jarvis-repo"
 MAX_JARVIS_CONFIG_BYTES = 1024 * 1024
 MAX_JARVIS_REPOS_BYTES = 4 * 1024 * 1024
 MAX_JARVIS_GRAPH_BYTES = 64 * 1024 * 1024
@@ -193,7 +195,7 @@ class BootstrapDesiredState(BaseModel):
     jarvis_config_dir: str = "~/.local/share/clio-relay/jarvis-config"
     jarvis_private_dir: str = "~/.local/share/clio-relay/jarvis-private"
     jarvis_shared_dir: str = "~/.local/share/clio-relay/jarvis-shared"
-    managed_jarvis_repo: str = "~/.local/share/clio-relay/managed-jarvis-repo"
+    managed_jarvis_repo: str = MANAGED_JARVIS_REPO_PATH
 
     @model_validator(mode="after")
     def validate_identity(self) -> BootstrapDesiredState:
@@ -1238,12 +1240,13 @@ def finish_staged_activation(
         raise ConfigurationError("prepared generation inspection did not bind its manifest")
     activation = reconcile_staged_activation_links(plan, generation=generation, home=home)
     lexical_home = Path(os.path.abspath((home or Path.home()).expanduser()))
-    managed_repo = lexical_home / ".local/share/clio-relay/managed-jarvis-repo"
+    managed_repo = _expand_home(desired.managed_jarvis_repo, lexical_home)
+    legacy_managed_repo = _expand_home(LEGACY_MANAGED_JARVIS_REPO_PATH, lexical_home)
     previous_repo = lexical_home / ".local/src/clio-relay/jarvis-packages/clio_relay"
     repositories = reconcile_managed_jarvis_repository(
         _expand_home(desired.jarvis_root, lexical_home) / "repos.yaml",
         managed_repo,
-        previous_managed_repos=(previous_repo,),
+        previous_managed_repos=(legacy_managed_repo, previous_repo),
         exchange_identity=desired.fingerprint,
     )
     expected_managed_target = (
@@ -1255,7 +1258,7 @@ def finish_staged_activation(
         label="relay-managed repository",
     )
     canonical_home = lexical_home.resolve(strict=True)
-    reported_managed_repo = canonical_home / ".local/share/clio-relay/managed-jarvis-repo"
+    reported_managed_repo = _expand_home(desired.managed_jarvis_repo, canonical_home)
     reported_managed_target = (
         canonical_home / ".local/share/clio-relay/current/source/jarvis-packages/clio_relay"
     )
@@ -2489,6 +2492,10 @@ def reconcile_managed_jarvis_repository(
     bootstrap lock; the final byte-and-file-identity comparison also detects
     non-cooperating writers before the atomic replacement.
     """
+    if managed_repo.name != "clio_relay":
+        raise ConfigurationError(
+            "relay-managed JARVIS repository basename must match its clio_relay namespace"
+        )
     lexical_managed = str(Path(os.path.abspath(managed_repo.expanduser())))
     managed = str(_canonical_path_preserving_final(managed_repo))
     managed_aliases = {lexical_managed, managed}
@@ -2707,16 +2714,17 @@ def repair_managed_jarvis_binding(
         exchange_identity=desired.fingerprint,
     )
     repos_file = _expand_home(desired.jarvis_root, lexical_home) / "repos.yaml"
+    legacy_managed_repo = _expand_home(LEGACY_MANAGED_JARVIS_REPO_PATH, lexical_home)
     repo_evidence = reconcile_managed_jarvis_repository(
         repos_file,
         managed,
-        previous_managed_repos=previous_managed_repos,
+        previous_managed_repos=(*previous_managed_repos, legacy_managed_repo),
         exchange_identity=desired.fingerprint,
     )
     canonical_home = lexical_home.resolve(strict=True)
     return {
         "link_action": link_action,
-        "link": str(canonical_home / ".local/share/clio-relay/managed-jarvis-repo"),
+        "link": str(_expand_home(desired.managed_jarvis_repo, canonical_home)),
         "target": str(
             canonical_home / ".local/share/clio-relay/current/source/jarvis-packages/clio_relay"
         ),
@@ -2850,7 +2858,7 @@ def _inspect_active_generation(
                 label=f"stable {executable} launcher",
             )
         _verify_stable_symlink(
-            home / ".local/share/clio-relay/managed-jarvis-repo",
+            _expand_home(desired.managed_jarvis_repo, home),
             expected=expected_target / "source/jarvis-packages/clio_relay",
             label="relay-managed JARVIS repository",
         )
@@ -3362,7 +3370,7 @@ def _capture_reconcile_activation_paths(
                 "active generation pointer does not name one managed generation"
             )
     managed = _capture_activation_path(
-        share / "managed-jarvis-repo",
+        _expand_home(MANAGED_JARVIS_REPO_PATH, lexical_home),
         kind="symlink",
         maximum=4096,
         allow_absent=True,
@@ -3644,7 +3652,7 @@ def reconcile_staged_activation_links(
         "install_receipt": lexical_home / ".local/share/clio-relay/install-receipt.json",
         "relay_launcher": lexical_home / ".local/bin/clio-relay",
         "jarvis_launcher": lexical_home / ".local/bin/jarvis",
-        "managed_repo": lexical_home / ".local/share/clio-relay/managed-jarvis-repo",
+        "managed_repo": _expand_home(MANAGED_JARVIS_REPO_PATH, lexical_home),
     }.items():
         if Path(plan.activation_paths[name].path) != target_path:
             raise ConfigurationError(f"staged activation path destination changed: {name}")

--- a/tests/test_bootstrap_fast_path.py
+++ b/tests/test_bootstrap_fast_path.py
@@ -15,6 +15,7 @@ import sys
 import tarfile
 from contextlib import nullcontext
 from datetime import UTC, datetime
+from io import BytesIO
 from pathlib import Path
 from typing import NoReturn, cast
 
@@ -1116,7 +1117,7 @@ with tempfile.TemporaryDirectory() as value:
             path=str(home / ".local/bin/jarvis"), kind="file_or_symlink"
         ),
         "managed_repo": BootstrapActivationPath(
-            path=str(home / ".local/share/clio-relay/managed-jarvis-repo"),
+            path=str(home / ".local/share/clio-relay/clio_relay"),
             kind="symlink",
         ),
     }
@@ -1170,7 +1171,7 @@ with tempfile.TemporaryDirectory() as value:
     (jarvis_root / "resource_graph.yaml").write_text(
         "storage:\n  nvme:\n    capacity: 100\n", encoding="utf-8"
     )
-    managed_repo = home / ".local/share/clio-relay/managed-jarvis-repo"
+    managed_repo = home / ".local/share/clio-relay/clio_relay"
     first_repository = reconcile_managed_jarvis_repository(
         repos_file,
         managed_repo,
@@ -1263,7 +1264,7 @@ with tempfile.TemporaryDirectory() as value:
     if first_repository["action"] != "updated" or second_repository["action"] != "reused":
         raise SystemExit("repository alias did not converge exactly once")
     canonical_managed = str(
-        canonical_home / ".local/share/clio-relay/managed-jarvis-repo"
+        canonical_home / ".local/share/clio-relay/clio_relay"
     )
     if yaml.safe_load(repos_file.read_text(encoding="utf-8"))["repos"] != [
         canonical_managed,
@@ -2082,7 +2083,7 @@ def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration(
         }
         for name, action in actions.items()
     }
-    managed_repo = "/home/operator/.local/share/clio-relay/managed-jarvis-repo"
+    managed_repo = "/home/operator/.local/share/clio-relay/clio_relay"
     repository_update: dict[str, object] = {
         "link_action": "created",
         "link": managed_repo,
@@ -2094,7 +2095,7 @@ def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration(
             "managed_repo": managed_repo,
             "added_managed_repos": [managed_repo],
             "removed_previous_managed_repos": [
-                "/home/operator/.local/src/clio-relay/jarvis-packages/clio_relay"
+                "/home/operator/.local/share/clio-relay/managed-jarvis-repo"
             ],
             "before_sha256": before.repos_sha256,
             "after_sha256": after.repos_sha256,
@@ -2461,6 +2462,126 @@ def test_release_identity_requires_exact_artifact_digest(tmp_path: Path) -> None
             relay_wheel=None,
             relay_artifact_sha256=None,
         )
+
+
+def test_retained_release_download_preserves_verified_wheel_filename(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The fd-bound installer receives a canonical wheel filename, not a placeholder."""
+    wheel_payload = b"verified release wheel payload"
+    wheel_sha256 = hashlib.sha256(wheel_payload).hexdigest()
+    wheel_filename = f"clio_relay-{__version__}-py3-none-any.whl"
+    wheel_url = f"https://files.pythonhosted.org/packages/release/{wheel_filename}"
+    metadata = json.dumps(
+        {
+            "urls": [
+                {
+                    "filename": wheel_filename,
+                    "packagetype": "bdist_wheel",
+                    "digests": {"sha256": wheel_sha256},
+                    "url": wheel_url,
+                }
+            ]
+        }
+    ).encode()
+    script = bootstrap.render_linux_user_bootstrap_script(
+        cluster="cluster-a",
+        relay_install_spec=f"clio-relay=={__version__}",
+        relay_artifact_sha256=wheel_sha256,
+        source_archive_sha256="b" * 64,
+    )
+    marker = "<<'__CLIO_RELAY_CANDIDATE_PYPI_WHEEL__'\n"
+    program = script.split(marker, 1)[1].split("\n__CLIO_RELAY_CANDIDATE_PYPI_WHEEL__", 1)[0]
+    responses = iter((metadata, wheel_payload))
+    requested_urls: list[str] = []
+
+    def fake_urlopen(url: str, *, timeout: int) -> BytesIO:
+        requested_urls.append(url)
+        assert timeout in {30, 60}
+        return BytesIO(next(responses))
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "candidate-wheel-download",
+            f"clio-relay=={__version__}",
+            wheel_sha256,
+            str(tmp_path),
+        ],
+    )
+
+    exec(compile(program, "<candidate-wheel-download>", "exec"), {"__name__": "__main__"})
+
+    destination = tmp_path / wheel_filename
+    assert capsys.readouterr().out.strip() == str(destination)
+    assert destination.read_bytes() == wheel_payload
+    assert "candidate-relay.whl" not in script
+    assert requested_urls == [
+        f"https://pypi.org/pypi/clio-relay/{__version__}/json",
+        wheel_url,
+    ]
+
+
+def test_retained_release_download_rejects_changed_url_basename(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A digest-pinned metadata entry cannot rename the wheel at its download URL."""
+    wheel_payload = b"verified release wheel payload"
+    wheel_sha256 = hashlib.sha256(wheel_payload).hexdigest()
+    wheel_filename = f"clio_relay-{__version__}-py3-none-any.whl"
+    metadata = json.dumps(
+        {
+            "urls": [
+                {
+                    "filename": wheel_filename,
+                    "packagetype": "bdist_wheel",
+                    "digests": {"sha256": wheel_sha256},
+                    "url": "https://files.pythonhosted.org/packages/release/renamed.whl",
+                }
+            ]
+        }
+    ).encode()
+    script = bootstrap.render_linux_user_bootstrap_script(
+        cluster="cluster-a",
+        relay_install_spec=f"clio-relay=={__version__}",
+        relay_artifact_sha256=wheel_sha256,
+        source_archive_sha256="b" * 64,
+    )
+    marker = "<<'__CLIO_RELAY_CANDIDATE_PYPI_WHEEL__'\n"
+    program = script.split(marker, 1)[1].split("\n__CLIO_RELAY_CANDIDATE_PYPI_WHEEL__", 1)[0]
+
+    def fake_urlopen(url: str, *, timeout: int) -> BytesIO:
+        assert url == f"https://pypi.org/pypi/clio-relay/{__version__}/json"
+        assert timeout == 30
+        return BytesIO(metadata)
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "candidate-wheel-download",
+            f"clio-relay=={__version__}",
+            wheel_sha256,
+            str(tmp_path),
+        ],
+    )
+
+    with pytest.raises(
+        SystemExit,
+        match="PyPI relay wheel URL does not preserve its verified filename",
+    ):
+        exec(
+            compile(program, "<candidate-wheel-download>", "exec"),
+            {"__name__": "__main__"},
+        )
+
+    assert list(tmp_path.iterdir()) == []
 
 
 def test_same_release_version_with_different_wheels_has_different_identity(

--- a/tests/test_bootstrap_reconcile.py
+++ b/tests/test_bootstrap_reconcile.py
@@ -132,7 +132,7 @@ def _write_jarvis_state(home: Path, desired: BootstrapDesiredState) -> tuple[Pat
         ".local/share/clio-relay/jarvis-config",
         ".local/share/clio-relay/jarvis-private",
         ".local/share/clio-relay/jarvis-shared",
-        ".local/share/clio-relay/managed-jarvis-repo",
+        ".local/share/clio-relay/clio_relay",
     ):
         (home / relative).mkdir(parents=True)
     config = {
@@ -147,7 +147,7 @@ def _write_jarvis_state(home: Path, desired: BootstrapDesiredState) -> tuple[Pat
     repos_bytes = yaml.safe_dump(
         {
             "repos": [
-                str((home / ".local/share/clio-relay/managed-jarvis-repo").absolute()),
+                str((home / ".local/share/clio-relay/clio_relay").absolute()),
                 "/operator/clio_relay",
             ]
         },
@@ -292,7 +292,7 @@ def test_managed_repository_converges_home_alias_to_one_canonical_stable_path(
     lexical_home = tmp_path / "home-alias"
     _create_directory_alias(lexical_home, canonical_home)
     root, _config, _graph = _write_jarvis_state(lexical_home, desired)
-    managed = lexical_home / ".local/share/clio-relay/managed-jarvis-repo"
+    managed = lexical_home / ".local/share/clio-relay/clio_relay"
     previous = lexical_home / ".local/src/clio-relay/jarvis-packages/clio_relay"
     previous.mkdir(parents=True)
     operator = "/operator/clio_relay"
@@ -312,7 +312,7 @@ def test_managed_repository_converges_home_alias_to_one_canonical_stable_path(
         exchange_identity=desired.fingerprint,
     )
 
-    canonical_managed = str(canonical_home / ".local/share/clio-relay/managed-jarvis-repo")
+    canonical_managed = str(canonical_home / ".local/share/clio-relay/clio_relay")
     canonical_previous = str(canonical_home / ".local/src/clio-relay/jarvis-packages/clio_relay")
     assert yaml.safe_load(repos_file.read_text(encoding="utf-8"))["repos"] == [
         canonical_managed,
@@ -453,7 +453,7 @@ def test_first_legacy_upgrade_stages_an_unbound_relay_execution_runtime(
         frps_sha256=_digest(b"frps"),
     )
     _write_jarvis_state(tmp_path, desired)
-    (tmp_path / ".local/share/clio-relay/managed-jarvis-repo").rmdir()
+    (tmp_path / ".local/share/clio-relay/clio_relay").rmdir()
     managed_generation = "b" * 64 if relay_provider == "staged-candidate" else None
     execution_root = tmp_path / ".local/share/clio-relay/jarvis-venv"
     if managed_generation is not None:
@@ -485,7 +485,7 @@ def test_first_legacy_upgrade_stages_an_unbound_relay_execution_runtime(
                     kind="file_or_symlink",
                 ),
                 "managed_repo": BootstrapActivationPath(
-                    path=str(home / ".local/share/clio-relay/managed-jarvis-repo"),
+                    path=str(home / ".local/share/clio-relay/clio_relay"),
                     kind="symlink",
                 ),
             }
@@ -972,7 +972,7 @@ def test_existing_jarvis_144_plans_staged_component_upgrade_to_148(
         }
     )
     jarvis_root, _config_before, _graph_before = _write_jarvis_state(tmp_path, desired)
-    (tmp_path / ".local/share/clio-relay/managed-jarvis-repo").rmdir()
+    (tmp_path / ".local/share/clio-relay/clio_relay").rmdir()
     (jarvis_root / "repos.yaml").write_text(
         yaml.safe_dump({"repos": ["/operator/clio_relay"]}, sort_keys=False),
         encoding="utf-8",
@@ -1185,13 +1185,38 @@ def test_existing_operator_jarvis_roots_are_adopted_without_mutation(tmp_path: P
     assert (root / "resource_graph.yaml").read_bytes() == graph_before
 
 
-def test_managed_repo_reconcile_preserves_same_name_operator_repository(tmp_path: Path) -> None:
-    repos_file = tmp_path / "repos.yaml"
+def test_managed_repo_migration_preserves_operator_repo_and_resolves_jarvis_package(
+    tmp_path: Path,
+) -> None:
+    """The stable basename satisfies JARVIS while migration removes only relay's old path."""
+    jarvis_root = tmp_path / "jarvis-root"
+    jarvis_root.mkdir()
+    repos_file = jarvis_root / "repos.yaml"
     operator_repo = tmp_path / "operator/clio_relay"
-    previous_managed = tmp_path / "legacy/clio_relay"
-    managed_repo = tmp_path / "relay/managed-jarvis-repo"
+    previous_managed = tmp_path / ".local/share/clio-relay/managed-jarvis-repo"
+    managed_repo = tmp_path / ".local/share/clio-relay/clio_relay"
+    operator_repo.mkdir(parents=True)
     previous_managed.parent.mkdir(parents=True)
-    managed_repo.parent.mkdir(parents=True)
+    shutil.copytree(Path("jarvis-packages/clio_relay"), managed_repo)
+    for name in ("config", "private", "shared"):
+        (tmp_path / name).mkdir()
+    (jarvis_root / "jarvis_config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "config_dir": str((tmp_path / "config").resolve()),
+                "private_dir": str((tmp_path / "private").resolve()),
+                "shared_dir": str((tmp_path / "shared").resolve()),
+                "current_pipeline": None,
+                "hostfile": None,
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (jarvis_root / "resource_graph.yaml").write_text(
+        yaml.safe_dump({"storage": {}, "network": {}}, sort_keys=False),
+        encoding="utf-8",
+    )
     repos_file.write_text(
         yaml.safe_dump(
             {
@@ -1218,6 +1243,12 @@ def test_managed_repo_reconcile_preserves_same_name_operator_repository(tmp_path
         str(operator_repo.absolute()),
     ]
     assert document["operator_extension"] == {"preserve": True}
+    registered_repo = next(
+        Path(value) for value in document["repos"] if Path(value).name == "clio_relay"
+    )
+    package_source = registered_repo / registered_repo.name / "mcp_call/pkg.py"
+    assert registered_repo == managed_repo.absolute()
+    assert package_source.is_file()
     before = repos_file.read_bytes()
     reused = reconcile_managed_jarvis_repository(repos_file, managed_repo)
     assert reused["action"] == "reused"
@@ -1230,7 +1261,7 @@ def test_managed_repo_reconcile_refuses_concurrent_operator_edit(
 ) -> None:
     repos_file = tmp_path / "repos.yaml"
     repos_file.write_text("repos:\n  - /operator/original\n", encoding="utf-8")
-    managed_repo = tmp_path / "relay/managed-jarvis-repo"
+    managed_repo = tmp_path / "relay/clio_relay"
     managed_repo.parent.mkdir(parents=True)
     operator_update = b"repos:\n  - /operator/concurrent\n"
     original_read = bootstrap_reconcile_module._read_regular_bounded_with_identity  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
@@ -1266,7 +1297,7 @@ def test_managed_repo_reconcile_refuses_concurrent_operator_edit(
 def test_managed_repo_reconcile_cleans_a_proven_previous_registration(tmp_path: Path) -> None:
     """An existing managed alias does not prevent exact legacy-path cleanup."""
     repos_file = tmp_path / "repos.yaml"
-    managed = tmp_path / "managed-jarvis-repo"
+    managed = tmp_path / "clio_relay"
     previous = tmp_path / "legacy/clio_relay"
     operator = tmp_path / "operator/clio_relay"
     repos_file.write_text(
@@ -1309,7 +1340,7 @@ def test_managed_repo_atomic_exchange_preserves_or_recovers_racing_state(
     repos_file = tmp_path / "repos.yaml"
     repos_file.write_text("repos:\n  - /operator/original\n", encoding="utf-8")
     operator_update = b"repos:\n  - /operator/concurrent\n"
-    managed = tmp_path / "managed-jarvis-repo"
+    managed = tmp_path / "clio_relay"
     original_exchange = bootstrap_reconcile_module._atomic_exchange_paths  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
     exchanged = False
 
@@ -1625,7 +1656,7 @@ def test_staged_activation_adopts_legacy_paths_idempotently(
         share / "install-receipt.json": share / "current/install-receipt.json",
         bin_dir / "clio-relay": share / "current/bin/clio-relay",
         bin_dir / "jarvis": share / "current/bin/jarvis",
-        share / "managed-jarvis-repo": share / "current/source/jarvis-packages/clio_relay",
+        share / "clio_relay": share / "current/source/jarvis-packages/clio_relay",
     }
     assert {path: bootstrap_reconcile_module.os.readlink(path) for path in expected_targets} == {
         path: str(target) for path, target in expected_targets.items()
@@ -1659,7 +1690,7 @@ def test_staged_activation_rejects_manifest_path_substitution_before_writes(
             kind="file_or_symlink",
         ),
         "managed_repo": BootstrapActivationPath(
-            path=str(share / "managed-jarvis-repo"),
+            path=str(share / "clio_relay"),
             kind="symlink",
         ),
     }
@@ -1877,7 +1908,7 @@ def test_staged_activation_resumes_across_repository_crash_boundaries(
         simulated_stable_link,
     )
     original_readlink = os.readlink
-    managed_repo = tmp_path / ".local/share/clio-relay/managed-jarvis-repo"
+    managed_repo = tmp_path / ".local/share/clio-relay/clio_relay"
     managed_target = tmp_path / ".local/share/clio-relay/current/source/jarvis-packages/clio_relay"
 
     def simulated_readlink(path: Path | str) -> str:
@@ -1961,7 +1992,7 @@ def test_managed_repo_repair_refuses_unproven_broken_link(
     expected = generation / "source/jarvis-packages/clio_relay"
     expected.mkdir(parents=True)
     current = tmp_path / ".local/share/clio-relay/current"
-    managed = tmp_path / ".local/share/clio-relay/managed-jarvis-repo"
+    managed = tmp_path / ".local/share/clio-relay/clio_relay"
     original_lstat = Path.lstat
     original_readlink = os.readlink
     original_resolve = Path.resolve

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1699,7 +1699,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "e54f60dce0caa564a221a48c27b74b604814bb0cd09837da510e9b3d3a87ee9f"
+        "fdea05c380e1d033acced2ce1b0caa7f5e4000e389adb4ef420ac1e5f4830b2d"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.22"
+    assert version == "1.4.23"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2354,13 +2354,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.22-py3-none-any.whl",
+            resource_id="clio-relay-1.4.23-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.22.tar.gz",
+            resource_id="clio_relay-1.4.23.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2499,7 +2499,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.22"
+    assert policy.release_version == "1.4.23"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.22"
+version = "1.4.23"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- preserve a verified PyPI candidate's canonical wheel filename so `uv` accepts the fd-bound artifact during cluster bootstrap
- register relay's JARVIS adapter repository under the `clio_relay` package namespace
- migrate only relay's proven legacy repository entry while preserving operator-managed JARVIS repositories
- prepare release metadata for 1.4.23

## Verification

- focused bootstrap tests: 19 passed
- focused release identity and policy tests: 3 passed
- Ruff and targeted Pyright checks passed
- live Ares candidate bootstrap migrated the repository and restarted all three workers with zero scheduler submissions or cancellations
- live Ares JARVIS MCP discovery completed as `job_3864fb0e8ad8412393a73746ae07223c`

