### PR TITLE
fix: bind worker tools to active generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.23` uses a release-first patch process. A maintainer builds the
+> Version `1.4.24` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.23"
+$Version = "1.4.24"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.23"
+release_version: "1.4.24"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: fdea05c380e1d033acced2ce1b0caa7f5e4000e389adb4ef420ac1e5f4830b2d
+acceptance_matrix_sha256: 91221052b75218a9760f9af48154ea682c91b32d7125f974f6564fc834c9709b
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.23"
+$Tag = "v1.4.24"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.23" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.24" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.23",
-  "matrix_sha256": "fdea05c380e1d033acced2ce1b0caa7f5e4000e389adb4ef420ac1e5f4830b2d",
+  "release_version": "1.4.24",
+  "matrix_sha256": "91221052b75218a9760f9af48154ea682c91b32d7125f974f6564fc834c9709b",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.23"
+version = "1.4.24"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.23"
+__version__ = "1.4.24"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -7611,10 +7611,13 @@ if [ -e "$HOME/.local/share/clio-relay/current" ] || \
 fi
 RELAY_TOOL_EXECUTABLE="$(readlink -f "$RELAY_EXECUTABLE")"
 JARVIS_TOOL_EXECUTABLE="$(readlink -f "$JARVIS_VENV/bin/jarvis")"
+CLIO_KIT_TOOL_EXECUTABLE="$(readlink -f "$JARVIS_MCP_EXECUTABLE")"
 test -x "$RELAY_TOOL_EXECUTABLE"
 test -x "$JARVIS_TOOL_EXECUTABLE"
+test -x "$CLIO_KIT_TOOL_EXECUTABLE"
 mkdir -m 0700 "$BOOTSTRAP_GENERATION/bin"
 ln -s "$RELAY_TOOL_EXECUTABLE" "$BOOTSTRAP_GENERATION/bin/clio-relay"
+ln -s "$CLIO_KIT_TOOL_EXECUTABLE" "$BOOTSTRAP_GENERATION/bin/clio-kit"
 mv "$CLIO_RELAY_INSTALL_RECEIPT" "$BOOTSTRAP_GENERATION/install-receipt.json"
 export CLIO_RELAY_INSTALL_RECEIPT="$BOOTSTRAP_GENERATION/install-receipt.json"
 export BOOTSTRAP_GENERATION JARVIS_VENV JARVIS_TOOL_EXECUTABLE
@@ -7688,6 +7691,7 @@ BOOTSTRAP_GENERATION_IDENTITY="$(bootstrap_path_set_identity \
   "$BOOTSTRAP_GENERATION/.prepared" \
   "$BOOTSTRAP_GENERATION/install-receipt.json" \
   "$BOOTSTRAP_GENERATION/bin/clio-relay" \
+  "$BOOTSTRAP_GENERATION/bin/clio-kit" \
   "$BOOTSTRAP_GENERATION/bin/jarvis" \
   "$BOOTSTRAP_GENERATION/source")"
 bootstrap_journal_action phase "$BOOTSTRAP_TRANSACTION_JOURNAL" \

--- a/src/clio_relay/deployment.py
+++ b/src/clio_relay/deployment.py
@@ -785,7 +785,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-Environment="PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin"
+Environment="PATH=%h/.local/share/clio-relay/current/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin"
 {core_line}
 {spool_line}
 {jarvis_line}

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -363,6 +363,29 @@ def test_fresh_bootstrap_loads_packaged_graph_before_explicit_build_fallback() -
     assert "\r" not in script
 
 
+def test_fresh_bootstrap_publishes_verified_clio_kit_in_generation() -> None:
+    """Keep component discovery on the active content-addressed generation."""
+    script = render_linux_user_bootstrap_script(cluster="operator-target")
+    full_prepare = script.index('RELAY_TOOL_EXECUTABLE="$(readlink -f "$RELAY_EXECUTABLE")"')
+    generation_identity = script.index(
+        'BOOTSTRAP_GENERATION_IDENTITY="$(bootstrap_path_set_identity',
+        full_prepare,
+    )
+    prepare = script[full_prepare:generation_identity]
+    identity = script[
+        generation_identity : script.index("bootstrap_journal_action phase", generation_identity)
+    ]
+
+    resolve = 'CLIO_KIT_TOOL_EXECUTABLE="$(readlink -f "$JARVIS_MCP_EXECUTABLE")"'
+    verify = 'test -x "$CLIO_KIT_TOOL_EXECUTABLE"'
+    publish = 'ln -s "$CLIO_KIT_TOOL_EXECUTABLE" "$BOOTSTRAP_GENERATION/bin/clio-kit"'
+    assert resolve in prepare
+    assert verify in prepare
+    assert publish in prepare
+    assert prepare.index(resolve) < prepare.index(verify) < prepare.index(publish)
+    assert '"$BOOTSTRAP_GENERATION/bin/clio-kit"' in identity
+
+
 def test_wheel_embeds_jarvis_package_modules_in_the_installed_namespace() -> None:
     """JARVIS must import relay packages after the relay distribution is installed."""
     with Path("pyproject.toml").open("rb") as stream:

--- a/tests/test_doctor_and_relay_host.py
+++ b/tests/test_doctor_and_relay_host.py
@@ -199,6 +199,10 @@ def test_endpoint_user_service_is_sudo_less_and_configured() -> None:
     assert (
         "ExecStart=%h/.local/bin/clio-relay endpoint start --role worker --cluster test-cluster"
     ) in rendered
+    assert (
+        'Environment="PATH=%h/.local/share/clio-relay/current/bin:'
+        '%h/.local/bin:/usr/local/bin:/usr/bin:/bin"'
+    ) in rendered
     assert 'Environment="CLIO_RELAY_CORE_DIR=%h/.local/share/clio-relay/core"' in rendered
     assert 'Environment="CLIO_RELAY_AGENT_BIN=%h/.local/bin/current-agent"' in rendered
     assert 'Environment="CLIO_RELAY_AGENT_ADAPTER=exec"' in rendered

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.23"
+    assert version == "1.4.24"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2354,13 +2354,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.23-py3-none-any.whl",
+            resource_id="clio-relay-1.4.24-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.23.tar.gz",
+            resource_id="clio_relay-1.4.24.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2499,7 +2499,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.23"
+    assert policy.release_version == "1.4.24"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.23"
+version = "1.4.24"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- prefer the active relay generation's `bin` directory in managed worker services, ahead of ambient user-local tools
- publish the verified `clio-kit` launcher in fresh content-addressed generations as well as upgrade generations
- prepare release metadata for 1.4.24

## Verification

- focused service PATH test passed
- focused fresh-generation launcher tests passed
- focused release identity and policy tests passed
- Ruff and targeted Pyright checks passed
- live Ares discovery job `job_684a895f212c4eafa53859d948d5770c` resolved `scientific-catalog` through the active generation's clio-kit 2.5.23 wheel (SHA-256 `a2fb747f...`) instead of stale ambient 2.5.22
- full production release-identity preflight subsequently passed for built-in JARVIS and scientific-catalog

No scheduler job was submitted or canceled by these validation steps.
