### PR TITLE
fix: preserve environment for remote session status

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.24` uses a release-first patch process. A maintainer builds the
+> Version `1.4.25` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.24"
+$Version = "1.4.25"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.24"
+release_version: "1.4.25"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 91221052b75218a9760f9af48154ea682c91b32d7125f974f6564fc834c9709b
+acceptance_matrix_sha256: c6a87dd6b453e1018c66c3a856c9aafd8865de695563bf20c25a05d8dcb75a35
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.24"
+$Tag = "v1.4.25"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.24" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.25" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.24",
-  "matrix_sha256": "91221052b75218a9760f9af48154ea682c91b32d7125f974f6564fc834c9709b",
+  "release_version": "1.4.25",
+  "matrix_sha256": "c6a87dd6b453e1018c66c3a856c9aafd8865de695563bf20c25a05d8dcb75a35",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.24"
+version = "1.4.25"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.24"
+__version__ = "1.4.25"

--- a/src/clio_relay/session_lifecycle.py
+++ b/src/clio_relay/session_lifecycle.py
@@ -6108,7 +6108,11 @@ def status_remote_session(
     _validate_session(session_id=session_id, remote_api_port=1)
     output = _ssh_script(
         definition,
-        _owned_status_script(cluster=definition.name, session_id=session_id),
+        _owned_status_script(
+            definition=definition,
+            cluster=definition.name,
+            session_id=session_id,
+        ),
     )
     return cast(dict[str, object], json.loads(output))
 
@@ -6124,7 +6128,7 @@ def status_remote_session_start(
     try:
         output = _ssh_script(
             definition,
-            _owned_start_status_script(selector),
+            _owned_start_status_script(definition=definition, selector=selector),
             timeout_seconds=_REMOTE_SESSION_START_RECOVERY_TIMEOUT_SECONDS,
         )
     except _RemoteSessionCommandDeadline as exc:
@@ -6740,19 +6744,30 @@ def _session_cluster_registry_authority(
     )
 
 
-def _owned_status_script(*, cluster: str, session_id: str) -> str:
+def _owned_status_script(
+    *,
+    definition: ClusterDefinition,
+    cluster: str,
+    session_id: str,
+) -> str:
     """Use the bounded, lock-coordinated recovery contract for public status."""
     return (
         "set -euo pipefail\n"
+        f"{remote_env(definition)}\n"
         f"clio-relay session recovery-status --cluster {shlex.quote(cluster)} "
         f"--session-id {shlex.quote(session_id)}\n"
     )
 
 
-def _owned_start_status_script(selector: OwnedSessionStartStatusSelector) -> str:
+def _owned_start_status_script(
+    *,
+    definition: ClusterDefinition,
+    selector: OwnedSessionStartStatusSelector,
+) -> str:
     """Render the nonblocking exact-operation start-status command."""
     return (
         "set -euo pipefail\n"
+        f"{remote_env(definition)}\n"
         f"clio-relay session start-status-owned --cluster {shlex.quote(selector.cluster)} "
         f"--session-id {shlex.quote(selector.session_id)} "
         f"--start-operation-id {shlex.quote(selector.start_operation_id)} "

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.24"
+    assert version == "1.4.25"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -3806,8 +3806,54 @@ def test_status_remote_session_returns_json(monkeypatch: MonkeyPatch) -> None:
     )
 
     assert status == {"session_id": "session-1", "running": True}
-    assert "clio-relay session recovery-status" in scripts[0]
-    assert "metadata.json" not in scripts[0]
+    script = scripts[0]
+    command_index = script.index("clio-relay session recovery-status")
+    for export in (
+        'export PATH="$HOME/.local/bin:$PATH";',
+        "export CLIO_RELAY_CLI_MODE=local;",
+        "export CLIO_RELAY_REMOTE_CLUSTER=ares;",
+        "export CLIO_RELAY_CORE_DIR=",
+        "export CLIO_RELAY_SPOOL_DIR=",
+    ):
+        assert script.index(export) < command_index
+    assert "metadata.json" not in script
+
+
+def test_remote_session_start_status_uses_cluster_environment(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scripts: list[str] = []
+    definition, _release, plan = _durable_start_plan()
+    expected = _durable_start_status(plan)
+
+    def fake_ssh(
+        _definition: ClusterDefinition,
+        script: str,
+        *,
+        timeout_seconds: float,
+    ) -> str:
+        assert timeout_seconds > 0
+        scripts.append(script)
+        return expected.model_dump_json()
+
+    monkeypatch.setattr(session_lifecycle, "_ssh_script", fake_ssh)
+
+    observed = session_lifecycle.status_remote_session_start(
+        definition=definition,
+        selector=plan.status_selector,
+    )
+
+    assert observed == expected
+    script = scripts[0]
+    command_index = script.index("clio-relay session start-status-owned")
+    for export in (
+        'export PATH="$HOME/.local/bin:$PATH";',
+        "export CLIO_RELAY_CLI_MODE=local;",
+        "export CLIO_RELAY_REMOTE_CLUSTER=ares;",
+        "export CLIO_RELAY_CORE_DIR=",
+        "export CLIO_RELAY_SPOOL_DIR=",
+    ):
+        assert script.index(export) < command_index
 
 
 def test_remote_session_identity_challenge_binds_process_cluster_and_nonce(

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2354,13 +2354,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.24-py3-none-any.whl",
+            resource_id="clio-relay-1.4.25-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.24.tar.gz",
+            resource_id="clio_relay-1.4.25.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2499,7 +2499,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.24"
+    assert policy.release_version == "1.4.25"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.24"
+version = "1.4.25"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- preserve the configured cluster environment for public remote-session status
- preserve the same environment for exact owned-start status recovery
- cover both non-login SSH scripts with focused ordering assertions
- prepare the 1.4.25 patch release

## Focused validation

- session lifecycle tests: 2 passed
- release metadata tests: 4 passed
- Ruff: passed
- Pyright: 0 errors
- uv lock check: passed
- git diff check: passed

This fixes the production Ares failure where a non-login remote status command could not resolve `clio-relay`. It does not change scheduler policy or cancel jobs.
