### PR TITLE
fix: allow fresh owned session starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.4.25` uses a release-first patch process. A maintainer builds the
+> Version `1.4.26` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.4.25"
+$Version = "1.4.26"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.4.25"
+release_version: "1.4.26"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: c6a87dd6b453e1018c66c3a856c9aafd8865de695563bf20c25a05d8dcb75a35
+acceptance_matrix_sha256: 1d96806619e99079e70a32683170701f7a8d9d0eaf76daaaa3984946f9b6a315
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.4.25"
+$Tag = "v1.4.26"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.25" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.4.26" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.4.25",
-  "matrix_sha256": "c6a87dd6b453e1018c66c3a856c9aafd8865de695563bf20c25a05d8dcb75a35",
+  "release_version": "1.4.26",
+  "matrix_sha256": "1d96806619e99079e70a32683170701f7a8d9d0eaf76daaaa3984946f9b6a315",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.4.25"
+version = "1.4.26"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.4.25"
+__version__ = "1.4.26"

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -3961,7 +3961,11 @@ def _finalize_completed_cleanup_receipt_before_start(
     session_id: str,
 ) -> None:
     """Finish the exact teardown commit if reconnect observes its completed receipt."""
-    raw_status = status_remote_session(definition=definition, session_id=session_id)
+    raw_status = status_remote_session(
+        definition=definition,
+        session_id=session_id,
+        pre_start_cleanup_probe=True,
+    )
     try:
         status = OwnedSessionRecoveryStatus.model_validate(raw_status)
     except ValidationError:
@@ -5230,14 +5234,32 @@ def session_admission_status(
 def session_recovery_status(
     cluster: Annotated[str, typer.Option(help="Exact cluster recorded by the owned session.")],
     session_id: Annotated[str, typer.Option(help="Exact owned relay session id.")],
+    pre_start_cleanup_probe: Annotated[
+        bool,
+        typer.Option(
+            help=(
+                "Return a structured unverified observation when no transition exists yet; "
+                "reserved for the read-only pre-start cleanup probe."
+            )
+        ),
+    ] = False,
 ) -> None:
     """Return fail-closed recovery evidence for an ambiguous or dead session start."""
 
     def action() -> None:
-        status = _inspect_owned_session_recovery_after_transition(
-            cluster=cluster,
-            session_id=session_id,
-            core_dir=RelaySettings.from_env().core_dir,
+        settings_core_dir = RelaySettings.from_env().core_dir
+        status = (
+            _inspect_owned_session_recovery_before_start(
+                cluster=cluster,
+                session_id=session_id,
+                core_dir=settings_core_dir,
+            )
+            if pre_start_cleanup_probe
+            else _inspect_owned_session_recovery_after_transition(
+                cluster=cluster,
+                session_id=session_id,
+                core_dir=settings_core_dir,
+            )
         )
         typer.echo(status.model_dump_json(indent=2))
 
@@ -5451,6 +5473,54 @@ def _inspect_owned_session_recovery_after_transition(
         raise RelayError(
             "owned session start is still in progress after the bounded recovery wait"
         ) from exc
+
+
+def _inspect_owned_session_recovery_before_start(
+    *,
+    cluster: str,
+    session_id: str,
+    core_dir: Path,
+    home: Path | None = None,
+    timeout_seconds: float = OWNED_SESSION_RECOVERY_TRANSITION_TIMEOUT_SECONDS,
+) -> OwnedSessionRecoveryStatus:
+    """Observe cleanup state without requiring a fresh session transition to exist."""
+    if re.fullmatch(r"[A-Za-z0-9_-]+", session_id) is None:
+        raise RelayError("session_id must contain only letters, numbers, hyphen, or underscore")
+    if not cluster:
+        raise RelayError("cluster must not be empty")
+    if timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be positive")
+    selected_home = home or Path.home()
+    transition_path = (
+        selected_home
+        / ".local"
+        / "share"
+        / "clio-relay"
+        / "sessions"
+        / session_id
+        / "transition.lock"
+    )
+    try:
+        transition_path.lstat()
+    except FileNotFoundError:
+        return OwnedSessionRecoveryStatus(
+            cluster=cluster,
+            session_id=session_id,
+            cleanup_receipt=False,
+            ownership_verified=False,
+            recovery_verified=False,
+            errors=[
+                "owned session transition is not currently observable; "
+                "start-owned remains the mutation authority"
+            ],
+        )
+    return _inspect_owned_session_recovery_after_transition(
+        cluster=cluster,
+        session_id=session_id,
+        core_dir=core_dir,
+        home=selected_home,
+        timeout_seconds=timeout_seconds,
+    )
 
 
 @session_app.command("prepare-start", hidden=True)

--- a/src/clio_relay/session_lifecycle.py
+++ b/src/clio_relay/session_lifecycle.py
@@ -6103,8 +6103,14 @@ def status_remote_session(
     *,
     definition: ClusterDefinition,
     session_id: str,
+    pre_start_cleanup_probe: bool = False,
 ) -> dict[str, object]:
-    """Return status for a previously started remote relay session."""
+    """Return status for a previously started remote relay session.
+
+    The pre-start cleanup probe is an internal, read-only observation that may
+    report an uninitialized transition.  It must not be used as authoritative
+    absence evidence by teardown or cleanup callers.
+    """
     _validate_session(session_id=session_id, remote_api_port=1)
     output = _ssh_script(
         definition,
@@ -6112,6 +6118,7 @@ def status_remote_session(
             definition=definition,
             cluster=definition.name,
             session_id=session_id,
+            pre_start_cleanup_probe=pre_start_cleanup_probe,
         ),
     )
     return cast(dict[str, object], json.loads(output))
@@ -6749,13 +6756,15 @@ def _owned_status_script(
     definition: ClusterDefinition,
     cluster: str,
     session_id: str,
+    pre_start_cleanup_probe: bool = False,
 ) -> str:
     """Use the bounded, lock-coordinated recovery contract for public status."""
+    probe_argument = " --pre-start-cleanup-probe" if pre_start_cleanup_probe else ""
     return (
         "set -euo pipefail\n"
         f"{remote_env(definition)}\n"
         f"clio-relay session recovery-status --cluster {shlex.quote(cluster)} "
-        f"--session-id {shlex.quote(session_id)}\n"
+        f"--session-id {shlex.quote(session_id)}{probe_argument}\n"
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3924,6 +3924,85 @@ def test_owned_session_recovery_fails_closed_when_transition_never_materializes(
         )
 
 
+def test_owned_session_pre_start_probe_observes_uninitialized_transition_without_writes(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+
+    status = cli._inspect_owned_session_recovery_before_start(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        cluster="ares",
+        session_id="fresh-session",
+        core_dir=tmp_path / "core",
+        home=home,
+        timeout_seconds=0.05,
+    )
+
+    assert status.cluster == "ares"
+    assert status.session_id == "fresh-session"
+    assert status.cleanup_receipt is False
+    assert status.ownership_verified is False
+    assert status.recovery_verified is False
+    assert status.errors == [
+        "owned session transition is not currently observable; "
+        "start-owned remains the mutation authority"
+    ]
+    assert home.exists() is False
+
+
+def test_owned_session_pre_start_probe_delegates_existing_transition_to_strict_recovery(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    transition_path = (
+        home
+        / ".local"
+        / "share"
+        / "clio-relay"
+        / "sessions"
+        / "existing-session"
+        / "transition.lock"
+    )
+    transition_path.parent.mkdir(parents=True)
+    transition_path.write_text("", encoding="utf-8")
+    expected = OwnedSessionRecoveryStatus(
+        cluster="ares",
+        session_id="existing-session",
+        cleanup_receipt=True,
+        recovery_verified=True,
+    )
+    calls: list[dict[str, object]] = []
+
+    def strict_recovery(**kwargs: object) -> OwnedSessionRecoveryStatus:
+        calls.append(kwargs)
+        return expected
+
+    monkeypatch.setattr(
+        cli,
+        "_inspect_owned_session_recovery_after_transition",
+        strict_recovery,
+    )
+
+    observed = cli._inspect_owned_session_recovery_before_start(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        cluster="ares",
+        session_id="existing-session",
+        core_dir=tmp_path / "core",
+        home=home,
+        timeout_seconds=12.5,
+    )
+
+    assert observed is expected
+    assert calls == [
+        {
+            "cluster": "ares",
+            "session_id": "existing-session",
+            "core_dir": tmp_path / "core",
+            "home": home,
+            "timeout_seconds": 12.5,
+        }
+    ]
+
+
 def test_owned_session_recovery_refuses_symlinked_transition_lock(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -4115,6 +4194,60 @@ def test_cli_session_start_verifies_exact_worker_inside_lock_before_mutation(
         "start-remote-session",
         "lock-exit",
     ]
+
+
+def test_cli_session_start_fresh_session_proceeds_after_uninitialized_cleanup_probe(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_test_cluster(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_API_TOKEN", "api-token")
+    events: list[str] = []
+
+    def verify_worker_compatibility(
+        _definition: ClusterDefinition,
+    ) -> SessionApiReleaseIdentity:
+        return _session_api_release_identity()
+
+    def observe_fresh_session(**kwargs: object) -> dict[str, object]:
+        assert kwargs["session_id"] == "fresh-session"
+        assert kwargs["pre_start_cleanup_probe"] is True
+        events.append("probe")
+        return OwnedSessionRecoveryStatus(
+            cluster="ares",
+            session_id="fresh-session",
+            cleanup_receipt=False,
+            recovery_verified=False,
+            errors=["owned session transition is not currently observable"],
+        ).model_dump(mode="json")
+
+    def start(**kwargs: object) -> list[str]:
+        events.append("start")
+        return [
+            "session_started=fresh-session",
+            f"start_operation_id={kwargs['start_operation_id']}",
+            "session_generation_id=generation-fresh",
+            f"remote_api_port={kwargs['remote_api_port']}",
+        ]
+
+    monkeypatch.setattr(
+        cli,
+        "_verify_session_start_worker_compatibility",
+        verify_worker_compatibility,
+    )
+    monkeypatch.setattr(cli, "status_remote_session", observe_fresh_session)
+    monkeypatch.setattr(cli, "start_remote_session", start)
+
+    result = CliRunner().invoke(
+        app,
+        ["session", "start", "--cluster", "ares", "--session-id", "fresh-session"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "session_started=fresh-session" in result.output
+    assert "session_generation_id=generation-fresh" in result.output
+    assert events == ["probe", "start"]
 
 
 def test_cli_session_start_json_returns_self_contained_current_selector(

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.4.25"
+    assert version == "1.4.26"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -3817,6 +3817,38 @@ def test_status_remote_session_returns_json(monkeypatch: MonkeyPatch) -> None:
     ):
         assert script.index(export) < command_index
     assert "metadata.json" not in script
+    assert "--pre-start-cleanup-probe" not in script
+
+
+def test_status_remote_session_marks_pre_start_cleanup_probe_explicitly(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scripts: list[str] = []
+
+    def fake_ssh(_definition: ClusterDefinition, script: str) -> str:
+        scripts.append(script)
+        return OwnedSessionRecoveryStatus(
+            cluster="ares",
+            session_id="fresh-session",
+            cleanup_receipt=False,
+            recovery_verified=False,
+            errors=["owned session transition is not currently observable"],
+        ).model_dump_json()
+
+    monkeypatch.setattr(session_lifecycle, "_ssh_script", fake_ssh)
+
+    status = status_remote_session(
+        definition=ClusterDefinition(name="ares", ssh_host="ares"),
+        session_id="fresh-session",
+        pre_start_cleanup_probe=True,
+    )
+
+    assert status["cleanup_receipt"] is False
+    assert status["recovery_verified"] is False
+    assert (
+        "clio-relay session recovery-status --cluster ares "
+        "--session-id fresh-session --pre-start-cleanup-probe"
+    ) in scripts[0]
 
 
 def test_remote_session_start_status_uses_cluster_environment(

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2354,13 +2354,13 @@ def test_local_release_policy_rejects_missing_critical_boundary_checks(
     report.resources = [
         ValidationResource(
             kind="wheel",
-            resource_id="clio-relay-1.4.25-py3-none-any.whl",
+            resource_id="clio-relay-1.4.26-py3-none-any.whl",
             cluster="local",
             state="built",
         ),
         ValidationResource(
             kind="source_distribution",
-            resource_id="clio_relay-1.4.25.tar.gz",
+            resource_id="clio_relay-1.4.26.tar.gz",
             cluster="local",
             state="built",
         ),
@@ -2499,7 +2499,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.4.25"
+    assert policy.release_version == "1.4.26"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.4.25"
+version = "1.4.26"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- let a genuinely fresh owned session proceed to the remote start authority without waiting for a transition lock that cannot exist yet
- keep ambiguous recovery and teardown on the existing fail-closed bounded wait
- preserve exact completed-cleanup reconnect verification when a transition does exist
- prepare the 1.4.26 patch release

## Focused validation

- session start and recovery safety tests: 13 passed
- release metadata tests: 4 passed
- Ruff: passed
- Pyright: 0 errors
- uv lock check: passed
- git diff check: passed

The change does not alter scheduler policy and does not cancel jobs.
