### PR TITLE
fix: preserve remote MCP execution authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.5.0` uses a release-first patch process. A maintainer builds the
+> Version `1.5.1` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.5.0"
+$Version = "1.5.1"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.5.0"
+release_version: "1.5.1"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 67880e65dfbba3dd7b64ac492a9e0d764728701630d59b42a6ec8551709ef612
+acceptance_matrix_sha256: c6eed7925c4490e6e9b1888922036b9136e0e52dea03749d21e16e2c89db8d3c
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.5.0"
+$Tag = "v1.5.1"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.0" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.1" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.5.0",
-  "matrix_sha256": "67880e65dfbba3dd7b64ac492a9e0d764728701630d59b42a6ec8551709ef612",
+  "release_version": "1.5.1",
+  "matrix_sha256": "c6eed7925c4490e6e9b1888922036b9136e0e52dea03749d21e16e2c89db8d3c",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.5.0"
+version = "1.5.1"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -215,6 +215,7 @@ from clio_relay.remote_cli import (
     run_remote_shell,
     should_execute_on_cluster,
     stage_jarvis_yaml,
+    staged_remote_cluster_registry,
     write_remote_file,
 )
 from clio_relay.remote_mcp import (
@@ -2361,7 +2362,14 @@ def remote_mcp_refresh(
                 remote_args.extend(["--server-arg", item])
             for child_name, source_name in sorted(registration.env_from.items()):
                 remote_args.extend(["--env-from", f"{child_name}={source_name}"])
-            job_id = _last_nonempty_line(run_remote_clio(definition, remote_args))
+            with staged_remote_cluster_registry(definition) as remote_registry_path:
+                job_id = _last_nonempty_line(
+                    run_remote_clio(
+                        definition,
+                        remote_args,
+                        cluster_registry_path=remote_registry_path,
+                    )
+                )
             wait_result = _json_output(
                 run_remote_clio(
                     definition,
@@ -10776,30 +10784,34 @@ def mcp_call(
             remote_command.extend(["--expected-registered-contract", expected_registered_contract])
         for ref in _artifact_use_refs(used_artifact):
             remote_command.extend(["--used-artifact", _artifact_use_cli_value(ref)])
-        try:
-            if remote_arguments_path is not None:
-                write_remote_file(
+        with staged_remote_cluster_registry(definition) as remote_registry_path:
+            try:
+                if remote_arguments_path is not None:
+                    write_remote_file(
+                        definition,
+                        remote_arguments_path,
+                        json.dumps(arguments, sort_keys=True, separators=(",", ":")).encode(
+                            "utf-8"
+                        ),
+                    )
+                _run_remote_or_exit(
                     definition,
-                    remote_arguments_path,
-                    json.dumps(arguments, sort_keys=True, separators=(",", ":")).encode("utf-8"),
+                    remote_command
+                    + (
+                        ["--timeout-seconds", str(timeout_seconds)]
+                        if timeout_seconds is not None
+                        else []
+                    )
+                    + [item for value in server_args for item in ("--server-arg", value)],
+                    cluster_registry_path=remote_registry_path,
                 )
-            _run_remote_or_exit(
-                definition,
-                remote_command
-                + (
-                    ["--timeout-seconds", str(timeout_seconds)]
-                    if timeout_seconds is not None
-                    else []
-                )
-                + [item for value in server_args for item in ("--server-arg", value)],
-            )
-        finally:
-            if remote_arguments_path is not None:
-                remove_remote_file(
-                    definition,
-                    remote_arguments_path,
-                    remove_empty_parent=True,
-                )
+            finally:
+                if remote_arguments_path is not None:
+                    remove_remote_file(
+                        definition,
+                        remote_arguments_path,
+                        remove_empty_parent=True,
+                    )
         return
     queue = _managed_queue_from_env()
     try:
@@ -18505,9 +18517,31 @@ def _try_remote_job_wait_passthrough(
     return True
 
 
-def _run_remote_or_exit(definition: ClusterDefinition, args: list[str]) -> None:
+def _run_remote_or_exit(
+    definition: ClusterDefinition,
+    args: list[str],
+    *,
+    cluster_registry_path: str | None = None,
+) -> None:
+    if cluster_registry_path is None:
+        _run_or_exit(
+            lambda: typer.echo(
+                _console_safe_text(run_remote_clio(definition, args)),
+                nl=False,
+            )
+        )
+        return
     _run_or_exit(
-        lambda: typer.echo(_console_safe_text(run_remote_clio(definition, args)), nl=False)
+        lambda: typer.echo(
+            _console_safe_text(
+                run_remote_clio(
+                    definition,
+                    args,
+                    cluster_registry_path=cluster_registry_path,
+                )
+            ),
+            nl=False,
+        )
     )
 
 

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -128,6 +128,7 @@ from clio_relay.remote_cli import (
     remove_remote_file,
     run_remote_clio,
     should_execute_on_cluster,
+    staged_remote_cluster_registry,
     write_remote_file,
 )
 from clio_relay.remote_mcp import (
@@ -4472,15 +4473,26 @@ def _submit_mcp_call(
             remote_args.extend(["--expected-registered-contract", expected_registered_contract])
         for item in used_artifact_refs:
             remote_args.extend(["--used-artifact", _artifact_use_cli_value(item)])
-        try:
-            write_remote_file(
-                definition,
-                remote_args_path,
-                json.dumps(tool_arguments, sort_keys=True, separators=(",", ":")).encode("utf-8"),
-            )
-            output = run_remote_clio(definition, remote_args)
-        finally:
-            remove_remote_file(definition, remote_args_path, remove_empty_parent=True)
+        with staged_remote_cluster_registry(definition) as remote_registry_path:
+            try:
+                write_remote_file(
+                    definition,
+                    remote_args_path,
+                    json.dumps(tool_arguments, sort_keys=True, separators=(",", ":")).encode(
+                        "utf-8"
+                    ),
+                )
+                output = run_remote_clio(
+                    definition,
+                    remote_args,
+                    cluster_registry_path=remote_registry_path,
+                )
+            finally:
+                remove_remote_file(
+                    definition,
+                    remote_args_path,
+                    remove_empty_parent=True,
+                )
         return _remote_mcp_submission_result(
             output,
             definition=definition,

--- a/src/clio_relay/mcp_stdio_validation.py
+++ b/src/clio_relay/mcp_stdio_validation.py
@@ -72,6 +72,7 @@ _PACKAGED_BASE_ENVIRONMENT_NAMES = frozenset(
         "LOGNAME",
         "PATH",
         "PATHEXT",
+        "PROGRAMDATA",
         "SYSTEMDRIVE",
         "SYSTEMROOT",
         "TEMP",

--- a/src/clio_relay/remote_cli.py
+++ b/src/clio_relay/remote_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import posixpath
 import shlex
@@ -15,10 +16,16 @@ from pathlib import Path
 from queue import Empty, Queue
 from threading import Thread
 from typing import cast
+from uuid import uuid4
 
 import yaml
 
-from clio_relay.cluster_config import ClusterDefinition
+from clio_relay.cluster_config import (
+    CLUSTER_REGISTRY_ENV,
+    MAX_CLUSTER_REGISTRY_BYTES,
+    ClusterDefinition,
+    ClusterRegistry,
+)
 from clio_relay.errors import ConfigurationError, ObservationTimeoutError, RelayError
 from clio_relay.jarvis_mcp import JARVIS_MCP_SPACK_COMMAND_ENV
 from clio_relay.remote_values import render_remote_shell_path, render_remote_shell_value
@@ -63,10 +70,27 @@ def should_execute_on_cluster(definition: ClusterDefinition) -> bool:
     return definition.ssh_host not in {"", "localhost", "127.0.0.1", "::1"}
 
 
-def run_remote_clio(definition: ClusterDefinition, args: list[str]) -> str:
-    """Run a clio-relay command on a configured cluster and return stdout."""
+def run_remote_clio(
+    definition: ClusterDefinition,
+    args: list[str],
+    *,
+    cluster_registry_path: str | None = None,
+) -> str:
+    """Run a clio-relay command on a configured cluster and return stdout.
+
+    ``cluster_registry_path`` is invocation-scoped. It makes a staged desktop
+    route authoritative for only this SSH command and never changes persistent
+    configuration on the cluster.
+    """
     rendered_args = " ".join(shlex.quote(arg) for arg in args)
-    return run_remote_shell(definition, f"{remote_env(definition)} clio-relay {rendered_args}")
+    environment = remote_env(definition)
+    if cluster_registry_path is not None:
+        rendered_registry_path = render_remote_shell_path(
+            cluster_registry_path,
+            field="staged cluster registry path",
+        )
+        environment = f"{environment} export {CLUSTER_REGISTRY_ENV}={rendered_registry_path};"
+    return run_remote_shell(definition, f"{environment} clio-relay {rendered_args}")
 
 
 def run_remote_jarvis_runtime_authority(
@@ -252,6 +276,38 @@ def remove_remote_file(
     if remove_empty_parent and parent:
         script += f" && {{ rmdir -- {shlex.quote(parent)} 2>/dev/null || true; }}"
     run_remote_shell(definition, script)
+
+
+@contextmanager
+def staged_remote_cluster_registry(
+    definition: ClusterDefinition,
+) -> Generator[str, None, None]:
+    """Stage one exact desktop cluster definition for a remote invocation.
+
+    The yielded path is safe to export as ``CLIO_RELAY_CLUSTER_REGISTRY``. The
+    private file and its invocation-unique parent are removed when the caller
+    leaves the context, without mutating the cluster's persistent registry.
+    """
+    registry = ClusterRegistry(clusters={definition.name: definition})
+    payload = (json.dumps(registry.model_dump(mode="json"), indent=2) + "\n").encode("utf-8")
+    if len(payload) > MAX_CLUSTER_REGISTRY_BYTES:
+        raise ConfigurationError(
+            f"staged cluster registry exceeds {MAX_CLUSTER_REGISTRY_BYTES} bytes"
+        )
+    digest = hashlib.sha256(payload).hexdigest()[:16]
+    relative_path = (
+        ".local/share/clio-relay/desktop-submissions/"
+        f"mcp-registry-{digest}-{uuid4().hex}/clusters.json"
+    )
+    try:
+        write_remote_file(definition, relative_path, payload)
+        yield f"$HOME/{relative_path}"
+    finally:
+        remove_remote_file(
+            definition,
+            relative_path,
+            remove_empty_parent=True,
+        )
 
 
 def stage_jarvis_yaml(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9030,6 +9030,243 @@ def test_cli_mcp_call_preserves_arguments(tmp_path: Path, monkeypatch: MonkeyPat
     assert job.spec.timeout_seconds == 90
 
 
+@pytest.mark.parametrize(
+    ("operation", "operation_arguments", "expected_tool_arguments"),
+    [
+        ("tools/list", [], None),
+        (
+            "tools/call",
+            [
+                "--tool",
+                "inspect",
+                "--arguments-json",
+                '{"dataset":"asteroid-first-five"}',
+            ],
+            {"dataset": "asteroid-first-five"},
+        ),
+    ],
+)
+def test_cli_remote_mcp_call_stages_exact_route_authority_for_one_invocation(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    operation: str,
+    operation_arguments: list[str],
+    expected_tool_arguments: dict[str, object] | None,
+) -> None:
+    """Remote discovery and calls receive the exact operator route, then remove it."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_CLI_MODE", "ssh")
+    registration = RemoteMcpServerConfig(
+        command="science-mcp",
+        args=["--stdio"],
+        allow_tools=["inspect"],
+        profiles=["user"],
+    )
+    definition = ClusterDefinition(
+        name="alpha",
+        ssh_host="alpha-login",
+        scheduler_provider="slurm",
+        core_dir="$HOME/site/relay-core",
+        spool_dir="$HOME/site/relay-spool",
+        remote_mcp_servers={"science": registration},
+    )
+    ClusterRegistry(clusters={definition.name: definition}).save(
+        tmp_path / ".clio-relay" / "clusters.json"
+    )
+    registry_writes: list[tuple[str, bytes]] = []
+    argument_writes: list[tuple[str, bytes]] = []
+    removals: list[tuple[str, str, bool]] = []
+    shell_scripts: list[str] = []
+    events: list[str] = []
+
+    def write_registry(
+        selected_definition: ClusterDefinition,
+        path: str,
+        data: bytes,
+    ) -> None:
+        assert selected_definition == definition
+        events.append("write-registry")
+        registry_writes.append((path, data))
+
+    def remove_registry(
+        selected_definition: ClusterDefinition,
+        path: str,
+        *,
+        remove_empty_parent: bool,
+    ) -> None:
+        assert selected_definition == definition
+        events.append("remove-registry")
+        removals.append(("registry", path, remove_empty_parent))
+
+    def write_arguments(
+        selected_definition: ClusterDefinition,
+        path: str,
+        data: bytes,
+    ) -> None:
+        assert selected_definition == definition
+        events.append("write-arguments")
+        argument_writes.append((path, data))
+
+    def remove_arguments(
+        selected_definition: ClusterDefinition,
+        path: str,
+        *,
+        remove_empty_parent: bool,
+    ) -> None:
+        assert selected_definition == definition
+        events.append("remove-arguments")
+        removals.append(("arguments", path, remove_empty_parent))
+
+    def run_remote_shell(selected_definition: ClusterDefinition, script: str) -> str:
+        assert selected_definition == definition
+        events.append("run")
+        shell_scripts.append(script)
+        return "job_remote_mcp\n"
+
+    monkeypatch.setattr("clio_relay.remote_cli.write_remote_file", write_registry)
+    monkeypatch.setattr("clio_relay.remote_cli.remove_remote_file", remove_registry)
+    monkeypatch.setattr("clio_relay.cli.write_remote_file", write_arguments)
+    monkeypatch.setattr("clio_relay.cli.remove_remote_file", remove_arguments)
+    monkeypatch.setattr("clio_relay.remote_cli.run_remote_shell", run_remote_shell)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "mcp-call",
+            "--cluster",
+            definition.name,
+            "--server",
+            registration.command,
+            "--server-arg=--stdio",
+            "--operation",
+            operation,
+            *operation_arguments,
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == "job_remote_mcp"
+    assert len(registry_writes) == 1
+    registry_path, registry_payload = registry_writes[0]
+    staged_registry = ClusterRegistry.model_validate_json(registry_payload)
+    assert staged_registry.clusters == {definition.name: definition}
+    staged_definition = staged_registry.require(definition.name)
+    assert staged_definition.remote_mcp_servers == {"science": registration}
+    assert cluster_route_revision(staged_definition) == cluster_route_revision(definition)
+    assert registry_path.startswith(".local/share/clio-relay/desktop-submissions/mcp-registry-")
+    assert registry_path.endswith("/clusters.json")
+    assert len(shell_scripts) == 1
+    assert f'export CLIO_RELAY_CLUSTER_REGISTRY="$HOME/{registry_path}";' in shell_scripts[0]
+    assert "export CLIO_RELAY_CLI_MODE=local;" in shell_scripts[0]
+    assert f"clio-relay mcp-call --cluster {definition.name}" in shell_scripts[0]
+    assert removals[-1] == ("registry", registry_path, True)
+    if expected_tool_arguments is None:
+        assert argument_writes == []
+        assert events == ["write-registry", "run", "remove-registry"]
+    else:
+        assert len(argument_writes) == 1
+        arguments_path, arguments_payload = argument_writes[0]
+        assert json.loads(arguments_payload) == expected_tool_arguments
+        assert removals == [
+            ("arguments", arguments_path, True),
+            ("registry", registry_path, True),
+        ]
+        assert events == [
+            "write-registry",
+            "write-arguments",
+            "run",
+            "remove-arguments",
+            "remove-registry",
+        ]
+
+
+def test_cli_remote_mcp_call_cleans_arguments_and_route_authority_after_failure(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A failed remote launch removes both invocation-scoped staging files."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_CLI_MODE", "ssh")
+    registration = RemoteMcpServerConfig(
+        command="science-mcp",
+        args=["--stdio"],
+        allow_tools=["inspect"],
+    )
+    definition = ClusterDefinition(
+        name="alpha",
+        ssh_host="alpha-login",
+        remote_mcp_servers={"science": registration},
+    )
+    ClusterRegistry(clusters={definition.name: definition}).save(
+        tmp_path / ".clio-relay" / "clusters.json"
+    )
+    staged_paths: list[tuple[str, str]] = []
+    removed_paths: list[tuple[str, str, bool]] = []
+
+    def write_registry(
+        _definition: ClusterDefinition,
+        path: str,
+        _data: bytes,
+    ) -> None:
+        staged_paths.append(("registry", path))
+
+    def write_arguments(
+        _definition: ClusterDefinition,
+        path: str,
+        _data: bytes,
+    ) -> None:
+        staged_paths.append(("arguments", path))
+
+    def remove_registry(
+        _definition: ClusterDefinition,
+        path: str,
+        *,
+        remove_empty_parent: bool,
+    ) -> None:
+        removed_paths.append(("registry", path, remove_empty_parent))
+
+    def remove_arguments(
+        _definition: ClusterDefinition,
+        path: str,
+        *,
+        remove_empty_parent: bool,
+    ) -> None:
+        removed_paths.append(("arguments", path, remove_empty_parent))
+
+    def fail_remote_shell(_definition: ClusterDefinition, _script: str) -> str:
+        raise RelayError("remote launch failed")
+
+    monkeypatch.setattr("clio_relay.remote_cli.write_remote_file", write_registry)
+    monkeypatch.setattr("clio_relay.remote_cli.remove_remote_file", remove_registry)
+    monkeypatch.setattr("clio_relay.cli.write_remote_file", write_arguments)
+    monkeypatch.setattr("clio_relay.cli.remove_remote_file", remove_arguments)
+    monkeypatch.setattr("clio_relay.remote_cli.run_remote_shell", fail_remote_shell)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "mcp-call",
+            "--cluster",
+            definition.name,
+            "--server",
+            registration.command,
+            "--server-arg=--stdio",
+            "--tool",
+            "inspect",
+            "--arguments-json",
+            '{"dataset":"asteroid-first-five"}',
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "remote launch failed" in result.output
+    assert [kind for kind, _path in staged_paths] == ["registry", "arguments"]
+    assert removed_paths == [
+        ("arguments", staged_paths[1][1], True),
+        ("registry", staged_paths[0][1], True),
+    ]
+
+
 @pytest.mark.parametrize("command", ["mcp-call", "jarvis-mcp-call"])
 def test_cli_mcp_call_rejects_public_admission_class_option(
     tmp_path: Path,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3703,24 +3703,64 @@ def test_registered_remote_mcp_ssh_forwarding_carries_evidence_not_lane(
         discovery_schema_digest="e" * 64,
         expected_server_artifact_digest="c" * 64,
     )
-    commands: list[list[str]] = []
+    commands: list[tuple[list[str], str | None]] = []
+    registry_writes: list[tuple[str, bytes]] = []
+    argument_writes: list[tuple[str, bytes]] = []
+    removals: list[tuple[str, str, bool]] = []
+    events: list[str] = []
 
-    def ignore_write(_definition: ClusterDefinition, _path: str, _data: bytes) -> None:
-        return None
+    def write_registry(
+        selected_definition: ClusterDefinition,
+        path: str,
+        data: bytes,
+    ) -> None:
+        assert selected_definition == definition
+        events.append("write-registry")
+        registry_writes.append((path, data))
 
-    def ignore_remove(
-        _definition: ClusterDefinition,
-        _path: str,
+    def remove_registry(
+        selected_definition: ClusterDefinition,
+        path: str,
         *,
         remove_empty_parent: bool,
     ) -> None:
-        del remove_empty_parent
+        assert selected_definition == definition
+        events.append("remove-registry")
+        removals.append(("registry", path, remove_empty_parent))
 
-    monkeypatch.setattr(mcp_server_module, "write_remote_file", ignore_write)
-    monkeypatch.setattr(mcp_server_module, "remove_remote_file", ignore_remove)
+    def write_arguments(
+        selected_definition: ClusterDefinition,
+        path: str,
+        data: bytes,
+    ) -> None:
+        assert selected_definition == definition
+        events.append("write-arguments")
+        argument_writes.append((path, data))
 
-    def run_remote(_definition: ClusterDefinition, command: list[str]) -> str:
-        commands.append(command)
+    def remove_arguments(
+        selected_definition: ClusterDefinition,
+        path: str,
+        *,
+        remove_empty_parent: bool,
+    ) -> None:
+        assert selected_definition == definition
+        events.append("remove-arguments")
+        removals.append(("arguments", path, remove_empty_parent))
+
+    monkeypatch.setattr("clio_relay.remote_cli.write_remote_file", write_registry)
+    monkeypatch.setattr("clio_relay.remote_cli.remove_remote_file", remove_registry)
+    monkeypatch.setattr(mcp_server_module, "write_remote_file", write_arguments)
+    monkeypatch.setattr(mcp_server_module, "remove_remote_file", remove_arguments)
+
+    def run_remote(
+        selected_definition: ClusterDefinition,
+        command: list[str],
+        *,
+        cluster_registry_path: str | None = None,
+    ) -> str:
+        assert selected_definition == definition
+        events.append("run")
+        commands.append((command, cluster_registry_path))
         return "job_remote_registered\n"
 
     monkeypatch.setattr(mcp_server_module, "run_remote_clio", run_remote)
@@ -3747,10 +3787,129 @@ def test_registered_remote_mcp_ssh_forwarding_carries_evidence_not_lane(
     )
 
     assert result["job_id"] == "job_remote_registered"
-    command = commands[0]
+    assert len(registry_writes) == 1
+    registry_path, registry_payload = registry_writes[0]
+    staged_registry = ClusterRegistry.model_validate_json(registry_payload)
+    assert staged_registry.clusters == {definition.name: definition}
+    staged_definition = staged_registry.require(definition.name)
+    assert staged_definition.remote_mcp_servers == {"science": registration}
+    assert cluster_route_revision(staged_definition) == cluster_route_revision(definition)
+    assert len(argument_writes) == 1
+    arguments_path, arguments_payload = argument_writes[0]
+    assert json.loads(arguments_payload) == {"dataset": "asteroid2018"}
+    command, remote_registry_path = commands[0]
+    assert remote_registry_path == f"$HOME/{registry_path}"
     assert "--admission-class" not in command
     evidence_json = command[command.index("--control-query-evidence-json") + 1]
     assert McpControlQueryEvidence.model_validate_json(evidence_json) == evidence
+    assert removals == [
+        ("arguments", arguments_path, True),
+        ("registry", registry_path, True),
+    ]
+    assert events == [
+        "write-registry",
+        "write-arguments",
+        "run",
+        "remove-arguments",
+        "remove-registry",
+    ]
+
+
+def test_registered_remote_mcp_ssh_failure_cleans_arguments_and_route_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Agent-facing SSH submission removes all invocation authority after failure."""
+    registration = RemoteMcpServerConfig(
+        command="science-mcp",
+        args=["--stdio"],
+        allow_tools=["inspect"],
+    )
+    definition = ClusterDefinition(
+        name="alpha",
+        ssh_host="alpha-login",
+        remote_mcp_servers={"science": registration},
+    )
+    registry_path = tmp_path / "clusters.json"
+    ClusterRegistry(clusters={definition.name: definition}).save(registry_path)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+    monkeypatch.setenv("CLIO_RELAY_CLI_MODE", "ssh")
+    staged_paths: list[tuple[str, str]] = []
+    removed_paths: list[tuple[str, str, bool]] = []
+
+    def write_registry(
+        _definition: ClusterDefinition,
+        path: str,
+        _data: bytes,
+    ) -> None:
+        staged_paths.append(("registry", path))
+
+    def write_arguments(
+        _definition: ClusterDefinition,
+        path: str,
+        _data: bytes,
+    ) -> None:
+        staged_paths.append(("arguments", path))
+
+    def remove_registry(
+        _definition: ClusterDefinition,
+        path: str,
+        *,
+        remove_empty_parent: bool,
+    ) -> None:
+        removed_paths.append(("registry", path, remove_empty_parent))
+
+    def remove_arguments(
+        _definition: ClusterDefinition,
+        path: str,
+        *,
+        remove_empty_parent: bool,
+    ) -> None:
+        removed_paths.append(("arguments", path, remove_empty_parent))
+
+    def fail_remote(
+        _definition: ClusterDefinition,
+        _command: list[str],
+        *,
+        cluster_registry_path: str | None = None,
+    ) -> str:
+        assert cluster_registry_path == f"$HOME/{staged_paths[0][1]}"
+        raise RelayError("remote MCP launch failed")
+
+    monkeypatch.setattr("clio_relay.remote_cli.write_remote_file", write_registry)
+    monkeypatch.setattr("clio_relay.remote_cli.remove_remote_file", remove_registry)
+    monkeypatch.setattr(mcp_server_module, "write_remote_file", write_arguments)
+    monkeypatch.setattr(mcp_server_module, "remove_remote_file", remove_arguments)
+    monkeypatch.setattr(mcp_server_module, "run_remote_clio", fail_remote)
+
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 124,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_submit_mcp_call",
+                "arguments": {
+                    "cluster": definition.name,
+                    "server": registration.command,
+                    "server_args": registration.args,
+                    "tool": "inspect",
+                    "arguments": {"dataset": "asteroid2018"},
+                },
+            },
+        },
+        queue=ClioCoreQueue(tmp_path / "core"),
+        settings=RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool"),
+        profile="admin",
+    )
+
+    assert response is not None
+    assert response["error"]["message"] == "remote MCP launch failed"
+    assert [kind for kind, _path in staged_paths] == ["registry", "arguments"]
+    assert removed_paths == [
+        ("arguments", staged_paths[1][1], True),
+        ("registry", staged_paths[0][1], True),
+    ]
 
 
 def test_virtual_remote_mcp_idempotency_replays_exactly_and_conflicts_on_drift(

--- a/tests/test_mcp_stdio_validation.py
+++ b/tests/test_mcp_stdio_validation.py
@@ -671,6 +671,19 @@ def test_packaged_stdio_child_does_not_inherit_ambient_credentials(
     assert secret not in json.dumps(session.evidence())
 
 
+def test_packaged_stdio_environment_retains_windows_programdata_only_when_present(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """OpenSSH receives PROGRAMDATA without widening the ambient environment."""
+    monkeypatch.setenv("PROGRAMDATA", r"C:\ProgramData")
+    monkeypatch.setenv("UNRELATED_AMBIENT_SETTING", "must-be-scrubbed")
+
+    environment = cast(Any, mcp_stdio_validation_module)._packaged_launch_environment()
+
+    assert environment["PROGRAMDATA"] == r"C:\ProgramData"
+    assert "UNRELATED_AMBIENT_SETTING" not in environment
+
+
 def test_packaged_user_profile_rejects_static_admin_tool_for_agent_alias(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.5.0"
+    assert version == "1.5.1"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_remote_mcp.py
+++ b/tests/test_remote_mcp.py
@@ -3062,6 +3062,129 @@ def test_cli_refresh_ingests_only_terminal_discovery_artifact(
     assert cache.entry_for("alpha", "science") is not None
 
 
+def test_cli_remote_refresh_stages_exact_registry_for_tools_list_and_cleans_it(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Remote refresh gives tools/list its exact operator route for one submission only."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CLIO_RELAY_CLI_MODE", "ssh")
+    registration = _registration(
+        profiles=["user"],
+        env_from={"SCIENCE_TOKEN": "SITE_SCIENCE_TOKEN"},
+    )
+    definition = ClusterDefinition(
+        name="alpha",
+        ssh_host="alpha-login",
+        core_dir="$HOME/site/relay-core",
+        spool_dir="$HOME/site/relay-spool",
+        remote_mcp_servers={"science": registration},
+    )
+    ClusterRegistry(clusters={definition.name: definition}).save(
+        tmp_path / ".clio-relay" / "clusters.json"
+    )
+    discovery_payload = _discovery_artifact(
+        registration,
+        tools=[_tool("inspect", required=["path"])],
+    )
+    registry_writes: list[tuple[str, bytes]] = []
+    registry_removals: list[tuple[str, bool]] = []
+    calls: list[tuple[list[str], str | None]] = []
+    events: list[str] = []
+
+    def write_registry(
+        selected_definition: ClusterDefinition,
+        path: str,
+        payload: bytes,
+    ) -> None:
+        assert selected_definition == definition
+        events.append("write-registry")
+        registry_writes.append((path, payload))
+
+    def remove_registry(
+        selected_definition: ClusterDefinition,
+        path: str,
+        *,
+        remove_empty_parent: bool,
+    ) -> None:
+        assert selected_definition == definition
+        events.append("remove-registry")
+        registry_removals.append((path, remove_empty_parent))
+
+    def run_remote(
+        selected_definition: ClusterDefinition,
+        arguments: list[str],
+        *,
+        cluster_registry_path: str | None = None,
+    ) -> str:
+        assert selected_definition == definition
+        calls.append((arguments, cluster_registry_path))
+        if arguments[0] == "mcp-call":
+            events.append("submit-tools-list")
+            return "job_remote_discovery\n"
+        assert arguments[:2] == ["job", "wait"]
+        events.append("wait")
+        return json.dumps({"job_id": "job_remote_discovery", "state": "succeeded"})
+
+    def read_artifact(
+        selected_definition: ClusterDefinition,
+        job_id: str,
+    ) -> tuple[dict[str, object], bytes]:
+        assert selected_definition == definition
+        assert job_id == "job_remote_discovery"
+        return (
+            {
+                "artifact_id": "artifact_remote_discovery",
+                "kind": "mcp_result",
+                "sha256": hashlib.sha256(discovery_payload).hexdigest(),
+            },
+            discovery_payload,
+        )
+
+    monkeypatch.setattr("clio_relay.remote_cli.write_remote_file", write_registry)
+    monkeypatch.setattr("clio_relay.remote_cli.remove_remote_file", remove_registry)
+    monkeypatch.setattr(relay_cli, "run_remote_clio", run_remote)
+    monkeypatch.setattr(relay_cli, "_read_remote_mcp_result_artifact", read_artifact)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "remote-mcp",
+            "refresh",
+            "--cluster",
+            definition.name,
+            "--name",
+            "science",
+            "--idempotency-key",
+            "remote-refresh-route-authority",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(registry_writes) == 1
+    registry_path, registry_payload = registry_writes[0]
+    staged_registry = ClusterRegistry.model_validate_json(registry_payload)
+    assert staged_registry.clusters == {definition.name: definition}
+    staged_definition = staged_registry.require(definition.name)
+    assert staged_definition.remote_mcp_servers == {"science": registration}
+    assert cluster_route_revision(staged_definition) == cluster_route_revision(definition)
+    submission, submission_registry_path = calls[0]
+    assert submission[:7] == [
+        "mcp-call",
+        "--cluster",
+        definition.name,
+        "--server",
+        registration.command,
+        "--operation",
+        "tools/list",
+    ]
+    assert submission_registry_path == f"$HOME/{registry_path}"
+    assert calls[1][0][:2] == ["job", "wait"]
+    assert calls[1][1] is None
+    assert registry_removals == [(registry_path, True)]
+    assert events == ["write-registry", "submit-tools-list", "remove-registry", "wait"]
+
+
 def test_acceptance_report_has_canonical_checks_and_durable_provenance() -> None:
     registration = _registration(namespace="science", profiles=["user"])
     server_artifact = _server_artifact(registration)

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2499,7 +2499,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.5.0"
+    assert policy.release_version == "1.5.1"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Closes #128.

## What changed

- Stage the operator's exact single-cluster registry for each remote MCP submission without mutating persistent cluster configuration.
- Apply the same authority boundary to direct `mcp-call`, agent-facing virtual MCP tools, and `remote-mcp refresh`.
- Remove invocation-scoped registry and argument staging on success and failure.
- Preserve Windows `PROGRAMDATA` in the otherwise scrubbed packaged-validation environment so Windows OpenSSH can start.
- Advance the release identity and acceptance matrix to 1.5.1.

## Root cause and impact

Remote MCP calls were admitted against the executor-local registry instead of the operator-selected route. A cluster whose persistent local registry differed from the desktop registration rejected otherwise current discovery evidence as a changed route. Packaged live validation also removed `PROGRAMDATA`, which makes Windows OpenSSH exit 255 without diagnostics. The fix preserves exact route and registration authority for only the authenticated SSH invocation while retaining bounded private staging and cleanup.

## Validation

- Ruff passed on all changed Python files.
- Pyright passed with zero errors and warnings on all changed source files.
- Seven focused route, cleanup, refresh, and Windows environment regressions passed.
- Release identity and machine-readable policy checks passed.
- A wheel-installed candidate submitted Ares relay job `job_784e7b7e4f544bb2a23fe4560a04a125` through the packaged user MCP boundary. It completed as a registered `control_query` with no scheduler action and returned LAMMPS 20240829.1 from the real Spack MCP.
