### PR TITLE
fix: stabilize JARVIS relay execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.5.1` uses a release-first patch process. A maintainer builds the
+> Version `1.5.2` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.5.1"
+$Version = "1.5.2"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.5.1"
+release_version: "1.5.2"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: c6eed7925c4490e6e9b1888922036b9136e0e52dea03749d21e16e2c89db8d3c
+acceptance_matrix_sha256: 75f605d24dee4d70f07140898ea3420b9d251b09b73815713e55b33809c6b12d
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.5.1"
+$Tag = "v1.5.2"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.1" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.2" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.5.1",
-  "matrix_sha256": "c6eed7925c4490e6e9b1888922036b9136e0e52dea03749d21e16e2c89db8d3c",
+  "release_version": "1.5.2",
+  "matrix_sha256": "75f605d24dee4d70f07140898ea3420b9d251b09b73815713e55b33809c6b12d",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.5.1"
+version = "1.5.2"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.5.1"
+__version__ = "1.5.2"

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -3135,6 +3135,8 @@ def _validate_bootstrap_receipt(
     if (
         repository_update.get("before_sha256") != before_state.get("repos_sha256")
         or repository_update.get("after_sha256") != after_state.get("repos_sha256")
+        or after_state.get("managed_repo_registered") is not True
+        or after_state.get("managed_builtin_repo_registered") is not True
         or not isinstance(repository_update.get("added_managed_repos"), list)
         or not isinstance(repository_update.get("removed_previous_managed_repos"), list)
     ):
@@ -3225,13 +3227,12 @@ def _validate_bootstrap_receipt(
         )
         expected_previous = remote_home + "/.local/src/clio-relay/jarvis-packages/clio_relay"
         expected_legacy = remote_home + LEGACY_MANAGED_JARVIS_REPO_PATH.removeprefix("~")
+        expected_builtin = remote_home + "/.ppi-jarvis/builtin"
         typed_removed_repositories = cast(list[object], removed_repositories)
-        removed_repositories_are_proven = bool(
-            all(isinstance(value, str) for value in typed_removed_repositories)
-            and typed_removed_repositories
-            == sorted(set(cast(list[str], typed_removed_repositories)))
-            and set(cast(list[str], typed_removed_repositories))
-            <= {expected_previous, expected_legacy}
+        removed_repositories_are_proven = _jarvis_repository_removals_are_proven(
+            typed_removed_repositories,
+            remote_home=remote_home,
+            exact_paths={expected_previous, expected_legacy},
         )
         repository_action = repository_update.get("action")
         if binding.get("target") != expected_target:
@@ -3246,7 +3247,11 @@ def _validate_bootstrap_receipt(
         elif repository_action == "updated":
             if (
                 typed_jarvis_preservation.get("repositories_byte_identical") is not False
-                or added_repositories not in ([], [managed_repo])
+                or not _jarvis_repository_additions_are_proven(
+                    cast(list[object], added_repositories),
+                    managed_repo=managed_repo,
+                    managed_builtin_repo=expected_builtin,
+                )
                 or not removed_repositories_are_proven
                 or (not added_repositories and not removed_repositories)
             ):
@@ -3320,13 +3325,12 @@ def _validate_bootstrap_receipt(
         )
         expected_previous = remote_home + "/.local/src/clio-relay/jarvis-packages/clio_relay"
         expected_legacy = remote_home + LEGACY_MANAGED_JARVIS_REPO_PATH.removeprefix("~")
+        expected_builtin = remote_home + "/.ppi-jarvis/builtin"
         typed_removed_repositories = cast(list[object], removed_repositories)
-        removed_repositories_are_proven = bool(
-            all(isinstance(value, str) for value in typed_removed_repositories)
-            and typed_removed_repositories
-            == sorted(set(cast(list[str], typed_removed_repositories)))
-            and set(cast(list[str], typed_removed_repositories))
-            <= {expected_previous, expected_legacy}
+        removed_repositories_are_proven = _jarvis_repository_removals_are_proven(
+            typed_removed_repositories,
+            remote_home=remote_home,
+            exact_paths={expected_previous, expected_legacy},
         )
         repository_action = repository_update.get("action")
         if (
@@ -3345,7 +3349,11 @@ def _validate_bootstrap_receipt(
         elif repository_action == "updated":
             if (
                 typed_jarvis_preservation.get("repositories_byte_identical") is not False
-                or added_repositories not in ([], [managed_repo])
+                or not _jarvis_repository_additions_are_proven(
+                    cast(list[object], added_repositories),
+                    managed_repo=managed_repo,
+                    managed_builtin_repo=expected_builtin,
+                )
                 or not removed_repositories_are_proven
                 or (not added_repositories and not removed_repositories)
             ):
@@ -3389,6 +3397,86 @@ def _is_sha256_value(value: object) -> bool:
         and value == value.lower()
         and all(character in "0123456789abcdef" for character in value)
     )
+
+
+def _jarvis_repository_removals_are_proven(
+    values: list[object],
+    *,
+    remote_home: str,
+    exact_paths: set[str],
+) -> bool:
+    """Accept only exact historical relay repository paths in bootstrap evidence."""
+    if not all(isinstance(value, str) for value in values):
+        return False
+    repositories = cast(list[str], values)
+    return bool(
+        repositories == sorted(set(repositories))
+        and all(
+            value in exact_paths
+            or _is_relay_owned_jarvis_builtin_repository(value, remote_home=remote_home)
+            for value in repositories
+        )
+    )
+
+
+def _jarvis_repository_additions_are_proven(
+    values: list[object],
+    *,
+    managed_repo: str,
+    managed_builtin_repo: str,
+) -> bool:
+    """Accept only the ordered relay and JARVIS stable repository bindings."""
+    allowed = [managed_repo, managed_builtin_repo]
+    if not all(isinstance(value, str) for value in values):
+        return False
+    repositories = cast(list[str], values)
+    return bool(
+        len(repositories) <= len(allowed)
+        and len(repositories) == len(set(repositories))
+        and all(value in allowed for value in repositories)
+        and repositories == [value for value in allowed if value in repositories]
+    )
+
+
+def _is_relay_owned_jarvis_builtin_repository(value: str, *, remote_home: str) -> bool:
+    """Recognize the exact legacy or content-addressed relay venv builtin path."""
+    if any(character in value for character in "\x00\r\n"):
+        return False
+    path = PurePosixPath(value)
+    home = PurePosixPath(remote_home)
+    if not path.is_absolute() or str(path) != value or not home.is_absolute():
+        return False
+    try:
+        relative = path.relative_to(home / ".local/share/clio-relay")
+    except ValueError:
+        return False
+    parts = relative.parts
+    legacy_prefix = ("jarvis-venv",)
+    generation_prefix = (
+        ("generations", parts[1], "jarvis-venv")
+        if len(parts) >= 3 and _is_sha256_value(parts[1])
+        else ()
+    )
+    for prefix in (legacy_prefix, generation_prefix):
+        if not prefix or parts[: len(prefix)] != prefix:
+            continue
+        suffix = parts[len(prefix) :]
+        if (
+            len(suffix) == 4
+            and suffix[0] in {"lib", "lib64"}
+            and _is_python_library_directory_name(suffix[1])
+            and suffix[2:] == ("site-packages", "builtin")
+        ):
+            return True
+    return False
+
+
+def _is_python_library_directory_name(value: str) -> bool:
+    """Recognize one CPython virtual-environment library component."""
+    if not value.startswith("python"):
+        return False
+    major, separator, minor = value.removeprefix("python").partition(".")
+    return bool(separator and major.isdigit() and minor.isdigit())
 
 
 def _worker_writer_proof_shell(*, rendered_core_dir: str, success_variable: str) -> str:
@@ -7577,12 +7665,22 @@ import os
 import sys
 from pathlib import Path
 
-from clio_relay.bootstrap_reconcile import reconcile_managed_jarvis_repository
+from clio_relay.bootstrap_reconcile import (
+    _relay_owned_jarvis_builtin_repositories,
+    reconcile_managed_jarvis_repository,
+)
+
+relay_owned_builtin_repos = _relay_owned_jarvis_builtin_repositories(home=Path.home())
 
 evidence = reconcile_managed_jarvis_repository(
     Path(os.environ["JARVIS_REPOS_FILE"]),
     Path(os.environ["MANAGED_JARVIS_REPO"]),
-    previous_managed_repos=(Path(sys.argv[1]), Path(sys.argv[2])),
+    managed_builtin_repo=Path(os.environ["JARVIS_REPOS_FILE"]).parent / "builtin",
+    previous_managed_repos=(
+        Path(sys.argv[1]),
+        Path(sys.argv[2]),
+        *relay_owned_builtin_repos,
+    ),
 )
 print(f"jarvis_managed_repo={{evidence['action']}}")
 __CLIO_RELAY_JARVIS_REPO_RECONCILE__

--- a/src/clio_relay/bootstrap_reconcile.py
+++ b/src/clio_relay/bootstrap_reconcile.py
@@ -8,8 +8,10 @@ and the fsync-backed transaction journal.
 
 from __future__ import annotations
 
+import csv
 import ctypes
 import hashlib
+import io
 import json
 import os
 import shlex
@@ -50,6 +52,8 @@ LEGACY_MANAGED_JARVIS_REPO_PATH = "~/.local/share/clio-relay/managed-jarvis-repo
 MAX_JARVIS_CONFIG_BYTES = 1024 * 1024
 MAX_JARVIS_REPOS_BYTES = 4 * 1024 * 1024
 MAX_JARVIS_GRAPH_BYTES = 64 * 1024 * 1024
+MAX_JARVIS_DISTRIBUTION_METADATA_BYTES = 1024 * 1024
+MAX_JARVIS_DISTRIBUTION_RECORD_BYTES = 64 * 1024 * 1024
 BOOTSTRAP_LOCK_TIMEOUT_SECONDS = 30.0
 _O_BINARY = cast(int, getattr(os, "O_BINARY", 0))
 _O_NOFOLLOW = cast(int, getattr(os, "O_NOFOLLOW", 0))
@@ -253,6 +257,7 @@ class JarvisStateEvidence(BaseModel):
     repos_sha256: str | None = None
     resource_graph_sha256: str | None = None
     managed_repo_registered: bool = False
+    managed_builtin_repo_registered: bool = False
 
 
 class BootstrapReadinessEvidence(BaseModel):
@@ -864,6 +869,8 @@ def inspect_exact_bootstrap_noop(
         reasons.append("JARVIS is not initialized")
     if not jarvis_state.managed_repo_registered:
         reasons.append("the exact relay-managed JARVIS repository is not registered")
+    if not jarvis_state.managed_builtin_repo_registered:
+        reasons.append("the exact JARVIS-managed builtin repository slot is not registered")
 
     queue_ready = _queue_readiness_verified(queue_evidence)
     if not queue_ready:
@@ -981,11 +988,22 @@ def inspect_jarvis_state(
     managed_repo_path = _expand_home(desired.managed_jarvis_repo, lexical_home)
     managed_repo = str(_canonical_path_preserving_final(managed_repo_path))
     managed_aliases = {str(managed_repo_path.absolute()), managed_repo}
+    managed_builtin_path = jarvis_root / "builtin"
+    managed_builtin = str(_canonical_path_preserving_final(managed_builtin_path))
+    managed_builtin_aliases = {
+        str(Path(os.path.abspath(managed_builtin_path.expanduser()))),
+        managed_builtin,
+    }
     repo_values = cast(list[str], raw_repo_values)
     managed_matches = [value for value in repo_values if value in managed_aliases]
     if len(managed_matches) > 1:
         raise ConfigurationError(
             "relay-managed JARVIS repository is registered through multiple path aliases"
+        )
+    managed_builtin_matches = [value for value in repo_values if value in managed_builtin_aliases]
+    if len(managed_builtin_matches) > 1:
+        raise ConfigurationError(
+            "JARVIS-managed builtin repository is registered through multiple path aliases"
         )
     return JarvisStateEvidence(
         initialized=True,
@@ -995,6 +1013,7 @@ def inspect_jarvis_state(
         repos_sha256=hashlib.sha256(raw_repos).hexdigest(),
         resource_graph_sha256=hashlib.sha256(raw_graph).hexdigest(),
         managed_repo_registered=len(managed_matches) == 1,
+        managed_builtin_repo_registered=len(managed_builtin_matches) == 1,
     )
 
 
@@ -1243,10 +1262,19 @@ def finish_staged_activation(
     managed_repo = _expand_home(desired.managed_jarvis_repo, lexical_home)
     legacy_managed_repo = _expand_home(LEGACY_MANAGED_JARVIS_REPO_PATH, lexical_home)
     previous_repo = lexical_home / ".local/src/clio-relay/jarvis-packages/clio_relay"
+    relay_owned_builtin_repos = _relay_owned_jarvis_builtin_repositories(
+        home=lexical_home,
+        execution_environments=(Path(legacy_venv), generation / "jarvis-venv"),
+    )
     repositories = reconcile_managed_jarvis_repository(
         _expand_home(desired.jarvis_root, lexical_home) / "repos.yaml",
         managed_repo,
-        previous_managed_repos=(legacy_managed_repo, previous_repo),
+        managed_builtin_repo=_expand_home(desired.jarvis_root, lexical_home) / "builtin",
+        previous_managed_repos=(
+            legacy_managed_repo,
+            previous_repo,
+            *relay_owned_builtin_repos,
+        ),
         exchange_identity=desired.fingerprint,
     )
     expected_managed_target = (
@@ -2427,12 +2455,200 @@ def write_bootstrap_receipt(path: Path, receipt: dict[str, object]) -> None:
     _atomic_json(path, receipt)
 
 
+def _relay_owned_jarvis_builtin_repositories(
+    *,
+    home: Path,
+    execution_environments: tuple[Path, ...] = (),
+) -> tuple[Path, ...]:
+    """Return builtin repositories proven to belong to relay-managed JARVIS venvs.
+
+    Old JARVIS releases registered their wheel-installed ``builtin`` package
+    directly in ``repos.yaml``.  JARVIS now owns a stable repository slot, but
+    that cannot identify the historical path when it lives in relay's legacy
+    virtual environment.  Constrain migration to the fixed legacy venv and to
+    content-addressed generation venvs, then require wheel ``METADATA`` and
+    ``RECORD`` evidence proving that ``jarvis-cd`` installed the repository.
+    """
+    lexical_home = Path(os.path.abspath(home.expanduser()))
+    resolved_home = lexical_home.resolve(strict=True)
+    lexical_relay_root = lexical_home / ".local/share/clio-relay"
+    resolved_relay_root = resolved_home / ".local/share/clio-relay"
+    fixed_legacy = lexical_relay_root / "jarvis-venv"
+    candidates = (fixed_legacy, *execution_environments)
+    repositories: dict[str, Path] = {}
+    seen_environments: set[str] = set()
+    for candidate in candidates:
+        lexical_environment = Path(os.path.abspath(candidate.expanduser()))
+        lexical_identity: tuple[int, int, int, int, int, int]
+        try:
+            before = lexical_environment.lstat()
+            if (
+                not stat.S_ISDIR(before.st_mode)
+                or _path_is_directory_alias(lexical_environment)
+                or not lexical_environment.is_absolute()
+                or ".." in lexical_environment.parts
+            ):
+                continue
+            resolved_environment = lexical_environment.resolve(strict=True)
+            fixed_environment = resolved_relay_root / "jarvis-venv"
+            owned_layout = resolved_environment == fixed_environment
+            if not owned_layout:
+                relative = resolved_environment.relative_to(
+                    (resolved_relay_root / "generations").resolve(strict=True)
+                )
+                owned_layout = bool(
+                    len(relative.parts) == 2
+                    and _is_sha256(relative.parts[0])
+                    and relative.parts[1] == "jarvis-venv"
+                )
+            if not owned_layout:
+                continue
+            lexical_identity = _stat_identity(before)
+            if _stat_identity(lexical_environment.lstat()) != lexical_identity:
+                continue
+            getuid = getattr(os, "getuid", None)
+            if callable(getuid) and before.st_uid != getuid():
+                continue
+        except (FileNotFoundError, OSError, RuntimeError, ValueError):
+            continue
+        environment_key = str(resolved_environment)
+        if environment_key in seen_environments:
+            continue
+        seen_environments.add(environment_key)
+        for site_packages in _jarvis_site_package_directories(lexical_environment):
+            repository = _jarvis_cd_builtin_repository(site_packages)
+            if repository is not None:
+                repositories[str(repository)] = repository
+        if _stat_identity(lexical_environment.lstat()) != lexical_identity:
+            raise ConfigurationError(
+                "relay-owned JARVIS environment changed during repository reconciliation"
+            )
+    return tuple(repositories[key] for key in sorted(repositories))
+
+
+def _jarvis_site_package_directories(environment: Path) -> tuple[Path, ...]:
+    """Enumerate bounded, real site-package directories inside one proven venv."""
+    candidates = [environment / "Lib/site-packages"]
+    for library_name in ("lib", "lib64"):
+        library = environment / library_name
+        try:
+            python_directories = sorted(library.glob("python*"), key=lambda path: path.name)
+        except OSError:
+            continue
+        if len(python_directories) > 16:
+            raise ConfigurationError("relay-owned JARVIS environment has too many Python roots")
+        candidates.extend(path / "site-packages" for path in python_directories)
+    directories: dict[str, Path] = {}
+    for candidate in candidates:
+        try:
+            before = candidate.lstat()
+            if not stat.S_ISDIR(before.st_mode) or _path_is_directory_alias(candidate):
+                continue
+            resolved = candidate.resolve(strict=True)
+            relative = resolved.relative_to(environment.resolve(strict=True))
+            parts = relative.parts
+            posix_shape = bool(
+                len(parts) == 3
+                and parts[0] in {"lib", "lib64"}
+                and _is_python_library_directory(parts[1])
+                and parts[2] == "site-packages"
+            )
+            windows_shape = parts == ("Lib", "site-packages")
+            if not posix_shape and not windows_shape:
+                continue
+            if _stat_identity(candidate.lstat()) != _stat_identity(before):
+                continue
+            directories[str(candidate)] = candidate
+        except (FileNotFoundError, OSError, RuntimeError, ValueError):
+            continue
+    return tuple(directories[key] for key in sorted(directories))
+
+
+def _is_python_library_directory(value: str) -> bool:
+    """Return whether a venv library name is exactly ``python<major>.<minor>``."""
+    if not value.startswith("python"):
+        return False
+    version = value.removeprefix("python")
+    major, separator, minor = version.partition(".")
+    return bool(separator and major.isdigit() and minor.isdigit())
+
+
+def _jarvis_cd_builtin_repository(site_packages: Path) -> Path | None:
+    """Prove that one site-packages ``builtin`` directory came from jarvis-cd."""
+    builtin = site_packages / "builtin"
+    try:
+        builtin_before = builtin.lstat()
+        if not stat.S_ISDIR(builtin_before.st_mode) or _path_is_directory_alias(builtin):
+            return None
+        distributions = sorted(
+            site_packages.glob("jarvis_cd-*.dist-info"),
+            key=lambda path: path.name,
+        )
+        if len(distributions) > 8:
+            raise ConfigurationError("relay-owned JARVIS environment has too many distributions")
+        for distribution in distributions:
+            distribution_before = distribution.lstat()
+            if not stat.S_ISDIR(distribution_before.st_mode) or _path_is_directory_alias(
+                distribution
+            ):
+                continue
+            metadata_payload = _read_regular_bounded(
+                distribution / "METADATA",
+                maximum=MAX_JARVIS_DISTRIBUTION_METADATA_BYTES,
+            )
+            record_payload = _read_regular_bounded(
+                distribution / "RECORD",
+                maximum=MAX_JARVIS_DISTRIBUTION_RECORD_BYTES,
+            )
+            if not _jarvis_cd_metadata(metadata_payload) or not _record_installs_jarvis_builtin(
+                record_payload
+            ):
+                continue
+            if _stat_identity(distribution.lstat()) != _stat_identity(
+                distribution_before
+            ) or _stat_identity(builtin.lstat()) != _stat_identity(builtin_before):
+                raise ConfigurationError(
+                    "relay-owned JARVIS distribution changed during repository reconciliation"
+                )
+            getuid = getattr(os, "getuid", None)
+            if callable(getuid) and (
+                distribution_before.st_uid != getuid() or builtin_before.st_uid != getuid()
+            ):
+                continue
+            return builtin
+    except (FileNotFoundError, OSError, RuntimeError, UnicodeError, ValueError):
+        return None
+    return None
+
+
+def _jarvis_cd_metadata(payload: bytes) -> bool:
+    """Return whether wheel metadata names the jarvis-cd distribution exactly."""
+    for line in payload.decode("utf-8").splitlines():
+        field, separator, value = line.partition(":")
+        if separator and field.casefold() == "name":
+            return value.strip().casefold().replace("_", "-") == "jarvis-cd"
+    return False
+
+
+def _record_installs_jarvis_builtin(payload: bytes) -> bool:
+    """Require both repository package markers in a jarvis-cd wheel RECORD."""
+    paths: set[str] = set()
+    reader = csv.reader(io.StringIO(payload.decode("utf-8"), newline=""))
+    for row in reader:
+        if row:
+            paths.add(row[0].replace("\\", "/"))
+    return {"builtin/__init__.py", "builtin/builtin/__init__.py"} <= paths
+
+
 def _managed_repository_payload(
     raw: bytes,
     *,
     managed: str,
     managed_aliases: set[str],
+    managed_builtin: str | None,
+    managed_builtin_aliases: set[str],
     previous_aliases: dict[str, str],
+    previous_builtin_aliases: set[str],
 ) -> tuple[bytes, list[str], list[str]]:
     """Return the exact converged repository bytes and mutation evidence."""
     document = _yaml_mapping(raw, label="JARVIS repositories")
@@ -2448,6 +2664,11 @@ def _managed_repository_payload(
         raise ConfigurationError(
             "relay-managed JARVIS repository is registered through multiple path aliases"
         )
+    managed_builtin_matches = [value for value in repos if value in managed_builtin_aliases]
+    if len(managed_builtin_matches) > 1:
+        raise ConfigurationError(
+            "JARVIS-managed builtin repository is registered through multiple path aliases"
+        )
     previous_matches: dict[str, list[str]] = {}
     for value in repos:
         normalized = previous_aliases.get(value)
@@ -2459,13 +2680,59 @@ def _managed_repository_payload(
             "multiple path aliases"
         )
     removed_previous = sorted(previous_matches)
-    if managed_matches == [managed] and not removed_previous:
+    if managed_builtin is None:
+        if managed_matches == [managed] and not removed_previous:
+            return raw, [], []
+        updated = [
+            value
+            for value in repos
+            if value not in managed_aliases and value not in previous_aliases
+        ]
+        updated.insert(0, managed)
+        added_managed = [managed] if managed_matches != [managed] else []
+        document["repos"] = updated
+        return (
+            yaml.safe_dump(document, sort_keys=False).encode("utf-8"),
+            added_managed,
+            removed_previous,
+        )
+    if (
+        managed_matches == [managed]
+        and managed_builtin_matches == [managed_builtin]
+        and not removed_previous
+    ):
         return raw, [], []
-    updated = [
-        value for value in repos if value not in managed_aliases and value not in previous_aliases
-    ]
-    updated.insert(0, managed)
-    added_managed = [managed] if managed_matches != [managed] else []
+    builtin_anchor: int | None = None
+    if managed_builtin_matches:
+        builtin_anchor = repos.index(managed_builtin_matches[0])
+    else:
+        builtin_anchor = next(
+            (index for index, value in enumerate(repos) if value in previous_builtin_aliases),
+            None,
+        )
+    operator_repositories: list[str] = []
+    builtin_position: int | None = None
+    for index, value in enumerate(repos):
+        if index == builtin_anchor:
+            builtin_position = len(operator_repositories)
+        if (
+            value in managed_aliases
+            or value in managed_builtin_aliases
+            or value in previous_aliases
+        ):
+            continue
+        operator_repositories.append(value)
+    if builtin_position is None:
+        builtin_position = len(operator_repositories)
+    operator_repositories.insert(builtin_position, managed_builtin)
+    updated = [managed, *operator_repositories]
+    if repos == updated and not removed_previous:
+        return raw, [], []
+    added_managed: list[str] = []
+    if not repos or repos[0] != managed:
+        added_managed.append(managed)
+    if managed_builtin_matches != [managed_builtin]:
+        added_managed.append(managed_builtin)
     document["repos"] = updated
     return (
         yaml.safe_dump(document, sort_keys=False).encode("utf-8"),
@@ -2478,6 +2745,7 @@ def reconcile_managed_jarvis_repository(
     repos_file: Path,
     managed_repo: Path,
     *,
+    managed_builtin_repo: Path | None = None,
     previous_managed_repos: tuple[Path, ...] = (),
     exchange_identity: str | None = None,
 ) -> dict[str, object]:
@@ -2485,8 +2753,12 @@ def reconcile_managed_jarvis_repository(
 
     JARVIS's public ``repo add --force`` replaces every repository with the
     same basename. Relay instead performs a compare-before-replace update of
-    its one exact path and leaves operator repositories, including same-name
-    repositories, untouched. ``previous_managed_repos`` is a caller-supplied
+    its exact paths and leaves operator repositories, including same-name
+    repositories, untouched. ``managed_builtin_repo`` may name only JARVIS's
+    exact ``<JARVIS_ROOT>/builtin`` slot. JARVIS 1.6+ rebinds that stable slot
+    in memory to the builtin repository shipped by the running distribution,
+    so the independently installed execution and MCP runtimes each see their
+    release-pinned package contract. ``previous_managed_repos`` is a caller-supplied
     provenance boundary: each path must come from an earlier relay receipt or
     an exact relay-owned generation path. This operation is serialized by the
     bootstrap lock; the final byte-and-file-identity comparison also detects
@@ -2499,18 +2771,39 @@ def reconcile_managed_jarvis_repository(
     lexical_managed = str(Path(os.path.abspath(managed_repo.expanduser())))
     managed = str(_canonical_path_preserving_final(managed_repo))
     managed_aliases = {lexical_managed, managed}
+    managed_builtin: str | None = None
+    managed_builtin_aliases: set[str] = set()
+    if managed_builtin_repo is not None:
+        lexical_builtin_path = Path(os.path.abspath(managed_builtin_repo.expanduser()))
+        expected_builtin_path = Path(os.path.abspath(repos_file.parent.expanduser())) / "builtin"
+        canonical_builtin_path = _canonical_path_preserving_final(managed_builtin_repo)
+        canonical_expected_builtin = _canonical_path_preserving_final(expected_builtin_path)
+        if (
+            lexical_builtin_path != expected_builtin_path
+            or canonical_builtin_path != canonical_expected_builtin
+        ):
+            raise ConfigurationError(
+                "JARVIS-managed builtin repository must be the exact active root slot"
+            )
+        managed_builtin = str(canonical_builtin_path)
+        managed_builtin_aliases = {str(lexical_builtin_path), managed_builtin}
+    managed_alias_union = managed_aliases | managed_builtin_aliases
     previous_aliases: dict[str, str] = {}
+    previous_builtin_aliases: set[str] = set()
     for path in previous_managed_repos:
         lexical_previous = str(Path(os.path.abspath(path.expanduser())))
         try:
             canonical_previous = str(_canonical_path_preserving_final(path))
         except ConfigurationError:
             canonical_previous = lexical_previous
-        if canonical_previous in managed_aliases:
+        if canonical_previous in managed_alias_union:
             continue
         previous_aliases[lexical_previous] = canonical_previous
         previous_aliases[canonical_previous] = canonical_previous
-    token = exchange_identity or hashlib.sha256(managed.encode("utf-8")).hexdigest()
+        if Path(canonical_previous).name == "builtin":
+            previous_builtin_aliases.update({lexical_previous, canonical_previous})
+    token_source = managed if managed_builtin is None else f"{managed}\0{managed_builtin}"
+    token = exchange_identity or hashlib.sha256(token_source.encode("utf-8")).hexdigest()
     try:
         _require_sha256(token, field="repository_exchange_identity")
     except ValueError as exc:
@@ -2524,7 +2817,10 @@ def reconcile_managed_jarvis_repository(
         raw,
         managed=managed,
         managed_aliases=managed_aliases,
+        managed_builtin=managed_builtin,
+        managed_builtin_aliases=managed_builtin_aliases,
         previous_aliases=previous_aliases,
+        previous_builtin_aliases=previous_builtin_aliases,
     )
     if temporary.exists() or temporary.is_symlink():
         displaced, _displaced_identity = _read_regular_bounded_with_identity(
@@ -2535,7 +2831,10 @@ def reconcile_managed_jarvis_repository(
             displaced,
             managed=managed,
             managed_aliases=managed_aliases,
+            managed_builtin=managed_builtin,
+            managed_builtin_aliases=managed_builtin_aliases,
             previous_aliases=previous_aliases,
+            previous_builtin_aliases=previous_builtin_aliases,
         )
         if displaced != displaced_payload and displaced_payload == raw:
             temporary.unlink()
@@ -2715,10 +3014,19 @@ def repair_managed_jarvis_binding(
     )
     repos_file = _expand_home(desired.jarvis_root, lexical_home) / "repos.yaml"
     legacy_managed_repo = _expand_home(LEGACY_MANAGED_JARVIS_REPO_PATH, lexical_home)
+    relay_owned_builtin_repos = _relay_owned_jarvis_builtin_repositories(
+        home=lexical_home,
+        execution_environments=(generation / "jarvis-venv",),
+    )
     repo_evidence = reconcile_managed_jarvis_repository(
         repos_file,
         managed,
-        previous_managed_repos=(*previous_managed_repos, legacy_managed_repo),
+        managed_builtin_repo=_expand_home(desired.jarvis_root, lexical_home) / "builtin",
+        previous_managed_repos=(
+            *previous_managed_repos,
+            legacy_managed_repo,
+            *relay_owned_builtin_repos,
+        ),
         exchange_identity=desired.fingerprint,
     )
     canonical_home = lexical_home.resolve(strict=True)

--- a/src/clio_relay/session_api.py
+++ b/src/clio_relay/session_api.py
@@ -25,6 +25,7 @@ from clio_relay.errors import ConfigurationError, ObservationTimeoutError, Relay
 from clio_relay.jarvis_mcp import is_virtual_jarvis_control_query
 from clio_relay.models import (
     MCP_ADMISSION_AUTHORITY_METADATA_KEY,
+    REGISTERED_JARVIS_USER_CONTRACT,
     ArtifactUse,
     JarvisRunSpec,
     JobKind,
@@ -398,15 +399,24 @@ def _validate_submission_receipt(
         else:
             _expected_class = McpAdmissionClass.WORKLOAD
             expected_authority = None
+        expected_arguments = payload.get("arguments", {})
+        raw_tool = payload.get("tool")
+        normalized_tool = raw_tool.replace("-", "_").lower() if isinstance(raw_tool, str) else ""
+        if (
+            normalized_tool == "jarvis_run"
+            and payload.get("expected_registered_contract") == REGISTERED_JARVIS_USER_CONTRACT
+        ):
+            expected_arguments = _expected_jarvis_mcp_arguments(job, payload=payload)
         expected = {
             "server": payload.get("server"),
             "server_args": payload.get("server_args", []),
             "env_from": payload.get("env_from", {}),
             "expected_server_artifact_digest": payload.get("expected_server_artifact_digest"),
+            "expected_registered_contract": payload.get("expected_registered_contract"),
             "admission_class": _expected_class.value,
             "operation": operation.value,
             "tool": payload.get("tool"),
-            "arguments": payload.get("arguments", {}),
+            "arguments": expected_arguments,
             "timeout_seconds": payload.get("timeout_seconds"),
         }
         observed = {
@@ -414,6 +424,7 @@ def _validate_submission_receipt(
             "server_args": job.spec.server_args,
             "env_from": job.spec.env_from,
             "expected_server_artifact_digest": (job.spec.expected_server_artifact_digest),
+            "expected_registered_contract": job.spec.expected_registered_contract,
             "admission_class": job.spec.admission_class.value,
             "operation": job.spec.operation.value,
             "tool": job.spec.tool,

--- a/tests/test_bootstrap_fast_path.py
+++ b/tests/test_bootstrap_fast_path.py
@@ -1318,6 +1318,7 @@ def test_exact_remote_bootstrap_never_reads_or_builds_payload(
         repos_sha256="c" * 64,
         resource_graph_sha256="d" * 64,
         managed_repo_registered=True,
+        managed_builtin_repo_registered=True,
     )
     inspection = BootstrapInspection(
         exact_match=True,
@@ -1749,6 +1750,7 @@ def test_public_cluster_bootstrap_noop_never_touches_nonexistent_wheel(
             repos_sha256="c" * 64,
             resource_graph_sha256="d" * 64,
             managed_repo_registered=True,
+            managed_builtin_repo_registered=True,
         )
         inspection = BootstrapInspection(
             exact_match=True,
@@ -1918,6 +1920,7 @@ def test_payload_free_inspector_fails_closed_after_repair_does_not_converge(
         repos_sha256="c" * 64,
         resource_graph_sha256="d" * 64,
         managed_repo_registered=True,
+        managed_builtin_repo_registered=True,
     )
     initial = BootstrapInspection(
         exact_match=False,
@@ -2033,7 +2036,13 @@ def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration(
         resource_graph_sha256="d" * 64,
         managed_repo_registered=False,
     )
-    after = before.model_copy(update={"repos_sha256": "e" * 64, "managed_repo_registered": True})
+    after = before.model_copy(
+        update={
+            "repos_sha256": "e" * 64,
+            "managed_repo_registered": True,
+            "managed_builtin_repo_registered": True,
+        }
+    )
     inspection = BootstrapInspection(
         exact_match=True,
         desired_fingerprint=desired.fingerprint,
@@ -2084,6 +2093,7 @@ def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration(
         for name, action in actions.items()
     }
     managed_repo = "/home/operator/.local/share/clio-relay/clio_relay"
+    managed_builtin_repo = "/home/operator/.ppi-jarvis/builtin"
     repository_update: dict[str, object] = {
         "link_action": "created",
         "link": managed_repo,
@@ -2093,7 +2103,7 @@ def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration(
         "repositories": {
             "action": "updated",
             "managed_repo": managed_repo,
-            "added_managed_repos": [managed_repo],
+            "added_managed_repos": [managed_repo, managed_builtin_repo],
             "removed_previous_managed_repos": [
                 "/home/operator/.local/share/clio-relay/managed-jarvis-repo"
             ],
@@ -2127,6 +2137,47 @@ def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration(
         expected_allow_jarvis_resource_graph_build=False,
         expected_worker_service=desired.worker_service,
     )
+
+    invalid_builtin_addition = copy.deepcopy(receipt)
+    invalid_preservation = cast(dict[str, object], invalid_builtin_addition["jarvis_preservation"])
+    invalid_binding = cast(dict[str, object], invalid_preservation["repositories"])
+    invalid_update = cast(dict[str, object], invalid_binding["repositories"])
+    invalid_update["added_managed_repos"] = [
+        managed_repo,
+        "/home/operator/custom/builtin",
+    ]
+    with pytest.raises(RelayError, match="repository migration is invalid"):
+        bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            invalid_builtin_addition,
+            bootstrap_profile="linux-user",
+            relay_install_spec=desired.relay_install_spec,
+            desired_fingerprint=desired.fingerprint,
+            expected_jarvis_resource_graph_profile="ares",
+            expected_allow_jarvis_resource_graph_build=False,
+            expected_worker_service=desired.worker_service,
+        )
+
+    for relay_builtin_path in (
+        "/home/operator/.local/share/clio-relay/jarvis-venv/lib/python3.12/site-packages/builtin",
+        (
+            "/home/operator/.local/share/clio-relay/generations/"
+            f"{'1' * 64}/jarvis-venv/lib/python3.12/site-packages/builtin"
+        ),
+    ):
+        builtin_cleanup = copy.deepcopy(receipt)
+        cleanup_preservation = cast(dict[str, object], builtin_cleanup["jarvis_preservation"])
+        cleanup_binding = cast(dict[str, object], cleanup_preservation["repositories"])
+        cleanup_update = cast(dict[str, object], cleanup_binding["repositories"])
+        cleanup_update["removed_previous_managed_repos"] = [relay_builtin_path]
+        bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            builtin_cleanup,
+            bootstrap_profile="linux-user",
+            relay_install_spec=desired.relay_install_spec,
+            desired_fingerprint=desired.fingerprint,
+            expected_jarvis_resource_graph_profile="ares",
+            expected_allow_jarvis_resource_graph_build=False,
+            expected_worker_service=desired.worker_service,
+        )
 
     relay_only = copy.deepcopy(receipt)
     relay_transaction = cast(dict[str, object], relay_only["transaction"])
@@ -2195,6 +2246,24 @@ def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration(
             expected_worker_service=desired.worker_service,
         )
 
+    lookalike_removal = copy.deepcopy(receipt)
+    preservation = cast(dict[str, object], lookalike_removal["jarvis_preservation"])
+    binding = cast(dict[str, object], preservation["repositories"])
+    update = cast(dict[str, object], binding["repositories"])
+    update["removed_previous_managed_repos"] = [
+        "/home/operator/.local/share/clio-relay/operator-venv/lib/python3.12/site-packages/builtin"
+    ]
+    with pytest.raises(RelayError, match="repository migration is invalid"):
+        bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            lookalike_removal,
+            bootstrap_profile="linux-user",
+            relay_install_spec=desired.relay_install_spec,
+            desired_fingerprint=desired.fingerprint,
+            expected_jarvis_resource_graph_profile="ares",
+            expected_allow_jarvis_resource_graph_build=False,
+            expected_worker_service=desired.worker_service,
+        )
+
     replaced_link = copy.deepcopy(receipt)
     preservation = cast(dict[str, object], replaced_link["jarvis_preservation"])
     binding = cast(dict[str, object], preservation["repositories"])
@@ -2254,6 +2323,7 @@ def test_fresh_bootstrap_receipt_allows_explicit_pending_service_install(
         repos_sha256="c" * 64,
         resource_graph_sha256="d" * 64,
         managed_repo_registered=True,
+        managed_builtin_repo_registered=True,
     )
     inspection = BootstrapInspection(
         exact_match=False,

--- a/tests/test_bootstrap_reconcile.py
+++ b/tests/test_bootstrap_reconcile.py
@@ -148,6 +148,7 @@ def _write_jarvis_state(home: Path, desired: BootstrapDesiredState) -> tuple[Pat
         {
             "repos": [
                 str((home / ".local/share/clio-relay/clio_relay").absolute()),
+                str((root / "builtin").absolute()),
                 "/operator/clio_relay",
             ]
         },
@@ -158,6 +159,29 @@ def _write_jarvis_state(home: Path, desired: BootstrapDesiredState) -> tuple[Pat
     (root / "repos.yaml").write_bytes(repos_bytes)
     (root / "resource_graph.yaml").write_bytes(graph_bytes)
     return root, config_bytes, graph_bytes
+
+
+def _write_jarvis_cd_builtin_distribution(environment: Path) -> Path:
+    """Create the minimal wheel-install evidence used by repository migration tests."""
+    if os.name == "nt":
+        site_packages = environment / "Lib/site-packages"
+    else:
+        site_packages = environment / "lib/python3.12/site-packages"
+    builtin = site_packages / "builtin"
+    (builtin / "builtin").mkdir(parents=True)
+    (builtin / "__init__.py").write_text("", encoding="utf-8")
+    (builtin / "builtin/__init__.py").write_text("", encoding="utf-8")
+    distribution = site_packages / "jarvis_cd-x.dist-info"
+    distribution.mkdir()
+    (distribution / "METADATA").write_text(
+        "Metadata-Version: 2.4\nName: jarvis-cd\nVersion: 1.3.18\n",
+        encoding="utf-8",
+    )
+    (distribution / "RECORD").write_text(
+        "builtin/__init__.py,,\nbuiltin/builtin/__init__.py,,\n",
+        encoding="utf-8",
+    )
+    return builtin
 
 
 def _installation_info(desired: BootstrapDesiredState) -> dict[str, object]:
@@ -1185,6 +1209,25 @@ def test_existing_operator_jarvis_roots_are_adopted_without_mutation(tmp_path: P
     assert (root / "resource_graph.yaml").read_bytes() == graph_before
 
 
+def test_jarvis_state_requires_the_managed_builtin_slot_for_exact_reuse(tmp_path: Path) -> None:
+    """Bootstrap evidence distinguishes relay packages from JARVIS builtins."""
+    desired = _desired(uv_sha256="a" * 64, frpc_sha256="b" * 64, frps_sha256="c" * 64)
+    root, _config, _graph = _write_jarvis_state(tmp_path, desired)
+
+    complete = inspect_jarvis_state(desired, home=tmp_path)
+    document = yaml.safe_load((root / "repos.yaml").read_text(encoding="utf-8"))
+    document["repos"].remove(str((root / "builtin").absolute()))
+    (root / "repos.yaml").write_text(
+        yaml.safe_dump(document, sort_keys=False),
+        encoding="utf-8",
+    )
+    missing = inspect_jarvis_state(desired, home=tmp_path)
+
+    assert complete.managed_builtin_repo_registered is True
+    assert missing.managed_repo_registered is True
+    assert missing.managed_builtin_repo_registered is False
+
+
 def test_managed_repo_migration_preserves_operator_repo_and_resolves_jarvis_package(
     tmp_path: Path,
 ) -> None:
@@ -1253,6 +1296,132 @@ def test_managed_repo_migration_preserves_operator_repo_and_resolves_jarvis_pack
     reused = reconcile_managed_jarvis_repository(repos_file, managed_repo)
     assert reused["action"] == "reused"
     assert repos_file.read_bytes() == before
+
+
+@pytest.mark.parametrize("environment_kind", ["legacy", "generation"])
+def test_relay_owned_jarvis_builtin_reconcile_preserves_operator_repositories(
+    tmp_path: Path,
+    environment_kind: str,
+) -> None:
+    """Only a RECORD-proven builtin under a relay-owned venv is migrated."""
+    relay_root = tmp_path / ".local/share/clio-relay"
+    if environment_kind == "legacy":
+        environment = relay_root / "jarvis-venv"
+        supplied_environments: tuple[Path, ...] = ()
+    else:
+        environment = relay_root / "generations" / ("a" * 64) / "jarvis-venv"
+        supplied_environments = (environment,)
+    relay_builtin = _write_jarvis_cd_builtin_distribution(environment)
+    operator_environment = tmp_path / "operator/jarvis-venv"
+    operator_builtin = _write_jarvis_cd_builtin_distribution(operator_environment)
+    managed = relay_root / "clio_relay"
+    managed.mkdir(parents=True)
+    repos_file = tmp_path / "repos.yaml"
+    repos_file.write_text(
+        yaml.safe_dump(
+            {
+                "repos": [
+                    str(relay_builtin.absolute()),
+                    str(operator_builtin.absolute()),
+                    str(managed.absolute()),
+                ],
+                "operator_extension": {"preserve": True},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    proven = bootstrap_reconcile_module._relay_owned_jarvis_builtin_repositories(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        home=tmp_path,
+        execution_environments=supplied_environments,
+    )
+    evidence = reconcile_managed_jarvis_repository(
+        repos_file,
+        managed,
+        managed_builtin_repo=tmp_path / "builtin",
+        previous_managed_repos=proven,
+    )
+    document = yaml.safe_load(repos_file.read_text(encoding="utf-8"))
+
+    assert proven == (relay_builtin,)
+    assert evidence["added_managed_repos"] == [
+        str(managed.absolute()),
+        str((tmp_path / "builtin").absolute()),
+    ]
+    assert evidence["removed_previous_managed_repos"] == [str(relay_builtin.absolute())]
+    assert document["repos"] == [
+        str(managed.absolute()),
+        str((tmp_path / "builtin").absolute()),
+        str(operator_builtin.absolute()),
+    ]
+    assert document["operator_extension"] == {"preserve": True}
+
+
+def test_managed_builtin_slot_replaces_stale_relay_path_without_operator_promotion(
+    tmp_path: Path,
+) -> None:
+    """Stable builtin binding retains explicit operator repository precedence."""
+    repos_file = tmp_path / ".ppi-jarvis/repos.yaml"
+    repos_file.parent.mkdir()
+    managed = tmp_path / ".local/share/clio-relay/clio_relay"
+    managed.mkdir(parents=True)
+    operator_builtin = tmp_path / "operator/builtin"
+    operator_builtin.mkdir(parents=True)
+    stale_builtin = _write_jarvis_cd_builtin_distribution(
+        tmp_path / ".local/share/clio-relay/jarvis-venv"
+    )
+    operator_other = tmp_path / "operator/science"
+    operator_other.mkdir(parents=True)
+    repos_file.write_text(
+        yaml.safe_dump(
+            {
+                "repos": [
+                    str(operator_builtin.absolute()),
+                    str(stale_builtin.absolute()),
+                    str(operator_other.absolute()),
+                ]
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    evidence = reconcile_managed_jarvis_repository(
+        repos_file,
+        managed,
+        managed_builtin_repo=repos_file.parent / "builtin",
+        previous_managed_repos=(stale_builtin,),
+    )
+
+    assert yaml.safe_load(repos_file.read_text(encoding="utf-8"))["repos"] == [
+        str(managed.absolute()),
+        str(operator_builtin.absolute()),
+        str((repos_file.parent / "builtin").absolute()),
+        str(operator_other.absolute()),
+    ]
+    assert evidence["added_managed_repos"] == [
+        str(managed.absolute()),
+        str((repos_file.parent / "builtin").absolute()),
+    ]
+    assert evidence["removed_previous_managed_repos"] == [str(stale_builtin.absolute())]
+
+
+def test_relay_owned_jarvis_builtin_requires_distribution_record_proof(tmp_path: Path) -> None:
+    """A lookalike directory in relay's legacy venv is not sufficient provenance."""
+    environment = tmp_path / ".local/share/clio-relay/jarvis-venv"
+    if os.name == "nt":
+        builtin = environment / "Lib/site-packages/builtin"
+    else:
+        builtin = environment / "lib/python3.12/site-packages/builtin"
+    builtin.mkdir(parents=True)
+
+    assert (
+        bootstrap_reconcile_module._relay_owned_jarvis_builtin_repositories(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            home=tmp_path,
+        )
+        == ()
+    )
 
 
 def test_managed_repo_reconcile_refuses_concurrent_operator_edit(
@@ -1818,6 +1987,7 @@ def test_staged_activation_resumes_across_repository_crash_boundaries(
     for path in (execution_python, execution_jarvis):
         path.write_bytes(path.name.encode())
         path.chmod(0o755)
+    stale_builtin_repo = _write_jarvis_cd_builtin_distribution(execution_root)
     legacy_identity = execution_environment_identity(
         execution_root,
         executables={"python": execution_python, "jarvis": execution_jarvis},
@@ -1856,7 +2026,13 @@ def test_staged_activation_resumes_across_repository_crash_boundaries(
     operator_repo = tmp_path / "operator/clio_relay"
     repos_file.write_text(
         yaml.safe_dump(
-            {"repos": [str(operator_repo.absolute()), str(previous_repo.absolute())]},
+            {
+                "repos": [
+                    str(operator_repo.absolute()),
+                    str(stale_builtin_repo.absolute()),
+                    str(previous_repo.absolute()),
+                ]
+            },
             sort_keys=False,
         ),
         encoding="utf-8",
@@ -1928,6 +2104,7 @@ def test_staged_activation_resumes_across_repository_crash_boundaries(
         path: Path,
         managed: Path,
         *,
+        managed_builtin_repo: Path | None = None,
         previous_managed_repos: tuple[Path, ...] = (),
         exchange_identity: str | None = None,
     ) -> dict[str, object]:
@@ -1938,6 +2115,7 @@ def test_staged_activation_resumes_across_repository_crash_boundaries(
         evidence = original_reconcile(
             path,
             managed,
+            managed_builtin_repo=managed_builtin_repo,
             previous_managed_repos=previous_managed_repos,
             exchange_identity=exchange_identity,
         )
@@ -1973,7 +2151,11 @@ def test_staged_activation_resumes_across_repository_crash_boundaries(
     )
 
     repositories = yaml.safe_load(repos_file.read_text(encoding="utf-8"))["repos"]
-    assert repositories == [str(managed_repo.absolute()), str(operator_repo.absolute())]
+    assert repositories == [
+        str(managed_repo.absolute()),
+        str(operator_repo.absolute()),
+        str((jarvis_root / "builtin").absolute()),
+    ]
     first_repository = cast(dict[str, object], first_completed["jarvis_repository"])
     second_repository = cast(dict[str, object], second_completed["jarvis_repository"])
     second_update = cast(dict[str, object], second_repository["repositories"])

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.5.1"
+    assert version == "1.5.2"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_session_api.py
+++ b/tests/test_session_api.py
@@ -14,6 +14,7 @@ from clio_relay.config import RelaySettings
 from clio_relay.errors import ObservationTimeoutError, RelayError
 from clio_relay.models import (
     MCP_ADMISSION_AUTHORITY_METADATA_KEY,
+    REGISTERED_JARVIS_USER_CONTRACT,
     JobKind,
     McpAdmissionAuthority,
     McpAdmissionClass,
@@ -406,6 +407,67 @@ def test_owned_session_submission_accepts_relay_owned_jarvis_execution_identity(
     assert isinstance(received.spec, McpCallSpec)
     assert isinstance(admitted.spec, McpCallSpec)
     assert received.spec.arguments == admitted.spec.arguments
+    assert received.spec.arguments["execution_id"].startswith("jarvis_")
+
+
+def test_owned_session_submission_accepts_registered_jarvis_execution_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Registered JARVIS admission may add its deterministic execution ID."""
+
+    expected_digest = "a" * 64
+    submitted = RelayJob(
+        cluster="ares",
+        kind=JobKind.MCP_CALL,
+        spec=McpCallSpec(
+            server="clio-kit",
+            server_args=["mcp-server", "jarvis"],
+            expected_server_artifact_digest=expected_digest,
+            expected_registered_contract=REGISTERED_JARVIS_USER_CONTRACT,
+            tool="jarvis_run",
+            arguments={"pipeline_id": "science-pipeline"},
+        ),
+        idempotency_key="owned-session-client",
+        metadata={
+            "owner": "clio-relay",
+            "owner_session_id": "desktop-session-1",
+            "owner_session_generation_id": "generation-1",
+        },
+    )
+    admitted = prepare_owned_jarvis_run_submission(submitted)
+    identity = session_identity_document(
+        owner_token="owner-token",
+        cluster="ares",
+        session_id="desktop-session-1",
+        generation_id="generation-1",
+        nonce="1" * 64,
+    )
+    _install_transport(
+        monkeypatch,
+        responses=[
+            _Response(identity),
+            _Response(admitted.model_dump(mode="json")),
+        ],
+    )
+
+    received = submit_owned_session_job(
+        definition=ClusterDefinition(name="ares", ssh_host="ares-login"),
+        settings=_settings(tmp_path),
+        path="/jobs/mcp-call",
+        payload={
+            "cluster": "ares",
+            "server": "clio-kit",
+            "server_args": ["mcp-server", "jarvis"],
+            "expected_server_artifact_digest": expected_digest,
+            "expected_registered_contract": REGISTERED_JARVIS_USER_CONTRACT,
+            "tool": "jarvis_run",
+            "arguments": {"pipeline_id": "science-pipeline"},
+            "idempotency_key": "owned-session-client",
+        },
+    )
+
+    assert isinstance(received.spec, McpCallSpec)
     assert received.spec.arguments["execution_id"].startswith("jarvis_")
 
 

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2499,7 +2499,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.5.1"
+    assert policy.release_version == "1.5.2"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.5.1"
+version = "1.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- reconcile JARVIS's stable builtin repository slot while preserving operator repository precedence
- remove only stale builtin paths proven to originate from relay-owned `jarvis-cd` wheel environments
- accept the deterministic execution ID injected by the registered JARVIS `jarvis_run` contract without weakening receipt correlation
- bump the patch release and acceptance metadata to 1.5.2

## Why

The live Ares LAMMPS demo exposed two production blockers. A stale relay-managed builtin path could shadow the current JARVIS package catalog, and a valid registered `jarvis_run` receipt was rejected after relay added its deterministic execution ID. The latter caused the desktop agent to retry a submission whose remote execution had already been accepted.

## Impact

Registered JARVIS MCP calls now produce a usable durable execution handle on the first logical submission, and bootstrapped clusters consistently resolve current builtin packages without deleting or reordering operator-owned repositories.

## Focused validation

- 12 targeted pytest cases passed
- Ruff passed on all changed Python files
- Pyright passed on the three changed source modules with zero errors
- live Ares candidate LAMMPS execution completed as JARVIS `jarvis_2bbdf4563f70683c7660957f970c874a`, Slurm `22240`, with structured progress and nine artifacts
