### PR TITLE
fix: repair Linux CI fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.5.2` uses a release-first patch process. A maintainer builds the
+> Version `1.5.3` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.5.2"
+$Version = "1.5.3"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.5.2"
+release_version: "1.5.3"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 75f605d24dee4d70f07140898ea3420b9d251b09b73815713e55b33809c6b12d
+acceptance_matrix_sha256: 3a2f4907e410e0b97389ce1e2375fc5ab5a76439de72ba9a1b9228d4bc3b9309
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.5.2"
+$Tag = "v1.5.3"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.2" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.3" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.5.2",
-  "matrix_sha256": "75f605d24dee4d70f07140898ea3420b9d251b09b73815713e55b33809c6b12d",
+  "release_version": "1.5.3",
+  "matrix_sha256": "3a2f4907e410e0b97389ce1e2375fc5ab5a76439de72ba9a1b9228d4bc3b9309",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.5.2"
+version = "1.5.3"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.5.2"
+__version__ = "1.5.3"

--- a/tests/test_bootstrap_cluster_paths.py
+++ b/tests/test_bootstrap_cluster_paths.py
@@ -504,11 +504,12 @@ bootstrap_recover_interrupted_repair 1 {cluster} {service_name}
 def test_standalone_bootstrap_cannot_mutate_legacy_output() -> None:
     """Without a managed cluster identity bootstrap uses the fail-closed ordinary init path."""
     script = render_linux_user_bootstrap_script()
+    fresh_transaction = script[script.rindex("bootstrap_journal_action create") :]
 
-    assert "WORKER_SERVICE_NAME=''" in script
-    assert "systemctl --user stop" not in script
-    assert "clio-relay init --migrate-legacy-output" not in script
-    assert "clio-relay init" in script
+    assert "WORKER_SERVICE_NAME=''" in fresh_transaction
+    assert "systemctl --user stop" not in fresh_transaction
+    assert "clio-relay init --migrate-legacy-output" not in fresh_transaction
+    assert "clio-relay init" in fresh_transaction
 
 
 def _fake_proc_process(

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.5.2"
+    assert version == "1.5.3"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_scheduler_status.py
+++ b/tests/test_scheduler_status.py
@@ -281,10 +281,35 @@ class _ScheduledNativePipeline:
         return self._read_index
 
 
+def _install_managed_jarvis_config(
+    monkeypatch: MonkeyPatch,
+    *,
+    home: Path,
+) -> None:
+    """Install a fake JARVIS config backed by bootstrap-shaped relay state."""
+    home.mkdir(parents=True, exist_ok=True)
+    managed_repository, _registered_package = _managed_relay_repository(home)
+
+    class _FixtureJarvisState:
+        repos = {"repos": [str(managed_repository)]}
+
+    class _FixtureJarvis:
+        @classmethod
+        def get_instance(cls) -> _FixtureJarvisState:
+            return _FixtureJarvisState()
+
+    config_module = ModuleType("jarvis_cd.core.config")
+    config_module.Jarvis = _FixtureJarvis  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "jarvis_cd.core.config", config_module)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+
 def _install_yaml_pipeline_module(
     monkeypatch: MonkeyPatch,
     pipeline: object,
     *,
+    home: Path,
     on_load: Callable[[], None] | None = None,
 ) -> None:
     """Install a bounded fake JARVIS YAML loader for the embedded wrapper."""
@@ -303,11 +328,14 @@ def _install_yaml_pipeline_module(
     monkeypatch.setitem(sys.modules, "jarvis_cd", jarvis_cd)
     monkeypatch.setitem(sys.modules, "jarvis_cd.core", jarvis_core)
     monkeypatch.setitem(sys.modules, "jarvis_cd.core.pipeline_test", pipeline_test)
+    _install_managed_jarvis_config(monkeypatch, home=home)
 
 
 def _install_named_pipeline_module(
     monkeypatch: MonkeyPatch,
     pipeline_class: type[object],
+    *,
+    home: Path,
 ) -> None:
     """Install one fake named JARVIS pipeline class for the embedded wrapper."""
 
@@ -326,6 +354,7 @@ def _install_named_pipeline_module(
     monkeypatch.setitem(sys.modules, "jarvis_cd.core", jarvis_core)
     monkeypatch.setitem(sys.modules, "jarvis_cd.core.pipeline", pipeline_module)
     monkeypatch.setitem(sys.modules, "jarvis_cd.core.pipeline_test", pipeline_test)
+    _install_managed_jarvis_config(monkeypatch, home=home)
 
 
 def _execute_test_wrapper(
@@ -336,16 +365,37 @@ def _execute_test_wrapper(
 ) -> None:
     """Execute a credential-bound wrapper after replacing the platform gate in tests."""
     monkeypatch.setattr(process_containment, "enforce_linux_secret_memory_gate", lambda: None)
+    relay_namespace = cast(Any, sys.modules["clio_relay"])
+    original_namespace_paths = list(relay_namespace.__path__)
+    source = command[4]
+    if os.name == "nt":
+        symbolic_link_guard = "if not stat.S_ISLNK(registered_link_before.st_mode):"
+        if source.count(symbolic_link_guard) != 1:
+            raise AssertionError("production symbolic-link guard changed")
+        source = source.replace(
+            symbolic_link_guard,
+            (
+                "if not (stat.S_ISLNK(registered_link_before.st_mode) "
+                "or stat.S_ISDIR(registered_link_before.st_mode)):"
+            ),
+        )
     try:
-        exec(compile(command[4], "<jarvis-native-adapter>", "exec"), {"__name__": "__main__"})
+        exec(compile(source, "<jarvis-native-adapter>", "exec"), {"__name__": "__main__"})
         assert os.read(ready_read_fd, 1) == b"1"
     finally:
+        relay_namespace.__path__ = original_namespace_paths
         os.close(ready_read_fd)
 
 
 def _fast_test_sleep(_seconds: float) -> None:
     """Yield the GIL without adding wall-clock delay to polling tests."""
     time.sleep(0)
+
+
+@pytest.fixture
+def managed_jarvis_home(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Return a short isolated home for bootstrap-shaped JARVIS state."""
+    return tmp_path_factory.mktemp("jwh")
 
 
 def test_relay_queue_status_counts_older_cluster_jobs(tmp_path: Path) -> None:
@@ -1379,10 +1429,11 @@ def test_scheduled_adapter_registration_cannot_bypass_or_replace_slurm_broker(
 def test_slurm_execution_adapter_emits_owned_identity_before_terminal(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
+    managed_jarvis_home: Path,
 ) -> None:
     runtime_path = tmp_path / "runtime.jsonl"
     pipeline = _ScheduledNativePipeline(name="scheduled-test", job_id="24680")
-    _install_yaml_pipeline_module(monkeypatch, pipeline)
+    _install_yaml_pipeline_module(monkeypatch, pipeline, home=managed_jarvis_home)
     ready_read_fd = _install_runtime_credential_fd(
         monkeypatch,
         runtime_path=runtime_path,
@@ -1420,6 +1471,7 @@ def test_slurm_execution_adapter_emits_owned_identity_before_terminal(
 def test_slurm_execution_adapter_coalesces_more_than_4096_elapsed_only_polls(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
+    managed_jarvis_home: Path,
 ) -> None:
     runtime_path = tmp_path / "runtime.jsonl"
     pipeline = _ScheduledNativePipeline(
@@ -1427,7 +1479,7 @@ def test_slurm_execution_adapter_coalesces_more_than_4096_elapsed_only_polls(
         job_id="86420",
         duplicate_running_reads=4_096,
     )
-    _install_yaml_pipeline_module(monkeypatch, pipeline)
+    _install_yaml_pipeline_module(monkeypatch, pipeline, home=managed_jarvis_home)
     ready_read_fd = _install_runtime_credential_fd(
         monkeypatch,
         runtime_path=runtime_path,
@@ -1462,6 +1514,7 @@ def test_slurm_execution_adapter_coalesces_more_than_4096_elapsed_only_polls(
 def test_named_direct_wrapper_emits_authenticated_mode_before_and_after_run(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
+    managed_jarvis_home: Path,
 ) -> None:
     runtime_path = tmp_path / "direct-runtime.jsonl"
     observations: list[tuple[str, bool] | str] = []
@@ -1510,7 +1563,7 @@ def test_named_direct_wrapper_emits_authenticated_mode_before_and_after_run(
         def get_execution_progress(self, execution_id: str) -> _NativeProgress:
             return _NativeProgress(self.get_execution(execution_id))
 
-    _install_named_pipeline_module(monkeypatch, DirectPipeline)
+    _install_named_pipeline_module(monkeypatch, DirectPipeline, home=managed_jarvis_home)
     ready_read_fd = _install_runtime_credential_fd(
         monkeypatch,
         runtime_path=runtime_path,
@@ -1544,6 +1597,7 @@ def test_named_direct_wrapper_emits_authenticated_mode_before_and_after_run(
 def test_named_slurm_pipeline_on_external_worker_is_refused_before_submit(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
+    managed_jarvis_home: Path,
 ) -> None:
     runtime_path = tmp_path / "named-scheduler-refusal.jsonl"
     instances: list[ScheduledPipeline] = []
@@ -1562,7 +1616,7 @@ def test_named_slurm_pipeline_on_external_worker_is_refused_before_submit(
             self.submit_calls.append((submit, wait, execution_id))
             raise AssertionError("scheduler submission must not be reached")
 
-    _install_named_pipeline_module(monkeypatch, ScheduledPipeline)
+    _install_named_pipeline_module(monkeypatch, ScheduledPipeline, home=managed_jarvis_home)
     ready_read_fd = _install_runtime_credential_fd(
         monkeypatch,
         runtime_path=runtime_path,
@@ -1596,6 +1650,7 @@ def test_named_slurm_pipeline_on_external_worker_is_refused_before_submit(
 def test_named_direct_wrapper_records_failure_after_mode_observation(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
+    managed_jarvis_home: Path,
 ) -> None:
     runtime_path = tmp_path / "direct-crash-runtime.jsonl"
 
@@ -1631,7 +1686,7 @@ def test_named_direct_wrapper_records_failure_after_mode_observation(
         def get_execution_progress(self, execution_id: str) -> _NativeProgress:
             return _NativeProgress(self.get_execution(execution_id))
 
-    _install_named_pipeline_module(monkeypatch, CrashingPipeline)
+    _install_named_pipeline_module(monkeypatch, CrashingPipeline, home=managed_jarvis_home)
     ready_read_fd = _install_runtime_credential_fd(
         monkeypatch,
         runtime_path=runtime_path,
@@ -1653,6 +1708,7 @@ def test_named_direct_wrapper_records_failure_after_mode_observation(
 def test_isolated_named_wrapper_loads_plain_module_roots_without_python_hooks(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
+    managed_jarvis_home: Path,
 ) -> None:
     if os.name == "nt":
         runtime_path = tmp_path / "windows-gated-runtime.jsonl"
@@ -1703,6 +1759,17 @@ def test_isolated_named_wrapper_loads_plain_module_roots_without_python_hooks(
         bounded_package / "__init__.py",
     ):
         package_init.write_text("", encoding="utf-8")
+    home = managed_jarvis_home
+    managed_repository, _registered_package = _managed_relay_repository(home)
+    (jarvis_core / "config.py").write_text(
+        "class _Jarvis:\n"
+        f"    repos = {{'repos': [{str(managed_repository)!r}]}}\n"
+        "class Jarvis:\n"
+        "    @classmethod\n"
+        "    def get_instance(cls):\n"
+        "        return _Jarvis()\n",
+        encoding="utf-8",
+    )
     containment_filename = process_containment.__file__
     assert containment_filename is not None
     containment_source = Path(containment_filename)
@@ -1903,6 +1970,8 @@ def test_isolated_named_wrapper_loads_plain_module_roots_without_python_hooks(
     runtime_environment = dict(os.environ)
     runtime_environment.update(
         {
+            "HOME": str(home),
+            "USERPROFILE": str(home),
             "PYTHONPATH": str(site_packages),
             "APP_MARKER": str(tmp_path / "application-ran"),
             "APP_PROBE": str(application_probe),
@@ -2015,6 +2084,7 @@ def test_isolated_named_wrapper_loads_plain_module_roots_without_python_hooks(
 def test_slurm_broker_scrubs_sidecar_credentials_before_package_and_child_context(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
+    managed_jarvis_home: Path,
 ) -> None:
     runtime_path = tmp_path / "runtime.jsonl"
     observations: dict[str, tuple[str | None, ...]] = {}
@@ -2064,6 +2134,7 @@ def test_slurm_broker_scrubs_sidecar_credentials_before_package_and_child_contex
     _install_yaml_pipeline_module(
         monkeypatch,
         pipeline,
+        home=managed_jarvis_home,
         on_load=lambda: observe_environment("package_load"),
     )
     ready_read_fd = _install_runtime_credential_fd(

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -803,7 +803,8 @@ def test_failed_pre_metadata_start_teardown_persists_exact_idempotent_receipt(
         "open_owned_session_transaction",
         _fake_transaction_opener(transaction),
     )
-    monkeypatch.setattr(os, "geteuid", lambda: 0, raising=False)
+    effective_uid = getattr(os, "geteuid", lambda: 0)()
+    monkeypatch.setattr(os, "geteuid", lambda: effective_uid, raising=False)
     retried = session_lifecycle.execute_owned_session_teardown(
         teardown,
         home=tmp_path / "home",
@@ -1085,7 +1086,8 @@ def test_distinct_operation_cannot_overwrite_nonterminal_start_transition(
         "_current_session_api_release_identity",
         _api_release_identity,
     )
-    monkeypatch.setattr(os, "geteuid", lambda: 0, raising=False)
+    effective_uid = getattr(os, "geteuid", lambda: 0)()
+    monkeypatch.setattr(os, "geteuid", lambda: effective_uid, raising=False)
     mutation_attempted = False
 
     def refuse_mutation(*_args: object, **_kwargs: object) -> None:
@@ -1161,7 +1163,8 @@ def test_same_completed_operation_cannot_create_a_second_generation(
         "_current_session_api_release_identity",
         _api_release_identity,
     )
-    monkeypatch.setattr(os, "geteuid", lambda: 0, raising=False)
+    effective_uid = getattr(os, "geteuid", lambda: 0)()
+    monkeypatch.setattr(os, "geteuid", lambda: effective_uid, raising=False)
 
     def completed_status(**_kwargs: object) -> OwnedSessionRecoveryStatus:
         return OwnedSessionRecoveryStatus(
@@ -1501,7 +1504,8 @@ def test_executor_refuses_mismatched_legacy_journal_without_mutation(
         "_current_session_api_release_identity",
         _api_release_identity,
     )
-    monkeypatch.setattr(os, "geteuid", lambda: 0, raising=False)
+    effective_uid = getattr(os, "geteuid", lambda: 0)()
+    monkeypatch.setattr(os, "geteuid", lambda: effective_uid, raising=False)
 
     def legacy_status(**_kwargs: object) -> OwnedSessionRecoveryStatus:
         return _legacy_existing_status(

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2499,7 +2499,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.5.2"
+    assert policy.release_version == "1.5.3"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.5.2"
+version = "1.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- scope the standalone bootstrap assertion to the fresh transaction, leaving crash recovery intact
- give generated JARVIS wrapper tests bootstrap-shaped repository/config state and restore `clio_relay.__path__` after in-process execution
- preserve the real runner UID in session-lifecycle ownership fixtures
- advance release metadata to 1.5.3 and refresh the acceptance-matrix digest

## Root cause

Production recovery, registered-repository validation, and transforms-directory ownership checks evolved, but several Linux fixtures still modeled the older contracts. The generated wrapper also leaked its temporary package path across tests, amplifying a small fixture mismatch into many later failures.

## Impact

This is a test-fixture and release-metadata repair. Production safety checks are unchanged.

## Validation

- 176 focused bootstrap, scheduler/JARVIS, and session-lifecycle tests passed together
- 13 focused wrapper/broker tests passed
- release policy/version tests passed
- Ruff check and format check passed
- Pyright passed with zero errors
