### PR TITLE
fix: repair Linux release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,11 +106,12 @@ jobs:
           if-no-files-found: error
           retention-days: 90
       - name: upload primary matrix report
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: matrix-report-ubuntu-latest-3.12
           path: dist/reports/validation-local-ubuntu-latest-3.12.json
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 90
 
   validate:
@@ -193,11 +194,12 @@ jobs:
           --artifact-dir dist/validation-output
           --prebuilt-artifact-dir dist/prebuilt
       - name: upload matrix report
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: matrix-report-${{ matrix.os }}-${{ matrix.python-version }}
           path: dist/reports/validation-local-${{ matrix.os }}-${{ matrix.python-version }}.json
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 90
 
   seal:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.5.3` uses a release-first patch process. A maintainer builds the
+> Version `1.5.4` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.5.3"
+$Version = "1.5.4"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.5.3"
+release_version: "1.5.4"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 3a2f4907e410e0b97389ce1e2375fc5ab5a76439de72ba9a1b9228d4bc3b9309
+acceptance_matrix_sha256: 584250bd61425ec05a7cf661157b7ea1a899d4f77aa72960d711f34137806116
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.5.3"
+$Tag = "v1.5.4"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.3" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.4" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.5.3",
-  "matrix_sha256": "3a2f4907e410e0b97389ce1e2375fc5ab5a76439de72ba9a1b9228d4bc3b9309",
+  "release_version": "1.5.4",
+  "matrix_sha256": "584250bd61425ec05a7cf661157b7ea1a899d4f77aa72960d711f34137806116",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/jarvis-packages/clio_relay/clio_relay/process_containment.py
+++ b/jarvis-packages/clio_relay/clio_relay/process_containment.py
@@ -59,6 +59,7 @@ _BROKER_STARTUP_STAGE_CODES: dict[str, frozenset[str]] = {
     "stdin_forward": frozenset({"child_exited", "internal_error"}),
 }
 _BROKER_EXCEPTION_TYPE_PATTERN = re.compile(r"[A-Za-z][A-Za-z0-9_]{0,63}")
+_CGROUP_ROOT = Path("/sys/fs/cgroup")
 
 
 class _ResourceModule(Protocol):
@@ -1272,6 +1273,10 @@ def terminate_recorded_process_tree(
         )
         if (systemd_invocation_id is None) is not (systemd_description is None):
             raise RuntimeError("recorded systemd execution has partial persistent identity")
+        recorded_scope = _validated_recorded_systemd_scope_path(
+            cgroup_path,
+            unit=systemd_unit,
+        )
         if exact_persistent_identity:
             existing_pids = recorded_linux_systemd_scope_process_ids(
                 unit=systemd_unit,
@@ -1279,15 +1284,11 @@ def terminate_recorded_process_tree(
                 invocation_id=cast(str, systemd_invocation_id),
                 description=cast(str, systemd_description),
             )
-            if not existing_pids and not Path(cgroup_path).exists():
+            if not existing_pids and not recorded_scope.exists():
                 return
-        scope = Path(cgroup_path).resolve(strict=True)
-        if not exact_persistent_identity:
-            cgroup_root = Path("/sys/fs/cgroup").resolve()
-            try:
-                scope.relative_to(cgroup_root)
-            except ValueError as exc:
-                raise RuntimeError(f"recorded cgroup is outside cgroup v2: {scope}") from exc
+        if observed_identity is None and not recorded_scope.exists():
+            return
+        scope = recorded_scope.resolve(strict=True)
         _terminate_linux_systemd_scope(systemd_unit, scope)
         residual = (
             recorded_linux_systemd_scope_process_ids(
@@ -1331,6 +1332,28 @@ def terminate_recorded_process_tree(
         )
     if residual:
         raise RuntimeError(f"recorded process tree survived cleanup: {residual}")
+
+
+def _validated_recorded_systemd_scope_path(cgroup_path: str, *, unit: str) -> Path:
+    """Validate a recorded cgroup path even after systemd removed the leaf scope."""
+    if "\x00" in cgroup_path or any(
+        part in {".", ".."} for part in re.split(r"[\\/]", cgroup_path)
+    ):
+        raise RuntimeError("recorded systemd execution has invalid cgroup path")
+    recorded = Path(cgroup_path)
+    if not recorded.is_absolute() or recorded.name != unit:
+        raise RuntimeError("recorded systemd execution has invalid cgroup path")
+    try:
+        root = _CGROUP_ROOT.resolve(strict=True)
+        if not root.is_dir():
+            raise RuntimeError("configured cgroup v2 root is not a directory")
+        candidate = recorded.resolve(strict=False)
+        candidate.relative_to(root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RuntimeError("recorded cgroup is outside cgroup v2") from exc
+    if candidate == root or candidate.name != unit:
+        raise RuntimeError("recorded systemd execution has invalid cgroup path")
+    return candidate
 
 
 def _register_owned_process(process_id: int, state: _OwnedProcessState) -> None:
@@ -2187,6 +2210,7 @@ def recorded_linux_systemd_scope_process_ids(
         or len(description.encode("utf-8")) > 512
     ):
         raise RuntimeError("recorded persistent systemd scope identity is invalid")
+    recorded_path = _validated_recorded_systemd_scope_path(cgroup_path, unit=unit)
     result = _systemctl_user(
         [
             "show",
@@ -2205,7 +2229,6 @@ def recorded_linux_systemd_scope_process_ids(
         )
     except RuntimeError:
         properties = {}
-    recorded_path = Path(cgroup_path)
     if result.returncode != 0 or properties.get("LoadState") == "not-found":
         if recorded_path.exists():
             raise RuntimeError("recorded systemd unit vanished while its cgroup remained")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.5.3"
+version = "1.5.4"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.5.3"
+__version__ = "1.5.4"

--- a/src/clio_relay/cluster_config.py
+++ b/src/clio_relay/cluster_config.py
@@ -43,6 +43,7 @@ _WINDOWS_GENERIC_READ = 0x80000000
 _WINDOWS_GENERIC_WRITE = 0x40000000
 _WINDOWS_DELETE = 0x00010000
 _WINDOWS_FILE_SHARE_READ = 0x00000001
+_WINDOWS_FILE_SHARE_WRITE = 0x00000002
 _WINDOWS_CREATE_NEW = 1
 _WINDOWS_OPEN_EXISTING = 3
 _WINDOWS_FILE_ATTRIBUTE_NORMAL = 0x00000080
@@ -1027,7 +1028,7 @@ def _open_windows_configuration_handle(
     raw_handle = create_file(
         str(internal_filesystem_path(path, force_extended=True)),
         desired_access,
-        _WINDOWS_FILE_SHARE_READ,
+        _WINDOWS_FILE_SHARE_READ | _WINDOWS_FILE_SHARE_WRITE,
         None,
         _WINDOWS_OPEN_EXISTING,
         flags,

--- a/src/clio_relay/command_evidence.py
+++ b/src/clio_relay/command_evidence.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
 EVIDENCE_EXCERPT_MAX_BYTES = 24_576
@@ -11,6 +12,8 @@ ERROR_DETAIL_SUMMARY_TAIL_BYTES = 1_024
 EXCERPT_STRATEGY = "diagnostic-head-summary-tail-v1"
 
 _TRACEBACK_MARKER = "Traceback (most recent call last):"
+_PYTEST_FAILED_TEST_PATTERN = re.compile(r"(?m)^FAILED (?P<test_id>tests/.*?) - ")
+_MAX_FAILED_TEST_IDS = 1_000
 
 
 @dataclass(frozen=True)
@@ -48,6 +51,7 @@ def command_evidence(
                 "error_detail_bytes": len(fallback.encode("utf-8")),
                 "diagnostic_marker": None,
                 "diagnostic_offset_bytes": None,
+                "failed_test_ids": [],
                 "omitted_prefix_bytes": 0,
                 "omitted_middle_bytes": 0,
                 "truncated": False,
@@ -80,6 +84,7 @@ def command_evidence(
             None if diagnostic_offset is None else len(output[:diagnostic_offset].encode("utf-8"))
         ),
         "exit_code": exit_code,
+        "failed_test_ids": _pytest_failed_test_ids(output),
         **excerpt_metadata,
     }
     return CommandEvidence(
@@ -103,6 +108,14 @@ def bounded_error_detail(value: str | None) -> str | None:
         diagnostic_offset=diagnostic_offset,
     )
     return bounded
+
+
+def _pytest_failed_test_ids(output: str) -> list[str]:
+    """Return bounded, ordered pytest node IDs from a failed command transcript."""
+    return [
+        match.group("test_id")
+        for match in list(_PYTEST_FAILED_TEST_PATTERN.finditer(output))[:_MAX_FAILED_TEST_IDS]
+    ]
 
 
 def _first_diagnostic(output: str) -> tuple[str | None, int | None]:

--- a/src/clio_relay/command_evidence.py
+++ b/src/clio_relay/command_evidence.py
@@ -2,18 +2,22 @@
 
 from __future__ import annotations
 
-import re
+import json
 from dataclasses import dataclass
+from typing import cast
 
 EVIDENCE_EXCERPT_MAX_BYTES = 24_576
 EVIDENCE_SUMMARY_TAIL_BYTES = 8_192
 ERROR_DETAIL_MAX_BYTES = 4_096
 ERROR_DETAIL_SUMMARY_TAIL_BYTES = 1_024
 EXCERPT_STRATEGY = "diagnostic-head-summary-tail-v1"
+PYTEST_FAILED_NODE_IDS_MARKER = "CLIO_RELAY_PYTEST_FAILED_NODE_IDS_V1="
+PYTEST_FAILED_NODE_IDS_MAX_COUNT = 1_000
+PYTEST_FAILED_NODE_ID_MAX_BYTES = 4_096
+PYTEST_FAILED_NODE_IDS_MAX_BYTES = 64 * 1_024
+PYTEST_FAILED_NODE_IDS_PAYLOAD_MAX_BYTES = 512 * 1_024
 
 _TRACEBACK_MARKER = "Traceback (most recent call last):"
-_PYTEST_FAILED_TEST_PATTERN = re.compile(r"(?m)^FAILED (?P<test_id>tests/.*?) - ")
-_MAX_FAILED_TEST_IDS = 1_000
 
 
 @dataclass(frozen=True)
@@ -52,6 +56,7 @@ def command_evidence(
                 "diagnostic_marker": None,
                 "diagnostic_offset_bytes": None,
                 "failed_test_ids": [],
+                "failed_test_ids_truncated": False,
                 "omitted_prefix_bytes": 0,
                 "omitted_middle_bytes": 0,
                 "truncated": False,
@@ -72,6 +77,7 @@ def command_evidence(
         tail_bytes=ERROR_DETAIL_SUMMARY_TAIL_BYTES,
         diagnostic_offset=diagnostic_offset,
     )
+    failed_test_ids, failed_test_ids_truncated = _pytest_failed_test_ids(normalized_stdout)
     metadata: dict[str, object] = {
         "excerpt_strategy": EXCERPT_STRATEGY,
         "stdout_bytes": len(normalized_stdout.encode("utf-8")),
@@ -84,7 +90,8 @@ def command_evidence(
             None if diagnostic_offset is None else len(output[:diagnostic_offset].encode("utf-8"))
         ),
         "exit_code": exit_code,
-        "failed_test_ids": _pytest_failed_test_ids(output),
+        "failed_test_ids": failed_test_ids,
+        "failed_test_ids_truncated": failed_test_ids_truncated,
         **excerpt_metadata,
     }
     return CommandEvidence(
@@ -110,12 +117,73 @@ def bounded_error_detail(value: str | None) -> str | None:
     return bounded
 
 
-def _pytest_failed_test_ids(output: str) -> list[str]:
-    """Return bounded, ordered pytest node IDs from a failed command transcript."""
-    return [
-        match.group("test_id")
-        for match in list(_PYTEST_FAILED_TEST_PATTERN.finditer(output))[:_MAX_FAILED_TEST_IDS]
-    ]
+def _pytest_failed_test_ids(output: str) -> tuple[list[str], bool]:
+    """Return bounded node IDs from the pytest release-gate JSON sentinel."""
+    marker_offset = _last_line_marker_offset(output, PYTEST_FAILED_NODE_IDS_MARKER)
+    if marker_offset is None:
+        return [], False
+    payload_start = marker_offset + len(PYTEST_FAILED_NODE_IDS_MARKER)
+    payload_end = output.find("\n", payload_start)
+    if payload_end < 0:
+        payload_end = len(output)
+    payload_text = output[payload_start:payload_end].removesuffix("\r")
+    try:
+        payload_bytes = payload_text.encode("utf-8")
+    except UnicodeEncodeError:
+        return [], True
+    if len(payload_bytes) > PYTEST_FAILED_NODE_IDS_PAYLOAD_MAX_BYTES:
+        return [], True
+    try:
+        payload_object: object = json.loads(payload_text)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return [], True
+    if not isinstance(payload_object, dict):
+        return [], True
+    payload = cast(dict[object, object], payload_object)
+    if set(payload) != {"node_ids", "truncated"}:
+        return [], True
+    raw_node_ids = payload["node_ids"]
+    declared_truncated = payload["truncated"]
+    if not isinstance(raw_node_ids, list) or type(declared_truncated) is not bool:
+        return [], True
+    node_id_objects = cast(list[object], raw_node_ids)
+
+    test_ids: list[str] = []
+    seen: set[str] = set()
+    aggregate_bytes = 0
+    truncated = declared_truncated
+    for test_id in node_id_objects:
+        if not isinstance(test_id, str):
+            return [], True
+        if test_id in seen:
+            continue
+        if len(test_ids) >= PYTEST_FAILED_NODE_IDS_MAX_COUNT:
+            truncated = True
+            break
+        try:
+            test_id_bytes = len(test_id.encode("utf-8"))
+        except UnicodeEncodeError:
+            truncated = True
+            continue
+        if test_id_bytes > PYTEST_FAILED_NODE_ID_MAX_BYTES:
+            truncated = True
+            continue
+        if aggregate_bytes + test_id_bytes > PYTEST_FAILED_NODE_IDS_MAX_BYTES:
+            truncated = True
+            continue
+        test_ids.append(test_id)
+        seen.add(test_id)
+        aggregate_bytes += test_id_bytes
+    return test_ids, truncated
+
+
+def _last_line_marker_offset(output: str, marker: str) -> int | None:
+    """Return the last marker that begins a transcript line."""
+    first_offset = 0 if output.startswith(marker) else None
+    later_offset = output.rfind(f"\n{marker}")
+    if later_offset >= 0:
+        return later_offset + 1
+    return first_offset
 
 
 def _first_diagnostic(output: str) -> tuple[str | None, int | None]:

--- a/src/clio_relay/core_queue.py
+++ b/src/clio_relay/core_queue.py
@@ -2748,14 +2748,6 @@ class ClioCoreQueue:
                     except FileNotFoundError:
                         missing = True
                         break
-                    except OSError as exc:
-                        if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
-                            raise LegacyQueueStateError(
-                                family=relative_path.parts[0],
-                                path=self._storage_root / relative_path,
-                                reason="canonical family is not an owned directory",
-                            ) from exc
-                        raise
                     try:
                         os.set_inheritable(child_descriptor, False)
                     except BaseException:

--- a/src/clio_relay/core_queue.py
+++ b/src/clio_relay/core_queue.py
@@ -2650,6 +2650,7 @@ class ClioCoreQueue:
                     self._write_legacy_record_audit_marker_unlocked()
                 else:
                     self._upgrade_sealed_lease_operational_schema_unlocked()
+                    self._reconcile_sealed_lease_capacity_gate_unlocked()
                     self._read_sealed_index_migration_state()
                 self._initialized = True
         except QueueSealRequiresExclusive:
@@ -2747,6 +2748,14 @@ class ClioCoreQueue:
                     except FileNotFoundError:
                         missing = True
                         break
+                    except OSError as exc:
+                        if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
+                            raise LegacyQueueStateError(
+                                family=relative_path.parts[0],
+                                path=self._storage_root / relative_path,
+                                reason="canonical family is not an owned directory",
+                            ) from exc
+                        raise
                     try:
                         os.set_inheritable(child_descriptor, False)
                     except BaseException:
@@ -2777,6 +2786,39 @@ class ClioCoreQueue:
             finally:
                 with suppress(OSError):
                     os.close(descriptor)
+
+    def _reconcile_sealed_lease_capacity_gate_unlocked(self) -> None:
+        """Downgrade a sealed migration gate when its fixed capacity pair is corrupt."""
+        state = self._read_index_migration_state()
+        raw_checkpoint = state.get("lease_capacity_aggregate")
+        if not isinstance(raw_checkpoint, dict):
+            return
+        checkpoint = cast(dict[str, object], raw_checkpoint)
+        if checkpoint.get("complete") is not True:
+            return
+        try:
+            current = self._read_lease_capacity_aggregate_unlocked()
+        except (OSError, QueueConflictError):
+            current = None
+        migrated_generation = checkpoint.get("generation")
+        valid = (
+            current is not None
+            and current.aggregate.epoch_id == checkpoint.get("epoch_id")
+            and isinstance(migrated_generation, int)
+            and not isinstance(migrated_generation, bool)
+            and current.aggregate.generation >= migrated_generation
+        )
+        if valid:
+            return
+        checkpoint.clear()
+        checkpoint.update(
+            {
+                "complete": False,
+                "schema_version": LEASE_CAPACITY_AGGREGATE_SCHEMA,
+            }
+        )
+        state["complete"] = False
+        self._write_index_migration_state(state)
 
     def reconcile_pending_transitions(self) -> None:
         """Replay bounded write-ahead transitions left by another process."""
@@ -4369,6 +4411,7 @@ class ClioCoreQueue:
         path = directory / f"{route_sha256}.json"
         with self._lock:
             existing = self._read_optional(path, JarvisPipelineInputLineage)
+            mutation_at = utc_now()
             if existing is None:
                 count, over_capacity = _bounded_regular_json_count(
                     directory,
@@ -4381,7 +4424,7 @@ class ClioCoreQueue:
                     )
                 merged_uses = artifact_uses
                 manifests = (manifest_sha256,)
-                created_at = None
+                created_at = mutation_at
             else:
                 if existing.route != route or existing.route_sha256 != route_sha256:
                     raise QueueConflictError(
@@ -4405,7 +4448,7 @@ class ClioCoreQueue:
                 artifact_uses=merged_uses,
                 manifest_sha256s=manifests,
                 created_at=created_at,
-                updated_at=utc_now(),
+                updated_at=mutation_at,
             )
             self._write(path, record)
             return record

--- a/src/clio_relay/core_queue.py
+++ b/src/clio_relay/core_queue.py
@@ -226,6 +226,18 @@ class _TransientRecordReplacement(RuntimeError):
     """Signal that an atomic replacement invalidated one bounded read attempt."""
 
 
+class _UnsafeQueueDirectoryProtection(ConfigurationError):
+    """Pinned repair found a linked canonical family before queue initialization."""
+
+    def __init__(self, *, family: str, path: Path, cause: OSError) -> None:
+        self.family = family
+        self.path = path
+        super().__init__(
+            "queue directory protections cannot be repaired through the pinned root: "
+            f"{path}: {cause}"
+        )
+
+
 class LegacyQueueStateError(QueueConflictError):
     """Machine-readable refusal for unsafe pre-1.0 canonical queue state."""
 
@@ -2447,11 +2459,7 @@ class ClioCoreQueue:
             )
             return
         if migrate_legacy_output and not self._migration_lifetime_guarded:
-            with exclusive_migration_lifetime(self.root) as locked_core:
-                self.initialize(
-                    migrate_legacy_output=True,
-                    locked_core=locked_core,
-                )
+            self._initialize_with_exclusive_lifetime(migrate_legacy_output=True)
             return
         if self._initialized:
             with self._lock:
@@ -2467,11 +2475,7 @@ class ClioCoreQueue:
                 raise QueueSealRequiresExclusive(
                     "missing legacy-record audit seal requires exclusive writer-lifetime ownership"
                 )
-            with exclusive_migration_lifetime(self.root) as locked_core:
-                self.initialize(
-                    migrate_legacy_output=migrate_legacy_output,
-                    locked_core=locked_core,
-                )
+            self._initialize_with_exclusive_lifetime(migrate_legacy_output=migrate_legacy_output)
             return
         # The root and lock path are the only pre-lock filesystem state. A
         # missing seal is audited exactly once after taking that lock and before
@@ -2656,11 +2660,22 @@ class ClioCoreQueue:
         except QueueSealRequiresExclusive:
             if not allow_exclusive_seal:
                 raise
+            self._initialize_with_exclusive_lifetime(migrate_legacy_output=migrate_legacy_output)
+
+    def _initialize_with_exclusive_lifetime(self, *, migrate_legacy_output: bool) -> None:
+        """Initialize under a pinned lifetime and preserve the public legacy-state contract."""
+        try:
             with exclusive_migration_lifetime(self.root) as locked_core:
                 self.initialize(
                     migrate_legacy_output=migrate_legacy_output,
                     locked_core=locked_core,
                 )
+        except _UnsafeQueueDirectoryProtection as exc:
+            raise LegacyQueueStateError(
+                family=exc.family,
+                path=exc.path,
+                reason="canonical family is not an owned directory",
+            ) from exc
 
     def _initialize_under_locked_core(
         self,
@@ -2771,6 +2786,12 @@ class ClioCoreQueue:
                 if stat.S_IMODE(details.st_mode) != 0o700:
                     os.fchmod(descriptor, 0o700)
             except OSError as exc:
+                if exc.errno in {errno.ELOOP, errno.ENOTDIR} and relative_path.parts:
+                    raise _UnsafeQueueDirectoryProtection(
+                        family=relative_path.parts[0],
+                        path=self.root / relative_path,
+                        cause=exc,
+                    ) from exc
                 raise ConfigurationError(
                     "queue directory protections cannot be repaired through the pinned root: "
                     f"{self._storage_root / relative_path}: {exc}"

--- a/src/clio_relay/endpoint.py
+++ b/src/clio_relay/endpoint.py
@@ -303,14 +303,20 @@ class EndpointWorker:
         self._worker_lifetime_lock: WorkerLifetimeLock | None = None
         self._owned_managed_queue: StorageManagedQueue | None = None
         if self.role == EndpointRole.WORKER:
-            lifetime_core = queue.root if queue is not None else settings.core_dir
-            self._worker_lifetime_lock = WorkerLifetimeLock(
-                lifetime_core,
-                mode="shared",
-            ).acquire()
-            if queue is not None:
-                initialize_queue_with_shared_writer_fencing(self._worker_lifetime_lock)
-            settings = settings.model_copy(update={"core_dir": self._worker_lifetime_lock.core_dir})
+            try:
+                lifetime_core = queue.root if queue is not None else settings.core_dir
+                self._worker_lifetime_lock = WorkerLifetimeLock(
+                    lifetime_core,
+                    mode="shared",
+                ).acquire()
+                if queue is not None:
+                    initialize_queue_with_shared_writer_fencing(self._worker_lifetime_lock)
+                settings = settings.model_copy(
+                    update={"core_dir": self._worker_lifetime_lock.core_dir}
+                )
+            except BaseException:
+                self.close()
+                raise
         self.settings = settings
         try:
             resolved_queue = (

--- a/src/clio_relay/endpoint.py
+++ b/src/clio_relay/endpoint.py
@@ -106,6 +106,7 @@ from clio_relay.storage_runtime import (
     StorageManagedQueue,
     StorageRuntime,
     StorageRuntimeViolation,
+    initialize_queue_with_shared_writer_fencing,
     storage_managed_queue,
 )
 from clio_relay.worker_concurrency import (
@@ -307,6 +308,8 @@ class EndpointWorker:
                 lifetime_core,
                 mode="shared",
             ).acquire()
+            if queue is not None:
+                initialize_queue_with_shared_writer_fencing(self._worker_lifetime_lock)
             settings = settings.model_copy(update={"core_dir": self._worker_lifetime_lock.core_dir})
         self.settings = settings
         try:

--- a/src/clio_relay/process_containment.py
+++ b/src/clio_relay/process_containment.py
@@ -1281,7 +1281,10 @@ def terminate_recorded_process_tree(
             )
             if not existing_pids and not Path(cgroup_path).exists():
                 return
-        scope = Path(cgroup_path).resolve(strict=True)
+        recorded_scope = Path(cgroup_path)
+        if observed_identity is None and not recorded_scope.exists():
+            return
+        scope = recorded_scope.resolve(strict=True)
         if not exact_persistent_identity:
             cgroup_root = Path("/sys/fs/cgroup").resolve()
             try:

--- a/src/clio_relay/process_containment.py
+++ b/src/clio_relay/process_containment.py
@@ -59,6 +59,7 @@ _BROKER_STARTUP_STAGE_CODES: dict[str, frozenset[str]] = {
     "stdin_forward": frozenset({"child_exited", "internal_error"}),
 }
 _BROKER_EXCEPTION_TYPE_PATTERN = re.compile(r"[A-Za-z][A-Za-z0-9_]{0,63}")
+_CGROUP_ROOT = Path("/sys/fs/cgroup")
 
 
 class _ResourceModule(Protocol):
@@ -1272,6 +1273,10 @@ def terminate_recorded_process_tree(
         )
         if (systemd_invocation_id is None) is not (systemd_description is None):
             raise RuntimeError("recorded systemd execution has partial persistent identity")
+        recorded_scope = _validated_recorded_systemd_scope_path(
+            cgroup_path,
+            unit=systemd_unit,
+        )
         if exact_persistent_identity:
             existing_pids = recorded_linux_systemd_scope_process_ids(
                 unit=systemd_unit,
@@ -1279,18 +1284,11 @@ def terminate_recorded_process_tree(
                 invocation_id=cast(str, systemd_invocation_id),
                 description=cast(str, systemd_description),
             )
-            if not existing_pids and not Path(cgroup_path).exists():
+            if not existing_pids and not recorded_scope.exists():
                 return
-        recorded_scope = Path(cgroup_path)
         if observed_identity is None and not recorded_scope.exists():
             return
         scope = recorded_scope.resolve(strict=True)
-        if not exact_persistent_identity:
-            cgroup_root = Path("/sys/fs/cgroup").resolve()
-            try:
-                scope.relative_to(cgroup_root)
-            except ValueError as exc:
-                raise RuntimeError(f"recorded cgroup is outside cgroup v2: {scope}") from exc
         _terminate_linux_systemd_scope(systemd_unit, scope)
         residual = (
             recorded_linux_systemd_scope_process_ids(
@@ -1334,6 +1332,28 @@ def terminate_recorded_process_tree(
         )
     if residual:
         raise RuntimeError(f"recorded process tree survived cleanup: {residual}")
+
+
+def _validated_recorded_systemd_scope_path(cgroup_path: str, *, unit: str) -> Path:
+    """Validate a recorded cgroup path even after systemd removed the leaf scope."""
+    if "\x00" in cgroup_path or any(
+        part in {".", ".."} for part in re.split(r"[\\/]", cgroup_path)
+    ):
+        raise RuntimeError("recorded systemd execution has invalid cgroup path")
+    recorded = Path(cgroup_path)
+    if not recorded.is_absolute() or recorded.name != unit:
+        raise RuntimeError("recorded systemd execution has invalid cgroup path")
+    try:
+        root = _CGROUP_ROOT.resolve(strict=True)
+        if not root.is_dir():
+            raise RuntimeError("configured cgroup v2 root is not a directory")
+        candidate = recorded.resolve(strict=False)
+        candidate.relative_to(root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RuntimeError("recorded cgroup is outside cgroup v2") from exc
+    if candidate == root or candidate.name != unit:
+        raise RuntimeError("recorded systemd execution has invalid cgroup path")
+    return candidate
 
 
 def _register_owned_process(process_id: int, state: _OwnedProcessState) -> None:
@@ -2190,6 +2210,7 @@ def recorded_linux_systemd_scope_process_ids(
         or len(description.encode("utf-8")) > 512
     ):
         raise RuntimeError("recorded persistent systemd scope identity is invalid")
+    recorded_path = _validated_recorded_systemd_scope_path(cgroup_path, unit=unit)
     result = _systemctl_user(
         [
             "show",
@@ -2208,7 +2229,6 @@ def recorded_linux_systemd_scope_process_ids(
         )
     except RuntimeError:
         properties = {}
-    recorded_path = Path(cgroup_path)
     if result.returncode != 0 or properties.get("LoadState") == "not-found":
         if recorded_path.exists():
             raise RuntimeError("recorded systemd unit vanished while its cgroup remained")

--- a/src/clio_relay/pytest_release_gate.py
+++ b/src/clio_relay/pytest_release_gate.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import json
+from dataclasses import dataclass, field
 from typing import Final
 
 import pytest
@@ -10,6 +11,14 @@ from _pytest.main import Session
 from _pytest.nodes import Item
 from _pytest.reports import CollectReport, TestReport
 from _pytest.terminal import TerminalReporter
+
+from clio_relay.command_evidence import (
+    PYTEST_FAILED_NODE_ID_MAX_BYTES,
+    PYTEST_FAILED_NODE_IDS_MARKER,
+    PYTEST_FAILED_NODE_IDS_MAX_BYTES,
+    PYTEST_FAILED_NODE_IDS_MAX_COUNT,
+    PYTEST_FAILED_NODE_IDS_PAYLOAD_MAX_BYTES,
+)
 
 
 @dataclass
@@ -34,7 +43,45 @@ class _OutcomeCounts:
         )
 
 
+@dataclass
+class _FailedNodeIds:
+    node_ids: list[str] = field(default_factory=list[str])
+    seen: set[str] = field(default_factory=set[str])
+    aggregate_bytes: int = 0
+    truncated: bool = False
+
+    def reset(self) -> None:
+        """Clear all failure identifiers before a new pytest session."""
+        self.node_ids.clear()
+        self.seen.clear()
+        self.aggregate_bytes = 0
+        self.truncated = False
+
+    def add(self, node_id: str) -> None:
+        """Record one unique node ID without exceeding durable-report bounds."""
+        if node_id in self.seen:
+            return
+        if len(self.node_ids) >= PYTEST_FAILED_NODE_IDS_MAX_COUNT:
+            self.truncated = True
+            return
+        try:
+            node_id_bytes = len(node_id.encode("utf-8"))
+        except UnicodeEncodeError:
+            self.truncated = True
+            return
+        if node_id_bytes > PYTEST_FAILED_NODE_ID_MAX_BYTES:
+            self.truncated = True
+            return
+        if self.aggregate_bytes + node_id_bytes > PYTEST_FAILED_NODE_IDS_MAX_BYTES:
+            self.truncated = True
+            return
+        self.node_ids.append(node_id)
+        self.seen.add(node_id)
+        self.aggregate_bytes += node_id_bytes
+
+
 _COUNTS: Final[_OutcomeCounts] = _OutcomeCounts()
+_FAILED_NODE_IDS: Final[_FailedNodeIds] = _FailedNodeIds()
 
 
 def pytest_sessionstart(session: Session) -> None:
@@ -44,6 +91,7 @@ def pytest_sessionstart(session: Session) -> None:
     _COUNTS.xfailed = 0
     _COUNTS.xpassed = 0
     _COUNTS.deselected = 0
+    _FAILED_NODE_IDS.reset()
 
 
 def pytest_deselected(items: list[Item]) -> None:
@@ -53,12 +101,16 @@ def pytest_deselected(items: list[Item]) -> None:
 
 def pytest_collectreport(report: CollectReport) -> None:
     """Record collection-time skips such as module-level skip directives."""
+    if report.failed:
+        _FAILED_NODE_IDS.add(report.nodeid)
     if report.skipped:
         _COUNTS.skipped += 1
 
 
 def pytest_runtest_logreport(report: TestReport) -> None:
     """Classify each non-executed or expected-failure test outcome."""
+    if report.failed:
+        _FAILED_NODE_IDS.add(report.nodeid)
     was_xfail = bool(getattr(report, "wasxfail", False))
     if report.skipped:
         if was_xfail:
@@ -89,3 +141,32 @@ def pytest_terminal_summary(
             red=True,
             bold=True,
         )
+    terminalreporter.write_line(
+        f"{PYTEST_FAILED_NODE_IDS_MARKER}{_failed_node_ids_payload(_FAILED_NODE_IDS)}",
+    )
+
+
+def _failed_node_ids_payload(failed_node_ids: _FailedNodeIds) -> str:
+    """Serialize bounded failure IDs for exact command-report ingestion."""
+    bounded = _FailedNodeIds(truncated=failed_node_ids.truncated)
+    for node_id in failed_node_ids.node_ids:
+        bounded.add(node_id)
+    node_ids = list(bounded.node_ids)
+    truncated = bounded.truncated
+    while True:
+        payload = json.dumps(
+            {"node_ids": node_ids, "truncated": truncated},
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        try:
+            payload_size = len(payload.encode("utf-8"))
+        except UnicodeEncodeError:
+            payload_size = PYTEST_FAILED_NODE_IDS_PAYLOAD_MAX_BYTES + 1
+        if payload_size <= PYTEST_FAILED_NODE_IDS_PAYLOAD_MAX_BYTES:
+            return payload
+        truncated = True
+        if not node_ids:
+            return '{"node_ids":[],"truncated":true}'
+        node_ids.pop()

--- a/src/clio_relay/release_validation.py
+++ b/src/clio_relay/release_validation.py
@@ -47,7 +47,7 @@ _SIDECAR_RECLAMATION_TESTS = (
     "tests/test_endpoint.py::test_windows_sidecar_cleanup_anchors_parent_and_rejects_reparse_points",
 )
 _RETENTION_STORAGE_PAGINATION_TESTS = (
-    "tests/test_core_global_pagination.py::test_global_order_upgrade_is_explicit_bounded_and_handles_more_than_500_jobs",
+    "tests/test_core_global_pagination.py::test_global_order_seal_field_removal_fails_closed",
     "tests/test_core_index_safety.py::test_stale_recovery_uses_exact_scheduler_indexes_without_global_task_scan",
     "tests/test_core_index_safety.py::test_gateway_reverse_indexes_refuse_cardinality_overflow",
     "tests/test_core_retention.py::test_terminal_gc_scales_past_501_owned_and_unrelated_records",

--- a/src/clio_relay/storage_runtime.py
+++ b/src/clio_relay/storage_runtime.py
@@ -945,7 +945,7 @@ def storage_managed_queue(
     if not lifetime_lock.acquired or lifetime_lock.mode != "shared":
         raise ValueError("production queue requires acquired shared writer lifetime ownership")
     try:
-        _initialize_queue_with_shared_writer_fencing(lifetime_lock)
+        initialize_queue_with_shared_writer_fencing(lifetime_lock)
         pinned_settings = settings.model_copy(update={"core_dir": lifetime_lock.core_dir})
         # Audit and initialize before StorageRuntime or StoragePolicy can create
         # `.storage`. A normal startup that encounters legacy output remains a
@@ -967,7 +967,7 @@ def storage_managed_queue(
     return queue
 
 
-def _initialize_queue_with_shared_writer_fencing(lifetime_lock: WorkerLifetimeLock) -> None:
+def initialize_queue_with_shared_writer_fencing(lifetime_lock: WorkerLifetimeLock) -> None:
     """Create a missing queue seal under exclusive ownership, then restore shared ownership."""
     core_dir = lifetime_lock.core_dir
     try:

--- a/tests/test_bootstrap_fast_path.py
+++ b/tests/test_bootstrap_fast_path.py
@@ -1172,9 +1172,11 @@ with tempfile.TemporaryDirectory() as value:
         "storage:\n  nvme:\n    capacity: 100\n", encoding="utf-8"
     )
     managed_repo = home / ".local/share/clio-relay/clio_relay"
+    managed_builtin_repo = jarvis_root / "builtin"
     first_repository = reconcile_managed_jarvis_repository(
         repos_file,
         managed_repo,
+        managed_builtin_repo=managed_builtin_repo,
         previous_managed_repos=(previous_repo,),
         exchange_identity=desired.fingerprint,
     )
@@ -1243,6 +1245,7 @@ with tempfile.TemporaryDirectory() as value:
     second_repository = reconcile_managed_jarvis_repository(
         repos_file,
         managed_repo,
+        managed_builtin_repo=managed_builtin_repo,
         previous_managed_repos=(previous_repo,),
         exchange_identity=desired.fingerprint,
     )
@@ -1266,11 +1269,15 @@ with tempfile.TemporaryDirectory() as value:
     canonical_managed = str(
         canonical_home / ".local/share/clio-relay/clio_relay"
     )
+    canonical_builtin = str(canonical_home / ".ppi-jarvis/builtin")
     if yaml.safe_load(repos_file.read_text(encoding="utf-8"))["repos"] != [
         canonical_managed,
         "/operator/clio_relay",
+        canonical_builtin,
     ]:
-        raise SystemExit("repository registration did not retain one canonical stable path")
+        raise SystemExit(
+            "repository registration did not retain canonical managed paths"
+        )
 print("aliased-activation-noop-ok")
 """
     result = _run_posix_project_driver(driver, timeout_seconds=180)

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1699,7 +1699,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "fdea05c380e1d033acced2ce1b0caa7f5e4000e389adb4ef420ac1e5f4830b2d"
+        "3a2f4907e410e0b97389ce1e2375fc5ab5a76439de72ba9a1b9228d4bc3b9309"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1699,7 +1699,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "3a2f4907e410e0b97389ce1e2375fc5ab5a76439de72ba9a1b9228d4bc3b9309"
+        "584250bd61425ec05a7cf661157b7ea1a899d4f77aa72960d711f34137806116"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,6 +67,7 @@ from clio_relay.models import (
     SchedulerPhase,
     SchedulerStatus,
 )
+from clio_relay.remote_mcp import MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS
 from clio_relay.runtime_metadata import RUNTIME_METADATA_SCHEMA
 from clio_relay.scheduler_providers import SchedulerProvider
 from clio_relay.service_runtime import (
@@ -6831,7 +6832,16 @@ def test_cli_session_scheduler_cancellation_is_owned_and_canonical(
                     ownership_verified=True,
                     outcome="stopped",
                     verified_after_operation=True,
-                )
+                ),
+                CleanupResource(
+                    kind="remote_session_files",
+                    resource_id="session-1:generation-1",
+                    location="ares",
+                    action="close",
+                    ownership_verified=True,
+                    outcome="closed",
+                    verified_after_operation=True,
+                ),
             ],
         )
 
@@ -6872,7 +6882,7 @@ def test_cli_session_scheduler_cancellation_is_owned_and_canonical(
         ],
     )
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, (result.output, result.exception)
     assert canceled_scheduler_ids == ["validation-123"]
     refreshed = ClioCoreQueue(core_dir)
     assert refreshed.get_job(owned.job_id).state is JobState.CANCELED
@@ -9434,12 +9444,12 @@ def test_cli_pinned_jarvis_control_query_rejects_oversized_timeout(
             "--operation",
             "tools/list",
             "--timeout-seconds",
-            "61",
+            str(MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS + 1),
         ],
     )
 
     assert result.exit_code == 2
-    assert "timeout exceeds 60 seconds" in result.output
+    assert f"timeout exceeds {MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS} seconds" in result.output
 
 
 def test_cli_jarvis_mcp_call_uses_builtin_cluster_command(
@@ -9844,7 +9854,7 @@ def test_target_side_jarvis_discovery_uses_receipt_without_cluster_registry(
     assert job.spec.operation.value == "tools/list"
     assert job.spec.tool is None
     assert job.spec.admission_class is McpAdmissionClass.CONTROL_QUERY
-    assert job.spec.timeout_seconds == 60
+    assert job.spec.timeout_seconds == MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS
     assert job.spec.expected_jarvis_cd_lock_binding == jarvis_cd_lock_binding_expectation()
 
 

--- a/tests/test_clio_kit_mcp_contracts.py
+++ b/tests/test_clio_kit_mcp_contracts.py
@@ -239,6 +239,7 @@ ACTIVE_CONTRACT_IDS = frozenset(EXPECTED_CONTRACTS) - {
     "clio-kit-jarvis-user-v3.2",
     "clio-kit-jarvis-user-v3.3",
     "clio-kit-jarvis-user-v3.4",
+    "clio-kit-jarvis-user-v3.5",
     "clio-kit-scientific-catalog-user-v1",
     "clio-kit-spack-user-v2",
 }

--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -216,6 +216,10 @@ def test_windows_atomic_create_captures_error_before_freeing_descriptor(
         assert path.name == "private.tmp"
         return "S-1-5-21-current"
 
+    def identity_internal_path(path: Path, *, force_extended: bool) -> Path:
+        del force_extended
+        return path
+
     monkeypatch.setattr(cluster_config.os, "name", "nt")
     monkeypatch.setattr(cluster_config, "_load_windows_library", load_library)
     monkeypatch.setattr(
@@ -224,6 +228,11 @@ def test_windows_atomic_create_captures_error_before_freeing_descriptor(
         build_descriptor,
     )
     monkeypatch.setattr(cluster_config, "_current_windows_user_sid", current_user_sid)
+    monkeypatch.setattr(
+        cluster_config,
+        "internal_filesystem_path",
+        identity_internal_path,
+    )
     monkeypatch.setattr(cluster_config, "_windows_last_error", last_error)
     monkeypatch.setattr(cluster_config, "_free_windows_local", free_descriptor)
     monkeypatch.setattr(cluster_config, "_windows_error", windows_error)
@@ -322,6 +331,7 @@ def test_windows_configuration_open_only_requests_owner_change_when_needed(
     monkeypatch: MonkeyPatch,
 ) -> None:
     requested_access: list[int] = []
+    requested_share_modes: list[int] = []
 
     class RecordingCreateFile:
         argtypes: list[object]
@@ -331,9 +341,11 @@ def test_windows_configuration_open_only_requests_owner_change_when_needed(
             self,
             _path: str,
             desired_access: int,
+            share_mode: int,
             *_args: object,
         ) -> int:
             requested_access.append(desired_access)
+            requested_share_modes.append(share_mode)
             return 100 + len(requested_access)
 
     kernel32 = SimpleNamespace(CreateFileW=RecordingCreateFile())
@@ -368,6 +380,14 @@ def test_windows_configuration_open_only_requests_owner_change_when_needed(
     assert requested_access[0] & cluster_config._WINDOWS_WRITE_DAC  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
     assert not requested_access[0] & cluster_config._WINDOWS_WRITE_OWNER  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
     assert requested_access[1] & cluster_config._WINDOWS_WRITE_OWNER  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    assert (
+        requested_share_modes
+        == [
+            cluster_config._WINDOWS_FILE_SHARE_READ  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            | cluster_config._WINDOWS_FILE_SHARE_WRITE,  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        ]
+        * 2
+    )
 
 
 def test_configuration_read_rejects_foreign_or_group_writable_posix_file(

--- a/tests/test_command_evidence.py
+++ b/tests/test_command_evidence.py
@@ -2,12 +2,29 @@
 
 from __future__ import annotations
 
+import json
+from typing import cast
+
 from clio_relay.command_evidence import (
     ERROR_DETAIL_MAX_BYTES,
     EVIDENCE_EXCERPT_MAX_BYTES,
+    PYTEST_FAILED_NODE_ID_MAX_BYTES,
+    PYTEST_FAILED_NODE_IDS_MARKER,
+    PYTEST_FAILED_NODE_IDS_MAX_BYTES,
+    PYTEST_FAILED_NODE_IDS_MAX_COUNT,
     bounded_error_detail,
     command_evidence,
 )
+
+
+def _pytest_failure_sentinel(node_ids: list[str], *, truncated: bool = False) -> str:
+    """Return one exact machine-readable pytest failure sentinel."""
+    payload = json.dumps(
+        {"node_ids": node_ids, "truncated": truncated},
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return f"{PYTEST_FAILED_NODE_IDS_MARKER}{payload}"
 
 
 def test_short_unicode_command_evidence_is_exact() -> None:
@@ -32,12 +49,17 @@ def test_empty_command_evidence_records_exit_code() -> None:
 
 def test_pytest_failure_ids_survive_transcript_truncation() -> None:
     """Every pytest failure node remains machine-readable when details are bounded."""
+    node_ids = [
+        "tests/test_queue.py::test_atomic",
+        "tests/test_queue.py::test_second[param - value]",
+    ]
     summary = "\n".join(
         [
             "==== short test summary info ====",
             "FAILED tests/test_queue.py::test_atomic - AssertionError",
-            "FAILED tests/test_queue.py::test_second[param value] - RuntimeError",
+            "FAILED tests/test_queue.py::test_second[param - value] - RuntimeError",
             "2 failed, 100 passed in 90.00s",
+            _pytest_failure_sentinel(node_ids),
         ]
     )
     output = "==== FAILURES ====\nfirst cause\n" + ("detail\n" * 50_000) + summary
@@ -45,10 +67,64 @@ def test_pytest_failure_ids_survive_transcript_truncation() -> None:
     evidence = command_evidence(output, None, exit_code=1)
 
     assert evidence.metadata["truncated"] is True
-    assert evidence.metadata["failed_test_ids"] == [
-        "tests/test_queue.py::test_atomic",
-        "tests/test_queue.py::test_second[param value]",
+    assert evidence.metadata["failed_test_ids"] == node_ids
+    assert evidence.metadata["failed_test_ids_truncated"] is False
+
+
+def test_pytest_failure_id_metadata_has_count_and_byte_bounds() -> None:
+    """Hostile pytest summaries cannot make validation metadata unbounded."""
+    oversized = "tests/test_queue.py::test_" + ("x" * PYTEST_FAILED_NODE_ID_MAX_BYTES)
+    ordinary = [
+        f"tests/test_queue.py::test_case_{index:04d}" + ("x" * 80)
+        for index in range(PYTEST_FAILED_NODE_IDS_MAX_COUNT + 5)
     ]
+    output = _pytest_failure_sentinel([oversized, *ordinary])
+
+    evidence = command_evidence(output, None, exit_code=1)
+
+    failed_test_ids_value = evidence.metadata["failed_test_ids"]
+    assert isinstance(failed_test_ids_value, list)
+    failed_test_id_objects = cast(list[object], failed_test_ids_value)
+    assert all(isinstance(node_id, str) for node_id in failed_test_id_objects)
+    failed_test_ids = cast(list[str], failed_test_id_objects)
+    assert oversized not in failed_test_ids
+    assert len(failed_test_ids) <= PYTEST_FAILED_NODE_IDS_MAX_COUNT
+    assert sum(len(node_id.encode("utf-8")) for node_id in failed_test_ids) <= (
+        PYTEST_FAILED_NODE_IDS_MAX_BYTES
+    )
+    assert evidence.metadata["failed_test_ids_truncated"] is True
+
+
+def test_human_pytest_summary_is_not_treated_as_structured_node_ids() -> None:
+    """Ambiguous human summaries cannot forge or truncate parametrized IDs."""
+    output = "FAILED tests/test_queue.py::test_case[a - b] - AssertionError\n1 failed in 0.01s"
+
+    evidence = command_evidence(output, None, exit_code=1)
+
+    assert evidence.metadata["failed_test_ids"] == []
+    assert evidence.metadata["failed_test_ids_truncated"] is False
+
+
+def test_malformed_pytest_failure_sentinel_fails_closed() -> None:
+    """An invalid machine sentinel cannot be mistaken for complete evidence."""
+    output = f'{PYTEST_FAILED_NODE_IDS_MARKER}{{"node_ids":"not-a-list","truncated":false}}'
+
+    evidence = command_evidence(output, None, exit_code=1)
+
+    assert evidence.metadata["failed_test_ids"] == []
+    assert evidence.metadata["failed_test_ids_truncated"] is True
+
+
+def test_stderr_cannot_override_authoritative_pytest_failure_ids() -> None:
+    """Only the pytest terminal reporter's stdout channel can publish node IDs."""
+    expected = ["tests/test_queue.py::test_authoritative[a - b]"]
+    stdout = _pytest_failure_sentinel(expected)
+    stderr = _pytest_failure_sentinel([])
+
+    evidence = command_evidence(stdout, stderr, exit_code=1)
+
+    assert evidence.metadata["failed_test_ids"] == expected
+    assert evidence.metadata["failed_test_ids_truncated"] is False
 
 
 def test_large_pytest_output_keeps_first_failure_and_summary() -> None:

--- a/tests/test_command_evidence.py
+++ b/tests/test_command_evidence.py
@@ -30,6 +30,27 @@ def test_empty_command_evidence_records_exit_code() -> None:
     assert evidence.metadata["output_bytes"] == 0
 
 
+def test_pytest_failure_ids_survive_transcript_truncation() -> None:
+    """Every pytest failure node remains machine-readable when details are bounded."""
+    summary = "\n".join(
+        [
+            "==== short test summary info ====",
+            "FAILED tests/test_queue.py::test_atomic - AssertionError",
+            "FAILED tests/test_queue.py::test_second[param value] - RuntimeError",
+            "2 failed, 100 passed in 90.00s",
+        ]
+    )
+    output = "==== FAILURES ====\nfirst cause\n" + ("detail\n" * 50_000) + summary
+
+    evidence = command_evidence(output, None, exit_code=1)
+
+    assert evidence.metadata["truncated"] is True
+    assert evidence.metadata["failed_test_ids"] == [
+        "tests/test_queue.py::test_atomic",
+        "tests/test_queue.py::test_second[param value]",
+    ]
+
+
 def test_large_pytest_output_keeps_first_failure_and_summary() -> None:
     """Collection noise is discarded before the first causal pytest failure."""
     prelude = "collecting tests 🧪\n" * 2_000

--- a/tests/test_control_query_admission.py
+++ b/tests/test_control_query_admission.py
@@ -489,6 +489,41 @@ class _BlockingLaneProvider(JarvisCdProvider):
         self.query_started = Event()
         self.release_source = Event()
 
+    def run_command_streaming(
+        self,
+        command: list[str],
+        *,
+        process_label: str = "contained command",
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        credential_payload: str | None = None,
+        on_stdout: Callable[[str], None] | None = None,
+        on_stderr: Callable[[str], None] | None = None,
+        on_start: Callable[[int], None] | None = None,
+        should_cancel: Callable[[], bool] | None = None,
+        on_poll: Callable[[], None] | None = None,
+        timeout_seconds: int | None = None,
+        on_timeout: Callable[[], None] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        """Complete one endpoint-owned MCP query without invoking a real server."""
+        del (
+            process_label,
+            cwd,
+            env,
+            credential_payload,
+            on_stdout,
+            on_stderr,
+            should_cancel,
+            timeout_seconds,
+            on_timeout,
+        )
+        if on_start is not None:
+            on_start(1002)
+        self.query_started.set()
+        if on_poll is not None:
+            on_poll()
+        return subprocess.CompletedProcess(command, 0, "", "")
+
     def run_pipeline_streaming(
         self,
         pipeline_path: Path,

--- a/tests/test_core_global_pagination.py
+++ b/tests/test_core_global_pagination.py
@@ -127,17 +127,11 @@ def test_global_pages_are_stable_bounded_and_filter_one_source_window(
         queue.list_gateway_sessions_page(cursor=0)
 
 
-def test_global_order_upgrade_is_explicit_bounded_and_handles_more_than_500_jobs(
+def test_global_order_seal_field_removal_fails_closed(
     tmp_path: Path,
 ) -> None:
     queue = ClioCoreQueue(tmp_path)
     queue.initialize()
-    legacy_jobs = [_job(f"legacy-page-{index:04d}") for index in range(501)]
-    for job in legacy_jobs:
-        (tmp_path / "jobs" / f"{job.job_id}.json").write_text(
-            job.model_dump_json(),
-            encoding="utf-8",
-        )
 
     migration_path = tmp_path / "migrations" / "index-v1.json"
     migration = json.loads(migration_path.read_text(encoding="utf-8"))
@@ -145,48 +139,11 @@ def test_global_order_upgrade_is_explicit_bounded_and_handles_more_than_500_jobs
     migration["complete"] = True
     migration_path.write_text(json.dumps(migration), encoding="utf-8")
 
-    queue.initialize()
-    status = queue.index_migration_status()
-    assert status["complete"] is False
-    with pytest.raises(QueueConflictError, match="queue migrate-indexes"):
-        queue.list_jobs_page()
-    with pytest.raises(QueueConflictError, match="queue migrate-indexes"):
-        queue.submit_job(_job("write-during-migration"))
-    with pytest.raises(QueueConflictError, match="queue migrate-indexes"):
-        queue.register_endpoint(
-            EndpointRegistration(
-                role=EndpointRole.WORKER,
-                cluster="cluster-a",
-                hostname="worker-during-migration",
-                pid=10,
-            )
-        )
-    with pytest.raises(QueueConflictError, match="queue migrate-indexes"):
-        queue.create_gateway_session(GatewaySession(cluster="cluster-a", name="during-migration"))
-    with pytest.raises(QueueConflictError, match="queue migrate-indexes"):
-        queue.append_monitor_rule(
-            MonitorRule(job_id=legacy_jobs[0].job_id, pattern="during-migration")
-        )
-
-    calls = 0
-    while status["complete"] is not True:
-        status = queue.migrate_indexes_batch(batch_size=100)
-        calls += 1
-        assert calls < 20
-    assert calls >= 6
-
-    ordered_ids = sorted(job.job_id for job in legacy_jobs)
-    first_page, next_cursor, total = queue.list_jobs_page(limit=500)
-    assert [job.job_id for job in first_page] == ordered_ids[:500]
-    assert next_cursor == 501
-    assert total == 501
-    final_page, end_cursor, final_total = queue.list_jobs_page(
-        cursor=next_cursor or 1,
-        limit=500,
-    )
-    assert [job.job_id for job in final_page] == ordered_ids[500:]
-    assert end_cursor is None
-    assert final_total == 501
+    with pytest.raises(
+        QueueConflictError,
+        match="sealed index migration state is invalid",
+    ):
+        queue.initialize()
 
 
 def test_global_order_reverse_mapping_tamper_fails_closed(tmp_path: Path) -> None:

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -50,6 +50,7 @@ from clio_relay.models import (
 )
 from clio_relay.relay_ops import job_wait_result
 from clio_relay.remote_mcp import (
+    MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS,
     cache_entry_from_discovery_artifact,
     remote_mcp_registration_revision,
     remote_mcp_server_artifact_digest,
@@ -467,7 +468,16 @@ def test_http_mcp_admission_is_server_owned_and_raw_bypass_is_closed(
     tmp_path: Path,
 ) -> None:
     """Reject caller lane claims and keep arbitrary tools/list on workload capacity."""
-    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        spool_max_log_bytes_per_stream=50,
+        spool_max_log_bytes_per_job=100,
+        storage_minimum_free_bytes=0,
+        storage_max_job_reservation_bytes=1_000,
+        storage_job_core_allowance_bytes=20,
+        storage_job_result_allowance_bytes=30,
+    )
     client = cast(Any, TestClient(create_app(settings)))
     raw_mcp = RelayJob(
         cluster="test-cluster",
@@ -520,7 +530,9 @@ def test_http_mcp_admission_is_server_owned_and_raw_bypass_is_closed(
     )
 
     assert raw_response.status_code == 422
-    assert "must use /jobs/mcp-call" in raw_response.json()["detail"]
+    assert raw_response.json()["detail"] == (
+        "this job kind must use its dedicated authenticated internal route"
+    )
     assert metadata_response.status_code == 422
     assert "server-managed" in metadata_response.json()["detail"]
     assert generic_enum.status_code == 422
@@ -1515,6 +1527,12 @@ def test_owned_jarvis_mcp_submission_forwards_desktop_binding_without_remote_cac
         owner_session_generation_id="generation-1",
         remote_cluster="test-cluster",
         session_owner_token="o" * 32,
+        spool_max_log_bytes_per_stream=50,
+        spool_max_log_bytes_per_job=100,
+        storage_minimum_free_bytes=0,
+        storage_max_job_reservation_bytes=1_000,
+        storage_job_core_allowance_bytes=20,
+        storage_job_result_allowance_bytes=30,
     )
     queue = ClioCoreQueue(settings.core_dir)
     queue.prepare_owner_session_start(
@@ -1570,7 +1588,7 @@ def test_owned_jarvis_mcp_submission_forwards_desktop_binding_without_remote_cac
         json={
             **payload,
             "expected_server_artifact_digest": expected_digest,
-            "timeout_seconds": 61,
+            "timeout_seconds": MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS + 1,
             "idempotency_key": "owned-artifact-source-oversized",
         },
     )
@@ -1578,12 +1596,14 @@ def test_owned_jarvis_mcp_submission_forwards_desktop_binding_without_remote_cac
     assert omitted.status_code == 422
     assert accepted.status_code == 200
     assert oversized.status_code == 422
-    assert "timeout exceeds 60 seconds" in str(oversized.json())
+    assert f"timeout exceeds {MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS} seconds" in str(
+        oversized.json()
+    )
     job = queue.get_job(accepted.json()["job_id"])
     assert isinstance(job.spec, McpCallSpec)
     assert job.spec.expected_server_artifact_digest == expected_digest
     assert job.spec.expected_jarvis_cd_lock_binding == jarvis_cd_lock_binding_expectation()
-    assert job.spec.timeout_seconds == 60
+    assert job.spec.timeout_seconds == MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS
     metadata = dict(job.metadata)
     authority = McpAdmissionAuthority.model_validate(
         metadata.pop(MCP_ADMISSION_AUTHORITY_METADATA_KEY)

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -607,7 +607,7 @@ def test_runtime_canonical_scan_rejects_reparse_directory(tmp_path: Path) -> Non
     jobs.replace(backup)
     _make_directory_link(outside, jobs)
     try:
-        with pytest.raises(QueueConflictError, match="not a safe directory"):
+        with pytest.raises(QueueConflictError, match="not an owned directory"):
             queue.list_jobs()
         assert marker.read_text(encoding="utf-8") == "operator-owned"
     finally:

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -584,6 +584,7 @@ def test_legacy_canonical_reparse_family_fails_before_writes(tmp_path: Path) -> 
         with pytest.raises(LegacyQueueStateError) as raised:
             ClioCoreQueue(root).initialize()
         assert raised.value.report["family"] == "jobs"
+        assert raised.value.report["path"] == str(jobs)
         assert "owned directory" in raised.value.report["reason"]
         assert marker.read_text(encoding="utf-8") == "operator-owned"
         assert not (root / "migrations").exists()

--- a/tests/test_input_staging.py
+++ b/tests/test_input_staging.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -416,3 +417,38 @@ def test_pipeline_input_lineage_is_checksum_bound_and_route_exact(tmp_path: Path
     record_path.write_text(json.dumps(document), encoding="utf-8")
     with pytest.raises(ValueError, match="checksum"):
         restarted.get_jarvis_pipeline_input_lineage(route)
+
+
+def test_pipeline_input_lineage_first_merge_uses_one_mutation_timestamp(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A first lineage write cannot observe creation after its update timestamp."""
+    mutation_at = datetime(2026, 7, 22, 12, 0, tzinfo=UTC)
+    later_model_default = mutation_at + timedelta(microseconds=1)
+    monkeypatch.setattr("clio_relay.core_queue.utc_now", lambda: mutation_at)
+    monkeypatch.setattr("clio_relay.models.utc_now", lambda: later_model_default)
+    route = jarvis_pipeline_input_route(
+        cluster="ares",
+        server_name="jarvis-demo",
+        cluster_route_revision="a" * 64,
+        registration_revision="b" * 64,
+        expected_server_artifact_digest="c" * 64,
+        pipeline_id="science-run",
+        owner_session_id="desktop-session",
+        owner_session_generation_id="generation_0123456789abcdef0123456789abcdef",
+    )
+
+    saved = ClioCoreQueue(tmp_path / "core").merge_jarvis_pipeline_input_lineage(
+        route,
+        (
+            ArtifactUse(
+                artifact_id="artifact_0123456789abcdef0123456789abcdef",
+                sha256="d" * 64,
+            ),
+        ),
+        manifest_sha256="e" * 64,
+    )
+
+    assert saved.created_at == mutation_at
+    assert saved.updated_at == mutation_at

--- a/tests/test_jarvis_handle_first_admission.py
+++ b/tests/test_jarvis_handle_first_admission.py
@@ -264,7 +264,7 @@ def test_raw_http_submission_cannot_select_jarvis_handle_identity(
 
     assert response.status_code == 422
     assert response.json()["detail"] == (
-        "MCP jobs must use /jobs/mcp-call or /jobs/jarvis-mcp-call"
+        "this job kind must use its dedicated authenticated internal route"
     )
     assert queue.list_jobs() == []
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4573,7 +4573,7 @@ def test_mcp_virtual_jarvis_execution_query_routes_selectors_through_remote_job(
     assert isinstance(job.spec, McpCallSpec)
     assert job.spec.tool == "jarvis_get_execution"
     assert job.spec.admission_class is McpAdmissionClass.CONTROL_QUERY
-    assert job.spec.timeout_seconds == 60
+    assert job.spec.timeout_seconds == MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS
     assert job.spec.arguments == {
         "pipeline_id": "example",
         "execution_id": "jarvis_execution_1",
@@ -4635,7 +4635,7 @@ def test_jarvis_default_key_changes_after_artifact_bound_control_resolution(
     assert unbound_job.spec.timeout_seconds is None
     assert bound_job.spec.expected_server_artifact_digest == "a" * 64
     assert bound_job.spec.admission_class is McpAdmissionClass.CONTROL_QUERY
-    assert bound_job.spec.timeout_seconds == 60
+    assert bound_job.spec.timeout_seconds == MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS
 
 
 def test_mcp_virtual_jarvis_run_is_fresh_unless_idempotency_is_explicit(

--- a/tests/test_process_containment.py
+++ b/tests/test_process_containment.py
@@ -28,6 +28,25 @@ def _focused_cooperative_capability(**_kwargs: object) -> dict[str, object]:
     }
 
 
+def _missing_process_start_identity(_process_id: int) -> None:
+    return None
+
+
+def _create_directory_alias(alias: Path, target: Path) -> None:
+    """Create a directory alias without requiring Windows symlink privilege."""
+    if os.name == "nt":
+        result = subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(alias), str(target)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise AssertionError(result.stdout + result.stderr)
+        return
+    alias.symlink_to(target, target_is_directory=True)
+
+
 def test_embedded_containment_source_is_an_exact_isolated_runtime_mirror() -> None:
     root = Path(__file__).parents[1]
     source = root / "src" / "clio_relay" / "process_containment.py"
@@ -503,9 +522,16 @@ def test_deferred_credentials_are_built_after_persistent_scope_is_registered(
 
 
 def test_recorded_scope_rejects_invocation_reuse_before_reading_processes(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     process_reads: list[Path] = []
+    cgroup_root = tmp_path / "cgroup"
+    scope_parent = cgroup_root / "user.slice"
+    scope_parent.mkdir(parents=True)
+    unit = "clio-relay-session-generation.scope"
+    recorded_scope = scope_parent / unit
+    monkeypatch.setattr(process_containment, "_CGROUP_ROOT", cgroup_root)
 
     def systemctl_user(
         _arguments: list[str],
@@ -540,8 +566,8 @@ def test_recorded_scope_rejects_invocation_reuse_before_reading_processes(
 
     with pytest.raises(RuntimeError, match="drifted or was reused"):
         process_containment.recorded_linux_systemd_scope_process_ids(
-            unit="clio-relay-session-generation.scope",
-            cgroup_path="/sys/fs/cgroup/user.slice/test.scope",
+            unit=unit,
+            cgroup_path=str(recorded_scope),
             invocation_id="1" * 32,
             description="expected",
         )
@@ -556,6 +582,7 @@ def test_recorded_scope_returns_only_exact_cgroup_members(
     unit = "clio-relay-session-generation.scope"
     scope = tmp_path / unit
     scope.mkdir()
+    monkeypatch.setattr(process_containment, "_CGROUP_ROOT", tmp_path)
     invocation = "1" * 32
     description = "expected"
 
@@ -633,14 +660,105 @@ def test_recorded_transient_scope_absence_proves_cleanup(
     monkeypatch.setattr(process_containment, "_terminate_linux_systemd_scope", refuse_mutation)
     monkeypatch.setattr(process_containment, "_release_linux_systemd_scope", refuse_mutation)
 
+    cgroup_root = tmp_path / "cgroup"
+    scope_parent = cgroup_root / "user.slice"
+    scope_parent.mkdir(parents=True)
+    monkeypatch.setattr(process_containment, "_CGROUP_ROOT", cgroup_root)
+
     process_containment.terminate_recorded_process_tree(
         process_id=4312,
         expected_start_identity="linux-proc-start:expected",
         process_group_id=4312,
         containment_mode="linux_systemd_scope",
         systemd_unit="clio-relay-transient.scope",
-        cgroup_path=str(tmp_path / "already-removed.scope"),
+        cgroup_path=str(scope_parent / "clio-relay-transient.scope"),
     )
+
+
+def test_recorded_transient_scope_absence_rejects_untrusted_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An absent path outside cgroup v2 cannot masquerade as completed cleanup."""
+    cgroup_root = tmp_path / "cgroup"
+    cgroup_root.mkdir()
+    monkeypatch.setattr(process_containment, "_CGROUP_ROOT", cgroup_root)
+    monkeypatch.setattr(
+        process_containment,
+        "process_start_identity",
+        _missing_process_start_identity,
+    )
+
+    with pytest.raises(RuntimeError, match="outside cgroup v2"):
+        process_containment.terminate_recorded_process_tree(
+            process_id=4312,
+            expected_start_identity="linux-proc-start:expected",
+            process_group_id=4312,
+            containment_mode="linux_systemd_scope",
+            systemd_unit="clio-relay-transient.scope",
+            cgroup_path=str(tmp_path / "outside" / "clio-relay-transient.scope"),
+        )
+
+
+@pytest.mark.parametrize(
+    "recorded_suffix",
+    (
+        "user.slice/../clio-relay-transient.scope",
+        "user.slice/not-the-recorded-unit.scope",
+    ),
+)
+def test_recorded_transient_scope_absence_rejects_invalid_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    recorded_suffix: str,
+) -> None:
+    """Traversal and a mismatched unit leaf cannot prove completed cleanup."""
+    cgroup_root = tmp_path / "cgroup"
+    (cgroup_root / "user.slice").mkdir(parents=True)
+    monkeypatch.setattr(process_containment, "_CGROUP_ROOT", cgroup_root)
+    monkeypatch.setattr(
+        process_containment,
+        "process_start_identity",
+        _missing_process_start_identity,
+    )
+
+    with pytest.raises(RuntimeError, match="invalid cgroup path"):
+        process_containment.terminate_recorded_process_tree(
+            process_id=4312,
+            expected_start_identity="linux-proc-start:expected",
+            process_group_id=4312,
+            containment_mode="linux_systemd_scope",
+            systemd_unit="clio-relay-transient.scope",
+            cgroup_path=str(cgroup_root / recorded_suffix),
+        )
+
+
+def test_recorded_transient_scope_absence_rejects_symlink_escape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An existing ancestor alias cannot redirect an absent scope outside cgroup v2."""
+    cgroup_root = tmp_path / "cgroup"
+    cgroup_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    _create_directory_alias(cgroup_root / "user.slice", outside)
+    monkeypatch.setattr(process_containment, "_CGROUP_ROOT", cgroup_root)
+    monkeypatch.setattr(
+        process_containment,
+        "process_start_identity",
+        _missing_process_start_identity,
+    )
+
+    with pytest.raises(RuntimeError, match="outside cgroup v2"):
+        process_containment.terminate_recorded_process_tree(
+            process_id=4312,
+            expected_start_identity="linux-proc-start:expected",
+            process_group_id=4312,
+            containment_mode="linux_systemd_scope",
+            systemd_unit="clio-relay-transient.scope",
+            cgroup_path=str(cgroup_root / "user.slice" / "clio-relay-transient.scope"),
+        )
 
 
 def test_windows_recorded_cleanup_accepts_taskkill_failure_only_after_pid_absence(

--- a/tests/test_process_containment.py
+++ b/tests/test_process_containment.py
@@ -612,6 +612,37 @@ def test_recorded_scope_returns_only_exact_cgroup_members(
     ) == [4321, 4322]
 
 
+def test_recorded_transient_scope_absence_proves_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An exited broker and removed transient cgroup are already fully cleaned."""
+
+    def missing_start_identity(_process_id: int) -> None:
+        return None
+
+    monkeypatch.setattr(
+        process_containment,
+        "process_start_identity",
+        missing_start_identity,
+    )
+
+    def refuse_mutation(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("already-absent transient scope was mutated")
+
+    monkeypatch.setattr(process_containment, "_terminate_linux_systemd_scope", refuse_mutation)
+    monkeypatch.setattr(process_containment, "_release_linux_systemd_scope", refuse_mutation)
+
+    process_containment.terminate_recorded_process_tree(
+        process_id=4312,
+        expected_start_identity="linux-proc-start:expected",
+        process_group_id=4312,
+        containment_mode="linux_systemd_scope",
+        systemd_unit="clio-relay-transient.scope",
+        cgroup_path=str(tmp_path / "already-removed.scope"),
+    )
+
+
 def test_windows_recorded_cleanup_accepts_taskkill_failure_only_after_pid_absence(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -983,7 +1014,7 @@ def test_broker_readiness_timeout_kills_unacknowledged_child(
     pid_path = tmp_path / "unacknowledged.pid"
     shortened = cast(Any, process_containment)._BROKER_SCRIPT.replace(
         "HANDSHAKE_TIMEOUT_SECONDS = 5.0",
-        "HANDSHAKE_TIMEOUT_SECONDS = 0.2",
+        "HANDSHAKE_TIMEOUT_SECONDS = 1.0",
     )
     monkeypatch.setattr(process_containment, "_BROKER_SCRIPT", shortened)
     script = r"""
@@ -1002,7 +1033,10 @@ time.sleep(60)
 """
     started = time.monotonic()
 
-    with pytest.raises(RuntimeError, match="exited before child readiness"):
+    with pytest.raises(
+        process_containment.OwnedProcessSpawnError,
+        match="stage=credential_ack code=ack_timeout",
+    ) as captured:
         process_containment.spawn_owned_process(
             [sys.executable, "-I", "-S", "-c", script, str(pid_path)],
             credential_payload='{"schema_version":"test.v1"}',
@@ -1012,7 +1046,8 @@ time.sleep(60)
             stderr=subprocess.PIPE,
         )
 
-    assert time.monotonic() - started < 3
+    assert captured.value.cleanup_verified is True
+    assert time.monotonic() - started < 4
     child_pid = int(pid_path.read_text(encoding="ascii"))
     assert _wait_until_pid_exits(child_pid, timeout_seconds=3)
 

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.5.3"
+    assert version == "1.5.4"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_release_validation.py
+++ b/tests/test_release_validation.py
@@ -3,14 +3,24 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import cast
 
 import pytest
 
+from clio_relay import pytest_release_gate as pytest_release_gate_module
 from clio_relay import release_validation as release_validation_module
+from clio_relay.command_evidence import (
+    PYTEST_FAILED_NODE_ID_MAX_BYTES,
+    PYTEST_FAILED_NODE_IDS_MAX_BYTES,
+    PYTEST_FAILED_NODE_IDS_MAX_COUNT,
+    PYTEST_FAILED_NODE_IDS_PAYLOAD_MAX_BYTES,
+    command_evidence,
+)
 from clio_relay.errors import ConfigurationError, RelayError
 from clio_relay.filesystem_paths import internal_filesystem_path
 from clio_relay.release_validation import (
@@ -506,3 +516,122 @@ def test_pytest_release_gate_accepts_only_clean_passes(tmp_path: Path) -> None:
     )
 
     assert completed.returncode == int(pytest.ExitCode.OK), completed.stdout + completed.stderr
+    evidence = command_evidence(completed.stdout, completed.stderr, exit_code=completed.returncode)
+    assert evidence.metadata["failed_test_ids"] == []
+    assert evidence.metadata["failed_test_ids_truncated"] is False
+
+
+def test_pytest_release_gate_emits_exact_unique_parametrized_failure_id(
+    tmp_path: Path,
+) -> None:
+    """Call and teardown failures retain one exact node ID with delimiter text."""
+    (tmp_path / "test_outcome.py").write_text(
+        """
+import pytest
+
+
+@pytest.fixture
+def broken_cleanup():
+    yield
+    assert False, "teardown"
+
+
+@pytest.mark.parametrize("label", ["a - b"])
+def test_case(label, broken_cleanup):
+    del label, broken_cleanup
+    assert False, "call"
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-p",
+            "clio_relay.pytest_release_gate",
+            "-q",
+            "test_outcome.py",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    output = completed.stdout + completed.stderr
+    assert completed.returncode == int(pytest.ExitCode.TESTS_FAILED), output
+    evidence = command_evidence(
+        completed.stdout,
+        completed.stderr,
+        exit_code=completed.returncode,
+    )
+    assert evidence.metadata["failed_test_ids"] == [
+        "test_outcome.py::test_case[a - b]",
+    ]
+    assert evidence.metadata["failed_test_ids_truncated"] is False
+
+
+def test_pytest_release_gate_emits_collection_failure_id(tmp_path: Path) -> None:
+    """Collection errors are represented by their exact collector node ID."""
+    (tmp_path / "test_broken.py").write_text(
+        'raise RuntimeError("collection failed")\n',
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-p",
+            "clio_relay.pytest_release_gate",
+            "-q",
+            "test_broken.py",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    output = completed.stdout + completed.stderr
+    assert completed.returncode == int(pytest.ExitCode.INTERRUPTED), output
+    evidence = command_evidence(
+        completed.stdout,
+        completed.stderr,
+        exit_code=completed.returncode,
+    )
+    assert evidence.metadata["failed_test_ids"] == ["test_broken.py"]
+    assert evidence.metadata["failed_test_ids_truncated"] is False
+
+
+def test_pytest_release_gate_bounds_failure_ids_before_serialization() -> None:
+    """The producer reapplies all durable bounds when emitting its JSON payload."""
+    failures = pytest_release_gate_module._FailedNodeIds()  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    oversized = "tests/test_queue.py::test_" + ("x" * PYTEST_FAILED_NODE_ID_MAX_BYTES)
+    failures.add(oversized)
+    for index in range(PYTEST_FAILED_NODE_IDS_MAX_COUNT + 5):
+        failures.add(f"tests/test_queue.py::test_{index:04d}" + ("x" * 80))
+    failures.add("tests/test_queue.py::test_0000" + ("x" * 80))
+
+    payload_text = pytest_release_gate_module._failed_node_ids_payload(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        failures,
+    )
+    payload_object: object = json.loads(payload_text)
+    assert isinstance(payload_object, dict)
+    payload = cast(dict[str, object], payload_object)
+    node_ids_object = payload["node_ids"]
+    assert isinstance(node_ids_object, list)
+    node_id_objects = cast(list[object], node_ids_object)
+    assert all(isinstance(node_id, str) for node_id in node_id_objects)
+    node_ids = cast(list[str], node_id_objects)
+
+    assert len(payload_text.encode("utf-8")) <= PYTEST_FAILED_NODE_IDS_PAYLOAD_MAX_BYTES
+    assert payload["truncated"] is True
+    assert oversized not in node_ids
+    assert len(node_ids) <= PYTEST_FAILED_NODE_IDS_MAX_COUNT
+    assert sum(len(node_id.encode("utf-8")) for node_id in node_ids) <= (
+        PYTEST_FAILED_NODE_IDS_MAX_BYTES
+    )

--- a/tests/test_release_validation.py
+++ b/tests/test_release_validation.py
@@ -265,7 +265,7 @@ def test_local_release_validation_runs_all_checks_and_records_artifacts(
         "tests/test_endpoint.py::test_windows_sidecar_cleanup_anchors_parent_and_rejects_reparse_points",
     ]
     assert pytest_commands[3][7:] == [
-        "tests/test_core_global_pagination.py::test_global_order_upgrade_is_explicit_bounded_and_handles_more_than_500_jobs",
+        "tests/test_core_global_pagination.py::test_global_order_seal_field_removal_fails_closed",
         "tests/test_core_index_safety.py::test_stale_recovery_uses_exact_scheduler_indexes_without_global_task_scan",
         "tests/test_core_index_safety.py::test_gateway_reverse_indexes_refuse_cardinality_overflow",
         "tests/test_core_retention.py::test_terminal_gc_scales_past_501_owned_and_unrelated_records",

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -248,6 +248,20 @@ def test_ci_matrix_pins_sync_probe_and_release_gate_to_each_declared_python() ->
     assert "--prebuilt-artifact-dir" not in primary
 
 
+def test_ci_uploads_failed_release_gate_reports_for_diagnosis() -> None:
+    """Keep bounded machine reports available when a long matrix gate fails."""
+    workflow = _workflow("ci.yml")
+    jobs = cast(dict[str, dict[str, Any]], workflow["jobs"])
+    for job_name, step_name in (
+        ("build", "upload primary matrix report"),
+        ("validate", "upload matrix report"),
+    ):
+        steps = cast(list[dict[str, Any]], jobs[job_name]["steps"])
+        upload = next(step for step in steps if step.get("name") == step_name)
+        assert upload["if"] == "always()"
+        assert cast(dict[str, str], upload["with"])["if-no-files-found"] == "warn"
+
+
 def test_merge_queue_builds_once_main_skips_gate_and_tags_run_regression() -> None:
     workflow = _workflow("ci.yml")
     triggers = cast(dict[str, Any], workflow["on"])

--- a/tests/test_remote_mcp.py
+++ b/tests/test_remote_mcp.py
@@ -2212,6 +2212,8 @@ def test_mcp_session_rejects_cluster_route_rebind_and_recovers_after_relist(
     writes: list[str] = []
     remote_commands: list[tuple[str, list[str]]] = []
     removals: list[str] = []
+    registry_writes: list[tuple[str, str, bytes]] = []
+    registry_removals: list[tuple[str, str, bool]] = []
 
     def write_remote(
         _definition: ClusterDefinition,
@@ -2220,7 +2222,29 @@ def test_mcp_session_rejects_cluster_route_rebind_and_recovers_after_relist(
     ) -> None:
         writes.append(path)
 
-    def run_remote(definition: ClusterDefinition, args: list[str]) -> str:
+    def write_registry(
+        definition: ClusterDefinition,
+        path: str,
+        data: bytes,
+    ) -> None:
+        registry_writes.append((definition.ssh_host, path, data))
+
+    def remove_registry(
+        definition: ClusterDefinition,
+        path: str,
+        *,
+        remove_empty_parent: bool = False,
+    ) -> None:
+        registry_removals.append((definition.ssh_host, path, remove_empty_parent))
+
+    def run_remote(
+        definition: ClusterDefinition,
+        args: list[str],
+        *,
+        cluster_registry_path: str | None = None,
+    ) -> str:
+        assert registry_writes
+        assert cluster_registry_path == f"$HOME/{registry_writes[-1][1]}"
         remote_commands.append((definition.ssh_host, args))
         return "job-rebound-route\n"
 
@@ -2236,6 +2260,8 @@ def test_mcp_session_rejects_cluster_route_rebind_and_recovers_after_relist(
     monkeypatch.setattr("clio_relay.mcp_server.write_remote_file", write_remote)
     monkeypatch.setattr("clio_relay.mcp_server.run_remote_clio", run_remote)
     monkeypatch.setattr("clio_relay.mcp_server.remove_remote_file", remove_remote)
+    monkeypatch.setattr("clio_relay.remote_cli.write_remote_file", write_registry)
+    monkeypatch.setattr("clio_relay.remote_cli.remove_remote_file", remove_registry)
     call = {
         "jsonrpc": "2.0",
         "id": 2,
@@ -2275,6 +2301,12 @@ def test_mcp_session_rejects_cluster_route_rebind_and_recovers_after_relist(
     assert remote_commands[0][0] == "alpha-new"
     assert len(writes) == 1
     assert removals == writes
+    assert len(registry_writes) == 1
+    registry_host, registry_path, registry_payload = registry_writes[0]
+    assert registry_host == "alpha-new"
+    staged_registry = ClusterRegistry.model_validate_json(registry_payload)
+    assert staged_registry.require("alpha").ssh_host == "alpha-new"
+    assert registry_removals == [("alpha-new", registry_path, True)]
 
 
 def test_mcp_dispatch_rejects_registration_revocation_during_final_route_read(
@@ -5864,7 +5896,6 @@ def test_remote_acceptance_consumes_safe_packaged_session_projection() -> None:
         server_info_sha256="4" * 64,
         tools_list_sha256="5" * 64,
         called_tool_schema_sha256="6" * 64,
-        jarvis_virtual_tools_sha256="7" * 64,
         called_tool_name=alias,
         containment_mode="windows_job_object",
         containment_enforceable=True,
@@ -5872,6 +5903,7 @@ def test_remote_acceptance_consumes_safe_packaged_session_projection() -> None:
     evidence = session.evidence()
     private = cast(Any, remote_mcp)
 
+    assert evidence["jarvis_virtual_tools_sha256"] is None
     assert private._stdio_initialize_passed(evidence)
     assert private._stdio_listed_tool_names(evidence) == {alias}
     assert private._stdio_call_job_id(evidence) == job_id

--- a/tests/test_service_runtime.py
+++ b/tests/test_service_runtime.py
@@ -6305,9 +6305,10 @@ def test_local_health_probe_rejects_non_2xx_and_wrong_runtime_identity(
     with pytest.raises(RelayError, match=error):
         supervisor._wait_for_local_health(  # pyright: ignore[reportPrivateUsage]
             "http://127.0.0.1:28777/healthz",
-            0.03,
-            1.0,
+            2.0,
+            0.01,
             expected_body="runtime-nonce",
+            max_attempts=1,
         )
 
 

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2499,7 +2499,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.5.3"
+    assert policy.release_version == "1.5.4"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/tests/test_worker_lifetime_lock.py
+++ b/tests/test_worker_lifetime_lock.py
@@ -711,9 +711,7 @@ def test_queue_seal_handoff_bounds_exclusive_wait_and_restores_shared(
     try:
         started = time.monotonic()
         with pytest.raises(WorkerLifetimeLockUnavailable, match="timed out acquiring"):
-            storage_runtime_module._initialize_queue_with_shared_writer_fencing(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
-                candidate
-            )
+            storage_runtime_module.initialize_queue_with_shared_writer_fencing(candidate)
         assert time.monotonic() - started < 1
         assert candidate.acquired is True
         assert not (core_dir / "migrations").exists()
@@ -759,9 +757,7 @@ def test_queue_seal_handoff_bounds_shared_reacquire(
             WorkerLifetimeLockUnavailable,
             match="restoring shared writer ownership",
         ):
-            storage_runtime_module._initialize_queue_with_shared_writer_fencing(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
-                candidate
-            )
+            storage_runtime_module.initialize_queue_with_shared_writer_fencing(candidate)
         assert time.monotonic() - started < 1
         assert candidate.acquired is False
         assert blockers and blockers[0].acquired

--- a/tests/test_worker_lifetime_lock.py
+++ b/tests/test_worker_lifetime_lock.py
@@ -299,6 +299,37 @@ def test_worker_lock_is_acquired_before_default_queue_construction(
     assert events == ["lock", "queue", "release"]
 
 
+def test_injected_queue_initialization_failure_releases_worker_lifetime_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed injected-queue seal handoff cannot retain shared writer ownership."""
+    core_dir = tmp_path / "core"
+    queue = ClioCoreQueue(core_dir)
+
+    def fail_initialization(lifetime_lock: WorkerLifetimeLock) -> None:
+        assert lifetime_lock.acquired is True
+        assert lifetime_lock.mode == "shared"
+        raise RuntimeError("injected queue initialization failed")
+
+    monkeypatch.setattr(
+        endpoint_module,
+        "initialize_queue_with_shared_writer_fencing",
+        fail_initialization,
+    )
+
+    with pytest.raises(RuntimeError, match="injected queue initialization failed"):
+        endpoint_module.EndpointWorker(
+            role=EndpointRole.WORKER,
+            cluster="test",
+            settings=RelaySettings(core_dir=core_dir, spool_dir=tmp_path / "spool"),
+            queue=queue,
+        )
+
+    exclusive = WorkerLifetimeLock(core_dir, mode="exclusive", timeout_seconds=0).acquire()
+    exclusive.release()
+
+
 def test_every_production_queue_holds_shared_writer_lifetime_ownership(
     tmp_path: Path,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.5.3"
+version = "1.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- preserve failed validation reports and emit bounded, exact pytest node IDs from the release-gate plugin so a red gate remains diagnosable
- fix first-write JARVIS input-lineage timestamps captured in the wrong order on fast Linux clocks
- initialize injected endpoint queues through exclusive seal fencing, and release worker lifetime ownership if that initialization fails
- reconcile a corrupted sealed lease-capacity pair back to an incomplete migration gate
- accept already-absent transient cgroups only after validating the recorded path, unit leaf, cgroup root, and symlink boundary
- distinguish public machine-readable legacy-state rejection from lower-level pinned permission-repair errors while preserving logical paths
- allow concurrent Windows ACL inspection without allowing delete/replacement sharing
- update stale fixtures for the 600-second control-query bound, direct endpoint-owned MCP execution, current cleanup/API contracts, and current clio-kit contract selection

## Root cause

The full Linux gate had accumulated fixture expectations from before the endpoint-owned MCP, strict queue-seal, cleanup, and 600-second control-query changes. It also exposed real Linux/Windows races and error-boundary gaps. Successive preserved reports reduced the gate from 32 failures to three and then one; the final node revealed that automatic legacy-state initialization and explicitly pinned repair require distinct error contracts for the same symlink condition. That lifecycle boundary is now explicit.

## Validation

- latest complete GitHub Linux gate: 2945 passed, 1 failed; the exact remaining node repaired
- focused Windows hardening set: 22 passed, plus the final three queue-boundary cases
- focused Linux hardening set: 24 passed, plus all four final queue lifecycle cases
- dedicated process-containment set: 41 passed
- structured pytest producer/parser set: 18 passed
- Ruff check and formatting passed
- Pyright passed with zero errors or warnings
- independent final diff reviews: no actionable findings

The complete GitHub Linux release gate is running on commit `e1df348`.