### PR TITLE
fix: repair Windows release validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.5.4` uses a release-first patch process. A maintainer builds the
+> Version `1.5.5` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.5.4"
+$Version = "1.5.5"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.5.4"
+release_version: "1.5.5"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 584250bd61425ec05a7cf661157b7ea1a899d4f77aa72960d711f34137806116
+acceptance_matrix_sha256: bb1f6d1f50f98a19c74700ab5dc4a36cc1749f033d5d4f434a6ffd584344fb7c
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.5.4"
+$Tag = "v1.5.5"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.4" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.5" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.5.4",
-  "matrix_sha256": "584250bd61425ec05a7cf661157b7ea1a899d4f77aa72960d711f34137806116",
+  "release_version": "1.5.5",
+  "matrix_sha256": "bb1f6d1f50f98a19c74700ab5dc4a36cc1749f033d5d4f434a6ffd584344fb7c",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.5.4"
+version = "1.5.5"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"
@@ -87,4 +87,7 @@ include = ["src", "jarvis-packages", "tests"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-q"
+addopts = "-q -p clio_relay.pytest_platform_partition"
+markers = [
+    "release_platform(platform): test is executed only on its named native platform and is covered by the release matrix",
+]

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.5.4"
+__version__ = "1.5.5"

--- a/src/clio_relay/ci_validation.py
+++ b/src/clio_relay/ci_validation.py
@@ -337,6 +337,96 @@ def verify_ci_status(
             raise ProvenanceError(f"CI receipt {field} is invalid")
 
 
+def _matrix_pytest_platform_partition(
+    report: dict[str, object],
+    *,
+    path_name: str,
+    expected_platform: str,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Return one report's exact native-platform marked-test partition."""
+    pytest_checks = [
+        check
+        for raw in _list(report.get("checks"), f"matrix report checks {path_name}")
+        if (check := _mapping(raw, f"matrix report check {path_name}")).get("check_id")
+        == "local.pytest"
+    ]
+    if len(pytest_checks) != 1:
+        raise ProvenanceError(
+            f"matrix report must contain exactly one local.pytest check: {path_name}"
+        )
+    command_evidence = [
+        evidence
+        for raw in _list(
+            pytest_checks[0].get("evidence"),
+            f"matrix report local.pytest evidence {path_name}",
+        )
+        if (evidence := _mapping(raw, f"matrix report local.pytest evidence {path_name}")).get(
+            "kind"
+        )
+        == "command"
+    ]
+    if len(command_evidence) != 1:
+        raise ProvenanceError(
+            "matrix report local.pytest must contain exactly one command evidence entry: "
+            f"{path_name}"
+        )
+    metadata = _mapping(
+        command_evidence[0].get("metadata"),
+        f"matrix report local.pytest command metadata {path_name}",
+    )
+    platform = _nonempty_string(
+        metadata.get("pytest_platform"),
+        f"matrix report pytest platform {path_name}",
+    )
+    if platform != expected_platform:
+        raise ProvenanceError(f"matrix report pytest platform differs from its job: {path_name}")
+    if metadata.get("platform_test_ids_truncated") is not False:
+        raise ProvenanceError(f"matrix report pytest platform partition is truncated: {path_name}")
+    selected = _canonical_string_list(
+        metadata.get("platform_selected_test_ids"),
+        f"matrix report selected platform tests {path_name}",
+    )
+    excluded = _canonical_string_list(
+        metadata.get("platform_excluded_test_ids"),
+        f"matrix report excluded platform tests {path_name}",
+    )
+    if set(selected).intersection(excluded):
+        raise ProvenanceError(f"matrix report pytest platform partition overlaps: {path_name}")
+    return tuple(selected), tuple(excluded)
+
+
+def _validate_matrix_pytest_platform_partitions(
+    *,
+    posix_platform_partitions: list[tuple[str, tuple[tuple[str, ...], tuple[str, ...]]]],
+    windows_platform_partitions: list[tuple[str, tuple[tuple[str, ...], tuple[str, ...]]]],
+) -> None:
+    """Require all six jobs to prove one complementary marked-test partition."""
+    if len(posix_platform_partitions) != 3 or len(windows_platform_partitions) != 3:
+        raise ProvenanceError("matrix reports do not prove all release-platform partitions")
+    expected_posix = posix_platform_partitions[0][1]
+    expected_windows = windows_platform_partitions[0][1]
+    if any(partition != expected_posix for _job, partition in posix_platform_partitions[1:]):
+        raise ProvenanceError("POSIX matrix reports disagree on their platform-test partition")
+    if any(partition != expected_windows for _job, partition in windows_platform_partitions[1:]):
+        raise ProvenanceError("Windows matrix reports disagree on their platform-test partition")
+    posix_selected, posix_excluded = expected_posix
+    windows_selected, windows_excluded = expected_windows
+    if posix_selected != windows_excluded or posix_excluded != windows_selected:
+        raise ProvenanceError(
+            "Windows and POSIX matrix reports do not prove complementary platform-test partitions"
+        )
+    if not posix_selected and not windows_selected:
+        raise ProvenanceError("matrix reports prove no release-platform marked tests")
+
+
+def _canonical_string_list(value: object, field: str) -> list[str]:
+    """Return an exact canonical set from a duplicate-free JSON string list."""
+    items = _string_list(value, field)
+    if len(items) != len(set(items)):
+        raise ProvenanceError(f"{field} must contain no duplicates")
+    return sorted(items)
+
+
 def build_candidate_build_receipt(
     candidate_dir: Path,
     reports_dir: Path,
@@ -403,6 +493,8 @@ def build_candidate_build_receipt(
     if {path.name for path in report_paths} != set(expected_reports):
         raise ProvenanceError("matrix validation report set is missing, extra, or renamed")
     reports: list[dict[str, object]] = []
+    posix_platform_partitions: list[tuple[str, tuple[tuple[str, ...], tuple[str, ...]]]] = []
+    windows_platform_partitions: list[tuple[str, tuple[tuple[str, ...], tuple[str, ...]]]] = []
     for path in report_paths:
         report = _mapping(_load_json(path), f"matrix validation report {path.name}")
         if (
@@ -430,11 +522,21 @@ def build_candidate_build_receipt(
             observed_digests[cast(str, name)] = digest
         if observed_digests != distribution_digests:
             raise ProvenanceError(f"matrix report artifact digests differ: {path.name}")
+        job = expected_reports[path.name]
+        expected_platform = "windows" if job.startswith("windows-latest") else "posix"
+        platform_partition = _matrix_pytest_platform_partition(
+            report,
+            path_name=path.name,
+            expected_platform=expected_platform,
+        )
+        if expected_platform == "windows":
+            windows_platform_partitions.append((job, platform_partition))
+        else:
+            posix_platform_partitions.append((job, platform_partition))
         checks = {
             _mapping(raw, f"matrix report check {path.name}").get("check_id")
             for raw in _list(report.get("checks"), f"matrix report checks {path.name}")
         }
-        job = expected_reports[path.name]
         primary = job == "ubuntu-latest / python 3.12"
         if primary:
             if "local.build" not in checks or "local.sdist-smoke" not in checks:
@@ -459,6 +561,10 @@ def build_candidate_build_receipt(
                 "artifact_sha256": distribution_digests,
             }
         )
+    _validate_matrix_pytest_platform_partitions(
+        posix_platform_partitions=posix_platform_partitions,
+        windows_platform_partitions=windows_platform_partitions,
+    )
     reports.sort(key=lambda item: REQUIRED_MATRIX_JOBS.index(cast(str, item["job"])))
     receipt: dict[str, object] = {
         "schema_version": "clio-relay.candidate-build.v1",

--- a/src/clio_relay/command_evidence.py
+++ b/src/clio_relay/command_evidence.py
@@ -16,6 +16,11 @@ PYTEST_FAILED_NODE_IDS_MAX_COUNT = 1_000
 PYTEST_FAILED_NODE_ID_MAX_BYTES = 4_096
 PYTEST_FAILED_NODE_IDS_MAX_BYTES = 64 * 1_024
 PYTEST_FAILED_NODE_IDS_PAYLOAD_MAX_BYTES = 512 * 1_024
+PYTEST_PLATFORM_PARTITION_MARKER = "CLIO_RELAY_PYTEST_PLATFORM_PARTITION_V1="
+PYTEST_PLATFORM_NODE_IDS_MAX_COUNT = 1_000
+PYTEST_PLATFORM_NODE_ID_MAX_BYTES = 4_096
+PYTEST_PLATFORM_NODE_IDS_MAX_BYTES = 64 * 1_024
+PYTEST_PLATFORM_PARTITION_PAYLOAD_MAX_BYTES = 512 * 1_024
 
 _TRACEBACK_MARKER = "Traceback (most recent call last):"
 
@@ -57,6 +62,10 @@ def command_evidence(
                 "diagnostic_offset_bytes": None,
                 "failed_test_ids": [],
                 "failed_test_ids_truncated": False,
+                "pytest_platform": None,
+                "platform_selected_test_ids": [],
+                "platform_excluded_test_ids": [],
+                "platform_test_ids_truncated": False,
                 "omitted_prefix_bytes": 0,
                 "omitted_middle_bytes": 0,
                 "truncated": False,
@@ -78,6 +87,12 @@ def command_evidence(
         diagnostic_offset=diagnostic_offset,
     )
     failed_test_ids, failed_test_ids_truncated = _pytest_failed_test_ids(normalized_stdout)
+    (
+        pytest_platform,
+        platform_selected_test_ids,
+        platform_excluded_test_ids,
+        platform_test_ids_truncated,
+    ) = _pytest_platform_partition(normalized_stdout)
     metadata: dict[str, object] = {
         "excerpt_strategy": EXCERPT_STRATEGY,
         "stdout_bytes": len(normalized_stdout.encode("utf-8")),
@@ -92,6 +107,10 @@ def command_evidence(
         "exit_code": exit_code,
         "failed_test_ids": failed_test_ids,
         "failed_test_ids_truncated": failed_test_ids_truncated,
+        "pytest_platform": pytest_platform,
+        "platform_selected_test_ids": platform_selected_test_ids,
+        "platform_excluded_test_ids": platform_excluded_test_ids,
+        "platform_test_ids_truncated": platform_test_ids_truncated,
         **excerpt_metadata,
     }
     return CommandEvidence(
@@ -175,6 +194,95 @@ def _pytest_failed_test_ids(output: str) -> tuple[list[str], bool]:
         seen.add(test_id)
         aggregate_bytes += test_id_bytes
     return test_ids, truncated
+
+
+def _pytest_platform_partition(
+    output: str,
+) -> tuple[str | None, list[str], list[str], bool]:
+    """Return the exact bounded platform partition from the pytest sentinel."""
+    marker_offset = _last_line_marker_offset(output, PYTEST_PLATFORM_PARTITION_MARKER)
+    if marker_offset is None:
+        return None, [], [], False
+    payload_start = marker_offset + len(PYTEST_PLATFORM_PARTITION_MARKER)
+    payload_end = output.find("\n", payload_start)
+    if payload_end < 0:
+        payload_end = len(output)
+    payload_text = output[payload_start:payload_end].removesuffix("\r")
+    try:
+        payload_bytes = payload_text.encode("utf-8")
+    except UnicodeEncodeError:
+        return None, [], [], True
+    if len(payload_bytes) > PYTEST_PLATFORM_PARTITION_PAYLOAD_MAX_BYTES:
+        return None, [], [], True
+    try:
+        payload_object: object = json.loads(payload_text)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None, [], [], True
+    if not isinstance(payload_object, dict):
+        return None, [], [], True
+    payload = cast(dict[object, object], payload_object)
+    if set(payload) != {
+        "excluded_node_ids",
+        "platform",
+        "selected_node_ids",
+        "truncated",
+    }:
+        return None, [], [], True
+    platform = payload["platform"]
+    raw_selected = payload["selected_node_ids"]
+    raw_excluded = payload["excluded_node_ids"]
+    declared_truncated = payload["truncated"]
+    if (
+        not isinstance(platform, str)
+        or platform not in {"posix", "windows"}
+        or not isinstance(raw_selected, list)
+        or not isinstance(raw_excluded, list)
+        or type(declared_truncated) is not bool
+    ):
+        return None, [], [], True
+    selected, selected_truncated = _bounded_platform_node_ids(cast(list[object], raw_selected))
+    excluded, excluded_truncated = _bounded_platform_node_ids(cast(list[object], raw_excluded))
+    if selected is None or excluded is None or set(selected).intersection(excluded):
+        return None, [], [], True
+    return (
+        platform,
+        selected,
+        excluded,
+        declared_truncated or selected_truncated or excluded_truncated,
+    )
+
+
+def _bounded_platform_node_ids(
+    node_id_objects: list[object],
+) -> tuple[list[str] | None, bool]:
+    """Validate and bound one platform-partition node-ID collection."""
+    node_ids: list[str] = []
+    seen: set[str] = set()
+    aggregate_bytes = 0
+    truncated = False
+    for node_id in node_id_objects:
+        if not isinstance(node_id, str):
+            return None, True
+        if node_id in seen:
+            continue
+        if len(node_ids) >= PYTEST_PLATFORM_NODE_IDS_MAX_COUNT:
+            truncated = True
+            break
+        try:
+            node_id_bytes = len(node_id.encode("utf-8"))
+        except UnicodeEncodeError:
+            truncated = True
+            continue
+        if node_id_bytes > PYTEST_PLATFORM_NODE_ID_MAX_BYTES:
+            truncated = True
+            continue
+        if aggregate_bytes + node_id_bytes > PYTEST_PLATFORM_NODE_IDS_MAX_BYTES:
+            truncated = True
+            continue
+        node_ids.append(node_id)
+        seen.add(node_id)
+        aggregate_bytes += node_id_bytes
+    return node_ids, truncated
 
 
 def _last_line_marker_offset(output: str, marker: str) -> int | None:

--- a/src/clio_relay/core_queue.py
+++ b/src/clio_relay/core_queue.py
@@ -14594,11 +14594,19 @@ def _gateway_direct_job_ids(session: GatewaySession) -> set[str]:
 
 
 def _gateway_direct_artifact_ids(session: GatewaySession) -> set[str]:
-    artifact_ids = {artifact_id for artifact_id in session.artifacts if artifact_id}
+    artifact_ids: set[str] = set()
+    candidates = list(session.artifacts)
     for provenance in _gateway_source_provenance(session):
         value = provenance.get("source_relay_artifact_id")
         if isinstance(value, str) and value:
-            artifact_ids.add(value)
+            candidates.append(value)
+    for candidate in candidates:
+        try:
+            artifact_ids.add(validate_durable_record_id(candidate))
+        except ValueError:
+            # Gateway artifacts may be external URIs. Only relay artifact IDs
+            # participate in canonical artifact and retention indexes.
+            continue
     return artifact_ids
 
 

--- a/src/clio_relay/pytest_platform_partition.py
+++ b/src/clio_relay/pytest_platform_partition.py
@@ -1,0 +1,185 @@
+"""Pytest plugin for explicit, machine-readable release-platform partitions."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Final
+
+import pytest
+from _pytest.config import Config
+from _pytest.main import Session
+from _pytest.nodes import Item
+from _pytest.terminal import TerminalReporter
+
+from clio_relay.command_evidence import (
+    PYTEST_PLATFORM_NODE_ID_MAX_BYTES,
+    PYTEST_PLATFORM_NODE_IDS_MAX_BYTES,
+    PYTEST_PLATFORM_NODE_IDS_MAX_COUNT,
+    PYTEST_PLATFORM_PARTITION_MARKER,
+    PYTEST_PLATFORM_PARTITION_PAYLOAD_MAX_BYTES,
+)
+
+_RELEASE_PLATFORM_MARKER: Final = "release_platform"
+_SUPPORTED_RELEASE_PLATFORMS: Final = frozenset({"posix", "windows"})
+
+
+@dataclass
+class _PlatformNodeIds:
+    node_ids: list[str] = field(default_factory=list[str])
+    seen: set[str] = field(default_factory=set[str])
+    aggregate_bytes: int = 0
+    truncated: bool = False
+
+    def reset(self) -> None:
+        """Clear platform-partition identifiers before a new pytest session."""
+        self.node_ids.clear()
+        self.seen.clear()
+        self.aggregate_bytes = 0
+        self.truncated = False
+
+    def add(self, node_id: str) -> None:
+        """Record one unique platform-partition node ID within durable bounds."""
+        if node_id in self.seen:
+            return
+        if len(self.node_ids) >= PYTEST_PLATFORM_NODE_IDS_MAX_COUNT:
+            self.truncated = True
+            return
+        try:
+            node_id_bytes = len(node_id.encode("utf-8"))
+        except UnicodeEncodeError:
+            self.truncated = True
+            return
+        if node_id_bytes > PYTEST_PLATFORM_NODE_ID_MAX_BYTES:
+            self.truncated = True
+            return
+        if self.aggregate_bytes + node_id_bytes > PYTEST_PLATFORM_NODE_IDS_MAX_BYTES:
+            self.truncated = True
+            return
+        self.node_ids.append(node_id)
+        self.seen.add(node_id)
+        self.aggregate_bytes += node_id_bytes
+
+
+@dataclass
+class _PlatformPartition:
+    platform: str = ""
+    selected: _PlatformNodeIds = field(default_factory=_PlatformNodeIds)
+    excluded: _PlatformNodeIds = field(default_factory=_PlatformNodeIds)
+
+    def reset(self, platform: str) -> None:
+        """Start one exact platform partition for a new pytest session."""
+        self.platform = platform
+        self.selected.reset()
+        self.excluded.reset()
+
+
+_PLATFORM_PARTITION: Final[_PlatformPartition] = _PlatformPartition()
+
+
+def pytest_configure(config: Config) -> None:
+    """Register the explicit platform marker used by every pytest invocation."""
+    config.addinivalue_line(
+        "markers",
+        "release_platform(name): execute only on the named release platform ('posix' or 'windows')",
+    )
+
+
+def pytest_sessionstart(session: Session) -> None:
+    """Reset partition evidence before collection starts."""
+    del session
+    _PLATFORM_PARTITION.reset(_current_release_platform())
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(items: list[Item]) -> None:
+    """Select marked tests for the actual platform and evidence every partition."""
+    selected_items: list[Item] = []
+    for item in items:
+        try:
+            required_platform = _marked_release_platform(item)
+        except ValueError as exc:
+            raise pytest.UsageError(f"{item.nodeid}: {exc}") from exc
+        if required_platform is None:
+            selected_items.append(item)
+        elif required_platform == _PLATFORM_PARTITION.platform:
+            _PLATFORM_PARTITION.selected.add(item.nodeid)
+            selected_items.append(item)
+        else:
+            _PLATFORM_PARTITION.excluded.add(item.nodeid)
+    items[:] = selected_items
+
+
+def pytest_terminal_summary(
+    terminalreporter: TerminalReporter,
+    exitstatus: int | pytest.ExitCode,
+) -> None:
+    """Emit the exact marked-test partition for durable command evidence."""
+    del exitstatus
+    terminalreporter.write_line(
+        f"{PYTEST_PLATFORM_PARTITION_MARKER}{_platform_partition_payload(_PLATFORM_PARTITION)}",
+    )
+
+
+def _current_release_platform() -> str:
+    """Return the canonical release-platform label for this process."""
+    if os.name == "nt":
+        return "windows"
+    if os.name == "posix":
+        return "posix"
+    raise pytest.UsageError(f"unsupported release platform os.name={os.name!r}")
+
+
+def _marked_release_platform(item: Item) -> str | None:
+    """Return one validated release-platform requirement for a collected item."""
+    markers = list(item.iter_markers(name=_RELEASE_PLATFORM_MARKER))
+    if not markers:
+        return None
+    if len(markers) != 1:
+        raise ValueError("release_platform must appear exactly once")
+    marker = markers[0]
+    if marker.kwargs or len(marker.args) != 1 or not isinstance(marker.args[0], str):
+        raise ValueError("release_platform requires exactly one positional string argument")
+    platform = marker.args[0]
+    if platform not in _SUPPORTED_RELEASE_PLATFORMS:
+        supported = ", ".join(sorted(_SUPPORTED_RELEASE_PLATFORMS))
+        raise ValueError(
+            f"release_platform value {platform!r} is unsupported; expected one of: {supported}"
+        )
+    return platform
+
+
+def _platform_partition_payload(partition: _PlatformPartition) -> str:
+    """Serialize the bounded marked-test partition for command-report ingestion."""
+    selected = list(partition.selected.node_ids)
+    excluded = list(partition.excluded.node_ids)
+    truncated = partition.selected.truncated or partition.excluded.truncated
+    while True:
+        payload = json.dumps(
+            {
+                "excluded_node_ids": excluded,
+                "platform": partition.platform,
+                "selected_node_ids": selected,
+                "truncated": truncated,
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        try:
+            payload_size = len(payload.encode("utf-8"))
+        except UnicodeEncodeError:
+            payload_size = PYTEST_PLATFORM_PARTITION_PAYLOAD_MAX_BYTES + 1
+        if payload_size <= PYTEST_PLATFORM_PARTITION_PAYLOAD_MAX_BYTES:
+            return payload
+        truncated = True
+        if excluded:
+            excluded.pop()
+        elif selected:
+            selected.pop()
+        else:
+            return (
+                '{"excluded_node_ids":[],"platform":"'
+                f'{partition.platform}","selected_node_ids":[],"truncated":true}}'
+            )

--- a/src/clio_relay/release_validation.py
+++ b/src/clio_relay/release_validation.py
@@ -69,7 +69,12 @@ _PACKAGED_MCP_BOUNDARY_TESTS = (
     "tests/test_process_containment.py",
     "tests/test_mcp_stdio_validation.py",
 )
-_PYTEST_RELEASE_GATE_ARGUMENTS = ("-p", "clio_relay.pytest_release_gate")
+_PYTEST_RELEASE_GATE_ARGUMENTS = (
+    "-p",
+    "clio_relay.pytest_platform_partition",
+    "-p",
+    "clio_relay.pytest_release_gate",
+)
 
 
 class ReleaseCommandRunner(Protocol):
@@ -163,7 +168,10 @@ def run_local_release_validation(
         _run_check(
             recorder,
             "local.pytest",
-            "full pytest suite with no failed, skipped, xfailed, xpassed, or deselected tests",
+            (
+                "native-platform pytest partition with no failed, skipped, xfailed, "
+                "xpassed, or deselected tests"
+            ),
             [
                 "uv",
                 "run",

--- a/tests/test_bootstrap_fast_path.py
+++ b/tests/test_bootstrap_fast_path.py
@@ -129,6 +129,7 @@ def _run_posix_project_driver(
     )
 
 
+@pytest.mark.release_platform("posix")
 def test_receipt_classifier_accepts_stable_generation_symlink() -> None:
     """Warm bootstraps classify the supported stable receipt link without following others."""
     driver = r"""
@@ -178,6 +179,7 @@ print("stable-receipt-ok")
     assert result.stdout.strip() == "stable-receipt-ok"
 
 
+@pytest.mark.release_platform("posix")
 def test_preparing_root_and_uv_copy_recover_without_following_links() -> None:
     """Power-loss scratch is reclaimed fd-relatively and uv executes from a private copy."""
     driver = r"""
@@ -267,6 +269,7 @@ print("scratch-and-uv-ok")
     assert result.stdout.strip() == "scratch-and-uv-ok"
 
 
+@pytest.mark.release_platform("posix")
 def test_fd_bound_candidate_verifier_rejects_swapped_wheel_install() -> None:
     """Installed relay bytes must match the wheel fd held across uv installation."""
     driver = r"""
@@ -381,6 +384,7 @@ print("swapped-wheel-rejected")
     assert result.stdout.strip() == "swapped-wheel-rejected"
 
 
+@pytest.mark.release_platform("posix")
 def test_candidate_verifier_accepts_pinned_uv_metadata_subset_only() -> None:
     """Pinned uv metadata and long-path launchers verify while unknown members fail closed."""
     driver = r"""
@@ -533,6 +537,7 @@ print("bounded-uv-metadata-ok")
     assert result.stdout.strip() == "bounded-uv-metadata-ok"
 
 
+@pytest.mark.release_platform("posix")
 def test_candidate_coordinator_rejects_provider_path_swap_after_open() -> None:
     """A provider pathname replacement cannot execute after its coordinator opens it."""
     driver = r"""
@@ -730,6 +735,7 @@ print("provider-swap-rejected")
     assert result.stdout.strip() == "provider-swap-rejected"
 
 
+@pytest.mark.release_platform("posix")
 def test_staged_provider_exec_is_hash_bound_sealed_and_venv_aware(tmp_path: Path) -> None:
     """The staged provider is executed from sealed bytes with lexical venv semantics."""
     if sys.platform != "linux":
@@ -873,6 +879,7 @@ def test_staged_provider_exec_is_hash_bound_sealed_and_venv_aware(tmp_path: Path
     assert preload_marker.read_bytes() == b""
 
 
+@pytest.mark.release_platform("posix")
 def test_active_generation_identity_accepts_lexical_home_alias() -> None:
     """A managed generation and provider survive a lexical HOME mount alias."""
     script = bootstrap.render_linux_user_bootstrap_script(cluster="cluster-a")
@@ -937,6 +944,7 @@ print("active-generation-alias-ok")
     assert result.stdout.strip() == "active-generation-alias-ok"
 
 
+@pytest.mark.release_platform("posix")
 def test_execution_boundary_round_trips_real_uv_venv_through_home_alias() -> None:
     """A real uv Python symlink remains inside the lexical venv boundary."""
     function_source = inspect.getsource(execution_environment_identity)
@@ -1014,6 +1022,7 @@ print("uv-venv-alias-ok")
     assert result.stdout.strip() == "uv-venv-alias-ok"
 
 
+@pytest.mark.release_platform("posix")
 def test_aliased_home_generation_activation_reaches_exact_noop() -> None:
     """Real Linux links activate once and then inspect as an exact warm no-op."""
     driver = r"""
@@ -1404,6 +1413,7 @@ def test_exact_remote_bootstrap_never_reads_or_builds_payload(
     assert operations["payload_transfer_bytes"] == 0
 
 
+@pytest.mark.release_platform("posix")
 def test_legacy_preflight_classifies_receipt_before_invoking_old_relay(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1533,6 +1543,7 @@ print("legacy-preflight-ok")
     assert execution.stdout.strip() == "legacy-preflight-ok"
 
 
+@pytest.mark.release_platform("posix")
 def test_preflight_allows_only_exact_repairable_queue_permission_report(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1666,6 +1677,7 @@ print("repairable-preflight-ok")
     assert execution.stdout.strip() == "repairable-preflight-ok"
 
 
+@pytest.mark.release_platform("posix")
 def test_locked_recovery_privatizes_legacy_cursor_directory_on_posix() -> None:
     """Recovery repairs the fixed legacy-only cursor family before auditing it."""
     driver = r"""
@@ -2819,6 +2831,7 @@ def test_staged_upgrade_uses_journal_bound_idempotent_forward_activation() -> No
     assert "scancel" not in script
 
 
+@pytest.mark.release_platform("posix")
 def test_forward_recovery_fence_is_idempotent_after_prior_restart() -> None:
     """A crash after restart is fenced again before forward migration resumes."""
     script = bootstrap.render_linux_user_bootstrap_script(cluster="cluster-a")

--- a/tests/test_bootstrap_journal.py
+++ b/tests/test_bootstrap_journal.py
@@ -49,7 +49,7 @@ def _owned_paths(home: Path) -> dict[str, dict[str, str]]:
 
 
 @pytest.mark.parametrize("failed_after", _REVERSIBLE_BOUNDARIES)
-@pytest.mark.skipif(os.name == "nt", reason="full bootstrap recovery is POSIX-only")
+@pytest.mark.release_platform("posix")
 def test_fresh_failure_injection_discards_owned_paths_and_reruns(
     tmp_path: Path,
     failed_after: str,
@@ -207,7 +207,7 @@ def test_hardlinked_journal_is_rejected(tmp_path: Path) -> None:
         load_journal(journal_path)
 
 
-@pytest.mark.skipif(os.name == "nt", reason="descriptor topology is POSIX-only")
+@pytest.mark.release_platform("posix")
 def test_preexisting_private_real_journal_parent_is_supported(tmp_path: Path) -> None:
     """A legitimate existing private directory topology remains supported."""
     parent = tmp_path / ".local/share/clio-relay"
@@ -229,7 +229,7 @@ def test_preexisting_private_real_journal_parent_is_supported(tmp_path: Path) ->
     assert created["state"] == "locked"
 
 
-@pytest.mark.skipif(os.name == "nt", reason="descriptor topology is POSIX-only")
+@pytest.mark.release_platform("posix")
 def test_journal_parent_swap_during_create_fails_closed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -301,7 +301,7 @@ def _reversible_owned_journal(
     return journal_path
 
 
-@pytest.mark.skipif(os.name == "nt", reason="full bootstrap recovery is POSIX-only")
+@pytest.mark.release_platform("posix")
 def test_parent_swap_after_journal_open_never_reaches_replacement_tree(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -338,7 +338,7 @@ def test_parent_swap_after_journal_open_never_reaches_replacement_tree(
     assert (relocated_local / "share/clio-relay/owned").is_dir()
 
 
-@pytest.mark.skipif(os.name == "nt", reason="full bootstrap recovery is POSIX-only")
+@pytest.mark.release_platform("posix")
 def test_target_swap_to_symlink_is_rejected_without_following(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -382,7 +382,7 @@ def test_target_swap_to_symlink_is_rejected_without_following(
     assert sentinel.read_text(encoding="utf-8") == "operator\n"
 
 
-@pytest.mark.skipif(os.name == "nt", reason="full bootstrap recovery is POSIX-only")
+@pytest.mark.release_platform("posix")
 @pytest.mark.parametrize("kind", ("directory", "file", "symlink"))
 def test_operator_replacement_at_owned_name_is_retained(
     tmp_path: Path,
@@ -416,7 +416,7 @@ def test_operator_replacement_at_owned_name_is_retained(
     assert target.exists() or target.is_symlink()
 
 
-@pytest.mark.skipif(os.name == "nt", reason="full bootstrap recovery is POSIX-only")
+@pytest.mark.release_platform("posix")
 def test_nested_symlink_and_hardlink_cleanup_preserves_external_objects(tmp_path: Path) -> None:
     """Recursive cleanup unlinks entries but never follows links outside its root."""
     target = tmp_path / ".local/share/clio-relay/owned"
@@ -439,7 +439,7 @@ def test_nested_symlink_and_hardlink_cleanup_preserves_external_objects(tmp_path
     assert outside_file.read_text(encoding="utf-8") == "hardlink\n"
 
 
-@pytest.mark.skipif(os.name == "nt", reason="full bootstrap recovery is POSIX-only")
+@pytest.mark.release_platform("posix")
 def test_interrupted_discard_is_idempotently_resumed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -479,7 +479,7 @@ def test_interrupted_discard_is_idempotently_resumed(
     assert not target.exists()
 
 
-@pytest.mark.skipif(os.name == "nt", reason="owned path publication is POSIX-only")
+@pytest.mark.release_platform("posix")
 @pytest.mark.parametrize("kind", ("directory", "file", "symlink"))
 def test_owned_publication_never_claims_a_racing_replacement(
     tmp_path: Path,

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -392,9 +392,15 @@ def test_ci_status_rejects_a_caller_supplied_non_push_or_wrong_sha_run() -> None
         select_ci_run(runs, repository=REPOSITORY, source_commit=TESTED_COMMIT)
 
 
-def test_candidate_build_receipt_proves_one_build_and_five_exact_reuses(
+_POSIX_PLATFORM_TEST_IDS = (
+    "tests/test_bootstrap_fast_path.py::test_receipt_classifier_accepts_stable_generation_symlink",
+    "tests/test_bootstrap_journal.py::test_recovery_after_prepared_journal",
+)
+
+
+def _write_candidate_build_inputs(
     tmp_path: Path,
-) -> None:
+) -> tuple[Path, Path, dict[str, str]]:
     candidate = tmp_path / "candidate"
     reports = tmp_path / "reports"
     candidate.mkdir()
@@ -419,12 +425,31 @@ def test_candidate_build_receipt_proves_one_build_and_five_exact_reuses(
         checks = (
             ["local.build", "local.sdist-smoke"] if index == 0 else ["local.prebuilt-artifacts"]
         )
+        platform = "windows" if job.startswith("windows-latest") else "posix"
+        selected = [] if platform == "windows" else list(_POSIX_PLATFORM_TEST_IDS)
+        excluded = list(_POSIX_PLATFORM_TEST_IDS) if platform == "windows" else []
         document = {
             "status": "passed",
             "scenario": "local-release",
             "cluster": "local",
             "software": {"commit": TESTED_COMMIT, "dirty": False},
-            "checks": [{"check_id": check_id} for check_id in checks],
+            "checks": [{"check_id": check_id} for check_id in checks]
+            + [
+                {
+                    "check_id": "local.pytest",
+                    "evidence": [
+                        {
+                            "kind": "command",
+                            "metadata": {
+                                "pytest_platform": platform,
+                                "platform_selected_test_ids": selected,
+                                "platform_excluded_test_ids": excluded,
+                                "platform_test_ids_truncated": False,
+                            },
+                        }
+                    ],
+                }
+            ],
             "resources": [
                 {
                     "resource_id": name,
@@ -434,6 +459,13 @@ def test_candidate_build_receipt_proves_one_build_and_five_exact_reuses(
             ],
         }
         (reports / filename).write_text(json.dumps(document), encoding="utf-8")
+    return candidate, reports, distribution_digests
+
+
+def test_candidate_build_receipt_proves_one_build_and_five_exact_reuses(
+    tmp_path: Path,
+) -> None:
+    candidate, reports, distribution_digests = _write_candidate_build_inputs(tmp_path)
 
     receipt = build_candidate_build_receipt(
         candidate,
@@ -456,6 +488,66 @@ def test_candidate_build_receipt_proves_one_build_and_five_exact_reuses(
     cast(list[dict[str, object]], changed["resources"])[0]["metadata"] = {"sha256": "0" * 64}
     (reports / cast(str, matrix[-1]["filename"])).write_text(json.dumps(changed), encoding="utf-8")
     with pytest.raises(ProvenanceError, match="artifact digests differ"):
+        build_candidate_build_receipt(
+            candidate,
+            reports,
+            repository=REPOSITORY,
+            source_commit=TESTED_COMMIT,
+            source_tree=TREE,
+            event="merge_group",
+            run_id=1001,
+            run_attempt=2,
+            head_ref="refs/heads/gh-readonly-queue/main/pr-23-deadbeef",
+            base_ref="refs/heads/main",
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_message"),
+    [
+        ("missing", "must be a JSON array"),
+        ("matrix-mismatch", "Windows matrix reports disagree"),
+        ("mirror-mismatch", "do not prove complementary"),
+        ("truncation", "platform partition is truncated"),
+    ],
+)
+def test_candidate_build_receipt_rejects_incomplete_platform_partition_evidence(
+    tmp_path: Path,
+    mutation: str,
+    expected_message: str,
+) -> None:
+    candidate, reports, _distribution_digests = _write_candidate_build_inputs(tmp_path)
+    report_path = reports / "validation-local-windows-latest-3.13.json"
+    document = cast(dict[str, object], json.loads(report_path.read_text(encoding="utf-8")))
+    checks = cast(list[dict[str, object]], document["checks"])
+    pytest_check = next(check for check in checks if check["check_id"] == "local.pytest")
+    evidence = cast(list[dict[str, object]], pytest_check["evidence"])
+    metadata = cast(dict[str, object], evidence[0]["metadata"])
+    if mutation == "missing":
+        metadata.pop("platform_excluded_test_ids")
+    elif mutation == "matrix-mismatch":
+        metadata["platform_excluded_test_ids"] = list(_POSIX_PLATFORM_TEST_IDS[:-1])
+    elif mutation == "mirror-mismatch":
+        for version in ("3.12", "3.13", "3.14"):
+            windows_path = reports / f"validation-local-windows-latest-{version}.json"
+            windows_document = cast(
+                dict[str, object],
+                json.loads(windows_path.read_text(encoding="utf-8")),
+            )
+            windows_checks = cast(list[dict[str, object]], windows_document["checks"])
+            windows_pytest = next(
+                check for check in windows_checks if check["check_id"] == "local.pytest"
+            )
+            windows_evidence = cast(list[dict[str, object]], windows_pytest["evidence"])
+            windows_metadata = cast(dict[str, object], windows_evidence[0]["metadata"])
+            windows_metadata["platform_excluded_test_ids"] = list(_POSIX_PLATFORM_TEST_IDS[:-1])
+            windows_path.write_text(json.dumps(windows_document), encoding="utf-8")
+    else:
+        metadata["platform_test_ids_truncated"] = True
+    if mutation != "mirror-mismatch":
+        report_path.write_text(json.dumps(document), encoding="utf-8")
+
+    with pytest.raises(ProvenanceError, match=expected_message):
         build_candidate_build_receipt(
             candidate,
             reports,

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1791,7 +1791,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "584250bd61425ec05a7cf661157b7ea1a899d4f77aa72960d711f34137806116"
+        "bb1f6d1f50f98a19c74700ab5dc4a36cc1749f033d5d4f434a6ffd584344fb7c"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -430,17 +430,16 @@ def test_windows_configuration_directory_removes_broad_inherited_acl(tmp_path: P
     ensure_private_configuration_path(path, directory=True)
 
 
-def test_windows_configuration_hardening_rejects_an_existing_writer(tmp_path: Path) -> None:
+def test_windows_configuration_hardening_allows_an_existing_writer(tmp_path: Path) -> None:
     if os.name != "nt":
         return
     path = tmp_path / "configuration.json"
     path.write_text("original", encoding="utf-8")
 
-    with (
-        path.open("r+b"),
-        pytest.raises(ConfigurationError, match="could not open Windows configuration path"),
-    ):
+    with path.open("r+b") as writer:
         ensure_private_configuration_path(path, directory=False)
+        writer.seek(0)
+        assert writer.read() == b"original"
 
     ensure_private_configuration_path(path, directory=False)
 

--- a/tests/test_command_evidence.py
+++ b/tests/test_command_evidence.py
@@ -12,6 +12,10 @@ from clio_relay.command_evidence import (
     PYTEST_FAILED_NODE_IDS_MARKER,
     PYTEST_FAILED_NODE_IDS_MAX_BYTES,
     PYTEST_FAILED_NODE_IDS_MAX_COUNT,
+    PYTEST_PLATFORM_NODE_ID_MAX_BYTES,
+    PYTEST_PLATFORM_NODE_IDS_MAX_BYTES,
+    PYTEST_PLATFORM_NODE_IDS_MAX_COUNT,
+    PYTEST_PLATFORM_PARTITION_MARKER,
     bounded_error_detail,
     command_evidence,
 )
@@ -25,6 +29,27 @@ def _pytest_failure_sentinel(node_ids: list[str], *, truncated: bool = False) ->
         sort_keys=True,
     )
     return f"{PYTEST_FAILED_NODE_IDS_MARKER}{payload}"
+
+
+def _pytest_platform_sentinel(
+    *,
+    platform: str,
+    selected_node_ids: list[str],
+    excluded_node_ids: list[str],
+    truncated: bool = False,
+) -> str:
+    """Return one exact machine-readable pytest platform sentinel."""
+    payload = json.dumps(
+        {
+            "excluded_node_ids": excluded_node_ids,
+            "platform": platform,
+            "selected_node_ids": selected_node_ids,
+            "truncated": truncated,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return f"{PYTEST_PLATFORM_PARTITION_MARKER}{payload}"
 
 
 def test_short_unicode_command_evidence_is_exact() -> None:
@@ -45,6 +70,10 @@ def test_empty_command_evidence_records_exit_code() -> None:
     assert evidence.excerpt == "exit_code=13"
     assert evidence.error_detail == "exit_code=13"
     assert evidence.metadata["output_bytes"] == 0
+    assert evidence.metadata["pytest_platform"] is None
+    assert evidence.metadata["platform_selected_test_ids"] == []
+    assert evidence.metadata["platform_excluded_test_ids"] == []
+    assert evidence.metadata["platform_test_ids_truncated"] is False
 
 
 def test_pytest_failure_ids_survive_transcript_truncation() -> None:
@@ -125,6 +154,69 @@ def test_stderr_cannot_override_authoritative_pytest_failure_ids() -> None:
 
     assert evidence.metadata["failed_test_ids"] == expected
     assert evidence.metadata["failed_test_ids_truncated"] is False
+
+
+def test_pytest_platform_partition_survives_transcript_truncation() -> None:
+    """The exact selected and excluded marked tests remain machine-readable."""
+    selected = ["tests/test_bootstrap.py::test_posix_selected"]
+    excluded = ["tests/test_bootstrap.py::test_windows_excluded"]
+    sentinel = _pytest_platform_sentinel(
+        platform="posix",
+        selected_node_ids=selected,
+        excluded_node_ids=excluded,
+    )
+    output = ("collection detail\n" * 50_000) + sentinel
+
+    evidence = command_evidence(output, None, exit_code=0)
+
+    assert evidence.metadata["pytest_platform"] == "posix"
+    assert evidence.metadata["platform_selected_test_ids"] == selected
+    assert evidence.metadata["platform_excluded_test_ids"] == excluded
+    assert evidence.metadata["platform_test_ids_truncated"] is False
+
+
+def test_pytest_platform_partition_metadata_has_count_and_byte_bounds() -> None:
+    """Hostile partition evidence cannot make validation metadata unbounded."""
+    oversized = "tests/test_bootstrap.py::test_" + ("x" * PYTEST_PLATFORM_NODE_ID_MAX_BYTES)
+    ordinary = [
+        f"tests/test_bootstrap.py::test_case_{index:04d}" + ("x" * 80)
+        for index in range(PYTEST_PLATFORM_NODE_IDS_MAX_COUNT + 5)
+    ]
+    sentinel = _pytest_platform_sentinel(
+        platform="windows",
+        selected_node_ids=[oversized, *ordinary],
+        excluded_node_ids=[],
+    )
+
+    evidence = command_evidence(sentinel, None, exit_code=0)
+
+    selected_value = evidence.metadata["platform_selected_test_ids"]
+    assert isinstance(selected_value, list)
+    selected_objects = cast(list[object], selected_value)
+    assert all(isinstance(node_id, str) for node_id in selected_objects)
+    selected = cast(list[str], selected_objects)
+    assert oversized not in selected
+    assert len(selected) <= PYTEST_PLATFORM_NODE_IDS_MAX_COUNT
+    assert sum(len(node_id.encode("utf-8")) for node_id in selected) <= (
+        PYTEST_PLATFORM_NODE_IDS_MAX_BYTES
+    )
+    assert evidence.metadata["platform_test_ids_truncated"] is True
+
+
+def test_malformed_pytest_platform_partition_fails_closed() -> None:
+    """An invalid platform sentinel cannot be mistaken for complete evidence."""
+    output = (
+        f"{PYTEST_PLATFORM_PARTITION_MARKER}"
+        '{"excluded_node_ids":[],"platform":"nt",'
+        '"selected_node_ids":[],"truncated":false}'
+    )
+
+    evidence = command_evidence(output, None, exit_code=0)
+
+    assert evidence.metadata["pytest_platform"] is None
+    assert evidence.metadata["platform_selected_test_ids"] == []
+    assert evidence.metadata["platform_excluded_test_ids"] == []
+    assert evidence.metadata["platform_test_ids_truncated"] is True
 
 
 def test_large_pytest_output_keeps_first_failure_and_summary() -> None:

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.5.4"
+    assert version == "1.5.5"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_release_validation.py
+++ b/tests/test_release_validation.py
@@ -7,11 +7,13 @@ import json
 import os
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 from typing import cast
 
 import pytest
 
+from clio_relay import pytest_platform_partition as pytest_platform_partition_module
 from clio_relay import pytest_release_gate as pytest_release_gate_module
 from clio_relay import release_validation as release_validation_module
 from clio_relay.command_evidence import (
@@ -19,6 +21,10 @@ from clio_relay.command_evidence import (
     PYTEST_FAILED_NODE_IDS_MAX_BYTES,
     PYTEST_FAILED_NODE_IDS_MAX_COUNT,
     PYTEST_FAILED_NODE_IDS_PAYLOAD_MAX_BYTES,
+    PYTEST_PLATFORM_NODE_ID_MAX_BYTES,
+    PYTEST_PLATFORM_NODE_IDS_MAX_BYTES,
+    PYTEST_PLATFORM_NODE_IDS_MAX_COUNT,
+    PYTEST_PLATFORM_PARTITION_PAYLOAD_MAX_BYTES,
     command_evidence,
 )
 from clio_relay.errors import ConfigurationError, RelayError
@@ -28,6 +34,27 @@ from clio_relay.release_validation import (
     run_local_release_validation,
 )
 from clio_relay.validation_report import ValidationStatus, load_validation_report
+
+_PYTEST_PLATFORM_PLUGIN = (
+    "-p",
+    "clio_relay.pytest_platform_partition",
+)
+_PYTEST_RELEASE_PLUGINS = (
+    *_PYTEST_PLATFORM_PLUGIN,
+    "-p",
+    "clio_relay.pytest_release_gate",
+)
+
+
+def test_pytest_configuration_loads_only_platform_partition_globally() -> None:
+    """Ordinary pytest runs partition platforms without enabling the strict gate."""
+    project = tomllib.loads(
+        (Path(__file__).parents[1] / "pyproject.toml").read_text(encoding="utf-8")
+    )
+
+    assert project["tool"]["pytest"]["ini_options"]["addopts"] == (
+        "-q -p clio_relay.pytest_platform_partition"
+    )
 
 
 def test_release_subprocess_preserves_logical_short_working_directory(
@@ -242,11 +269,9 @@ def test_local_release_validation_runs_all_checks_and_records_artifacts(
         command for command in commands if command[:4] == ["uv", "run", "--no-sync", "pytest"]
     ]
     assert len(pytest_commands) == 6
-    assert all(
-        command[4:6] == ["-p", "clio_relay.pytest_release_gate"] for command in pytest_commands
-    )
+    assert all(command[4:8] == list(_PYTEST_RELEASE_PLUGINS) for command in pytest_commands)
     assert all("--collect-only" not in command for command in pytest_commands)
-    assert pytest_commands[1][7:] == [
+    assert pytest_commands[1][9:] == [
         "tests/test_process_containment.py::test_enforceable_provider_rejects_and_kills_background_escape",
         "tests/test_endpoint.py::test_hard_crashed_worker_is_reconciled_before_cancellation_acknowledgment",
         "tests/test_endpoint.py::test_hard_crash_before_broker_release_never_starts_workload_and_reconciles",
@@ -255,7 +280,7 @@ def test_local_release_validation_runs_all_checks_and_records_artifacts(
         "tests/test_storage_process_guard.py::test_runtime_storage_violation_terminates_owned_child_tree",
         "tests/test_storage_managed_queue.py::test_hard_crash_reservation_is_reconciled_before_canonical_retry",
     ]
-    assert pytest_commands[2][7:] == [
+    assert pytest_commands[2][9:] == [
         "tests/test_endpoint.py::test_pending_execution_cleanup_processes_truncated_batches_automatically",
         "tests/test_endpoint.py::test_cleanup_batch_reaches_expired_marker_after_live_lease_markers",
         "tests/test_endpoint.py::test_execution_cleanup_marker_is_durable_before_task_metadata_update",
@@ -264,7 +289,7 @@ def test_local_release_validation_runs_all_checks_and_records_artifacts(
         "tests/test_endpoint.py::test_execution_sidecar_cleanup_removes_only_owned_non_directory_entries",
         "tests/test_endpoint.py::test_windows_sidecar_cleanup_anchors_parent_and_rejects_reparse_points",
     ]
-    assert pytest_commands[3][7:] == [
+    assert pytest_commands[3][9:] == [
         "tests/test_core_global_pagination.py::test_global_order_seal_field_removal_fails_closed",
         "tests/test_core_index_safety.py::test_stale_recovery_uses_exact_scheduler_indexes_without_global_task_scan",
         "tests/test_core_index_safety.py::test_gateway_reverse_indexes_refuse_cardinality_overflow",
@@ -276,11 +301,11 @@ def test_local_release_validation_runs_all_checks_and_records_artifacts(
         "tests/test_storage_managed_queue.py::test_managed_queue_recovers_crash_reserved_canonical_id_without_leak",
         "tests/test_surface_pagination.py::test_sparse_job_filters_return_empty_source_page_with_next_cursor",
     ]
-    assert pytest_commands[4][7:] == [
+    assert pytest_commands[4][9:] == [
         "tests/test_process_containment.py",
         "tests/test_mcp_stdio_validation.py",
     ]
-    assert pytest_commands[5][7:] == [
+    assert pytest_commands[5][9:] == [
         "tests/test_live_acceptance.py::test_secure_runtime_probe_config_is_generic_strict_and_bounded",
         "tests/test_live_acceptance.py::test_secure_runtime_secret_scanner_rejects_capabilities_without_key_false_positives",
         "tests/test_live_acceptance.py::test_secure_runtime_browser_http_is_direct_strict_bounded_and_deadlined",
@@ -475,8 +500,7 @@ def test_pytest_release_gate_rejects_non_clean_structured_outcomes(
             sys.executable,
             "-m",
             "pytest",
-            "-p",
-            "clio_relay.pytest_release_gate",
+            *_PYTEST_RELEASE_PLUGINS,
             "-q",
             *extra_arguments,
             "test_outcome.py",
@@ -504,8 +528,7 @@ def test_pytest_release_gate_accepts_only_clean_passes(tmp_path: Path) -> None:
             sys.executable,
             "-m",
             "pytest",
-            "-p",
-            "clio_relay.pytest_release_gate",
+            *_PYTEST_RELEASE_PLUGINS,
             "-q",
             "test_outcome.py",
         ],
@@ -519,6 +542,170 @@ def test_pytest_release_gate_accepts_only_clean_passes(tmp_path: Path) -> None:
     evidence = command_evidence(completed.stdout, completed.stderr, exit_code=completed.returncode)
     assert evidence.metadata["failed_test_ids"] == []
     assert evidence.metadata["failed_test_ids_truncated"] is False
+    assert evidence.metadata["pytest_platform"] == ("windows" if os.name == "nt" else "posix")
+    assert evidence.metadata["platform_selected_test_ids"] == []
+    assert evidence.metadata["platform_excluded_test_ids"] == []
+    assert evidence.metadata["platform_test_ids_truncated"] is False
+
+
+def test_pytest_platform_partition_selects_marked_tests_by_actual_platform(
+    tmp_path: Path,
+) -> None:
+    """Only incompatible marked tests are excluded, with exact durable evidence."""
+    current_platform = "windows" if os.name == "nt" else "posix"
+    other_platform = "posix" if os.name == "nt" else "windows"
+    (tmp_path / "test_outcome.py").write_text(
+        f"""
+import pytest
+
+
+@pytest.mark.release_platform({current_platform!r})
+def test_selected():
+    assert True
+
+
+@pytest.mark.release_platform({other_platform!r})
+def test_excluded():
+    assert False, "an incompatible platform test must not execute"
+
+
+def test_unmarked():
+    assert True
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            *_PYTEST_RELEASE_PLUGINS,
+            "-q",
+            "test_outcome.py",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    output = completed.stdout + completed.stderr
+    assert completed.returncode == int(pytest.ExitCode.OK), output
+    assert "skipped" not in output
+    assert "deselected" not in output
+    evidence = command_evidence(
+        completed.stdout,
+        completed.stderr,
+        exit_code=completed.returncode,
+    )
+    assert evidence.metadata["pytest_platform"] == current_platform
+    assert evidence.metadata["platform_selected_test_ids"] == ["test_outcome.py::test_selected"]
+    assert evidence.metadata["platform_excluded_test_ids"] == ["test_outcome.py::test_excluded"]
+    assert evidence.metadata["platform_test_ids_truncated"] is False
+
+
+def test_pytest_platform_partition_allows_ordinary_focused_deselection(
+    tmp_path: Path,
+) -> None:
+    """The always-on partition plugin does not turn a normal -k filter into failure."""
+    (tmp_path / "test_outcome.py").write_text(
+        "def test_keep():\n    assert True\n\n"
+        "def test_drop():\n    assert False, 'filtered test must not execute'\n",
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            *_PYTEST_PLATFORM_PLUGIN,
+            "-q",
+            "-k",
+            "keep",
+            "test_outcome.py",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    output = completed.stdout + completed.stderr
+    assert completed.returncode == int(pytest.ExitCode.OK), output
+    assert "release gate rejected outcomes" not in output
+    evidence = command_evidence(
+        completed.stdout,
+        completed.stderr,
+        exit_code=completed.returncode,
+    )
+    assert evidence.metadata["pytest_platform"] == ("windows" if os.name == "nt" else "posix")
+    assert evidence.metadata["platform_selected_test_ids"] == []
+    assert evidence.metadata["platform_excluded_test_ids"] == []
+
+
+@pytest.mark.parametrize(
+    ("decorators", "expected_error"),
+    [
+        (
+            "@pytest.mark.release_platform",
+            "requires exactly one positional string argument",
+        ),
+        (
+            "@pytest.mark.release_platform(123)",
+            "requires exactly one positional string argument",
+        ),
+        (
+            "@pytest.mark.release_platform('linux')",
+            "value 'linux' is unsupported",
+        ),
+        (
+            "@pytest.mark.release_platform('posix', reason='invalid')",
+            "requires exactly one positional string argument",
+        ),
+        (
+            "@pytest.mark.release_platform('posix')\n@pytest.mark.release_platform('windows')",
+            "must appear exactly once",
+        ),
+    ],
+)
+def test_pytest_platform_partition_rejects_invalid_markers(
+    tmp_path: Path,
+    decorators: str,
+    expected_error: str,
+) -> None:
+    """Malformed or unknown platform markers fail collection explicitly."""
+    (tmp_path / "test_outcome.py").write_text(
+        f"import pytest\n\n{decorators}\ndef test_case():\n    assert True\n",
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            *_PYTEST_RELEASE_PLUGINS,
+            "-q",
+            "test_outcome.py",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    output = completed.stdout + completed.stderr
+    assert completed.returncode == int(pytest.ExitCode.USAGE_ERROR), output
+    assert expected_error in output
+    evidence = command_evidence(
+        completed.stdout,
+        completed.stderr,
+        exit_code=completed.returncode,
+    )
+    assert evidence.metadata["failed_test_ids"] == []
+    assert evidence.metadata["pytest_platform"] in {"posix", "windows"}
 
 
 def test_pytest_release_gate_emits_exact_unique_parametrized_failure_id(
@@ -549,8 +736,7 @@ def test_case(label, broken_cleanup):
             sys.executable,
             "-m",
             "pytest",
-            "-p",
-            "clio_relay.pytest_release_gate",
+            *_PYTEST_RELEASE_PLUGINS,
             "-q",
             "test_outcome.py",
         ],
@@ -585,8 +771,7 @@ def test_pytest_release_gate_emits_collection_failure_id(tmp_path: Path) -> None
             sys.executable,
             "-m",
             "pytest",
-            "-p",
-            "clio_relay.pytest_release_gate",
+            *_PYTEST_RELEASE_PLUGINS,
             "-q",
             "test_broken.py",
         ],
@@ -634,4 +819,37 @@ def test_pytest_release_gate_bounds_failure_ids_before_serialization() -> None:
     assert len(node_ids) <= PYTEST_FAILED_NODE_IDS_MAX_COUNT
     assert sum(len(node_id.encode("utf-8")) for node_id in node_ids) <= (
         PYTEST_FAILED_NODE_IDS_MAX_BYTES
+    )
+
+
+def test_pytest_platform_partition_bounds_ids_before_serialization() -> None:
+    """The producer bounds both platform partitions before emitting its sentinel."""
+    partition = pytest_platform_partition_module._PlatformPartition()  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    partition.reset("windows")
+    oversized = "tests/test_queue.py::test_" + ("x" * PYTEST_PLATFORM_NODE_ID_MAX_BYTES)
+    partition.selected.add(oversized)
+    for index in range(PYTEST_PLATFORM_NODE_IDS_MAX_COUNT + 5):
+        partition.selected.add(f"tests/test_queue.py::test_{index:04d}" + ("x" * 80))
+    partition.excluded.add("tests/test_bootstrap.py::test_posix_only")
+
+    payload_text = pytest_platform_partition_module._platform_partition_payload(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        partition,
+    )
+    payload_object: object = json.loads(payload_text)
+    assert isinstance(payload_object, dict)
+    payload = cast(dict[str, object], payload_object)
+    selected_object = payload["selected_node_ids"]
+    assert isinstance(selected_object, list)
+    selected_objects = cast(list[object], selected_object)
+    assert all(isinstance(node_id, str) for node_id in selected_objects)
+    selected = cast(list[str], selected_objects)
+
+    assert len(payload_text.encode("utf-8")) <= PYTEST_PLATFORM_PARTITION_PAYLOAD_MAX_BYTES
+    assert payload["platform"] == "windows"
+    assert payload["excluded_node_ids"] == ["tests/test_bootstrap.py::test_posix_only"]
+    assert payload["truncated"] is True
+    assert oversized not in selected
+    assert len(selected) <= PYTEST_PLATFORM_NODE_IDS_MAX_COUNT
+    assert sum(len(node_id.encode("utf-8")) for node_id in selected) <= (
+        PYTEST_PLATFORM_NODE_IDS_MAX_BYTES
     )

--- a/tests/test_service_runtime.py
+++ b/tests/test_service_runtime.py
@@ -5,7 +5,6 @@ import errno
 import gzip
 import hashlib
 import json
-import os
 import shlex
 import signal
 import socket
@@ -724,12 +723,11 @@ __CLIO_TEST_SUBMISSION_SIDECARS__
 {script}
 """
         if sys.platform == "win32":
-            wsl = Path(os.environ.get("SYSTEMROOT", r"C:\Windows")) / "System32" / "wsl.exe"
-            if not wsl.is_file():
-                return self._emulate_verifier_result(command, script)
-            shell_command = [str(wsl), "-e", "bash", "-s"]
-        else:
-            shell_command = ["bash", "-s"]
+            # Windows runners expose wsl.exe even when no distribution is
+            # installed. Emulate the POSIX verifier response deterministically;
+            # Linux CI exercises the generated shell verifier itself.
+            return self._emulate_verifier_result(command, script)
+        shell_command = ["bash", "-s"]
         completed = subprocess.run(  # noqa: S603
             shell_command,
             input=wrapper.encode("utf-8"),

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2499,7 +2499,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.5.4"
+    assert policy.release_version == "1.5.5"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.5.4"
+version = "1.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- Fix gateway cleanup on Windows by keeping external artifact URIs out of durable relay artifact indexes.
- Replace implicit WSL availability with an explicit, machine-readable release-platform test partition; Ubuntu executes all POSIX-only assertions while Windows records the exact complementary exclusions without skips or deselection.
- Seal the six validation reports by requiring identical Python 3.12-3.14 partitions within each OS and complementary coverage across Ubuntu and Windows.
- Align the Windows ACL/verifier fixtures with their production contracts and bump the patch release to 1.5.5.

## Focused validation

- Reproduced all 16 failed Windows nodes from the v1.5.4 tag run.
- Windows: 7 applicable tests passed; all 32 POSIX cases were explicitly recorded as excluded with zero skips/deselections.
- Linux/WSL: all 13 formerly failing fast-path POSIX probes passed; the prior Ubuntu matrix already passed all 19 journal cases.
- Platform evidence/parser/seal tests passed, including malformed, truncated, mismatched, and incomplete evidence.
- Ruff, Ruff format, Pyright, `uv lock --check`, release-policy digest validation, and `git diff --check` passed.