### PR TITLE
feat: reconcile tracked JARVIS inputs on run

### DIFF
--- a/docs/ai/interface-context.md
+++ b/docs/ai/interface-context.md
@@ -175,8 +175,12 @@ profile exposes transform mutation.
 Registered remote MCP calls execute the packaged stdio client and server in
 endpoint-owned process containment. They do not create an outer JARVIS pipeline
 or scheduler job. Exact `clio-kit-jarvis-user-v3.6` routes additionally support
-package-described local-file staging; other registered contracts remain generic
-pass-through.
+package-described local-file staging. Accepted bindings retain only
+workspace-relative Host paths and immutable cluster artifact identities. A new
+`jarvis_run` admission reconciles those paths into a checksum-bound input
+manifest; the endpoint MCP runner materializes the manifest before the final
+run call, while the same idempotency key reuses its original manifest without a
+new snapshot. Other registered contracts remain generic pass-through.
 
 `relay_bind_jarvis_runtime` is in the user profile. A waited
 `jarvis_get_execution(include_service_runtimes=true)` response supplies compact

--- a/docs/ai/system-context.md
+++ b/docs/ai/system-context.md
@@ -99,9 +99,14 @@ same-call terminal observation when staging/lineage is needed. Relay snapshots
 only a stable regular file under
 `CLIO_RELAY_INPUT_WORKSPACE_ROOT`, applies the configured per-file, aggregate,
 and count bounds, ingests through the authenticated owner-generation API,
-rewrites the package argument, and records schema-argument provenance. Pipeline
-lineage is durable and bound to route, server artifact, pipeline, and session
-generation. Other schemas and path-looking arguments are pass-through.
+rewrites the package argument, and records schema-argument provenance. Each
+accepted binding is durable and exact to route, server artifact, pipeline,
+step, canonical setting, and session generation. Every genuinely new
+`jarvis_run` snapshots the stable logical paths again, reuses unchanged
+artifacts, ingests changed bytes, and admits one immutable per-run input
+manifest before the worker materializes those settings and calls JARVIS.
+Idempotent retries reuse that manifest without rescanning Host state. Other
+schemas and path-looking arguments are pass-through.
 
 ## Transports
 

--- a/docs/remote-mcp-federation.md
+++ b/docs/remote-mcp-federation.md
@@ -299,12 +299,26 @@ pipeline lineage. The resulting job dependency has
 `clio-relay.artifact-use-provenance.v1` evidence `schema-arg` naming the exact
 package setting.
 
-After the add-step call succeeds, relay records the input lineage against the
-exact cluster route revision, MCP registration revision, immutable server
-artifact, pipeline id, and owner-session generation. A later `jarvis_run`
-inherits those content pins even after the desktop MCP process reconnects. A
-changed route, registration, artifact, pipeline, session generation, checksum,
-or provenance fails closed rather than reusing stale bytes.
+After the add-step call succeeds, relay records each stable workspace-relative
+logical path against the exact cluster route revision, MCP registration
+revision, immutable server artifact, pipeline id, step id, canonical setting,
+and owner-session generation. Tracked `jarvis_edit_step` calls replace or remove
+those exact bindings only after JARVIS accepts the edit.
+
+On the first admission of every genuinely new `jarvis_run`, relay securely
+snapshots every tracked path again. Unchanged content reuses its immutable
+artifact; changed content is ingested as a new artifact. Relay persists a
+checksum-bound per-run manifest and the cluster worker materializes its exact
+step settings before invoking `jarvis_run`, so failure during reconciliation
+cannot reach scheduler submission. The relay job's artifact dependencies and
+private MCP result retain machine-readable reused/updated evidence, while
+earlier executions keep their original hashes. Retrying the same run
+idempotency key reuses the already admitted manifest without rescanning the
+mutable workspace. A missing, unsafe, oversized, or concurrently changing file
+fails before run submission.
+
+A changed route, registration, artifact, pipeline, session generation,
+checksum, or provenance fails closed rather than reusing stale bytes.
 
 Settings without the exact declaration are passed through unchanged; a
 path-looking name is never sufficient authority to read a local file. Legacy or

--- a/jarvis-packages/clio_relay/clio_relay/mcp_call/runner.py
+++ b/jarvis-packages/clio_relay/clio_relay/mcp_call/runner.py
@@ -1788,6 +1788,14 @@ def run_mcp_call_from_params(params: dict[str, Any]) -> int:
     operation = _operation(params.get("operation", "tools/call"))
     tool = _optional_str(params.get("tool"))
     arguments = _object(params.get("arguments", {}))
+    jarvis_input_manifest = _jarvis_input_manifest(
+        params.get("jarvis_input_manifest"),
+        operation=operation,
+        tool=tool,
+        arguments=arguments,
+        expected_registered_contract=expected_registered_contract,
+        expected_jarvis_cd_lock_binding=expected_jarvis_cd_lock_binding,
+    )
     if operation == "tools/call" and tool is None:
         raise ValueError("tool is required for tools/call")
     if operation == "tools/list" and (tool is not None or arguments):
@@ -1849,13 +1857,26 @@ def run_mcp_call_from_params(params: dict[str, Any]) -> int:
             server_artifact=server_artifact,
         ) as prepared:
             launch_command, execution_artifact = prepared
-            if operation == "tools/call" and progress_bridge is None:
+            if (
+                operation == "tools/call"
+                and progress_bridge is None
+                and jarvis_input_manifest is None
+            ):
                 process = _run_mcp_session(
                     launch_command,
                     tool=tool,
                     arguments=arguments,
                     timeout=timeout,
                     env_from=env_from,
+                )
+            elif operation == "tools/call" and jarvis_input_manifest is None:
+                process = _run_mcp_session(
+                    launch_command,
+                    tool=tool,
+                    arguments=arguments,
+                    timeout=timeout,
+                    env_from=env_from,
+                    progress_bridge=progress_bridge,
                 )
             elif operation == "tools/call":
                 process = _run_mcp_session(
@@ -1865,6 +1886,7 @@ def run_mcp_call_from_params(params: dict[str, Any]) -> int:
                     timeout=timeout,
                     env_from=env_from,
                     progress_bridge=progress_bridge,
+                    jarvis_input_manifest=jarvis_input_manifest,
                 )
             else:
                 process = _run_mcp_session(
@@ -1939,6 +1961,7 @@ def run_mcp_call_from_params(params: dict[str, Any]) -> int:
         operation=operation,
         tool=tool,
         arguments=arguments,
+        jarvis_input_manifest=jarvis_input_manifest,
         returncode=returncode,
         stdout=str(process.stdout or ""),
         stderr=str(process.stderr or ""),
@@ -2021,13 +2044,14 @@ def _call_message(
     tool: str,
     arguments: dict[str, Any],
     progress_token: str | None = None,
+    response_id: str = "clio-relay-mcp-call",
 ) -> dict[str, Any]:
     params: dict[str, Any] = {"name": tool, "arguments": arguments}
     if progress_token is not None:
         params["_meta"] = {"progressToken": progress_token}
     return {
         "jsonrpc": "2.0",
-        "id": "clio-relay-mcp-call",
+        "id": response_id,
         "method": "tools/call",
         "params": params,
     }
@@ -2169,6 +2193,7 @@ def _write_mcp_result(
     operation: str,
     tool: str | None,
     arguments: dict[str, Any],
+    jarvis_input_manifest: dict[str, Any] | None,
     returncode: int,
     stdout: str,
     stderr: str,
@@ -2212,6 +2237,7 @@ def _write_mcp_result(
         "operation": operation,
         "tool": tool,
         "arguments": arguments,
+        "input_reconciliation": jarvis_input_manifest,
         "protocol_result": protocol_result,
         "structured_result": _structured_result(protocol_result, operation=operation),
         "protocol_version": protocol_version,
@@ -4744,6 +4770,7 @@ def _run_mcp_session(
     operation: str = "tools/call",
     env_from: dict[str, str] | None = None,
     progress_bridge: _McpProgressBridge | None = None,
+    jarvis_input_manifest: dict[str, Any] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     process = _open_process(command, env_from=env_from or {})
     previous_handlers = _install_parent_termination_handlers(process)
@@ -4780,6 +4807,15 @@ def _run_mcp_session(
         )
         _write_message(process, _initialized_message())
         if operation == "tools/call":
+            if jarvis_input_manifest is not None:
+                _run_jarvis_input_reconciliation(
+                    process,
+                    stdout_queue,
+                    stdout_lines,
+                    manifest=jarvis_input_manifest,
+                    deadline=deadline,
+                    command=command,
+                )
             request = _call_message(
                 tool=_required_optional_str(tool, "tool"),
                 arguments=arguments,
@@ -4851,6 +4887,66 @@ def _run_mcp_session(
         stdout="".join(stdout_lines),
         stderr="".join(stderr_lines),
     )
+
+
+def _run_jarvis_input_reconciliation(
+    process: subprocess.Popen[str],
+    stdout_queue: Queue[_StreamEvent],
+    stdout_lines: list[str],
+    *,
+    manifest: dict[str, Any],
+    deadline: float | None,
+    command: list[str],
+) -> None:
+    """Materialize an admitted input manifest before the final jarvis_run call."""
+    route = cast(dict[str, Any], manifest["route"])
+    pipeline_id = cast(str, route["pipeline_id"])
+    configs: dict[str, dict[str, str]] = {}
+    for raw_resolution in cast(list[dict[str, Any]], manifest["resolutions"]):
+        binding = cast(dict[str, Any], raw_resolution["binding"])
+        step_id = cast(str, binding["step_id"])
+        setting = cast(str, binding["canonical_setting"])
+        remote_path = cast(str, binding["remote_path"])
+        step_config = configs.setdefault(step_id, {})
+        if setting in step_config:
+            raise _McpProtocolFailure(
+                "JARVIS input manifest repeated one step setting during materialization"
+            )
+        step_config[setting] = remote_path
+    response_bytes = [0]
+    for index, step_id in enumerate(sorted(configs), start=1):
+        response_id = f"clio-relay-mcp-input-reconcile-{index}"
+        _write_message(
+            process,
+            _call_message(
+                tool="jarvis_edit_step",
+                arguments={
+                    "pipeline_id": pipeline_id,
+                    "step_id": step_id,
+                    "config": configs[step_id],
+                    "operation": "edit",
+                },
+                response_id=response_id,
+            ),
+        )
+        response = _wait_for_response(
+            stdout_queue,
+            response_id,
+            stdout_lines,
+            process=process,
+            deadline=deadline,
+            command=command,
+            response_bytes=response_bytes,
+            max_response_bytes=MCP_CALL_MAX_RESPONSE_BYTES,
+            response_label="JARVIS input reconciliation",
+        )
+        if response.get("error") is not None:
+            raise _McpProtocolFailure(f"JARVIS input reconciliation failed for step {step_id}")
+        result = response.get("result")
+        if not isinstance(result, dict) or cast(dict[str, Any], result).get("isError") is True:
+            raise _McpProtocolFailure(
+                f"JARVIS input reconciliation was rejected for step {step_id}"
+            )
 
 
 def _run_bounded_tools_list(
@@ -5233,6 +5329,208 @@ def _object(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError("arguments must be an object")
     return cast(dict[str, Any], value)
+
+
+def _jarvis_input_manifest(
+    value: Any,
+    *,
+    operation: str,
+    tool: str | None,
+    arguments: dict[str, Any],
+    expected_registered_contract: str | None,
+    expected_jarvis_cd_lock_binding: dict[str, str] | None,
+) -> dict[str, Any] | None:
+    """Validate one relay-owned resolved-input manifest before MCP launch."""
+    if value is None:
+        return None
+    if (
+        operation != "tools/call"
+        or tool != "jarvis_run"
+        or expected_registered_contract != REGISTERED_JARVIS_EXECUTION_QUERY_CONTRACT
+        or expected_jarvis_cd_lock_binding is not None
+        or not isinstance(value, dict)
+    ):
+        raise ValueError("JARVIS input manifest requires the registered jarvis_run contract")
+    manifest = cast(dict[str, Any], value)
+    expected_fields = {
+        "schema_version",
+        "route",
+        "route_sha256",
+        "idempotency_key",
+        "resolutions",
+        "artifact_uses",
+        "manifest_sha256",
+        "created_at",
+        "document_sha256",
+    }
+    if (
+        set(manifest) != expected_fields
+        or manifest.get("schema_version") != "clio-relay.jarvis-run-input-manifest.v1"
+    ):
+        raise ValueError("JARVIS input manifest fields are invalid")
+    route = manifest.get("route")
+    expected_route_fields = {
+        "schema_version",
+        "cluster",
+        "server_name",
+        "contract",
+        "cluster_route_revision",
+        "registration_revision",
+        "expected_server_artifact_digest",
+        "pipeline_id",
+        "owner_session_id",
+        "owner_session_generation_id",
+    }
+    if not isinstance(route, dict):
+        raise ValueError("JARVIS input manifest route is invalid")
+    typed_route = cast(dict[str, Any], route)
+    if (
+        set(typed_route) != expected_route_fields
+        or typed_route.get("schema_version") != "clio-relay.jarvis-pipeline-input-route.v1"
+        or typed_route.get("contract") != REGISTERED_JARVIS_EXECUTION_QUERY_CONTRACT
+        or typed_route.get("pipeline_id") != arguments.get("pipeline_id")
+    ):
+        raise ValueError("JARVIS input manifest route is invalid")
+    route_sha256 = _canonical_json_sha256(typed_route)
+    if manifest.get("route_sha256") != route_sha256:
+        raise ValueError("JARVIS input manifest route checksum is invalid")
+    if not isinstance(manifest.get("idempotency_key"), str) or not manifest["idempotency_key"]:
+        raise ValueError("JARVIS input manifest idempotency key is invalid")
+    raw_resolutions = manifest.get("resolutions")
+    if not isinstance(raw_resolutions, list):
+        raise ValueError("JARVIS input manifest resolutions are invalid")
+    typed_resolutions = cast(list[object], raw_resolutions)
+    if not typed_resolutions or len(typed_resolutions) > 1_000:
+        raise ValueError("JARVIS input manifest resolutions are invalid")
+    resolutions: list[dict[str, Any]] = []
+    identities: list[tuple[str, str]] = []
+    expected_uses: list[dict[str, Any]] = []
+    for raw_resolution in typed_resolutions:
+        if not isinstance(raw_resolution, dict):
+            raise ValueError("JARVIS input manifest resolution fields are invalid")
+        resolution = cast(dict[str, Any], raw_resolution)
+        if set(resolution) != {
+            "binding",
+            "disposition",
+            "previous_sha256",
+        }:
+            raise ValueError("JARVIS input manifest resolution fields are invalid")
+        binding = resolution.get("binding")
+        if not isinstance(binding, dict):
+            raise ValueError("JARVIS input manifest binding fields are invalid")
+        typed_binding = cast(dict[str, Any], binding)
+        if set(typed_binding) != {
+            "step_id",
+            "canonical_setting",
+            "accepted_names",
+            "workspace_relative_path",
+            "logical_name",
+            "size_bytes",
+            "sha256",
+            "remote_path",
+            "artifact_use",
+        }:
+            raise ValueError("JARVIS input manifest binding fields are invalid")
+        step_id = typed_binding.get("step_id")
+        setting = typed_binding.get("canonical_setting")
+        accepted_names = typed_binding.get("accepted_names")
+        relative_path = typed_binding.get("workspace_relative_path")
+        remote_path = typed_binding.get("remote_path")
+        sha256 = typed_binding.get("sha256")
+        artifact_use = typed_binding.get("artifact_use")
+        typed_accepted_names = (
+            cast(list[object], accepted_names) if isinstance(accepted_names, list) else []
+        )
+        typed_artifact_use = (
+            cast(dict[str, Any], artifact_use) if isinstance(artifact_use, dict) else {}
+        )
+        if (
+            not isinstance(step_id, str)
+            or not step_id
+            or not isinstance(setting, str)
+            or not setting
+            or not isinstance(accepted_names, list)
+            or not accepted_names
+            or accepted_names[0] != setting
+            or not all(isinstance(item, str) and item for item in typed_accepted_names)
+            or len(typed_accepted_names) != len(set(cast(list[str], typed_accepted_names)))
+            or not isinstance(relative_path, str)
+            or not relative_path
+            or "\\" in relative_path
+            or relative_path.startswith("/")
+            or any(part in {"", ".", ".."} for part in relative_path.split("/"))
+            or not isinstance(remote_path, str)
+            or not remote_path.startswith("/")
+            or remote_path.startswith("//")
+            or not _is_sha256(sha256)
+            or not isinstance(artifact_use, dict)
+            or typed_artifact_use.get("sha256") != sha256
+        ):
+            raise ValueError("JARVIS input manifest binding identity is invalid")
+        previous_sha256 = resolution.get("previous_sha256")
+        disposition = resolution.get("disposition")
+        if not _is_sha256(previous_sha256) or (
+            (disposition == "reused") != (previous_sha256 == sha256)
+        ):
+            raise ValueError("JARVIS input manifest resolution disposition is invalid")
+        identities.append((step_id, setting))
+        expected_uses.append(typed_artifact_use)
+        resolutions.append(resolution)
+    if identities != sorted(identities) or len(identities) != len(set(identities)):
+        raise ValueError("JARVIS input manifest binding identities are not canonical")
+    expected_uses.sort(key=lambda item: (str(item.get("artifact_id")), str(item.get("sha256"))))
+    if manifest.get("artifact_uses") != expected_uses:
+        raise ValueError("JARVIS input manifest artifact uses do not match its bindings")
+    expected_manifest_sha256 = _canonical_json_sha256(
+        {
+            "route_sha256": route_sha256,
+            "idempotency_key": manifest["idempotency_key"],
+            "resolutions": resolutions,
+            "artifact_uses": expected_uses,
+        }
+    )
+    if manifest.get("manifest_sha256") != expected_manifest_sha256:
+        raise ValueError("JARVIS input manifest resolution checksum is invalid")
+    document = dict(manifest)
+    document.pop("document_sha256")
+    if manifest.get("document_sha256") != _canonical_json_sha256(document):
+        raise ValueError("JARVIS input manifest document checksum is invalid")
+    if (
+        len(
+            json.dumps(
+                manifest,
+                allow_nan=False,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
+        > 1 * 1024 * 1024
+    ):
+        raise ValueError("JARVIS input manifest exceeded its byte limit")
+    return manifest
+
+
+def _is_sha256(value: object) -> bool:
+    """Return whether a value is one canonical lowercase SHA-256 digest."""
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _canonical_json_sha256(value: object) -> str:
+    """Return the SHA-256 of one finite canonical JSON value."""
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
 
 
 def _str_list(value: Any, *, key: str) -> list[str]:

--- a/src/clio_relay/core_queue.py
+++ b/src/clio_relay/core_queue.py
@@ -53,8 +53,11 @@ from clio_relay.models import (
     InputArtifactSpec,
     JarvisPackageInputContractRecord,
     JarvisPackageInputRoute,
+    JarvisPipelineInputBinding,
+    JarvisPipelineInputBindings,
     JarvisPipelineInputLineage,
     JarvisPipelineInputRoute,
+    JarvisRunInputManifest,
     JobGcPhase,
     JobKind,
     JobState,
@@ -133,7 +136,9 @@ MAX_GATEWAY_INDEX_RECORDS = 10_000
 MAX_SCHEDULER_METADATA_RECORDS = 1_000
 MAX_TRANSITION_INTENT_RECORDS = 10_000
 MAX_JARVIS_PACKAGE_INPUT_CONTRACT_RECORDS = 10_000
+MAX_JARVIS_PIPELINE_INPUT_BINDING_RECORDS = 10_000
 MAX_JARVIS_PIPELINE_INPUT_LINEAGE_RECORDS = 10_000
+MAX_JARVIS_RUN_INPUT_MANIFEST_RECORDS = 10_000
 MAX_ARTIFACT_USES_PER_JOB = 1_000
 MAX_ARTIFACT_CONSUMERS = 10_000
 ARTIFACT_USER_CURSOR_PREFIX = "edge_"
@@ -189,7 +194,9 @@ RECORD_FAMILY_MAX_BYTES: dict[str, int] = {
     "jobs_active": 1_048_576,
     "jobs_queued": 1_048_576,
     "jarvis_package_input_contracts": 262_144,
+    "jarvis_pipeline_input_bindings": 1_048_576,
     "jarvis_pipeline_input_lineage": 1_048_576,
+    "jarvis_run_input_manifests": 1_048_576,
     "leases": 65_536,
     "legacy_output_archives": MAX_LEGACY_OUTPUT_RECORD_BYTES,
     "legacy_output_receipts": 65_536,
@@ -4402,6 +4409,135 @@ class ClioCoreQueue:
                 raise QueueConflictError(
                     "durable JARVIS pipeline input lineage route identity changed"
                 )
+            return record
+
+    def get_jarvis_pipeline_input_bindings(
+        self,
+        route: JarvisPipelineInputRoute,
+    ) -> JarvisPipelineInputBindings | None:
+        """Load current local-file bindings for one exact registered pipeline route."""
+        self.initialize()
+        route_sha256 = route.identity_sha256()
+        path = self._storage_root / "jarvis_pipeline_input_bindings" / f"{route_sha256}.json"
+        with self._lock:
+            record = self._read_optional(path, JarvisPipelineInputBindings)
+            if record is None:
+                return None
+            if record.route != route or record.route_sha256 != route_sha256:
+                raise QueueConflictError(
+                    "durable JARVIS pipeline input bindings route identity changed"
+                )
+            return record
+
+    def update_jarvis_pipeline_input_bindings(
+        self,
+        route: JarvisPipelineInputRoute,
+        *,
+        upserts: tuple[JarvisPipelineInputBinding, ...] = (),
+        remove: tuple[tuple[str, str], ...] = (),
+    ) -> JarvisPipelineInputBindings:
+        """Atomically update exact step/setting bindings for one pipeline route."""
+        self.initialize()
+        route_sha256 = route.identity_sha256()
+        directory = self._storage_root / "jarvis_pipeline_input_bindings"
+        path = directory / f"{route_sha256}.json"
+        remove_set = set(remove)
+        if len(remove_set) != len(remove):
+            raise ValueError("pipeline input binding removals must be unique")
+        upsert_identities = [item.identity() for item in upserts]
+        if len(upsert_identities) != len(set(upsert_identities)):
+            raise ValueError("pipeline input binding upserts must be unique")
+        if remove_set.intersection(upsert_identities):
+            raise ValueError("pipeline input binding cannot be removed and upserted together")
+        with self._lock:
+            existing = self._read_optional(path, JarvisPipelineInputBindings)
+            mutation_at = utc_now()
+            if existing is None:
+                count, over_capacity = _bounded_regular_json_count(
+                    directory,
+                    limit=MAX_JARVIS_PIPELINE_INPUT_BINDING_RECORDS,
+                    label="JARVIS pipeline input bindings",
+                )
+                if over_capacity or count >= MAX_JARVIS_PIPELINE_INPUT_BINDING_RECORDS:
+                    raise QueueConflictError(
+                        "JARVIS pipeline input bindings reached their bounded record capacity"
+                    )
+                by_identity: dict[tuple[str, str], JarvisPipelineInputBinding] = {}
+                created_at = mutation_at
+            else:
+                if existing.route != route or existing.route_sha256 != route_sha256:
+                    raise QueueConflictError(
+                        "durable JARVIS pipeline input bindings route identity changed"
+                    )
+                by_identity = {item.identity(): item for item in existing.bindings}
+                created_at = existing.created_at
+            for identity in remove_set:
+                by_identity.pop(identity, None)
+            for item in upserts:
+                by_identity[item.identity()] = item
+            record = JarvisPipelineInputBindings.create(
+                route=route,
+                bindings=tuple(by_identity.values()),
+                created_at=created_at,
+                updated_at=mutation_at,
+            )
+            self._write(path, record)
+            return record
+
+    def get_jarvis_run_input_manifest(
+        self,
+        route: JarvisPipelineInputRoute,
+        *,
+        idempotency_key: str,
+    ) -> JarvisRunInputManifest | None:
+        """Load an immutable input manifest for one exact jarvis_run admission."""
+        self.initialize()
+        identity_sha256 = JarvisRunInputManifest.storage_identity_sha256(
+            route=route,
+            idempotency_key=idempotency_key,
+        )
+        path = self._storage_root / "jarvis_run_input_manifests" / f"{identity_sha256}.json"
+        with self._lock:
+            record = self._read_optional(path, JarvisRunInputManifest)
+            if record is None:
+                return None
+            if (
+                record.route != route
+                or record.idempotency_key != idempotency_key
+                or record.identity_sha256() != identity_sha256
+            ):
+                raise QueueConflictError("durable JARVIS run input manifest identity changed")
+            return record
+
+    def put_jarvis_run_input_manifest(
+        self,
+        record: JarvisRunInputManifest,
+    ) -> JarvisRunInputManifest:
+        """Persist the first exact input manifest admitted for one run key."""
+        self.initialize()
+        identity_sha256 = record.identity_sha256()
+        directory = self._storage_root / "jarvis_run_input_manifests"
+        path = directory / f"{identity_sha256}.json"
+        with self._lock:
+            existing = self._read_optional(path, JarvisRunInputManifest)
+            if existing is not None:
+                if (
+                    existing.route != record.route
+                    or existing.idempotency_key != record.idempotency_key
+                    or existing.identity_sha256() != identity_sha256
+                ):
+                    raise QueueConflictError("durable JARVIS run input manifest identity changed")
+                return existing
+            count, over_capacity = _bounded_regular_json_count(
+                directory,
+                limit=MAX_JARVIS_RUN_INPUT_MANIFEST_RECORDS,
+                label="JARVIS run input manifest",
+            )
+            if over_capacity or count >= MAX_JARVIS_RUN_INPUT_MANIFEST_RECORDS:
+                raise QueueConflictError(
+                    "JARVIS run input manifests reached their bounded record capacity"
+                )
+            self._write(path, record)
             return record
 
     def merge_jarvis_pipeline_input_lineage(

--- a/src/clio_relay/http_api.py
+++ b/src/clio_relay/http_api.py
@@ -68,6 +68,7 @@ from clio_relay.jarvis_service_runtime import (
 from clio_relay.models import (
     INPUT_INGEST_POLICY_METADATA_KEY,
     MCP_ADMISSION_AUTHORITY_METADATA_KEY,
+    REGISTERED_JARVIS_USER_CONTRACT,
     ArtifactRef,
     ArtifactUse,
     Cursor,
@@ -75,6 +76,7 @@ from clio_relay.models import (
     GatewaySessionState,
     InputArtifactIngestPolicy,
     InputArtifactSpec,
+    JarvisRunInputManifest,
     JarvisRunSpec,
     JobKind,
     JobState,
@@ -641,6 +643,7 @@ class McpCallSubmitRequest(BaseModel):
     operation: McpOperation = McpOperation.TOOLS_CALL
     tool: str | None = None
     arguments: dict[str, object] = Field(default_factory=dict)
+    jarvis_input_manifest: JarvisRunInputManifest | None = None
     control_query_evidence: McpControlQueryEvidence | None = None
     timeout_seconds: int | None = Field(default=None, gt=0)
     idempotency_key: str
@@ -661,6 +664,14 @@ class McpCallSubmitRequest(BaseModel):
         if self.operation is McpOperation.TOOLS_CALL:
             if not self.tool:
                 raise ValueError("tool is required for tools/call")
+            if self.jarvis_input_manifest is not None and (
+                self.tool != "jarvis_run"
+                or self.expected_registered_contract != REGISTERED_JARVIS_USER_CONTRACT
+                or self.arguments.get("pipeline_id") != self.jarvis_input_manifest.route.pipeline_id
+            ):
+                raise ValueError(
+                    "JARVIS input manifests require the exact registered jarvis_run pipeline"
+                )
             return self
         if self.tool is not None:
             raise ValueError("tool must be omitted for tools/list")
@@ -672,6 +683,8 @@ class McpCallSubmitRequest(BaseModel):
             raise ValueError("tools/list must not carry a registered semantic contract binding")
         if self.control_query_evidence is not None:
             raise ValueError("tools/list must not carry control-query route evidence")
+        if self.jarvis_input_manifest is not None:
+            raise ValueError("tools/list must not carry a JARVIS input manifest")
         return self
 
 
@@ -1497,6 +1510,7 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
                     operation=request.operation,
                     tool=request.tool,
                     arguments=request.arguments,
+                    jarvis_input_manifest=request.jarvis_input_manifest,
                     timeout_seconds=request.timeout_seconds,
                 ),
                 idempotency_key=request.idempotency_key,

--- a/src/clio_relay/input_staging.py
+++ b/src/clio_relay/input_staging.py
@@ -26,7 +26,10 @@ from clio_relay.models import (
     JarvisPackageInputContractRecord,
     JarvisPackageInputRoute,
     JarvisPackageLocalFileInput,
+    JarvisPipelineInputBinding,
+    JarvisPipelineInputBindings,
     JarvisPipelineInputRoute,
+    JarvisRunInputResolution,
     JobKind,
     RelayJob,
     deterministic_input_artifact_id,
@@ -59,6 +62,23 @@ class StagedJarvisInputs:
     arguments: JSON
     artifact_uses: tuple[ArtifactUse, ...]
     manifest_sha256: str | None
+    bindings: tuple[JarvisPipelineInputBinding, ...]
+    removed_binding_identities: tuple[tuple[str, str], ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class _InputSnapshot:
+    """One securely captured workspace input awaiting immutable ingestion."""
+
+    step_id: str
+    canonical_setting: str
+    accepted_names: tuple[str, ...]
+    supplied_setting: str
+    workspace_relative_path: str
+    logical_name: str
+    data: bytes
+    size_bytes: int
+    sha256: str
 
 
 def jarvis_package_input_cache_key(
@@ -283,7 +303,11 @@ def stage_jarvis_add_step_inputs(
     rewritten = copy.deepcopy(arguments)
     config = copy.deepcopy(cast(JSON, raw_config))
     rewritten["config"] = config
-    requested: list[tuple[str, Path, str]] = []
+    requested: list[tuple[str, tuple[str, ...], str, Path, str]] = []
+    raw_step_id = arguments.get("step_id")
+    if raw_step_id is not None and (not isinstance(raw_step_id, str) or not raw_step_id):
+        raise ValueError("jarvis_add_step step_id must be a non-empty string when supplied")
+    step_id = raw_step_id if raw_step_id is not None else package_name.rsplit(".", 1)[-1]
     for local_file_input in contract.local_file_settings:
         supplied = [
             (setting_name, config[setting_name])
@@ -302,14 +326,224 @@ def stage_jarvis_add_step_inputs(
         setting_name, raw_value = supplied[0]
         if not isinstance(raw_value, str):
             raise ValueError(f"local-file setting {setting_name!r} must be a path string")
-        requested.append((setting_name, _workspace_path(raw_value, settings=settings), raw_value))
+        requested.append(
+            (
+                local_file_input.canonical_name,
+                local_file_input.accepted_names,
+                setting_name,
+                _workspace_path(raw_value, settings=settings),
+                raw_value,
+            )
+        )
     if not requested:
         return StagedJarvisInputs(
             arguments=rewritten,
             artifact_uses=(),
             manifest_sha256=None,
+            bindings=(),
         )
-    if settings.input_workspace_root is None:
+    snapshots = _snapshot_inputs(
+        step_id=step_id,
+        requested=requested,
+        settings=settings,
+    )
+    bindings: list[JarvisPipelineInputBinding] = []
+    with OwnedSessionApiClient(definition=definition, settings=settings) as client:
+        for snapshot in snapshots:
+            binding = _ingest_input_snapshot(
+                snapshot,
+                client=client,
+                definition=definition,
+                settings=settings,
+            )
+            config[snapshot.supplied_setting] = binding.remote_path
+            bindings.append(binding)
+    artifact_uses = tuple(
+        sorted((item.artifact_use for item in bindings), key=lambda item: item.artifact_id)
+    )
+    return StagedJarvisInputs(
+        arguments=rewritten,
+        artifact_uses=artifact_uses,
+        manifest_sha256=_stable_digest(
+            {"inputs": [item.model_dump(mode="json") for item in bindings]}
+        ),
+        bindings=tuple(sorted(bindings, key=lambda item: item.identity())),
+    )
+
+
+def stage_jarvis_edit_step_inputs(
+    arguments: JSON,
+    *,
+    current: JarvisPipelineInputBindings,
+    definition: ClusterDefinition,
+    settings: RelaySettings,
+) -> StagedJarvisInputs:
+    """Stage changed logical paths for tracked settings on one edited JARVIS step."""
+    rewritten = copy.deepcopy(arguments)
+    step_id = _required_string(arguments, "step_id")
+    operation = arguments.get("operation", "edit")
+    tracked = tuple(item for item in current.bindings if item.step_id == step_id)
+    if operation == "remove":
+        return StagedJarvisInputs(
+            arguments=rewritten,
+            artifact_uses=(),
+            manifest_sha256=None,
+            bindings=(),
+            removed_binding_identities=tuple(item.identity() for item in tracked),
+        )
+    if operation != "edit":
+        raise ValueError("jarvis_edit_step operation must be edit or remove")
+    raw_config = arguments.get("config")
+    if not isinstance(raw_config, dict):
+        raise ValueError("jarvis_edit_step config must be an object for operation='edit'")
+    config = copy.deepcopy(cast(JSON, raw_config))
+    rewritten["config"] = config
+    requested: list[tuple[str, tuple[str, ...], str, Path, str]] = []
+    removed: list[tuple[str, str]] = []
+    for binding in tracked:
+        supplied = [(name, config[name]) for name in binding.accepted_names if name in config]
+        if not supplied:
+            continue
+        if len(supplied) > 1:
+            raise ValueError(
+                "local-file setting was supplied through more than one canonical name or alias: "
+                f"{binding.canonical_setting!r}"
+            )
+        setting_name, raw_value = supplied[0]
+        if raw_value is None or raw_value == "":
+            removed.append(binding.identity())
+            continue
+        if not isinstance(raw_value, str):
+            raise ValueError(f"local-file setting {setting_name!r} must be a path string")
+        requested.append(
+            (
+                binding.canonical_setting,
+                binding.accepted_names,
+                setting_name,
+                _workspace_path(raw_value, settings=settings),
+                raw_value,
+            )
+        )
+    snapshots = _snapshot_inputs(
+        step_id=step_id,
+        requested=requested,
+        settings=settings,
+    )
+    bindings: list[JarvisPipelineInputBinding] = []
+    if snapshots:
+        with OwnedSessionApiClient(definition=definition, settings=settings) as client:
+            for snapshot in snapshots:
+                binding = _ingest_input_snapshot(
+                    snapshot,
+                    client=client,
+                    definition=definition,
+                    settings=settings,
+                )
+                config[snapshot.supplied_setting] = binding.remote_path
+                bindings.append(binding)
+    artifact_uses = tuple(
+        sorted((item.artifact_use for item in bindings), key=lambda item: item.artifact_id)
+    )
+    return StagedJarvisInputs(
+        arguments=rewritten,
+        artifact_uses=artifact_uses,
+        manifest_sha256=(
+            _stable_digest({"inputs": [item.model_dump(mode="json") for item in bindings]})
+            if bindings
+            else None
+        ),
+        bindings=tuple(sorted(bindings, key=lambda item: item.identity())),
+        removed_binding_identities=tuple(sorted(removed)),
+    )
+
+
+def reconcile_jarvis_run_inputs(
+    current: JarvisPipelineInputBindings,
+    *,
+    definition: ClusterDefinition,
+    settings: RelaySettings,
+) -> tuple[JarvisRunInputResolution, ...]:
+    """Resolve every tracked logical path to immutable bytes for one new execution."""
+    snapshots = _snapshot_inputs_by_binding(current=current, settings=settings)
+    existing_by_identity = {item.identity(): item for item in current.bindings}
+    resolutions: list[JarvisRunInputResolution] = []
+    changed = [
+        snapshot
+        for snapshot in snapshots
+        if existing_by_identity[(snapshot.step_id, snapshot.canonical_setting)].sha256
+        != snapshot.sha256
+    ]
+    updated_by_identity: dict[tuple[str, str], JarvisPipelineInputBinding] = {}
+    if changed:
+        with OwnedSessionApiClient(definition=definition, settings=settings) as client:
+            for snapshot in changed:
+                updated = _ingest_input_snapshot(
+                    snapshot,
+                    client=client,
+                    definition=definition,
+                    settings=settings,
+                )
+                updated_by_identity[updated.identity()] = updated
+    for snapshot in snapshots:
+        identity = (snapshot.step_id, snapshot.canonical_setting)
+        previous = existing_by_identity[identity]
+        updated = updated_by_identity.get(identity, previous)
+        resolutions.append(
+            JarvisRunInputResolution(
+                binding=updated,
+                disposition=("reused" if updated.sha256 == previous.sha256 else "updated"),
+                previous_sha256=previous.sha256,
+            )
+        )
+    return tuple(sorted(resolutions, key=lambda item: item.binding.identity()))
+
+
+def _snapshot_inputs(
+    *,
+    step_id: str,
+    requested: list[tuple[str, tuple[str, ...], str, Path, str]],
+    settings: RelaySettings,
+) -> tuple[_InputSnapshot, ...]:
+    """Capture a bounded set of requested settings for one pipeline step."""
+    return _snapshot_input_requests(
+        [
+            (step_id, canonical, accepted, supplied, local_path, model_path)
+            for canonical, accepted, supplied, local_path, model_path in requested
+        ],
+        settings=settings,
+    )
+
+
+def _snapshot_inputs_by_binding(
+    *,
+    current: JarvisPipelineInputBindings,
+    settings: RelaySettings,
+) -> tuple[_InputSnapshot, ...]:
+    """Capture the stable logical path held by every current pipeline binding."""
+    return _snapshot_input_requests(
+        [
+            (
+                binding.step_id,
+                binding.canonical_setting,
+                binding.accepted_names,
+                binding.canonical_setting,
+                _workspace_path(binding.workspace_relative_path, settings=settings),
+                binding.workspace_relative_path,
+            )
+            for binding in current.bindings
+        ],
+        settings=settings,
+    )
+
+
+def _snapshot_input_requests(
+    requested: list[tuple[str, str, tuple[str, ...], str, Path, str]],
+    *,
+    settings: RelaySettings,
+) -> tuple[_InputSnapshot, ...]:
+    """Securely snapshot exact workspace-relative requests with aggregate limits."""
+    root = settings.input_workspace_root
+    if root is None:
         raise ValueError(
             "local JARVIS inputs require CLIO_RELAY_INPUT_WORKSPACE_ROOT to be configured"
         )
@@ -317,17 +551,14 @@ def stage_jarvis_add_step_inputs(
         raise ValueError(
             f"JARVIS input count exceeds the configured limit of {settings.input_file_max_count}"
         )
-    owner_session_id = settings.owner_session_id
-    owner_session_generation_id = settings.owner_session_generation_id
-    if owner_session_id is None or owner_session_generation_id is None:
+    if settings.owner_session_id is None or settings.owner_session_generation_id is None:
         raise ValueError("local JARVIS inputs require an active relay-owned remote session")
-
-    snapshots: list[tuple[str, str, bytes, int, str]] = []
+    snapshots: list[_InputSnapshot] = []
     total_bytes = 0
-    for setting_name, local_path, model_path in requested:
+    for step_id, canonical, accepted, supplied, local_path, model_path in requested:
         snapshot = snapshot_owned_regular_file(
             local_path,
-            owned_root=settings.input_workspace_root,
+            owned_root=root,
             max_bytes=settings.input_file_max_bytes,
             capture_data=True,
         )
@@ -340,75 +571,91 @@ def stage_jarvis_add_step_inputs(
                 f"{settings.input_total_max_bytes}"
             )
         snapshots.append(
-            (
-                setting_name,
-                _logical_name(model_path),
-                snapshot.data,
-                snapshot.size_bytes,
-                snapshot.sha256,
+            _InputSnapshot(
+                step_id=step_id,
+                canonical_setting=canonical,
+                accepted_names=accepted,
+                supplied_setting=supplied,
+                workspace_relative_path=_workspace_relative_path(local_path, root=root),
+                logical_name=_logical_name(model_path),
+                data=snapshot.data,
+                size_bytes=snapshot.size_bytes,
+                sha256=snapshot.sha256,
             )
         )
+    return tuple(
+        sorted(
+            snapshots,
+            key=lambda item: (item.step_id, item.canonical_setting),
+        )
+    )
 
-    artifact_uses: list[ArtifactUse] = []
-    manifest: list[JSON] = []
-    with OwnedSessionApiClient(definition=definition, settings=settings) as client:
-        for setting_name, logical_name, data, size_bytes, sha256 in snapshots:
-            ingest_key = "input-ingest:" + _stable_digest(
-                {
-                    "cluster": definition.name,
-                    "owner_session_id": owner_session_id,
-                    "owner_session_generation_id": str(owner_session_generation_id),
-                    "logical_name": logical_name,
-                    "size_bytes": size_bytes,
-                    "sha256": sha256,
-                }
-            )
-            raw_response = client.request_json(
-                method="POST",
-                path="/input-artifacts/ingest",
-                body={
-                    "schema_version": INPUT_INGEST_SCHEMA,
-                    "cluster": definition.name,
-                    "logical_name": logical_name,
-                    "size_bytes": size_bytes,
-                    "sha256": sha256,
-                    "data_base64": base64.b64encode(data).decode("ascii"),
-                    "idempotency_key": ingest_key,
-                },
-            )
-            artifact, producer = _validated_ingest_response(
-                raw_response,
-                definition=definition,
-                settings=settings,
-                logical_name=logical_name,
-                size_bytes=size_bytes,
-                sha256=sha256,
-                idempotency_key=ingest_key,
-            )
-            config[setting_name] = _cluster_path_from_file_uri(artifact.uri)
-            assert artifact.sha256 is not None
-            use = ArtifactUse(
-                artifact_id=artifact.artifact_id,
-                sha256=artifact.sha256,
-                provenance=ArtifactUseProvenance(
-                    evidence=ArtifactUseEvidence.SCHEMA_ARG,
-                    arg=setting_name,
-                ),
-            )
-            artifact_uses.append(use)
-            manifest.append(
-                {
-                    "setting": setting_name,
-                    "artifact_id": artifact.artifact_id,
-                    "producer_job_id": producer.job_id,
-                    "size_bytes": artifact.size_bytes,
-                    "sha256": artifact.sha256,
-                }
-            )
-    return StagedJarvisInputs(
-        arguments=rewritten,
-        artifact_uses=tuple(sorted(artifact_uses, key=lambda item: item.artifact_id)),
-        manifest_sha256=_stable_digest({"inputs": manifest}),
+
+def _ingest_input_snapshot(
+    snapshot: _InputSnapshot,
+    *,
+    client: OwnedSessionApiClient,
+    definition: ClusterDefinition,
+    settings: RelaySettings,
+) -> JarvisPipelineInputBinding:
+    """Ingest one immutable snapshot and return its exact durable binding."""
+    owner_session_id = settings.owner_session_id
+    owner_session_generation_id = settings.owner_session_generation_id
+    if owner_session_id is None or owner_session_generation_id is None:
+        raise ValueError("local JARVIS inputs require an active relay-owned remote session")
+    ingest_key = "input-ingest:" + _stable_digest(
+        {
+            "cluster": definition.name,
+            "owner_session_id": owner_session_id,
+            "owner_session_generation_id": str(owner_session_generation_id),
+            "step_id": snapshot.step_id,
+            "canonical_setting": snapshot.canonical_setting,
+            "workspace_relative_path": snapshot.workspace_relative_path,
+            "logical_name": snapshot.logical_name,
+            "size_bytes": snapshot.size_bytes,
+            "sha256": snapshot.sha256,
+        }
+    )
+    raw_response = client.request_json(
+        method="POST",
+        path="/input-artifacts/ingest",
+        body={
+            "schema_version": INPUT_INGEST_SCHEMA,
+            "cluster": definition.name,
+            "logical_name": snapshot.logical_name,
+            "size_bytes": snapshot.size_bytes,
+            "sha256": snapshot.sha256,
+            "data_base64": base64.b64encode(snapshot.data).decode("ascii"),
+            "idempotency_key": ingest_key,
+        },
+    )
+    artifact, _producer = _validated_ingest_response(
+        raw_response,
+        definition=definition,
+        settings=settings,
+        logical_name=snapshot.logical_name,
+        size_bytes=snapshot.size_bytes,
+        sha256=snapshot.sha256,
+        idempotency_key=ingest_key,
+    )
+    assert artifact.sha256 is not None
+    return JarvisPipelineInputBinding(
+        step_id=snapshot.step_id,
+        canonical_setting=snapshot.canonical_setting,
+        accepted_names=snapshot.accepted_names,
+        workspace_relative_path=snapshot.workspace_relative_path,
+        logical_name=snapshot.logical_name,
+        size_bytes=snapshot.size_bytes,
+        sha256=artifact.sha256,
+        remote_path=_cluster_path_from_file_uri(artifact.uri),
+        artifact_use=ArtifactUse(
+            artifact_id=artifact.artifact_id,
+            sha256=artifact.sha256,
+            provenance=ArtifactUseProvenance(
+                evidence=ArtifactUseEvidence.SCHEMA_ARG,
+                arg=snapshot.canonical_setting,
+            ),
+        ),
     )
 
 
@@ -488,6 +735,18 @@ def _workspace_path(value: str, *, settings: RelaySettings) -> Path:
         )
     supplied = Path(value)
     return supplied if supplied.is_absolute() else root / supplied
+
+
+def _workspace_relative_path(value: Path, *, root: Path) -> str:
+    """Return one normalized private-root-relative path without leaking the Host root."""
+    try:
+        relative = value.resolve(strict=True).relative_to(root.resolve(strict=True))
+    except (OSError, ValueError) as exc:
+        raise ValueError("local JARVIS input is not within the configured workspace") from exc
+    rendered = relative.as_posix()
+    if not rendered or rendered in {".", ".."} or rendered.startswith("../"):
+        raise ValueError("local JARVIS input has no safe workspace-relative path")
+    return rendered
 
 
 def _logical_name(value: str) -> str:

--- a/src/clio_relay/jarvis_provider.py
+++ b/src/clio_relay/jarvis_provider.py
@@ -168,6 +168,11 @@ class JarvisCdProvider:
                     "operation": spec.operation.value,
                     "tool": spec.tool,
                     "arguments": spec.arguments or None,
+                    "jarvis_input_manifest": (
+                        spec.jarvis_input_manifest.model_dump(mode="json")
+                        if spec.jarvis_input_manifest is not None
+                        else None
+                    ),
                     "timeout_seconds": spec.timeout_seconds,
                 }
             ],

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -49,7 +49,9 @@ from clio_relay.input_staging import (
     jarvis_pipeline_input_route,
     merge_artifact_uses,
     parse_jarvis_package_input_contract,
+    reconcile_jarvis_run_inputs,
     stage_jarvis_add_step_inputs,
+    stage_jarvis_edit_step_inputs,
 )
 from clio_relay.jarvis_mcp import (
     JARVIS_MCP_CACHE_SERVER_NAME,
@@ -79,6 +81,8 @@ from clio_relay.models import (
     GatewaySession,
     GatewaySessionState,
     JarvisPackageInputRoute,
+    JarvisPipelineInputBinding,
+    JarvisRunInputManifest,
     JarvisRunSpec,
     JobKind,
     JobState,
@@ -1797,6 +1801,11 @@ def _call_tool(
         pipeline_input_route = None
         automatic_input_uses: tuple[ArtifactUse, ...] = ()
         staged_input_manifest_sha256: str | None = None
+        staged_input_bindings: tuple[JarvisPipelineInputBinding, ...] = ()
+        removed_input_binding_identities: tuple[tuple[str, str], ...] = ()
+        binding_mutation_required = False
+        run_input_manifest: JarvisRunInputManifest | None = None
+        base_idempotency_key: str | None = None
         if route.contract == REGISTERED_JARVIS_CONTRACT_ID:
             if session is None:
                 raise ValueError("registered JARVIS package semantics require an MCP session")
@@ -1849,6 +1858,7 @@ def _call_tool(
                 forwarded_arguments = staged.arguments
                 automatic_input_uses = staged.artifact_uses
                 staged_input_manifest_sha256 = staged.manifest_sha256
+                staged_input_bindings = staged.bindings
                 if automatic_input_uses:
                     # Staged inputs become durable pipeline lineage only after JARVIS accepts
                     # this exact add-step. Never return an asynchronous receipt that can lose
@@ -1865,6 +1875,36 @@ def _call_tool(
                     owner_session_generation_id=settings.owner_session_generation_id,
                 )
                 pipeline_cache_key = pipeline_input_route.identity_sha256()
+            elif route.remote_tool_name == "jarvis_edit_step":
+                pipeline_input_route = jarvis_pipeline_input_route(
+                    cluster=cluster,
+                    server_name=route.server_name,
+                    cluster_route_revision=route.cluster_route_revision,
+                    registration_revision=route.registration_revision,
+                    expected_server_artifact_digest=route.expected_server_artifact_digest,
+                    pipeline_id=_required_str(forwarded_arguments, "pipeline_id"),
+                    owner_session_id=settings.owner_session_id,
+                    owner_session_generation_id=settings.owner_session_generation_id,
+                )
+                pipeline_cache_key = pipeline_input_route.identity_sha256()
+                current_bindings = queue.get_jarvis_pipeline_input_bindings(pipeline_input_route)
+                if current_bindings is not None:
+                    staged = stage_jarvis_edit_step_inputs(
+                        forwarded_arguments,
+                        current=current_bindings,
+                        definition=_remote_cluster_definition(cluster),
+                        settings=settings,
+                    )
+                    forwarded_arguments = staged.arguments
+                    automatic_input_uses = staged.artifact_uses
+                    staged_input_manifest_sha256 = staged.manifest_sha256
+                    staged_input_bindings = staged.bindings
+                    removed_input_binding_identities = staged.removed_binding_identities
+                    binding_mutation_required = bool(
+                        staged_input_bindings or removed_input_binding_identities
+                    )
+                    if binding_mutation_required:
+                        relay_arguments["wait_for_terminal"] = True
             elif route.remote_tool_name == "jarvis_run":
                 pipeline_input_route = jarvis_pipeline_input_route(
                     cluster=cluster,
@@ -1877,14 +1917,46 @@ def _call_tool(
                     owner_session_generation_id=settings.owner_session_generation_id,
                 )
                 pipeline_cache_key = pipeline_input_route.identity_sha256()
-                durable_lineage = queue.get_jarvis_pipeline_input_lineage(pipeline_input_route)
-                durable_uses = () if durable_lineage is None else durable_lineage.artifact_uses
-                automatic_input_uses = tuple(
-                    merge_artifact_uses(
-                        list(session.jarvis_pipeline_inputs(pipeline_cache_key)),
-                        durable_uses,
+                base_idempotency_key = str(
+                    relay_arguments.get("idempotency_key")
+                    or (
+                        f"mcp:virtual:{cluster}:{route.server_name}:"
+                        f"{route.remote_tool_name}:{uuid4().hex}"
                     )
                 )
+                current_bindings = queue.get_jarvis_pipeline_input_bindings(pipeline_input_route)
+                if current_bindings is not None and current_bindings.bindings:
+                    run_input_manifest = queue.get_jarvis_run_input_manifest(
+                        pipeline_input_route,
+                        idempotency_key=base_idempotency_key,
+                    )
+                    if run_input_manifest is None:
+                        resolutions = reconcile_jarvis_run_inputs(
+                            current_bindings,
+                            definition=_remote_cluster_definition(cluster),
+                            settings=settings,
+                        )
+                        run_input_manifest = queue.put_jarvis_run_input_manifest(
+                            JarvisRunInputManifest.create(
+                                route=pipeline_input_route,
+                                idempotency_key=base_idempotency_key,
+                                resolutions=resolutions,
+                            )
+                        )
+                        queue.update_jarvis_pipeline_input_bindings(
+                            pipeline_input_route,
+                            upserts=tuple(item.binding for item in run_input_manifest.resolutions),
+                        )
+                    automatic_input_uses = run_input_manifest.artifact_uses
+                else:
+                    durable_lineage = queue.get_jarvis_pipeline_input_lineage(pipeline_input_route)
+                    durable_uses = () if durable_lineage is None else durable_lineage.artifact_uses
+                    automatic_input_uses = tuple(
+                        merge_artifact_uses(
+                            list(session.jarvis_pipeline_inputs(pipeline_cache_key)),
+                            durable_uses,
+                        )
+                    )
         merged_input_uses = merge_artifact_uses(
             _artifact_use_refs(relay_arguments),
             automatic_input_uses,
@@ -1909,17 +1981,18 @@ def _call_tool(
                 "used_artifact_refs": [artifact_use_payload(item) for item in merged_input_uses],
             }
         )
-        base_idempotency_key = str(
-            relay_arguments.get("idempotency_key")
-            or (
-                reconciliation_idempotency_key
-                if reconciliation_required
-                else (
-                    f"mcp:virtual:{cluster}:{route.server_name}:"
-                    f"{route.remote_tool_name}:{uuid4().hex}"
+        if base_idempotency_key is None:
+            base_idempotency_key = str(
+                relay_arguments.get("idempotency_key")
+                or (
+                    reconciliation_idempotency_key
+                    if reconciliation_required
+                    else (
+                        f"mcp:virtual:{cluster}:{route.server_name}:"
+                        f"{route.remote_tool_name}:{uuid4().hex}"
+                    )
                 )
             )
-        )
         result = _submit_mcp_call(
             {
                 "cluster": cluster,
@@ -1944,6 +2017,11 @@ def _call_tool(
                 ),
                 "tool": route.remote_tool_name,
                 "arguments": forwarded_arguments,
+                "jarvis_input_manifest": (
+                    run_input_manifest.model_dump(mode="json")
+                    if run_input_manifest is not None
+                    else None
+                ),
                 "timeout_seconds": route.timeout_seconds,
                 **relay_arguments,
                 "idempotency_key": base_idempotency_key,
@@ -1997,6 +2075,37 @@ def _call_tool(
                     )
         if route.remote_tool_name == "jarvis_add_step" and automatic_input_uses:
             _require_terminal_staging_reconciliation(result, operation="jarvis_add_step")
+        if route.remote_tool_name == "jarvis_edit_step" and binding_mutation_required:
+            _require_terminal_staging_reconciliation(result, operation="jarvis_edit_step")
+        if (
+            route.remote_tool_name == "jarvis_add_step"
+            and pipeline_input_route is not None
+            and staged_input_bindings
+            and result.get("state") == "succeeded"
+            and result.get("terminal") is True
+        ):
+            observed_step_id = _jarvis_add_step_result_step_id(result)
+            expected_step_ids = {item.step_id for item in staged_input_bindings}
+            if expected_step_ids != {observed_step_id}:
+                raise ValueError(
+                    "jarvis_add_step returned a different step identity than its staged inputs"
+                )
+            queue.update_jarvis_pipeline_input_bindings(
+                pipeline_input_route,
+                upserts=staged_input_bindings,
+            )
+        if (
+            route.remote_tool_name == "jarvis_edit_step"
+            and pipeline_input_route is not None
+            and binding_mutation_required
+            and result.get("state") == "succeeded"
+            and result.get("terminal") is True
+        ):
+            queue.update_jarvis_pipeline_input_bindings(
+                pipeline_input_route,
+                upserts=staged_input_bindings,
+                remove=removed_input_binding_identities,
+            )
         if (
             route.remote_tool_name == "jarvis_add_step"
             and pipeline_cache_key is not None
@@ -4281,6 +4390,15 @@ def _submit_mcp_call(
         arguments,
         "expected_registered_contract",
     )
+    raw_jarvis_input_manifest = arguments.get("jarvis_input_manifest")
+    try:
+        jarvis_input_manifest = (
+            JarvisRunInputManifest.model_validate(raw_jarvis_input_manifest)
+            if raw_jarvis_input_manifest is not None
+            else None
+        )
+    except ValidationError as exc:
+        raise ValueError("invalid JARVIS run input manifest") from exc
     raw_expected_jarvis_cd_lock_binding = arguments.get("expected_jarvis_cd_lock_binding")
     expected_jarvis_cd_lock_binding = (
         _string_mapping(
@@ -4319,6 +4437,8 @@ def _submit_mcp_call(
         identity["control_query_evidence"] = control_query_evidence.model_dump(mode="json")
     if expected_registered_contract is not None:
         identity["expected_registered_contract"] = expected_registered_contract
+    if jarvis_input_manifest is not None:
+        identity["jarvis_input_manifest"] = jarvis_input_manifest.model_dump(mode="json")
     if expected_jarvis_cd_lock_binding is not None:
         identity["expected_jarvis_cd_lock_binding"] = expected_jarvis_cd_lock_binding
     if used_artifact_refs:
@@ -4412,6 +4532,8 @@ def _submit_mcp_call(
                 payload["expected_server_artifact_digest"] = expected_server_artifact_digest
             if expected_registered_contract is not None:
                 payload["expected_registered_contract"] = expected_registered_contract
+            if jarvis_input_manifest is not None:
+                payload["jarvis_input_manifest"] = jarvis_input_manifest.model_dump(mode="json")
             job = submit_owned_session_job(
                 definition=definition,
                 settings=settings,
@@ -4548,6 +4670,7 @@ def _submit_mcp_call(
                 operation=operation,
                 tool=tool,
                 arguments=tool_arguments,
+                jarvis_input_manifest=jarvis_input_manifest,
                 timeout_seconds=timeout_seconds,
             ),
             idempotency_key=idempotency_key,
@@ -4803,6 +4926,23 @@ def _require_terminal_staging_reconciliation(result: JSON, *, operation: str) ->
         "reconciliation identity when idempotency_key was omitted. No package contract or "
         "staged-input lineage was accepted locally."
     )
+
+
+def _jarvis_add_step_result_step_id(result: JSON) -> str:
+    """Extract the exact accepted step identity from a terminal add-step result."""
+    raw_mcp_result = result.get("mcp_result")
+    if not isinstance(raw_mcp_result, dict):
+        raise ValueError("jarvis_add_step terminal result omitted its MCP result")
+    raw_structured = cast(JSON, raw_mcp_result).get("structured_result")
+    if not isinstance(raw_structured, dict):
+        raise ValueError("jarvis_add_step terminal result omitted structured output")
+    raw_payload = cast(JSON, raw_structured).get("result")
+    if not isinstance(raw_payload, dict):
+        raise ValueError("jarvis_add_step structured output omitted its result object")
+    step_id = cast(JSON, raw_payload).get("step_id")
+    if not isinstance(step_id, str) or not step_id:
+        raise ValueError("jarvis_add_step structured output omitted its step identity")
+    return step_id
 
 
 def _submit_local_job(

--- a/src/clio_relay/models.py
+++ b/src/clio_relay/models.py
@@ -29,6 +29,8 @@ INPUT_INGEST_POLICY_METADATA_KEY = "input_ingest_policy"
 MAX_ARTIFACT_USE_PROVENANCE_BYTES = 8 * 1024
 MAX_ARTIFACT_USE_AGGREGATE_BYTES = 256 * 1024
 MAX_JARVIS_PACKAGE_INPUT_CONTRACT_BYTES = 256 * 1024
+MAX_JARVIS_PIPELINE_INPUT_BINDINGS_BYTES = 1 * 1024 * 1024
+MAX_JARVIS_RUN_INPUT_MANIFEST_BYTES = 1 * 1024 * 1024
 MAX_TRANSFORM_ENVIRONMENT_BYTES = 16 * 1024
 MAX_TRANSFORM_REF_BYTES = 192 * 1024
 MAX_TRANSFORM_USED_EVIDENCE = 1_000
@@ -711,6 +713,253 @@ class JarvisPipelineInputLineage(BaseModel):
         )
 
 
+class JarvisPipelineInputBinding(BaseModel):
+    """One stable Host-workspace reference bound to an exact pipeline step setting."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    step_id: str = Field(min_length=1, max_length=512)
+    canonical_setting: str = Field(min_length=1, max_length=512)
+    accepted_names: tuple[Annotated[str, Field(min_length=1, max_length=512)], ...] = Field(
+        min_length=1,
+        max_length=64,
+    )
+    workspace_relative_path: str = Field(min_length=1, max_length=4096)
+    logical_name: str = Field(min_length=1, max_length=512)
+    size_bytes: int = Field(ge=0)
+    sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    remote_path: str = Field(min_length=1, max_length=4096)
+    artifact_use: ArtifactUse
+
+    @model_validator(mode="after")
+    def identity_and_paths_are_exact(self) -> JarvisPipelineInputBinding:
+        """Reject aliases, paths, or artifact evidence that can change meaning."""
+        if self.accepted_names[0] != self.canonical_setting:
+            raise ValueError("pipeline input accepted names must start with the canonical setting")
+        if len(self.accepted_names) != len(set(self.accepted_names)):
+            raise ValueError("pipeline input accepted names must be unique")
+        if (
+            "\\" in self.workspace_relative_path
+            or self.workspace_relative_path.startswith("/")
+            or any(
+                component in {"", ".", ".."}
+                for component in self.workspace_relative_path.split("/")
+            )
+        ):
+            raise ValueError("pipeline input workspace path must be normalized and relative")
+        if (
+            not self.remote_path.startswith("/")
+            or self.remote_path.startswith("//")
+            or any(ord(character) < 32 or ord(character) == 127 for character in self.remote_path)
+        ):
+            raise ValueError("pipeline input remote path must be an absolute control-free path")
+        if self.artifact_use.sha256 != self.sha256:
+            raise ValueError("pipeline input artifact digest does not match its local snapshot")
+        provenance = self.artifact_use.provenance
+        if provenance is None or provenance.arg != self.canonical_setting:
+            raise ValueError("pipeline input artifact provenance must name its canonical setting")
+        return self
+
+    def identity(self) -> tuple[str, str]:
+        """Return the exact step-and-setting identity within one pipeline route."""
+        return (self.step_id, self.canonical_setting)
+
+
+class JarvisPipelineInputBindings(BaseModel):
+    """Checksum-bound current local-file bindings for one exact pipeline route."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal["clio-relay.jarvis-pipeline-input-bindings.v1"] = (
+        "clio-relay.jarvis-pipeline-input-bindings.v1"
+    )
+    route: JarvisPipelineInputRoute
+    route_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    bindings: tuple[JarvisPipelineInputBinding, ...] = Field(max_length=1_000)
+    created_at: datetime
+    updated_at: datetime
+    document_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+    @model_validator(mode="after")
+    def identity_and_document_are_exact(self) -> JarvisPipelineInputBindings:
+        """Reject route substitution, duplicate settings, and record mutation."""
+        if self.route_sha256 != self.route.identity_sha256():
+            raise ValueError("pipeline input bindings route checksum does not match its identity")
+        canonical = tuple(sorted(self.bindings, key=lambda item: item.identity()))
+        if self.bindings != canonical:
+            raise ValueError("pipeline input bindings must be canonically ordered")
+        identities = [item.identity() for item in self.bindings]
+        if len(identities) != len(set(identities)):
+            raise ValueError("pipeline input bindings must have unique step and setting identities")
+        if self.updated_at < self.created_at:
+            raise ValueError("pipeline input bindings updated_at predates created_at")
+        if self.document_sha256 != _jarvis_pipeline_input_bindings_sha256(self):
+            raise ValueError("pipeline input bindings checksum does not match its document")
+        _require_canonical_json_size(
+            self.model_dump(mode="json"),
+            label="JARVIS pipeline input bindings",
+            maximum=MAX_JARVIS_PIPELINE_INPUT_BINDINGS_BYTES,
+        )
+        return self
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        route: JarvisPipelineInputRoute,
+        bindings: tuple[JarvisPipelineInputBinding, ...],
+        created_at: datetime | None = None,
+        updated_at: datetime | None = None,
+    ) -> JarvisPipelineInputBindings:
+        """Create one validated current-binding document."""
+        created = created_at or utc_now()
+        updated = updated_at or created
+        provisional = cls.model_construct(
+            route=route,
+            route_sha256=route.identity_sha256(),
+            bindings=tuple(sorted(bindings, key=lambda item: item.identity())),
+            created_at=created,
+            updated_at=updated,
+            document_sha256="0" * 64,
+        )
+        return cls.model_validate(
+            {
+                **provisional.model_dump(mode="python"),
+                "document_sha256": _jarvis_pipeline_input_bindings_sha256(provisional),
+            }
+        )
+
+
+class JarvisRunInputResolution(BaseModel):
+    """One exact input selected for a newly admitted JARVIS execution."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    binding: JarvisPipelineInputBinding
+    disposition: Literal["reused", "updated"]
+    previous_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+    @model_validator(mode="after")
+    def disposition_matches_content(self) -> JarvisRunInputResolution:
+        """Bind reuse/update evidence to the before and after content digests."""
+        unchanged = self.previous_sha256 == self.binding.sha256
+        if unchanged != (self.disposition == "reused"):
+            raise ValueError("JARVIS run input disposition does not match its content digest")
+        return self
+
+
+class JarvisRunInputManifest(BaseModel):
+    """Immutable resolved local-input manifest for one jarvis_run admission key."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal["clio-relay.jarvis-run-input-manifest.v1"] = (
+        "clio-relay.jarvis-run-input-manifest.v1"
+    )
+    route: JarvisPipelineInputRoute
+    route_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    idempotency_key: str = Field(min_length=1, max_length=4096)
+    resolutions: tuple[JarvisRunInputResolution, ...] = Field(min_length=1, max_length=1_000)
+    artifact_uses: tuple[ArtifactUse, ...] = Field(min_length=1, max_length=1_000)
+    manifest_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    created_at: datetime
+    document_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+    @staticmethod
+    def storage_identity_sha256(
+        *,
+        route: JarvisPipelineInputRoute,
+        idempotency_key: str,
+    ) -> str:
+        """Return the exact route-and-admission storage identity."""
+        return _canonical_json_sha256(
+            {
+                "schema_version": "clio-relay.jarvis-run-input-manifest-identity.v1",
+                "route_sha256": route.identity_sha256(),
+                "idempotency_key": idempotency_key,
+            }
+        )
+
+    def identity_sha256(self) -> str:
+        """Return this manifest's exact route-and-admission storage identity."""
+        return self.storage_identity_sha256(
+            route=self.route,
+            idempotency_key=self.idempotency_key,
+        )
+
+    @model_validator(mode="after")
+    def identity_and_document_are_exact(self) -> JarvisRunInputManifest:
+        """Reject admission, binding, artifact, or checksum substitution."""
+        if self.route_sha256 != self.route.identity_sha256():
+            raise ValueError("JARVIS run input route checksum does not match its identity")
+        canonical_resolutions = tuple(
+            sorted(self.resolutions, key=lambda item: item.binding.identity())
+        )
+        if self.resolutions != canonical_resolutions:
+            raise ValueError("JARVIS run input resolutions must be canonically ordered")
+        identities = [item.binding.identity() for item in self.resolutions]
+        if len(identities) != len(set(identities)):
+            raise ValueError("JARVIS run input resolutions must have unique binding identities")
+        expected_uses = tuple(
+            sorted(
+                (item.binding.artifact_use for item in self.resolutions),
+                key=lambda item: (item.artifact_id, item.sha256),
+            )
+        )
+        if self.artifact_uses != expected_uses:
+            raise ValueError("JARVIS run input artifact uses do not match its resolutions")
+        validate_artifact_use_collection(self.artifact_uses)
+        if self.manifest_sha256 != _jarvis_run_input_manifest_payload_sha256(self):
+            raise ValueError("JARVIS run input manifest checksum does not match its resolutions")
+        if self.document_sha256 != _jarvis_run_input_manifest_document_sha256(self):
+            raise ValueError("JARVIS run input manifest checksum does not match its document")
+        _require_canonical_json_size(
+            self.model_dump(mode="json"),
+            label="JARVIS run input manifest",
+            maximum=MAX_JARVIS_RUN_INPUT_MANIFEST_BYTES,
+        )
+        return self
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        route: JarvisPipelineInputRoute,
+        idempotency_key: str,
+        resolutions: tuple[JarvisRunInputResolution, ...],
+        created_at: datetime | None = None,
+    ) -> JarvisRunInputManifest:
+        """Create one exact immutable per-admission input manifest."""
+        canonical_resolutions = tuple(sorted(resolutions, key=lambda item: item.binding.identity()))
+        artifact_uses = tuple(
+            sorted(
+                (item.binding.artifact_use for item in canonical_resolutions),
+                key=lambda item: (item.artifact_id, item.sha256),
+            )
+        )
+        provisional = cls.model_construct(
+            route=route,
+            route_sha256=route.identity_sha256(),
+            idempotency_key=idempotency_key,
+            resolutions=canonical_resolutions,
+            artifact_uses=artifact_uses,
+            manifest_sha256="0" * 64,
+            created_at=created_at or utc_now(),
+            document_sha256="0" * 64,
+        )
+        with_manifest = provisional.model_copy(
+            update={
+                "manifest_sha256": _jarvis_run_input_manifest_payload_sha256(provisional),
+            }
+        )
+        return cls.model_validate(
+            {
+                **with_manifest.model_dump(mode="python"),
+                "document_sha256": _jarvis_run_input_manifest_document_sha256(with_manifest),
+            }
+        )
+
+
 def _canonical_json_sha256(value: object) -> str:
     """Hash one finite canonical JSON value."""
     return hashlib.sha256(
@@ -760,6 +1009,28 @@ def _jarvis_pipeline_input_lineage_sha256(record: JarvisPipelineInputLineage) ->
     payload = record.model_dump(mode="json", exclude={"document_sha256"})
     payload["artifact_uses"] = [artifact_use_payload(item) for item in record.artifact_uses]
     return _canonical_json_sha256(payload)
+
+
+def _jarvis_pipeline_input_bindings_sha256(record: JarvisPipelineInputBindings) -> str:
+    """Hash every current-binding field except the checksum itself."""
+    return _canonical_json_sha256(record.model_dump(mode="json", exclude={"document_sha256"}))
+
+
+def _jarvis_run_input_manifest_payload_sha256(record: JarvisRunInputManifest) -> str:
+    """Hash the exact resolved input selection independently from record metadata."""
+    return _canonical_json_sha256(
+        {
+            "route_sha256": record.route_sha256,
+            "idempotency_key": record.idempotency_key,
+            "resolutions": [item.model_dump(mode="json") for item in record.resolutions],
+            "artifact_uses": [artifact_use_payload(item) for item in record.artifact_uses],
+        }
+    )
+
+
+def _jarvis_run_input_manifest_document_sha256(record: JarvisRunInputManifest) -> str:
+    """Hash every immutable run-manifest field except the document checksum."""
+    return _canonical_json_sha256(record.model_dump(mode="json", exclude={"document_sha256"}))
 
 
 def _jarvis_package_input_contract_sha256(record: JarvisPackageInputContractRecord) -> str:
@@ -1039,6 +1310,7 @@ class McpCallSpec(BaseModel):
     operation: McpOperation = McpOperation.TOOLS_CALL
     tool: str | None = None
     arguments: dict[str, Any] = Field(default_factory=dict)
+    jarvis_input_manifest: JarvisRunInputManifest | None = None
     timeout_seconds: int | None = Field(default=None, gt=0)
 
     @field_validator("env_from")
@@ -1106,6 +1378,15 @@ class McpCallSpec(BaseModel):
                 raise ValueError(
                     "registered MCP contract binding and built-in JARVIS lock pin are exclusive"
                 )
+            if self.jarvis_input_manifest is not None and (
+                self.tool != "jarvis_run"
+                or self.expected_registered_contract != REGISTERED_JARVIS_USER_CONTRACT
+                or self.expected_jarvis_cd_lock_binding is not None
+                or self.arguments.get("pipeline_id") != self.jarvis_input_manifest.route.pipeline_id
+            ):
+                raise ValueError(
+                    "JARVIS input manifests require the exact registered jarvis_run pipeline"
+                )
             return self
         if self.tool is not None:
             raise ValueError("tool must be omitted for tools/list")
@@ -1113,6 +1394,8 @@ class McpCallSpec(BaseModel):
             raise ValueError("arguments must be empty for tools/list")
         if self.expected_registered_contract is not None:
             raise ValueError("expected_registered_contract must be omitted for tools/list")
+        if self.jarvis_input_manifest is not None:
+            raise ValueError("jarvis_input_manifest must be omitted for tools/list")
         return self
 
 

--- a/src/clio_relay/remote_mcp.py
+++ b/src/clio_relay/remote_mcp.py
@@ -1420,6 +1420,13 @@ class VirtualRemoteMcpTool:
                 "lineage; calls without staged local inputs retain ordinary asynchronous "
                 "semantics."
             )
+        elif exact_v36_routes and self.remote_tool.name == "jarvis_run":
+            description += (
+                " On each genuinely new run identity, relay securely reconciles every tracked "
+                "local-file setting and pins the execution to an immutable input manifest. "
+                "Retrying the same idempotency key reuses that admitted manifest without "
+                "rescanning mutable Host files."
+            )
         definition: JSON = {
             "name": self.alias,
             "description": (

--- a/src/clio_relay/session_api.py
+++ b/src/clio_relay/session_api.py
@@ -417,6 +417,7 @@ def _validate_submission_receipt(
             "operation": operation.value,
             "tool": payload.get("tool"),
             "arguments": expected_arguments,
+            "jarvis_input_manifest": payload.get("jarvis_input_manifest"),
             "timeout_seconds": payload.get("timeout_seconds"),
         }
         observed = {
@@ -429,6 +430,11 @@ def _validate_submission_receipt(
             "operation": job.spec.operation.value,
             "tool": job.spec.tool,
             "arguments": job.spec.arguments,
+            "jarvis_input_manifest": (
+                job.spec.jarvis_input_manifest.model_dump(mode="json")
+                if job.spec.jarvis_input_manifest is not None
+                else None
+            ),
             "timeout_seconds": job.spec.timeout_seconds,
         }
         if observed != expected:

--- a/src/clio_relay/spool.py
+++ b/src/clio_relay/spool.py
@@ -808,6 +808,8 @@ def _lstat_owned_directory(path: Path) -> os.stat_result:
 def _stat_at(directory_descriptor: int, name: str, *, path: Path) -> os.stat_result:
     try:
         return os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"owned path does not exist: {path}") from exc
     except OSError as exc:
         raise RuntimeError(f"cannot inspect owned path {path}: {exc}") from exc
 

--- a/tests/test_input_staging.py
+++ b/tests/test_input_staging.py
@@ -21,12 +21,19 @@ from clio_relay.input_staging import (
     jarvis_package_input_route,
     jarvis_pipeline_input_route,
     parse_jarvis_package_input_contract,
+    reconcile_jarvis_run_inputs,
     stage_jarvis_add_step_inputs,
 )
 from clio_relay.models import (
     ArtifactRef,
     ArtifactUse,
+    ArtifactUseEvidence,
+    ArtifactUseProvenance,
     InputArtifactSpec,
+    JarvisPipelineInputBinding,
+    JarvisPipelineInputBindings,
+    JarvisRunInputManifest,
+    JarvisRunInputResolution,
     JobKind,
     JobState,
     RelayJob,
@@ -86,6 +93,34 @@ def _contract() -> JarvisPackageInputContract:
     )
     assert result is not None
     return result
+
+
+def _tracked_binding(
+    *,
+    step_id: str = "simulation",
+    sha256: str = "d" * 64,
+    artifact_id: str = "artifact_0123456789abcdef0123456789abcdef",
+    remote_path: str = "/srv/clio-relay/v1/inputs/in.lj",
+) -> JarvisPipelineInputBinding:
+    """Return one exact tracked local-file setting."""
+    return JarvisPipelineInputBinding(
+        step_id=step_id,
+        canonical_setting="script",
+        accepted_names=("script", "input_script"),
+        workspace_relative_path=f"{step_id}/in.lj",
+        logical_name="in.lj",
+        size_bytes=12,
+        sha256=sha256,
+        remote_path=remote_path,
+        artifact_use=ArtifactUse(
+            artifact_id=artifact_id,
+            sha256=sha256,
+            provenance=ArtifactUseProvenance(
+                evidence=ArtifactUseEvidence.SCHEMA_ARG,
+                arg="script",
+            ),
+        ),
+    )
 
 
 def test_package_description_declares_local_file_without_name_inference() -> None:
@@ -452,3 +487,240 @@ def test_pipeline_input_lineage_first_merge_uses_one_mutation_timestamp(
 
     assert saved.created_at == mutation_at
     assert saved.updated_at == mutation_at
+
+
+def test_run_reconciliation_reuses_unchanged_and_restages_changed_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each new run snapshots the logical path but uploads only changed bytes."""
+    workspace = tmp_path / "workspace"
+    local_input = workspace / "simulation" / "in.lj"
+    local_input.parent.mkdir(parents=True)
+    original = b"units lj\nrun 1\n"
+    local_input.write_bytes(original)
+    original_sha256 = hashlib.sha256(original).hexdigest()
+    binding = _tracked_binding(sha256=original_sha256)
+    route = jarvis_pipeline_input_route(
+        cluster="ares",
+        server_name="jarvis-demo",
+        cluster_route_revision="a" * 64,
+        registration_revision="b" * 64,
+        expected_server_artifact_digest="c" * 64,
+        pipeline_id="science-run",
+        owner_session_id="desktop-session",
+        owner_session_generation_id="generation_0123456789abcdef0123456789abcdef",
+    )
+    current = JarvisPipelineInputBindings.create(route=route, bindings=(binding,))
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        owner_session_id="desktop-session",
+        owner_session_generation_id="generation_0123456789abcdef0123456789abcdef",
+        input_workspace_root=workspace,
+    )
+    definition = ClusterDefinition(name="ares", ssh_host="ares")
+
+    class UnexpectedClient:
+        def __init__(self, **_kwargs: object) -> None:
+            raise AssertionError("unchanged input must not be ingested again")
+
+    monkeypatch.setattr("clio_relay.input_staging.OwnedSessionApiClient", UnexpectedClient)
+    reused = reconcile_jarvis_run_inputs(
+        current,
+        definition=definition,
+        settings=settings,
+    )
+    assert reused[0].disposition == "reused"
+    assert reused[0].binding == binding
+
+    changed = b"units lj\nrun 2\n"
+    local_input.write_bytes(changed)
+    changed_sha256 = hashlib.sha256(changed).hexdigest()
+
+    class IngestClient:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        def __enter__(self) -> IngestClient:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def request_json(
+            self,
+            *,
+            method: str,
+            path: str,
+            body: dict[str, object],
+        ) -> object:
+            assert method == "POST"
+            assert path == "/input-artifacts/ingest"
+            assert body["sha256"] == changed_sha256
+            producer = RelayJob(
+                cluster="ares",
+                kind=JobKind.INPUT_INGEST,
+                state=JobState.SUCCEEDED,
+                spec=InputArtifactSpec(
+                    logical_name="in.lj",
+                    size_bytes=len(changed),
+                    sha256=changed_sha256,
+                ),
+                idempotency_key=str(body["idempotency_key"]),
+                metadata={
+                    "owner": "clio-relay",
+                    "owner_session_id": "desktop-session",
+                    "owner_session_generation_id": ("generation_0123456789abcdef0123456789abcdef"),
+                },
+            )
+            artifact = ArtifactRef(
+                artifact_id=deterministic_input_artifact_id(producer.job_id),
+                job_id=producer.job_id,
+                uri=f"file:///srv/clio-relay/{producer.job_id}/inputs/in.lj",
+                kind="input",
+                size_bytes=len(changed),
+                sha256=changed_sha256,
+            )
+            return {
+                "job": producer.model_dump(mode="json"),
+                "artifact": artifact.model_dump(mode="json"),
+            }
+
+    monkeypatch.setattr("clio_relay.input_staging.OwnedSessionApiClient", IngestClient)
+    updated = reconcile_jarvis_run_inputs(
+        current,
+        definition=definition,
+        settings=settings,
+    )
+    assert updated[0].disposition == "updated"
+    assert updated[0].previous_sha256 == original_sha256
+    assert updated[0].binding.sha256 == changed_sha256
+    assert updated[0].binding.remote_path.endswith("/inputs/in.lj")
+
+
+def test_run_reconciliation_rejects_missing_or_mutating_tracked_input(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unsafe snapshots fail before any remote run can be admitted."""
+    workspace = tmp_path / "workspace"
+    local_input = workspace / "simulation" / "in.lj"
+    local_input.parent.mkdir(parents=True)
+    local_input.write_text("run 1\n", encoding="utf-8")
+    route = jarvis_pipeline_input_route(
+        cluster="ares",
+        server_name="jarvis-demo",
+        cluster_route_revision="a" * 64,
+        registration_revision="b" * 64,
+        expected_server_artifact_digest="c" * 64,
+        pipeline_id="science-run",
+        owner_session_id="desktop-session",
+        owner_session_generation_id="generation_0123456789abcdef0123456789abcdef",
+    )
+    current = JarvisPipelineInputBindings.create(
+        route=route,
+        bindings=(
+            _tracked_binding(
+                sha256=hashlib.sha256(local_input.read_bytes()).hexdigest(),
+            ),
+        ),
+    )
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        owner_session_id="desktop-session",
+        owner_session_generation_id="generation_0123456789abcdef0123456789abcdef",
+        input_workspace_root=workspace,
+    )
+    definition = ClusterDefinition(name="ares", ssh_host="ares")
+    local_input.unlink()
+    with pytest.raises((OSError, RuntimeError), match="exist|regular|open|find"):
+        reconcile_jarvis_run_inputs(current, definition=definition, settings=settings)
+
+    local_input.write_text("run 2\n", encoding="utf-8")
+
+    def changed_during_snapshot(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("local input changed during snapshot")
+
+    monkeypatch.setattr(
+        "clio_relay.input_staging.snapshot_owned_regular_file",
+        changed_during_snapshot,
+    )
+    with pytest.raises(RuntimeError, match="changed during snapshot"):
+        reconcile_jarvis_run_inputs(current, definition=definition, settings=settings)
+
+
+def test_run_manifest_is_restart_safe_idempotent_and_step_setting_exact(
+    tmp_path: Path,
+) -> None:
+    """The first admitted run key wins and two steps cannot overwrite each other."""
+    route = jarvis_pipeline_input_route(
+        cluster="ares",
+        server_name="jarvis-demo",
+        cluster_route_revision="a" * 64,
+        registration_revision="b" * 64,
+        expected_server_artifact_digest="c" * 64,
+        pipeline_id="science-run",
+        owner_session_id="desktop-session",
+        owner_session_generation_id="generation_0123456789abcdef0123456789abcdef",
+    )
+    first = _tracked_binding(step_id="analysis")
+    second = _tracked_binding(
+        step_id="simulation",
+        sha256="e" * 64,
+        artifact_id="artifact_fedcba9876543210fedcba9876543210",
+        remote_path="/srv/clio-relay/v2/inputs/in.lj",
+    )
+    queue = ClioCoreQueue(tmp_path / "core")
+    saved_bindings = queue.update_jarvis_pipeline_input_bindings(
+        route,
+        upserts=(second, first),
+    )
+    assert [item.identity() for item in saved_bindings.bindings] == [
+        ("analysis", "script"),
+        ("simulation", "script"),
+    ]
+    manifest = JarvisRunInputManifest.create(
+        route=route,
+        idempotency_key="new-run-1",
+        resolutions=tuple(
+            JarvisRunInputResolution(
+                binding=item,
+                disposition="reused",
+                previous_sha256=item.sha256,
+            )
+            for item in saved_bindings.bindings
+        ),
+    )
+    admitted = queue.put_jarvis_run_input_manifest(manifest)
+    changed_second = second.model_copy(
+        update={
+            "sha256": "f" * 64,
+            "artifact_use": second.artifact_use.model_copy(update={"sha256": "f" * 64}),
+        }
+    )
+    competing = JarvisRunInputManifest.create(
+        route=route,
+        idempotency_key="new-run-1",
+        resolutions=(
+            JarvisRunInputResolution(
+                binding=first,
+                disposition="reused",
+                previous_sha256=first.sha256,
+            ),
+            JarvisRunInputResolution(
+                binding=changed_second,
+                disposition="updated",
+                previous_sha256=second.sha256,
+            ),
+        ),
+    )
+    assert queue.put_jarvis_run_input_manifest(competing) == admitted
+    assert (
+        ClioCoreQueue(tmp_path / "core").get_jarvis_run_input_manifest(
+            route,
+            idempotency_key="new-run-1",
+        )
+        == admitted
+    )

--- a/tests/test_mcp_call_runner.py
+++ b/tests/test_mcp_call_runner.py
@@ -26,6 +26,15 @@ from clio_relay.bootstrap import (
     JARVIS_CD_WHEEL_SHA256,
     JARVIS_CD_WHEEL_URL,
 )
+from clio_relay.models import (
+    ArtifactUse,
+    ArtifactUseEvidence,
+    ArtifactUseProvenance,
+    JarvisPipelineInputBinding,
+    JarvisPipelineInputRoute,
+    JarvisRunInputManifest,
+    JarvisRunInputResolution,
+)
 
 
 class McpCallRunnerModule(Protocol):
@@ -483,6 +492,116 @@ for line in sys.stdin:
     assert result.returncode == 0
     assert "threaded-test-server" in result.stdout
     assert result.stderr == ""
+
+
+def test_mcp_session_materializes_input_manifest_before_jarvis_run(tmp_path: Path) -> None:
+    """The worker edits exact resolved paths before it can submit the scheduler run."""
+    runner = _load_runner()
+    server_path = tmp_path / "input_reconciliation_server.py"
+    server_path.write_text(
+        """import json
+import sys
+
+calls = []
+for line in sys.stdin:
+    message = json.loads(line)
+    method = message.get("method")
+    if method == "initialize":
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "input-test", "version": "1.0"},
+            },
+        }), flush=True)
+    elif method == "tools/call":
+        calls.append(message["params"])
+        name = message["params"]["name"]
+        if name == "jarvis_edit_step":
+            structured = {"configured": message["params"]["arguments"]["step_id"]}
+        else:
+            structured = {"pipeline_id": "science-run", "calls": calls}
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "result": {"structuredContent": structured, "content": []},
+        }), flush=True)
+        if name == "jarvis_run":
+            break
+""",
+        encoding="utf-8",
+    )
+    route = JarvisPipelineInputRoute(
+        cluster="ares",
+        server_name="jarvis-demo",
+        cluster_route_revision="a" * 64,
+        registration_revision="b" * 64,
+        expected_server_artifact_digest="c" * 64,
+        pipeline_id="science-run",
+        owner_session_id="desktop-session",
+        owner_session_generation_id="generation_0123456789abcdef0123456789abcdef",
+    )
+    use = ArtifactUse(
+        artifact_id="artifact_0123456789abcdef0123456789abcdef",
+        sha256="d" * 64,
+        provenance=ArtifactUseProvenance(
+            evidence=ArtifactUseEvidence.SCHEMA_ARG,
+            arg="script",
+        ),
+    )
+    binding = JarvisPipelineInputBinding(
+        step_id="simulation",
+        canonical_setting="script",
+        accepted_names=("script",),
+        workspace_relative_path="in.lj",
+        logical_name="in.lj",
+        size_bytes=12,
+        sha256="d" * 64,
+        remote_path="/srv/clio-relay/v2/inputs/in.lj",
+        artifact_use=use,
+    )
+    manifest = JarvisRunInputManifest.create(
+        route=route,
+        idempotency_key="run-v2",
+        resolutions=(
+            JarvisRunInputResolution(
+                binding=binding,
+                disposition="reused",
+                previous_sha256=binding.sha256,
+            ),
+        ),
+    )
+
+    result = cast(Any, runner)._run_mcp_session(
+        [sys.executable, str(server_path)],
+        tool="jarvis_run",
+        arguments={"pipeline_id": "science-run"},
+        timeout=10,
+        env_from={},
+        jarvis_input_manifest=manifest.model_dump(mode="json"),
+    )
+    protocol_result = cast(Any, runner)._response_result(
+        result.stdout,
+        response_id="clio-relay-mcp-call",
+    )
+    structured = cast(Any, runner)._structured_result(
+        protocol_result,
+        operation="tools/call",
+    )
+
+    assert result.returncode == 0
+    assert [call["name"] for call in structured["calls"]] == [
+        "jarvis_edit_step",
+        "jarvis_run",
+    ]
+    assert structured["calls"][0]["arguments"] == {
+        "pipeline_id": "science-run",
+        "step_id": "simulation",
+        "config": {"script": "/srv/clio-relay/v2/inputs/in.lj"},
+        "operation": "edit",
+    }
 
 
 def test_direct_console_launcher_binds_real_distribution_record_and_detects_mutation(

--- a/tests/test_mcp_input_staging.py
+++ b/tests/test_mcp_input_staging.py
@@ -27,6 +27,7 @@ from clio_relay.models import (
     ArtifactRef,
     ArtifactUse,
     InputArtifactSpec,
+    JarvisRunInputManifest,
     JobKind,
     JobState,
     McpCallSpec,
@@ -44,6 +45,7 @@ from clio_relay.remote_mcp import (
 JSON = dict[str, Any]
 DESCRIBE_ALIAS = "remote_jarvis_demo_jarvis_describe"
 ADD_STEP_ALIAS = "remote_jarvis_demo_jarvis_add_step"
+EDIT_STEP_ALIAS = "remote_jarvis_demo_jarvis_edit_step"
 RUN_ALIAS = "remote_jarvis_demo_jarvis_run"
 GET_EXECUTION_ALIAS = "remote_jarvis_demo_jarvis_get_execution"
 
@@ -90,6 +92,11 @@ class _McpFlowHarness:
                 ),
                 tool=cast(str, payload["tool"]),
                 arguments=copy.deepcopy(cast(JSON, payload["arguments"])),
+                jarvis_input_manifest=(
+                    JarvisRunInputManifest.model_validate(payload["jarvis_input_manifest"])
+                    if payload.get("jarvis_input_manifest") is not None
+                    else None
+                ),
                 timeout_seconds=cast(int | None, payload.get("timeout_seconds")),
             ),
             idempotency_key=idempotency_key,
@@ -120,6 +127,8 @@ class _McpFlowHarness:
             assert wait_for_terminal_result is True
         if job.spec.tool == "jarvis_add_step" and job.used_artifact_refs:
             assert wait_for_terminal_result is True
+        if job.spec.tool == "jarvis_edit_step" and job.used_artifact_refs:
+            assert wait_for_terminal_result is True
         if job.spec.tool in self.nonterminal_tools:
             return {
                 "cluster": definition.name,
@@ -142,6 +151,21 @@ class _McpFlowHarness:
         }
         if job.spec.tool == "jarvis_describe":
             result["mcp_result"] = _describe_mcp_result()
+        elif job.spec.tool == "jarvis_add_step":
+            package_name = cast(str, job.spec.arguments["package_name"])
+            result["mcp_result"] = {
+                "tool": "jarvis_add_step",
+                "structured_result": {
+                    "result": {
+                        "pipeline_id": job.spec.arguments["pipeline_id"],
+                        "appended": package_name,
+                        "step_id": job.spec.arguments.get("step_id")
+                        or package_name.rsplit(".", 1)[-1],
+                        "configured": True,
+                        "config": job.spec.arguments.get("config", {}),
+                    }
+                },
+            }
         return result
 
     def ingest(self, body: JSON) -> JSON:
@@ -276,6 +300,9 @@ def test_registered_jarvis_input_flows_from_describe_through_run(
             "cluster": "ares",
             "owner_session_id": "desktop-session",
             "owner_session_generation_id": "generation_0123456789abcdef0123456789abcdef",
+            "step_id": "lammps",
+            "canonical_setting": "script",
+            "workspace_relative_path": "in.lj",
             "logical_name": "in.lj",
             "size_bytes": source.stat().st_size,
             "sha256": source_sha256,
@@ -305,6 +332,55 @@ def test_registered_jarvis_input_flows_from_describe_through_run(
     assert run_payload["tool"] == "jarvis_run"
     assert run_payload["expected_registered_contract"] == REGISTERED_JARVIS_CONTRACT_ID
     assert run_payload["used_artifact_refs"] == add_payload["used_artifact_refs"]
+    first_manifest = cast(JSON, run_payload["jarvis_input_manifest"])
+    assert first_manifest["resolutions"][0]["disposition"] == "reused"
+    assert first_manifest["resolutions"][0]["binding"]["sha256"] == source_sha256
+
+    source.write_text("units lj\nrun 6000\n", encoding="utf-8")
+    changed_sha256 = hashlib.sha256(source.read_bytes()).hexdigest()
+    second = _call(
+        queue,
+        settings=settings,
+        session=session,
+        name=RUN_ALIAS,
+        arguments={
+            "cluster": "ares",
+            "pipeline_id": "science-run",
+            "idempotency_key": "run-lammps-input-v2",
+        },
+    )
+    assert "error" not in second
+    second_payload = copy.deepcopy(harness.submitted_payloads[-1])
+    second_manifest = cast(JSON, second_payload["jarvis_input_manifest"])
+    assert second_manifest["resolutions"][0]["disposition"] == "updated"
+    assert second_manifest["resolutions"][0]["previous_sha256"] == source_sha256
+    assert second_manifest["resolutions"][0]["binding"]["sha256"] == changed_sha256
+    assert cast(list[JSON], second_payload["used_artifact_refs"])[0]["sha256"] == changed_sha256
+    assert len(harness.ingest_bodies) == 2
+
+    # The same admitted run key must not inspect mutable Host state again.
+    source.write_text("units lj\nrun 7000\n", encoding="utf-8")
+    retried = _call(
+        queue,
+        settings=settings,
+        session=session,
+        name=RUN_ALIAS,
+        arguments={
+            "cluster": "ares",
+            "pipeline_id": "science-run",
+            "idempotency_key": "run-lammps-input-v2",
+        },
+    )
+    assert "error" not in retried
+    assert harness.submitted_payloads[-1] == second_payload
+    assert len(harness.ingest_bodies) == 2
+    assert [payload["tool"] for payload in harness.submitted_payloads] == [
+        "jarvis_describe",
+        "jarvis_add_step",
+        "jarvis_run",
+        "jarvis_run",
+        "jarvis_run",
+    ]
 
 
 def test_legacy_jarvis_contract_does_not_activate_transparent_staging(
@@ -353,6 +429,113 @@ def test_legacy_jarvis_contract_does_not_activate_transparent_staging(
     payload = harness.submitted_payloads[-1]
     assert cast(JSON, payload["arguments"])["config"] == {"script": "in.lj"}
     assert payload.get("used_artifact_refs", []) == []
+
+
+def test_tracked_edit_replaces_binding_and_remove_clears_future_run_inputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tracked edits stay transparent and removing the step clears its live binding."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    first = workspace / "first.lj"
+    second = workspace / "second.lj"
+    first.write_text("run 1\n", encoding="utf-8")
+    second.write_text("run 2\n", encoding="utf-8")
+    settings, definition, catalog, harness = _configured_flow(tmp_path, workspace=workspace)
+    _patch_flow(
+        monkeypatch,
+        current_catalog={"value": catalog},
+        definition=definition,
+        harness=harness,
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+    session = McpSessionState()
+    _advertise(queue, settings=settings, session=session)
+    _describe_package(queue, settings=settings, session=session)
+    added = _call(
+        queue,
+        settings=settings,
+        session=session,
+        name=ADD_STEP_ALIAS,
+        arguments={
+            "cluster": "ares",
+            "pipeline_id": "edited-pipeline",
+            "package_name": "lammps",
+            "config": {"script": "first.lj"},
+            "idempotency_key": "edited-add",
+        },
+    )
+    assert "error" not in added
+
+    edited = _call(
+        queue,
+        settings=settings,
+        session=session,
+        name=EDIT_STEP_ALIAS,
+        arguments={
+            "cluster": "ares",
+            "pipeline_id": "edited-pipeline",
+            "step_id": "lammps",
+            "config": {"script": "second.lj"},
+            "operation": "edit",
+            "idempotency_key": "edited-v2",
+        },
+    )
+    assert "error" not in edited
+    edit_payload = harness.submitted_payloads[-1]
+    edit_config = cast(JSON, cast(JSON, edit_payload["arguments"])["config"])
+    assert edit_config["script"].endswith("/inputs/second.lj")
+    assert cast(list[JSON], edit_payload["used_artifact_refs"])[0]["sha256"] == (
+        hashlib.sha256(second.read_bytes()).hexdigest()
+    )
+
+    ran = _call(
+        queue,
+        settings=settings,
+        session=session,
+        name=RUN_ALIAS,
+        arguments={
+            "cluster": "ares",
+            "pipeline_id": "edited-pipeline",
+            "idempotency_key": "edited-run",
+        },
+    )
+    assert "error" not in ran
+    assert (
+        cast(JSON, harness.submitted_payloads[-1]["jarvis_input_manifest"])["resolutions"][0][
+            "binding"
+        ]["workspace_relative_path"]
+        == "second.lj"
+    )
+
+    removed = _call(
+        queue,
+        settings=settings,
+        session=session,
+        name=EDIT_STEP_ALIAS,
+        arguments={
+            "cluster": "ares",
+            "pipeline_id": "edited-pipeline",
+            "step_id": "lammps",
+            "operation": "remove",
+            "idempotency_key": "edited-remove",
+        },
+    )
+    assert "error" not in removed
+    after_remove = _call(
+        queue,
+        settings=settings,
+        session=session,
+        name=RUN_ALIAS,
+        arguments={
+            "cluster": "ares",
+            "pipeline_id": "edited-pipeline",
+            "idempotency_key": "edited-run-after-remove",
+        },
+    )
+    assert "error" not in after_remove
+    assert harness.submitted_payloads[-1].get("jarvis_input_manifest") is None
 
 
 def test_durable_pipeline_inputs_do_not_cross_server_artifact_revision(
@@ -713,6 +896,7 @@ def _configured_flow(
         allow_tools=[
             "jarvis_describe",
             "jarvis_add_step",
+            "jarvis_edit_step",
             "jarvis_run",
             "jarvis_get_execution",
         ],
@@ -767,6 +951,20 @@ def _catalog(
                     "config": {"type": "object"},
                 },
                 "required": ["pipeline_id", "package_name"],
+                "additionalProperties": False,
+            },
+        ),
+        EDIT_STEP_ALIAS: RemoteMcpToolSchema(
+            name="jarvis_edit_step",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "pipeline_id": {"type": "string"},
+                    "step_id": {"type": "string"},
+                    "config": {"type": "object"},
+                    "operation": {"type": "string"},
+                },
+                "required": ["pipeline_id", "step_id"],
                 "additionalProperties": False,
             },
         ),


### PR DESCRIPTION
Closes #135.

Tracks declared local-file settings by pipeline step and canonical setting, snapshots their current workspace bytes for every new run, reuses unchanged immutable artifacts, ingests changed content, and applies the exact resolved paths before jarvis_run. Repeated use of the same explicit idempotency key reuses the first immutable input manifest without rescanning.

Validation:
- uv run ruff check src tests jarvis-packages/clio_relay/clio_relay
- uv run pyright src/clio_relay jarvis-packages/clio_relay/clio_relay
- uv run pytest -q tests/test_input_staging.py tests/test_mcp_call_runner.py tests/test_mcp_input_staging.py