### PR TITLE
feat: complete ParaView live runtime acceptance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,13 @@ jobs:
       - name: stage exact clio-kit release wheel
         shell: bash
         env:
-          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.6.2-py3-none-any.whl
-          CLIO_KIT_WHEEL_SHA256: 96ce0f85bacad637b715704565be0c57df9d1891193c1c00c3c85dc2904725a4
-          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.6.2/clio_kit-2.6.2-py3-none-any.whl
+          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.6.5-py3-none-any.whl
+          CLIO_KIT_WHEEL_SHA256: 15a24746453041009f5b3618a72ea8b1c044927def46395ba383eb444ee9c82d
+          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.6.5/clio_kit-2.6.5-py3-none-any.whl
         run: |
           set -euo pipefail
           umask 077
-          wheel_dir="$RUNNER_TEMP/clio-kit-v2.6.2"
+          wheel_dir="$RUNNER_TEMP/clio-kit-v2.6.5"
           mkdir "$wheel_dir"
           wheel="$wheel_dir/$CLIO_KIT_WHEEL_FILENAME"
           curl --fail --show-error --silent --location \
@@ -161,13 +161,13 @@ jobs:
       - name: stage exact clio-kit release wheel
         shell: bash
         env:
-          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.6.2-py3-none-any.whl
-          CLIO_KIT_WHEEL_SHA256: 96ce0f85bacad637b715704565be0c57df9d1891193c1c00c3c85dc2904725a4
-          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.6.2/clio_kit-2.6.2-py3-none-any.whl
+          CLIO_KIT_WHEEL_FILENAME: clio_kit-2.6.5-py3-none-any.whl
+          CLIO_KIT_WHEEL_SHA256: 15a24746453041009f5b3618a72ea8b1c044927def46395ba383eb444ee9c82d
+          CLIO_KIT_WHEEL_URL: https://github.com/iowarp/clio-kit/releases/download/v2.6.5/clio_kit-2.6.5-py3-none-any.whl
         run: |
           set -euo pipefail
           umask 077
-          wheel_dir="$RUNNER_TEMP/clio-kit-v2.6.2"
+          wheel_dir="$RUNNER_TEMP/clio-kit-v2.6.5"
           mkdir "$wheel_dir"
           wheel="$wheel_dir/$CLIO_KIT_WHEEL_FILENAME"
           curl --fail --show-error --silent --location \

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -427,7 +427,7 @@ For the legacy clio-kit 2.2.6 compatibility path, a successful synchronous
 `jarvis_run` MCP return is normalized to a terminal `completed` record even
 though that release labels the result `status=running`; the original status and
 completion basis remain in `details.completion_normalization` for auditability.
-The pinned clio-kit 2.6.2 production path removes that ambiguity upstream and
+The pinned clio-kit 2.6.5 production path removes that ambiguity upstream and
 returns a structured durable execution handle immediately. The legacy normalization is
 diagnostic compatibility evidence and cannot satisfy the 1.0 gate. Scheduler
 submissions remain non-terminal and are observed through `jarvis_get_execution`.
@@ -675,7 +675,7 @@ Install the cluster-side server once, then launch its persistent executable:
 
 ```bash
 uv tool install --python 3.12 --no-config \
-  https://github.com/iowarp/clio-kit/releases/download/v2.6.2/clio_kit-2.6.2-py3-none-any.whl
+  https://github.com/iowarp/clio-kit/releases/download/v2.6.5/clio_kit-2.6.5-py3-none-any.whl
 clio-kit mcp-server jarvis
 ```
 

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -954,7 +954,7 @@ cannot satisfy either requirement.
 
 ## Run the scientific catalog v1.1 contract
 
-Use the exact clio-kit 2.6.2 persistent executable installed and receipt-bound
+Use the exact clio-kit 2.6.5 persistent executable installed and receipt-bound
 by bootstrap. The catalog file is operator-owned site metadata supplied through
 `CLIO_RELAY_VALIDATION_ARES_SCIENTIFIC_CATALOG_FILE`; it is not copied into the
 relay release. This policy uses

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -112,16 +112,16 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.6.2"
-            jarvis-cd: "1.6.0"
+            clio-kit: "2.6.5"
+            jarvis-cd: "1.7.0"
             jarvis-util: c91bfdc9bba802e4b03bfb1babe614ffa3e09644
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.6.2"
-              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.6.2/clio_kit-2.6.2-py3-none-any.whl
+              distribution_version: "2.6.5"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.6.5/clio_kit-2.6.5-py3-none-any.whl
               requested_source: github_release
-              artifact_sha256: 96ce0f85bacad637b715704565be0c57df9d1891193c1c00c3c85dc2904725a4
+              artifact_sha256: 15a24746453041009f5b3618a72ea8b1c044927def46395ba383eb444ee9c82d
               native_execution:
                 schema_version: clio-relay.jarvis-native-execution-capability.v1
                 handle_schema: jarvis.execution.handle.v1
@@ -133,11 +133,11 @@ requirements:
                 contract_sha256: 055c6697dc9a25fb033c949db92c928aee8d5673f7b2e3a4d90a237f4f87a40d
             jarvis-cd:
               distribution: jarvis_cd
-              distribution_version: "1.6.0"
-              install_spec: https://github.com/grc-iit/jarvis-cd/releases/download/v1.6.0/jarvis_cd-1.6.0-py3-none-any.whl
+              distribution_version: "1.7.0"
+              install_spec: https://github.com/grc-iit/jarvis-cd/releases/download/v1.7.0/jarvis_cd-1.7.0-py3-none-any.whl
               requested_source: github_release
-              artifact_filename: jarvis_cd-1.6.0-py3-none-any.whl
-              artifact_sha256: c4853138f3263715e806fcd794233d89f4aa58161e3c5fbab59e7f96d24f0e98
+              artifact_filename: jarvis_cd-1.7.0-py3-none-any.whl
+              artifact_sha256: f61d2c9b01af1794263013b9045916230c36c318c2984ba4f35d82d8c994e9bb
               native_execution:
                 schema_version: clio-relay.jarvis-native-execution-capability.v1
                 handle_schema: jarvis.execution.handle.v1
@@ -223,14 +223,14 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.6.2"
+            clio-kit: "2.6.5"
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.6.2"
-              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.6.2/clio_kit-2.6.2-py3-none-any.whl
+              distribution_version: "2.6.5"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.6.5/clio_kit-2.6.5-py3-none-any.whl
               requested_source: github_release
-              artifact_sha256: 96ce0f85bacad637b715704565be0c57df9d1891193c1c00c3c85dc2904725a4
+              artifact_sha256: 15a24746453041009f5b3618a72ea8b1c044927def46395ba383eb444ee9c82d
       - kind: scheduler_job
         roles: [queue-preservation-fixture]
         states: [completed]
@@ -291,24 +291,24 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.6.2"
-            jarvis-cd: "1.6.0"
+            clio-kit: "2.6.5"
+            jarvis-cd: "1.7.0"
           component_artifacts:
             clio-kit:
               distribution: clio-kit
-              distribution_version: "2.6.2"
-              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.6.2/clio_kit-2.6.2-py3-none-any.whl
+              distribution_version: "2.6.5"
+              install_spec: https://github.com/iowarp/clio-kit/releases/download/v2.6.5/clio_kit-2.6.5-py3-none-any.whl
               requested_source: github_release
-              artifact_filename: clio_kit-2.6.2-py3-none-any.whl
-              artifact_sha256: 96ce0f85bacad637b715704565be0c57df9d1891193c1c00c3c85dc2904725a4
+              artifact_filename: clio_kit-2.6.5-py3-none-any.whl
+              artifact_sha256: 15a24746453041009f5b3618a72ea8b1c044927def46395ba383eb444ee9c82d
               persistent_tool:
                 manager: uv
                 uv_version: "0.11.28"
                 pyvenv_uv_version: "0.11.28"
                 distribution: clio-kit
-                distribution_version: "2.6.2"
+                distribution_version: "2.6.5"
                 entry_point: clio-kit
-                source_artifact_sha256: 96ce0f85bacad637b715704565be0c57df9d1891193c1c00c3c85dc2904725a4
+                source_artifact_sha256: 15a24746453041009f5b3618a72ea8b1c044927def46395ba383eb444ee9c82d
               native_execution:
                 schema_version: clio-relay.jarvis-native-execution-capability.v1
                 handle_schema: jarvis.execution.handle.v1
@@ -322,11 +322,11 @@ requirements:
                 contract_sha256: 055c6697dc9a25fb033c949db92c928aee8d5673f7b2e3a4d90a237f4f87a40d
             jarvis-cd:
               distribution: jarvis_cd
-              distribution_version: "1.6.0"
-              install_spec: https://github.com/grc-iit/jarvis-cd/releases/download/v1.6.0/jarvis_cd-1.6.0-py3-none-any.whl
+              distribution_version: "1.7.0"
+              install_spec: https://github.com/grc-iit/jarvis-cd/releases/download/v1.7.0/jarvis_cd-1.7.0-py3-none-any.whl
               requested_source: github_release
-              artifact_filename: jarvis_cd-1.6.0-py3-none-any.whl
-              artifact_sha256: c4853138f3263715e806fcd794233d89f4aa58161e3c5fbab59e7f96d24f0e98
+              artifact_filename: jarvis_cd-1.7.0-py3-none-any.whl
+              artifact_sha256: f61d2c9b01af1794263013b9045916230c36c318c2984ba4f35d82d8c994e9bb
               native_execution:
                 schema_version: clio-relay.jarvis-native-execution-capability.v1
                 handle_schema: jarvis.execution.handle.v1
@@ -368,10 +368,10 @@ requirements:
         states: [verified]
         metadata_equals:
           install_source: uv-tool
-          install_artifact_sha256: 96ce0f85bacad637b715704565be0c57df9d1891193c1c00c3c85dc2904725a4
+          install_artifact_sha256: 15a24746453041009f5b3618a72ea8b1c044927def46395ba383eb444ee9c82d
           python_distribution_runtime:
             distribution: clio-kit
-            distribution_version: "2.6.2"
+            distribution_version: "2.6.5"
             entry_point: clio-kit
             runtime_closure_verified: true
           nested_runtime:
@@ -382,9 +382,9 @@ requirements:
               schema_version: clio-relay.jarvis-cd-lock-binding.v1
               dependency: jarvis-cd
               error: null
-              expected_version: "1.6.0"
-              expected_url: https://github.com/grc-iit/jarvis-cd/releases/download/v1.6.0/jarvis_cd-1.6.0-py3-none-any.whl
-              expected_sha256: c4853138f3263715e806fcd794233d89f4aa58161e3c5fbab59e7f96d24f0e98
+              expected_version: "1.7.0"
+              expected_url: https://github.com/grc-iit/jarvis-cd/releases/download/v1.7.0/jarvis_cd-1.7.0-py3-none-any.whl
+              expected_sha256: f61d2c9b01af1794263013b9045916230c36c318c2984ba4f35d82d8c994e9bb
               jarvis_mcp_package_entry_count: 1
               resolved_dependency_entry_count: 1
               observed_resolved_dependency_entries:
@@ -392,15 +392,15 @@ requirements:
               metadata_requirement_entry_count: 1
               observed_metadata_requirement_entries:
                 - name: jarvis-cd
-                  url: https://github.com/grc-iit/jarvis-cd/releases/download/v1.6.0/jarvis_cd-1.6.0-py3-none-any.whl
+                  url: https://github.com/grc-iit/jarvis-cd/releases/download/v1.7.0/jarvis_cd-1.7.0-py3-none-any.whl
               observed_metadata_requirement_urls:
-                - https://github.com/grc-iit/jarvis-cd/releases/download/v1.6.0/jarvis_cd-1.6.0-py3-none-any.whl
+                - https://github.com/grc-iit/jarvis-cd/releases/download/v1.7.0/jarvis_cd-1.7.0-py3-none-any.whl
               package_entry_count: 1
               wheel_entry_count: 1
-              observed_version: "1.6.0"
-              observed_source_url: https://github.com/grc-iit/jarvis-cd/releases/download/v1.6.0/jarvis_cd-1.6.0-py3-none-any.whl
-              observed_wheel_url: https://github.com/grc-iit/jarvis-cd/releases/download/v1.6.0/jarvis_cd-1.6.0-py3-none-any.whl
-              observed_wheel_sha256: c4853138f3263715e806fcd794233d89f4aa58161e3c5fbab59e7f96d24f0e98
+              observed_version: "1.7.0"
+              observed_source_url: https://github.com/grc-iit/jarvis-cd/releases/download/v1.7.0/jarvis_cd-1.7.0-py3-none-any.whl
+              observed_wheel_url: https://github.com/grc-iit/jarvis-cd/releases/download/v1.7.0/jarvis_cd-1.7.0-py3-none-any.whl
+              observed_wheel_sha256: f61d2c9b01af1794263013b9045916230c36c318c2984ba4f35d82d8c994e9bb
               verified: true
           server_process_artifact_verified: true
           verified: true
@@ -513,15 +513,15 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            jarvis-cd: "1.6.0"
+            jarvis-cd: "1.7.0"
           component_artifacts:
             jarvis-cd:
               distribution: jarvis_cd
-              distribution_version: "1.6.0"
-              install_spec: https://github.com/grc-iit/jarvis-cd/releases/download/v1.6.0/jarvis_cd-1.6.0-py3-none-any.whl
+              distribution_version: "1.7.0"
+              install_spec: https://github.com/grc-iit/jarvis-cd/releases/download/v1.7.0/jarvis_cd-1.7.0-py3-none-any.whl
               requested_source: github_release
-              artifact_filename: jarvis_cd-1.6.0-py3-none-any.whl
-              artifact_sha256: c4853138f3263715e806fcd794233d89f4aa58161e3c5fbab59e7f96d24f0e98
+              artifact_filename: jarvis_cd-1.7.0-py3-none-any.whl
+              artifact_sha256: f61d2c9b01af1794263013b9045916230c36c318c2984ba4f35d82d8c994e9bb
               native_execution:
                 schema_version: clio-relay.jarvis-native-execution-capability.v1
                 handle_schema: jarvis.execution.handle.v1
@@ -591,15 +591,15 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            jarvis-cd: "1.6.0"
+            jarvis-cd: "1.7.0"
           component_artifacts:
             jarvis-cd:
               distribution: jarvis_cd
-              distribution_version: "1.6.0"
-              install_spec: https://github.com/grc-iit/jarvis-cd/releases/download/v1.6.0/jarvis_cd-1.6.0-py3-none-any.whl
+              distribution_version: "1.7.0"
+              install_spec: https://github.com/grc-iit/jarvis-cd/releases/download/v1.7.0/jarvis_cd-1.7.0-py3-none-any.whl
               requested_source: github_release
-              artifact_filename: jarvis_cd-1.6.0-py3-none-any.whl
-              artifact_sha256: c4853138f3263715e806fcd794233d89f4aa58161e3c5fbab59e7f96d24f0e98
+              artifact_filename: jarvis_cd-1.7.0-py3-none-any.whl
+              artifact_sha256: f61d2c9b01af1794263013b9045916230c36c318c2984ba4f35d82d8c994e9bb
               native_execution:
                 schema_version: clio-relay.jarvis-native-execution-capability.v1
                 handle_schema: jarvis.execution.handle.v1
@@ -677,7 +677,7 @@ requirements:
           remote_tool_names: [scientific_dataset_describe, scientific_dataset_search]
           allowlisted_tool_names: [scientific_dataset_describe, scientific_dataset_search]
           install_source: wheel
-          install_artifact_sha256: 96ce0f85bacad637b715704565be0c57df9d1891193c1c00c3c85dc2904725a4
+          install_artifact_sha256: 15a24746453041009f5b3618a72ea8b1c044927def46395ba383eb444ee9c82d
           contract_id: clio-kit-scientific-catalog-user-v1.1
           contract_sha256: 80a9b583c26a084ff07d638ddf0c2c7d4325dbc8d4299931d0c4f3627cb8674c
           server_process_artifact_verified: true
@@ -779,7 +779,7 @@ requirements:
           remote_tool_names: [spack_find, spack_install, spack_locate]
           allowlisted_tool_names: [spack_find, spack_install, spack_locate]
           install_source: wheel
-          install_artifact_sha256: 96ce0f85bacad637b715704565be0c57df9d1891193c1c00c3c85dc2904725a4
+          install_artifact_sha256: 15a24746453041009f5b3618a72ea8b1c044927def46395ba383eb444ee9c82d
           contract_id: clio-kit-spack-user-v2.1
           contract_sha256: f1a62d96179012975f763402446571146e04e519f98df30583f9800f233216fc
           server_process_artifact_verified: true
@@ -884,7 +884,7 @@ requirements:
           remote_tool_names: [spack_find, spack_install, spack_locate]
           allowlisted_tool_names: [spack_find, spack_install, spack_locate]
           install_source: wheel
-          install_artifact_sha256: 96ce0f85bacad637b715704565be0c57df9d1891193c1c00c3c85dc2904725a4
+          install_artifact_sha256: 15a24746453041009f5b3618a72ea8b1c044927def46395ba383eb444ee9c82d
           contract_id: clio-kit-spack-user-v2.1
           contract_sha256: f1a62d96179012975f763402446571146e04e519f98df30583f9800f233216fc
           server_process_artifact_verified: true
@@ -1184,8 +1184,8 @@ requirements:
         states: [running]
         metadata_equals:
           components:
-            clio-kit: "2.6.2"
-            jarvis-cd: "1.6.0"
+            clio-kit: "2.6.5"
+            jarvis-cd: "1.7.0"
       - kind: cluster_target
         roles: [physical_cluster_target]
         states: [verified]

--- a/docs/remote-mcp-federation.md
+++ b/docs/remote-mcp-federation.md
@@ -369,7 +369,7 @@ that returns the handle, never for workload completion. Use
 an explicit `idempotency_key` only when retry de-duplication is intentional; an
 identical second `jarvis_run` is otherwise a new execution.
 
-The released clio-kit 2.6.2 artifact carries the pinned six-tool JARVIS v3.6
+The released clio-kit 2.6.5 artifact carries the pinned six-tool JARVIS v3.6
 contract.
 Bootstrap
 downloads and hashes the exact coordinated wheel, installs it once with
@@ -389,13 +389,13 @@ relay's exact JARVIS-CD release pin. That dependency edge is recorded in the
 install receipt and call result. Operator-registered MCP servers remain bound
 by their own discovery artifact and are not constrained to the relay's
 JARVIS-CD version.
-The release gate requires that exact 2.6.2 artifact to be rerun on every target
+The release gate requires that exact 2.6.5 artifact to be rerun on every target
 selected by the release policy. Other servers use the operator registry and
 generated `remote_...` aliases.
 
 The exact release wheel is
-`clio_kit-2.6.2-py3-none-any.whl` with SHA-256
-`96ce0f85bacad637b715704565be0c57df9d1891193c1c00c3c85dc2904725a4`.
+`clio_kit-2.6.5-py3-none-any.whl` with SHA-256
+`15a24746453041009f5b3618a72ea8b1c044927def46395ba383eb444ee9c82d`.
 Its canonical contract is `clio-kit-jarvis-user-v3.6`, with contract SHA-256
 `055c6697dc9a25fb033c949db92c928aee8d5673f7b2e3a4d90a237f4f87a40d`
 and canonical tools-wire SHA-256
@@ -403,9 +403,9 @@ and canonical tools-wire SHA-256
 The bundled contract artifact SHA-256 is
 `6e839f3ac975f247053ef4b6a048c53686882c2ab6a1b103f91dfc744ed29ed5`.
 The nested runtime lock is bound to the public
-[`jarvis_cd-1.6.0-py3-none-any.whl`](https://github.com/grc-iit/jarvis-cd/releases/download/v1.6.0/jarvis_cd-1.6.0-py3-none-any.whl)
+[`jarvis_cd-1.7.0-py3-none-any.whl`](https://github.com/grc-iit/jarvis-cd/releases/download/v1.7.0/jarvis_cd-1.7.0-py3-none-any.whl)
 release artifact with SHA-256
-`c4853138f3263715e806fcd794233d89f4aa58161e3c5fbab59e7f96d24f0e98`;
+`f61d2c9b01af1794263013b9045916230c36c318c2984ba4f35d82d8c994e9bb`;
 bootstrap and call-time validation reject any other URL, version, or bytes.
 
 ## Register the Spack MCP
@@ -429,7 +429,7 @@ and its bundled artifact SHA-256 is
 
 ## Register the scientific catalog MCP
 
-clio-kit 2.6.2 also ships the two-tool
+clio-kit 2.6.5 also ships the two-tool
 `clio-kit-scientific-catalog-user-v1.1` contract. It separates dataset discovery
 from visualization control: `scientific_dataset_search` finds operator catalog
 records and `scientific_dataset_describe` returns the complete catalog record

--- a/jarvis-packages/clio_relay/clio_relay/mcp_call/runner.py
+++ b/jarvis-packages/clio_relay/clio_relay/mcp_call/runner.py
@@ -165,12 +165,12 @@ _JARVIS_CD_LOCK_BINDING_SCHEMA = "clio-relay.jarvis-cd-lock-binding.v1"
 # prevents either copy from moving independently. The JARVIS package also runs as
 # a standalone repository package, where importing the installed relay bootstrap
 # module is not a valid dependency boundary.
-JARVIS_CD_VERSION = "1.6.0"
+JARVIS_CD_VERSION = "1.7.0"
 JARVIS_CD_WHEEL_URL = (
     "https://github.com/grc-iit/jarvis-cd/releases/download/"
     f"v{JARVIS_CD_VERSION}/jarvis_cd-{JARVIS_CD_VERSION}-py3-none-any.whl"
 )
-JARVIS_CD_WHEEL_SHA256 = "c4853138f3263715e806fcd794233d89f4aa58161e3c5fbab59e7f96d24f0e98"
+JARVIS_CD_WHEEL_SHA256 = "f61d2c9b01af1794263013b9045916230c36c318c2984ba4f35d82d8c994e9bb"
 _CLIO_KIT_RUNTIME_PROJECT_EXCLUDED_NAMES = frozenset(
     {
         ".git",

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -71,24 +71,68 @@ UV_LINUX_AMD64_EXECUTABLE_SHA256 = (
     "1cb9cd0a1749debf6049d7d2bb933882cc52d81016326ee6d99a786d6c988b03"
 )
 JARVIS_UTIL_COMMIT = "c91bfdc9bba802e4b03bfb1babe614ffa3e09644"
-JARVIS_CD_VERSION = "1.6.0"
+JARVIS_CD_VERSION = "1.7.0"
 JARVIS_CD_WHEEL_FILENAME = f"jarvis_cd-{JARVIS_CD_VERSION}-py3-none-any.whl"
 JARVIS_CD_WHEEL_URL = (
     "https://github.com/grc-iit/jarvis-cd/releases/download/"
     f"v{JARVIS_CD_VERSION}/{JARVIS_CD_WHEEL_FILENAME}"
 )
-JARVIS_CD_WHEEL_SHA256 = "c4853138f3263715e806fcd794233d89f4aa58161e3c5fbab59e7f96d24f0e98"
+JARVIS_CD_WHEEL_SHA256 = "f61d2c9b01af1794263013b9045916230c36c318c2984ba4f35d82d8c994e9bb"
 DEFAULT_REMOTE_CORE_DIR = "$HOME/.local/share/clio-relay/core"
 DEFAULT_REMOTE_SPOOL_DIR = "$HOME/.local/share/clio-relay/spool"
 
 
 _STAGED_PROVIDER_ENVIRONMENT_SANITIZER = r"""
-while IFS= read -r bootstrap_environment_name; do
-  case "$bootstrap_environment_name" in
-    LD_*|PYTHON*|BASH_ENV|ENV) unset "$bootstrap_environment_name" ;;
-  esac
-done < <(compgen -e)
+for bootstrap_environment_name in "${!LD_@}" "${!PYTHON@}" BASH_ENV ENV; do
+  unset "$bootstrap_environment_name"
+done
 """.strip()
+_POSIX_REMOTE_SHELL_STARTUP_ENVIRONMENT_NAMES = (
+    "BASH_ENV",
+    "ENV",
+    "LD_AUDIT",
+    "LD_BIND_NOT",
+    "LD_BIND_NOW",
+    "LD_DEBUG",
+    "LD_DEBUG_OUTPUT",
+    "LD_DYNAMIC_WEAK",
+    "LD_HWCAP_MASK",
+    "LD_LIBRARY_PATH",
+    "LD_ORIGIN_PATH",
+    "LD_POINTER_GUARD",
+    "LD_PRELOAD",
+    "LD_PROFILE",
+    "LD_PROFILE_OUTPUT",
+    "LD_SHOW_AUXV",
+    "LD_TRACE_LOADED_OBJECTS",
+    "LD_TRACE_PRELINKING",
+    "LD_USE_LOAD_BIAS",
+    "LD_VERBOSE",
+    "LD_WARN",
+    "PYTHONCASEOK",
+    "PYTHONDEBUG",
+    "PYTHONDONTWRITEBYTECODE",
+    "PYTHONEXECUTABLE",
+    "PYTHONFAULTHANDLER",
+    "PYTHONHASHSEED",
+    "PYTHONHOME",
+    "PYTHONINSPECT",
+    "PYTHONIOENCODING",
+    "PYTHONMALLOC",
+    "PYTHONNOUSERSITE",
+    "PYTHONOPTIMIZE",
+    "PYTHONPATH",
+    "PYTHONPROFILEIMPORTTIME",
+    "PYTHONPYCACHEPREFIX",
+    "PYTHONSAFEPATH",
+    "PYTHONSTARTUP",
+    "PYTHONTRACEMALLOC",
+    "PYTHONUNBUFFERED",
+    "PYTHONUSERBASE",
+    "PYTHONUTF8",
+    "PYTHONWARNDEFAULTENCODING",
+    "PYTHONWARNINGS",
+)
 _STAGED_PROVIDER_EXEC_PROGRAM = r"""
 import ctypes
 import fcntl
@@ -872,6 +916,132 @@ finally:
     os.close(root_descriptor)
     os.close(source_descriptor)
 print(root / "pinned-uv")"""
+_BOOTSTRAP_PINNED_LOCAL_ARTIFACT_COPY_SOURCE = r"""import hashlib
+import os
+import stat
+import sys
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+
+def identity(details):
+    return (
+        details.st_dev,
+        details.st_ino,
+        details.st_mode,
+        details.st_size,
+        details.st_mtime_ns,
+        details.st_ctime_ns,
+    )
+
+
+def cross_handle_identity(details):
+    if os.name == "nt":
+        return (
+            details.st_dev,
+            details.st_ino,
+            stat.S_IFMT(details.st_mode),
+            details.st_size,
+            details.st_mtime_ns,
+        )
+    return identity(details)
+
+
+source_url, expected_sha256, destination_value, allowed_root_value = sys.argv[1:]
+parsed = urlsplit(source_url)
+source_path_value = unquote(parsed.path)
+if os.name == "nt" and len(source_path_value) > 2 and source_path_value[0] == "/":
+    source_path_value = source_path_value[1:]
+if (
+    parsed.scheme != "file"
+    or parsed.netloc
+    or parsed.query
+    or parsed.fragment
+    or not source_path_value
+    or any(character in source_path_value for character in "\x00\r\n")
+    or len(expected_sha256) != 64
+    or any(character not in "0123456789abcdef" for character in expected_sha256)
+):
+    raise SystemExit("pinned local artifact arguments are invalid")
+
+source = Path(source_path_value)
+destination = Path(destination_value)
+allowed_root = Path(allowed_root_value)
+if not source.is_absolute() or not destination.is_absolute() or not allowed_root.is_absolute():
+    raise SystemExit("pinned local artifact paths must be absolute")
+try:
+    allowed_root_before = allowed_root.lstat()
+    source_before = source.lstat()
+    destination_before = destination.lstat()
+    resolved_allowed_root = allowed_root.resolve(strict=True)
+    resolved_source = source.resolve(strict=True)
+    resolved_source.relative_to(resolved_allowed_root)
+except (OSError, RuntimeError, ValueError) as exc:
+    raise SystemExit("pinned local artifact escaped its managed staging root") from exc
+getuid = getattr(os, "getuid", None)
+if (
+    not stat.S_ISDIR(allowed_root_before.st_mode)
+    or allowed_root.is_symlink()
+    or not stat.S_ISREG(source_before.st_mode)
+    or source.is_symlink()
+    or not 1 <= source_before.st_size <= 256 * 1024 * 1024
+    or not stat.S_ISREG(destination_before.st_mode)
+    or destination.is_symlink()
+    or destination_before.st_nlink != 1
+    or destination_before.st_size != 0
+    or (callable(getuid) and allowed_root_before.st_uid != getuid())
+    or (callable(getuid) and source_before.st_uid != getuid())
+    or (callable(getuid) and destination_before.st_uid != getuid())
+):
+    raise SystemExit("pinned local artifact paths are not owned bounded files")
+
+read_flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+write_flags = os.O_WRONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+source_descriptor = os.open(source, read_flags)
+destination_descriptor = os.open(destination, write_flags)
+try:
+    source_opened = os.fstat(source_descriptor)
+    destination_opened = os.fstat(destination_descriptor)
+    if (
+        identity(source_opened) != identity(source_before)
+        or identity(destination_opened) != identity(destination_before)
+    ):
+        raise SystemExit("pinned local artifact changed before copying")
+    digest = hashlib.sha256()
+    copied = 0
+    while chunk := os.read(source_descriptor, 1024 * 1024):
+        copied += len(chunk)
+        if copied > 256 * 1024 * 1024:
+            raise SystemExit("pinned local artifact exceeded its copy bound")
+        digest.update(chunk)
+        view = memoryview(chunk)
+        while view:
+            written = os.write(destination_descriptor, view)
+            if written < 1:
+                raise SystemExit("pinned local artifact copy made no progress")
+            view = view[written:]
+    os.fsync(destination_descriptor)
+    source_after = os.fstat(source_descriptor)
+    destination_after = os.fstat(destination_descriptor)
+    if (
+        copied != source_opened.st_size
+        or digest.hexdigest() != expected_sha256
+        or identity(source_after) != identity(source_opened)
+        or identity(source.lstat()) != identity(source_opened)
+        or destination_after.st_size != copied
+        or destination_after.st_nlink != 1
+        or (destination_after.st_dev, destination_after.st_ino)
+        == (source_opened.st_dev, source_opened.st_ino)
+    ):
+        os.ftruncate(destination_descriptor, 0)
+        os.fsync(destination_descriptor)
+        raise SystemExit("pinned local artifact changed or did not match its digest")
+finally:
+    os.close(destination_descriptor)
+    os.close(source_descriptor)
+
+if cross_handle_identity(destination.lstat()) != cross_handle_identity(destination_after):
+    raise SystemExit("pinned local artifact destination changed after copying")"""
 _BOOTSTRAP_CANDIDATE_UV_INSTALL_SOURCE = r"""import base64
 import ctypes
 import csv
@@ -2436,10 +2606,17 @@ def _bootstrap_preflight_over_ssh(
             "printf '%s\\n' \"$BOOTSTRAP_PREFLIGHT_OUTPUT\"",
         ]
     )
-    result = _run(
-        ["ssh", ssh_host, "bash", "-c", command],
-        timeout_seconds=timeout_seconds,
+    remote_command = "\n".join(
+        [
+            'if [ -n "${BASH_VERSION-}" ]; then',
+            f"  eval {shlex.quote(_STAGED_PROVIDER_ENVIRONMENT_SANITIZER)}",
+            "else",
+            "  unset " + " ".join(_POSIX_REMOTE_SHELL_STARTUP_ENVIRONMENT_NAMES),
+            "fi",
+            f"exec bash -c {shlex.quote(command)}",
+        ]
     )
+    result = _run(["ssh", ssh_host, remote_command], timeout_seconds=timeout_seconds)
     lines = result.stdout.splitlines()
     payload_lines = [
         line.removeprefix("bootstrap_preflight_json=")
@@ -3758,6 +3935,44 @@ def _worker_upgrade_fence_script(
     return fence, recheck, "clio-relay init --migrate-legacy-output", restart
 
 
+def _pinned_artifact_fetch_shell_function() -> str:
+    """Render the digest-pinned HTTPS or managed local artifact fetcher."""
+    local_copy_program = shlex.quote(_BOOTSTRAP_PINNED_LOCAL_ARTIFACT_COPY_SOURCE)
+    return f"""bootstrap_fetch_exact_artifact() {{
+  local source_url="$1"
+  local expected_sha256="$2"
+  local destination="$3"
+  case "$expected_sha256" in
+    (*[!0-9a-f]*|'')
+      echo "bootstrap artifact digest is invalid" >&2
+      return 1
+      ;;
+  esac
+  if [ "${{#expected_sha256}}" -ne 64 ]; then
+    echo "bootstrap artifact digest has an invalid length" >&2
+    return 1
+  fi
+  case "$source_url" in
+    file://*)
+      python3 -I -c {local_copy_program} \
+        "$source_url" "$expected_sha256" "$destination" \
+        "$HOME/.local/share/clio-relay/candidate-wheels"
+      ;;
+    https://*)
+      curl --fail --location --proto '=https' --proto-redir '=https' --tlsv1.2 \
+        --retry 3 --retry-all-errors --retry-max-time 180 \
+        --connect-timeout 20 --max-time 180 \
+        --output "$destination" "$source_url"
+      echo "$expected_sha256 *$destination" | sha256sum --check --strict -
+      ;;
+    *)
+      echo "bootstrap artifact URL must use HTTPS or managed file staging" >&2
+      return 1
+      ;;
+  esac
+}}"""
+
+
 def _relay_only_reconcile_script(
     *,
     worker_fence: str,
@@ -4553,10 +4768,10 @@ bootstrap_relay_only_reconcile() {{
         "$HOME/.local/src/jarvis-util"
 
       mkdir -m 0700 "$BOOTSTRAP_GENERATION/artifacts"
-      curl --fail --location --proto '=https' --proto-redir '=https' --tlsv1.2 \
-        --retry 3 --retry-all-errors --retry-max-time 180 \
-        --connect-timeout 20 --max-time 180 \
-        --output "$JARVIS_CD_WHEEL" "{JARVIS_CD_WHEEL_URL}"
+      JARVIS_CD_STAGING="$(mktemp "${{JARVIS_CD_WHEEL}}.XXXXXX")"
+      bootstrap_fetch_exact_artifact \\
+        "{JARVIS_CD_WHEEL_URL}" "{JARVIS_CD_WHEEL_SHA256}" "$JARVIS_CD_STAGING"
+      mv "$JARVIS_CD_STAGING" "$JARVIS_CD_WHEEL"
       echo "{JARVIS_CD_WHEEL_SHA256} *$JARVIS_CD_WHEEL" | \
         sha256sum --check --strict -
       BOOTSTRAP_JARVIS_CD_DOWNLOAD_COUNT=1
@@ -5717,6 +5932,7 @@ def render_linux_user_bootstrap_script(
     preparing_root_program = shlex.quote(_BOOTSTRAP_PREPARING_ROOT_SOURCE)
     pinned_uv_copy_program = shlex.quote(_BOOTSTRAP_PINNED_UV_COPY_SOURCE)
     candidate_uv_install_program = shlex.quote(_BOOTSTRAP_CANDIDATE_UV_INSTALL_SOURCE)
+    artifact_fetch_function = _pinned_artifact_fetch_shell_function()
     candidate_package_sha256 = {
         name: hashlib.sha256(payload).hexdigest()
         for name, payload in candidate_package_sources.items()
@@ -5767,6 +5983,7 @@ while IFS= read -r variable_name; do
   esac
 done < <(compgen -e)
 mkdir -p "$HOME/.local/bin" "$HOME/.local/src" "$HOME/.local/share/clio-relay"
+{artifact_fetch_function}
 bootstrap_active_generation_identity() {{
   local current target prefix identity
   current="$HOME/.local/share/clio-relay/current"
@@ -7031,7 +7248,8 @@ JARVIS_CD_WHEEL="$JARVIS_CD_WHEEL_DIR/{JARVIS_CD_WHEEL_FILENAME}"
 mkdir -m 0700 -p "$(dirname "$JARVIS_CD_WHEEL_DIR")"
 bootstrap_journal_action mkdir-owned "$BOOTSTRAP_TRANSACTION_JOURNAL" jarvis_cd_wheels
 JARVIS_CD_STAGING="$(mktemp "${{JARVIS_CD_WHEEL}}.XXXXXX")"
-curl -L --fail --retry 3 -o "$JARVIS_CD_STAGING" "$JARVIS_CD_WHEEL_URL"
+bootstrap_fetch_exact_artifact \\
+  "$JARVIS_CD_WHEEL_URL" "$JARVIS_CD_WHEEL_SHA256" "$JARVIS_CD_STAGING"
 BOOTSTRAP_JARVIS_CD_DOWNLOADED=1
 echo "$JARVIS_CD_WHEEL_SHA256 *$JARVIS_CD_STAGING" | sha256sum --check --strict -
 mv "$JARVIS_CD_STAGING" "$JARVIS_CD_WHEEL"

--- a/src/clio_relay/bootstrap_reconcile.py
+++ b/src/clio_relay/bootstrap_reconcile.py
@@ -3056,6 +3056,77 @@ def _is_generation_repository_target(path: Path, *, home: Path) -> bool:
     )
 
 
+def proven_active_generation_mismatch(
+    desired: BootstrapDesiredState,
+    *,
+    home: Path | None = None,
+) -> str | None:
+    """Return a safely identified active generation only when it differs.
+
+    This deliberately proves only that the stable ``current`` pointer names a
+    different relay-managed generation.  It never proves an exact deployment
+    match, so callers may use it solely to request normal payload
+    reconciliation before performing the comparatively expensive runtime
+    identity inspection.
+    """
+    lexical_home = Path(os.path.abspath((home or Path.home()).expanduser()))
+    share = lexical_home / ".local/share/clio-relay"
+    generations_path = share / "generations"
+    current = share / "current"
+    try:
+        before = current.lstat()
+        if not stat.S_ISLNK(before.st_mode):
+            return None
+        raw_target = os.readlink(current)
+        if not raw_target or any(character in raw_target for character in "\x00\r\n"):
+            return None
+        target = Path(raw_target)
+        if not target.is_absolute():
+            target = current.parent / target
+        generations_before = generations_path.lstat()
+        if not stat.S_ISDIR(generations_before.st_mode) or _path_is_directory_alias(
+            generations_path
+        ):
+            return None
+        generations = generations_path.resolve(strict=True)
+        resolved_target = target.resolve(strict=True)
+        relative = resolved_target.relative_to(generations)
+        generation = relative.name
+        generation_path = generations_path / generation
+        generation_before = generation_path.lstat()
+        if (
+            not stat.S_ISDIR(generation_before.st_mode)
+            or _path_is_directory_alias(generation_path)
+            or generation_path.resolve(strict=True) != resolved_target
+        ):
+            return None
+        after = current.lstat()
+        generations_after = generations_path.lstat()
+        generation_after = generation_path.lstat()
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if (
+        _stat_identity(after) != _stat_identity(before)
+        or _stat_identity(generations_after) != _stat_identity(generations_before)
+        or _stat_identity(generation_after) != _stat_identity(generation_before)
+        or len(relative.parts) != 1
+        or len(generation) != 64
+        or any(character not in "0123456789abcdef" for character in generation)
+        or generation == desired.fingerprint
+    ):
+        return None
+    getuid = getattr(os, "getuid", None)
+    if callable(getuid) and any(
+        details.st_uid != getuid()
+        for details in (
+            generations_after,
+            generation_after,
+        )
+    ):
+        return None
+    return generation
+
+
 def _inspect_installation_identity(
     desired: BootstrapDesiredState,
     info: dict[str, object],

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -47,6 +47,7 @@ from clio_relay.bootstrap_reconcile import (
     bootstrap_invocation_lock,
     inspect_exact_bootstrap_noop,
     make_bootstrap_receipt,
+    proven_active_generation_mismatch,
     write_bootstrap_receipt,
 )
 from clio_relay.bounded_process import BoundedProcessError, run_bounded_process
@@ -94,6 +95,7 @@ from clio_relay.installation import (
     attach_verified_worker_identity,
     default_install_receipt_path,
     installation_info,
+    verified_session_api_install_receipt,
     verify_remote_worker_info,
     worker_runtime_info,
 )
@@ -3482,6 +3484,56 @@ print(json.dumps({
 """.strip()
 
 
+def _invalidate_remote_mcp_cache_after_bootstrap(
+    *,
+    cluster: str,
+    receipt: dict[str, object],
+    registry_path: Path | None = None,
+) -> dict[str, object]:
+    """Invalidate cluster-scoped MCP schemas when bootstrap changes its generation."""
+    raw_generation = receipt.get("generation")
+    if not isinstance(raw_generation, dict):
+        return {
+            "schema_version": "clio-relay.remote-mcp-cache-invalidation.v1",
+            "cluster": cluster,
+            "previous_generation": None,
+            "active_generation": None,
+            "generation_changed": None,
+            "action": "generation_unreported",
+            "removed_server_count": 0,
+            "removed_server_names": [],
+        }
+    generation = cast(dict[str, object], raw_generation)
+    previous_generation = generation.get("previous")
+    active_generation = generation.get("active")
+    if previous_generation is not None and (
+        not isinstance(previous_generation, str) or not previous_generation
+    ):
+        raise RelayError("bootstrap receipt has an invalid previous generation identity")
+    if not isinstance(active_generation, str) or not active_generation:
+        raise RelayError("bootstrap receipt has an invalid active generation identity")
+    generation_changed = previous_generation != active_generation
+    removed_server_names: tuple[str, ...] = ()
+    if generation_changed:
+        cache_path = default_remote_mcp_cache_path(
+            registry_path=registry_path or default_registry_path()
+        )
+        _cache, removed_server_names = RemoteMcpSchemaCache.invalidate_cluster_entries(
+            cache_path,
+            cluster,
+        )
+    return {
+        "schema_version": "clio-relay.remote-mcp-cache-invalidation.v1",
+        "cluster": cluster,
+        "previous_generation": previous_generation,
+        "active_generation": active_generation,
+        "generation_changed": generation_changed,
+        "action": "invalidated" if generation_changed else "preserved",
+        "removed_server_count": len(removed_server_names),
+        "removed_server_names": list(removed_server_names),
+    }
+
+
 @cluster_app.command("bootstrap")
 @_acceptance_report_command
 def cluster_bootstrap(
@@ -3601,6 +3653,17 @@ def cluster_bootstrap(
                     receipt_lines[0].partition("=")[2],
                     "bootstrap invocation receipt",
                 )
+                cache_invalidation = _invalidate_remote_mcp_cache_after_bootstrap(
+                    cluster=cluster,
+                    receipt=receipt,
+                )
+                evidence.append(
+                    EvidenceReference(
+                        kind="remote_mcp_cache_invalidation",
+                        reference=f"remote-mcp-cache:{cluster}",
+                        metadata=cache_invalidation,
+                    )
+                )
                 invocation_id = receipt.get("invocation_id")
                 if not isinstance(invocation_id, str) or not invocation_id.startswith("bootstrap_"):
                     raise RelayError("bootstrap receipt omitted its unique invocation identity")
@@ -3624,6 +3687,7 @@ def cluster_bootstrap(
                             "ssh_host": ssh_host or definition.ssh_host,
                             "bootstrap_profile": definition.bootstrap_profile,
                             "output_sha256": hashlib.sha256("\n".join(lines).encode()).hexdigest(),
+                            "remote_mcp_cache_invalidation": cache_invalidation,
                         },
                     )
                 )
@@ -5074,9 +5138,14 @@ def _require_process_bound_session_api_release() -> None:
         return
     if re.fullmatch(r"[0-9a-f]{64}", expected_sha256) is None:
         raise ConfigurationError("session API release identity marker is invalid")
-    observed = _session_api_release_identity_from_installation(
-        installation_info(),
-        label="session API",
+    receipt = verified_session_api_install_receipt()
+    artifact_sha256 = receipt.artifact_sha256
+    if artifact_sha256 is None:  # pragma: no cover - verified helper requires it
+        raise ConfigurationError("session API installation identity is incomplete")
+    observed = SessionApiReleaseIdentity(
+        distribution_version=receipt.distribution_version,
+        artifact_sha256=artifact_sha256,
+        software=receipt.software,
     )
     if observed.sha256() != expected_sha256:
         raise ConfigurationError("session API release identity does not match running package")
@@ -11662,6 +11731,23 @@ def bootstrap_inspect(
             desired = BootstrapDesiredState.model_validate_json(raw)
         except (binascii.Error, UnicodeError, ValidationError, ValueError) as exc:
             raise ConfigurationError("bootstrap desired state is invalid") from exc
+        active_generation = proven_active_generation_mismatch(desired)
+        if active_generation is not None:
+            payload: dict[str, object] = {
+                "schema_version": "clio-relay.bootstrap-preflight.v1",
+                "exact_match": False,
+                "desired_fingerprint": desired.fingerprint,
+                "reasons": [
+                    "active generation differs from desired fingerprint",
+                ],
+                "receipt": None,
+                "action": "payload_required",
+            }
+            typer.echo(
+                "bootstrap_preflight_json="
+                + json.dumps(payload, sort_keys=True, separators=(",", ":"))
+            )
+            return
         started_at = datetime.now(UTC)
         started = monotonic()
         deadline = started + (

--- a/src/clio_relay/installation.py
+++ b/src/clio_relay/installation.py
@@ -1080,16 +1080,47 @@ def _path_within(path: Path, root: Path) -> bool:
         return False
 
 
-def installation_info(path: Path | None = None) -> dict[str, object]:
-    """Return current package identity together with its durable install receipt."""
+def _current_install_receipt(
+    path: Path | None = None,
+) -> tuple[InstallReceipt, Literal["bootstrap", "uv-tool"], InstallSource | None]:
+    """Load the durable receipt that owns the current relay installation."""
     receipt_path = path or default_install_receipt_path()
-    receipt_origin = "bootstrap"
+    receipt_origin: Literal["bootstrap", "uv-tool"] = "bootstrap"
     install_source: InstallSource | None = None
     if receipt_path.exists() or path is not None or os.environ.get(INSTALL_RECEIPT_PATH_ENV):
         receipt = load_install_receipt(receipt_path)
     else:
         receipt, install_source = _persistent_uv_tool_install_receipt()
         receipt_origin = "uv-tool"
+    return receipt, receipt_origin, install_source
+
+
+def verified_session_api_install_receipt(path: Path | None = None) -> InstallReceipt:
+    """Return the durable relay receipt verified against this API process.
+
+    Session API identity depends only on the relay distribution version,
+    embedded software identity, and relay artifact digest. Component runtime
+    probes validate separate execution surfaces and can launch expensive child
+    processes, so they are deliberately excluded from this startup-critical
+    check.
+    """
+    receipt, _receipt_origin, _install_source = _current_install_receipt(path)
+    current_software = detect_software_identity()
+    current_version = metadata.version("clio-relay")
+    if (
+        receipt.distribution_version != current_version
+        or receipt.software != current_software
+        or receipt.artifact_sha256 is None
+    ):
+        raise ConfigurationError(
+            "session API installation receipt does not match the running package"
+        )
+    return receipt
+
+
+def installation_info(path: Path | None = None) -> dict[str, object]:
+    """Return current package identity together with its durable install receipt."""
+    receipt, receipt_origin, install_source = _current_install_receipt(path)
     current_software = detect_software_identity()
     current_version = metadata.version("clio-relay")
     component_runtime = _component_runtime_identity(receipt)

--- a/src/clio_relay/jarvis_mcp.py
+++ b/src/clio_relay/jarvis_mcp.py
@@ -11,27 +11,29 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
-from clio_relay.identifiers import durable_record_id_json_schema
 from clio_relay.remote_mcp import (
     MAX_PINNED_CONTROL_QUERY_TIMEOUT_SECONDS,
-    VIRTUAL_REMOTE_MCP_JOB_OUTPUT_SCHEMA,
     RemoteMcpSchemaCache,
     RemoteMcpSchemaCacheEntry,
     default_remote_mcp_cache_path,
     remote_mcp_server_artifact_digest,
+    virtual_jarvis_job_output_schema,
+)
+from clio_relay.remote_mcp import (
+    jarvis_service_runtime_handoff_json_schema as jarvis_service_runtime_handoff_json_schema,
 )
 
 if TYPE_CHECKING:
     from clio_relay.installation import ComponentArtifactIdentity, InstallReceipt
 
-CLIO_KIT_JARVIS_MCP_VERSION = "2.6.2"
+CLIO_KIT_JARVIS_MCP_VERSION = "2.6.5"
 CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME = f"clio_kit-{CLIO_KIT_JARVIS_MCP_VERSION}-py3-none-any.whl"
 CLIO_KIT_JARVIS_MCP_WHEEL_URL = (
     "https://github.com/iowarp/clio-kit/releases/download/"
     f"v{CLIO_KIT_JARVIS_MCP_VERSION}/{CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME}"
 )
 CLIO_KIT_JARVIS_MCP_WHEEL_SHA256 = (
-    "96ce0f85bacad637b715704565be0c57df9d1891193c1c00c3c85dc2904725a4"
+    "15a24746453041009f5b3618a72ea8b1c044927def46395ba383eb444ee9c82d"
 )
 CLIO_KIT_JARVIS_USER_CONTRACT_ID = "clio-kit-jarvis-user-v3.6"
 DEFAULT_JARVIS_MCP_COMMAND = [
@@ -627,65 +629,6 @@ def virtual_jarvis_tool_definitions(*, clusters: list[str] | None = None) -> lis
             }
         )
     return tools
-
-
-def jarvis_service_runtime_handoff_json_schema(
-    *,
-    clusters: list[str] | None = None,
-) -> JSON:
-    """Return the exact agent-facing JARVIS service handoff schema."""
-    return {
-        "type": "object",
-        "properties": {
-            "cluster": {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": 256,
-                **({"enum": sorted(clusters)} if clusters is not None else {}),
-            },
-            "source_job_id": durable_record_id_json_schema(),
-            "source_artifact_id": durable_record_id_json_schema(),
-            "package_id": {"type": "string", "minLength": 1, "maxLength": 256},
-            "package_name": {"type": "string", "minLength": 1, "maxLength": 256},
-            "service_instance_id": {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": 512,
-            },
-        },
-        "required": [
-            "cluster",
-            "source_job_id",
-            "source_artifact_id",
-            "package_id",
-            "package_name",
-            "service_instance_id",
-        ],
-        "additionalProperties": False,
-    }
-
-
-def virtual_jarvis_job_output_schema(
-    remote_tool: str,
-    *,
-    clusters: list[str] | None = None,
-) -> JSON:
-    """Return the exact relay job receipt schema for one virtual JARVIS tool."""
-    if remote_tool not in _VIRTUAL_JARVIS_TOOLS:
-        raise ValueError(f"unknown virtual JARVIS tool: {remote_tool}")
-    output_schema = deepcopy(VIRTUAL_REMOTE_MCP_JOB_OUTPUT_SCHEMA)
-    if remote_tool == "jarvis_get_execution":
-        output_properties = cast(JSON, output_schema["properties"])
-        output_properties["service_runtime_bindings"] = {
-            "type": "array",
-            "description": (
-                "Ready-service handoffs derived from the verified durable MCP result. "
-                "Pass one item unchanged as relay_bind_jarvis_runtime.binding."
-            ),
-            "items": jarvis_service_runtime_handoff_json_schema(clusters=clusters),
-            "maxItems": 4_096,
-        }
-    return output_schema
 
 
 def jarvis_user_contract() -> dict[str, JSON]:

--- a/src/clio_relay/jarvis_service_runtime.py
+++ b/src/clio_relay/jarvis_service_runtime.py
@@ -23,6 +23,7 @@ from clio_relay.jarvis_mcp import (
 )
 from clio_relay.jarvis_provider import JarvisCdProvider
 from clio_relay.models import (
+    REGISTERED_JARVIS_USER_CONTRACT,
     ArtifactRef,
     JobKind,
     JobState,
@@ -36,6 +37,7 @@ from clio_relay.remote_cli import (
     run_remote_jarvis_runtime_authority,
     should_execute_on_cluster,
 )
+from clio_relay.remote_mcp import remote_mcp_server_artifact_binding_verified
 from clio_relay.runtime_metadata import JarvisNativeExecutionDocuments, native_execution_documents
 from clio_relay.session_api import OwnedSessionApiClient
 
@@ -948,18 +950,30 @@ def _validate_source_job(job: RelayJob, *, cluster: str) -> McpCallSpec:
         raise ValueError("JARVIS service source job is not an MCP call")
     if job.spec.operation is not McpOperation.TOOLS_CALL or job.spec.tool != "jarvis_get_execution":
         raise ValueError("JARVIS service source must be jarvis_get_execution")
-    server_name = job.spec.server.replace("\\", "/").rsplit("/", maxsplit=1)[-1].casefold()
-    if server_name not in {"clio-kit", "clio-kit.exe"} or job.spec.server_args != [
-        "mcp-server",
-        "jarvis",
-    ]:
-        raise ValueError("JARVIS service source does not use the configured clio-kit JARVIS MCP")
     if job.spec.arguments.get("include_service_runtimes") is not True:
         raise ValueError(
             "jarvis_get_execution service source must set include_service_runtimes=true"
         )
-    if job.spec.expected_jarvis_cd_lock_binding != jarvis_cd_lock_binding_expectation():
-        raise ValueError("JARVIS service source did not enforce the relay JARVIS-CD lock pin")
+    if job.spec.expected_registered_contract is not None:
+        if job.spec.expected_registered_contract != REGISTERED_JARVIS_USER_CONTRACT:
+            raise ValueError(
+                "registered JARVIS service source does not use the supported JARVIS contract"
+            )
+        if job.spec.expected_jarvis_cd_lock_binding is not None:
+            raise ValueError(
+                "registered JARVIS service source also supplied a built-in JARVIS-CD lock pin"
+            )
+    else:
+        server_name = job.spec.server.replace("\\", "/").rsplit("/", maxsplit=1)[-1].casefold()
+        if server_name not in {"clio-kit", "clio-kit.exe"} or job.spec.server_args != [
+            "mcp-server",
+            "jarvis",
+        ]:
+            raise ValueError(
+                "JARVIS service source does not use the configured clio-kit JARVIS MCP"
+            )
+        if job.spec.expected_jarvis_cd_lock_binding != jarvis_cd_lock_binding_expectation():
+            raise ValueError("JARVIS service source did not enforce the relay JARVIS-CD lock pin")
     if job.spec.expected_server_artifact_digest is None:
         raise ValueError("JARVIS service source is not bound to a discovered server artifact")
     return job.spec
@@ -980,6 +994,8 @@ def _validate_mcp_result(
         or document.get("env_from") != spec.env_from
     ):
         raise ValueError("JARVIS MCP result route did not match its durable relay job")
+    if document.get("expected_registered_contract") != spec.expected_registered_contract:
+        raise ValueError("JARVIS MCP result registered contract did not match")
     if document.get("expected_jarvis_cd_lock_binding") != spec.expected_jarvis_cd_lock_binding:
         raise ValueError("JARVIS MCP result JARVIS-CD lock pin did not match")
     if (
@@ -987,11 +1003,22 @@ def _validate_mcp_result(
         or document.get("observed_server_artifact_digest") != spec.expected_server_artifact_digest
     ):
         raise ValueError("JARVIS MCP result server artifact binding did not match")
-    if not jarvis_mcp_server_artifact_binding_verified(
-        document.get("server_artifact"),
-        expected_digest=spec.expected_server_artifact_digest,
-    ):
-        raise ValueError("JARVIS MCP result server artifact identity is not the exact release pin")
+    if spec.expected_registered_contract is not None:
+        artifact_verified = remote_mcp_server_artifact_binding_verified(
+            document.get("server_artifact"),
+            expected_digest=spec.expected_server_artifact_digest,
+        )
+        artifact_failure = (
+            "JARVIS MCP result server artifact identity is not the immutable registered route"
+        )
+    else:
+        artifact_verified = jarvis_mcp_server_artifact_binding_verified(
+            document.get("server_artifact"),
+            expected_digest=spec.expected_server_artifact_digest,
+        )
+        artifact_failure = "JARVIS MCP result server artifact identity is not the exact release pin"
+    if not artifact_verified:
+        raise ValueError(artifact_failure)
     if (
         document.get("returncode") != 0
         or document.get("timed_out") is True

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -68,6 +68,8 @@ from clio_relay.jarvis_mcp import (
     virtual_jarvis_tool_definitions,
 )
 from clio_relay.jarvis_service_runtime import (
+    JARVIS_SERVICE_RUNTIME_SCHEMA_V2,
+    JarvisServiceAuthorization,
     JarvisServiceRuntimeHandoff,
     derive_jarvis_service_runtime_handoffs,
     resolve_jarvis_service_runtime,
@@ -2361,7 +2363,7 @@ def _call_tool(
     return {
         "content": [{"type": "text", "text": _serialize_tool_result(result)}],
         "structuredContent": result,
-        "isError": _mcp_result_delivery_failed(result),
+        "isError": _mcp_tool_result_failed(result),
     }
 
 
@@ -3559,7 +3561,11 @@ def _mcp_result_artifact(artifacts: list[JSON], *, job_id: str) -> JSON | None:
     return matches[0] if matches else None
 
 
-def _bounded_mcp_result(result: JSON) -> JSON:
+def _bounded_mcp_result(
+    result: JSON,
+    *,
+    preserve_verified_jarvis_authorization_descriptors: bool = False,
+) -> JSON:
     """Return a bounded agent projection while the artifact retains full protocol evidence."""
 
     original = copy.deepcopy(result)
@@ -3567,8 +3573,22 @@ def _bounded_mcp_result(result: JSON) -> JSON:
     if not isinstance(sanitized, dict):
         raise ValueError("MCP result redaction did not preserve its object shape")
     projected = cast(JSON, sanitized)
+    if preserve_verified_jarvis_authorization_descriptors:
+        _restore_jarvis_service_authorization_descriptors(
+            original=original,
+            projected=projected,
+        )
     sensitive_values_redacted = projected != result
-    if projected.get("structured_result") is not None and "protocol_result" in projected:
+    protocol_result = projected.get("protocol_result")
+    protocol_result_is_error = (
+        isinstance(protocol_result, dict)
+        and cast(dict[str, object], protocol_result).get("isError") is True
+    )
+    if (
+        projected.get("structured_result") is not None
+        and "protocol_result" in projected
+        and not protocol_result_is_error
+    ):
         projected.pop("protocol_result")
         projected["protocol_result_omitted"] = "redundant_with_structured_result"
     if sensitive_values_redacted:
@@ -3607,13 +3627,93 @@ def _bounded_mcp_result(result: JSON) -> JSON:
     return failure
 
 
-def _mcp_result_delivery_failed(result: JSON) -> bool:
-    """Return whether a terminal MCP result could not be delivered to the agent."""
+def _restore_jarvis_service_authorization_descriptors(
+    *,
+    original: JSON,
+    projected: JSON,
+) -> None:
+    """Restore only exact public JARVIS bearer fingerprints after source verification.
+
+    The caller enables this only after the durable MCP artifact has passed the
+    exact built-in or registered JARVIS contract validation. This second,
+    deliberately narrow check accepts only service-runtime v2 authorization
+    descriptors with the strict public shape defined by JARVIS. Raw bearer
+    capabilities, additional keys, and malformed digests remain redacted.
+    """
+
+    original_runtimes = _jarvis_service_runtime_items(original)
+    projected_runtimes = _jarvis_service_runtime_items(projected)
+    if original_runtimes is None or projected_runtimes is None:
+        return
+    if len(original_runtimes) != len(projected_runtimes):
+        return
+    for original_runtime, projected_runtime in zip(
+        original_runtimes,
+        projected_runtimes,
+        strict=True,
+    ):
+        if (
+            original_runtime.get("schema_version") != JARVIS_SERVICE_RUNTIME_SCHEMA_V2
+            or projected_runtime.get("schema_version") != JARVIS_SERVICE_RUNTIME_SCHEMA_V2
+        ):
+            continue
+        raw_authorization = original_runtime.get("authorization")
+        try:
+            authorization = JarvisServiceAuthorization.model_validate(raw_authorization)
+        except ValidationError:
+            continue
+        descriptor = authorization.model_dump(mode="json")
+        if raw_authorization != descriptor:
+            continue
+        projected_runtime["authorization"] = descriptor
+
+
+def _jarvis_service_runtime_items(result: JSON) -> list[JSON] | None:
+    """Return the exact execution-v2 service-runtime list, if structurally present."""
+
+    structured = result.get("structured_result")
+    if not isinstance(structured, dict):
+        return None
+    snapshot = cast(dict[str, object], structured).get("service_runtimes")
+    if not isinstance(snapshot, dict):
+        return None
+    raw_runtimes = cast(dict[str, object], snapshot).get("service_runtimes")
+    if not isinstance(raw_runtimes, list):
+        return None
+    typed_runtimes = cast(list[object], raw_runtimes)
+    if not all(isinstance(runtime, dict) for runtime in typed_runtimes):
+        return None
+    return [cast(JSON, runtime) for runtime in typed_runtimes]
+
+
+def _mcp_tool_result_failed(result: JSON) -> bool:
+    """Keep failed terminal remote MCP operations failed at the agent tool boundary."""
+
+    if (
+        result.get("kind") == JobKind.MCP_CALL.value
+        and result.get("terminal") is True
+        and result.get("state") in {JobState.FAILED.value, JobState.CANCELED.value}
+    ):
+        return True
 
     mcp_result = result.get("mcp_result")
     if not isinstance(mcp_result, dict):
         return False
-    delivery = cast(dict[str, object], mcp_result).get("delivery")
+    typed_result = cast(dict[str, object], mcp_result)
+    returncode = typed_result.get("returncode")
+    if (
+        typed_result.get("timed_out") is True
+        or isinstance(typed_result.get("protocol_error"), str)
+        or (isinstance(returncode, int) and not isinstance(returncode, bool) and returncode != 0)
+    ):
+        return True
+    protocol_result = typed_result.get("protocol_result")
+    if (
+        isinstance(protocol_result, dict)
+        and cast(dict[str, object], protocol_result).get("isError") is True
+    ):
+        return True
+    delivery = typed_result.get("delivery")
     if not isinstance(delivery, dict):
         return False
     typed_delivery = cast(dict[str, object], delivery)
@@ -3669,6 +3769,7 @@ def _attach_terminal_mcp_evidence(
     if artifact is None:
         raise ValueError(f"verified MCP result for {source_job.job_id} has no durable artifact")
     receipt["mcp_result_artifact"] = _public_mcp_result_artifact(artifact)
+    verified_jarvis_authorization_descriptors = False
     if (
         source_job.state is JobState.SUCCEEDED
         and isinstance(source_job.spec, McpCallSpec)
@@ -3676,16 +3777,22 @@ def _attach_terminal_mcp_evidence(
         and source_job.spec.arguments.get("include_service_runtimes") is True
     ):
         source_artifact = ArtifactRef.model_validate(artifact)
+        service_runtime_handoffs = derive_jarvis_service_runtime_handoffs(
+            cluster=source_job.cluster,
+            source_job=source_job,
+            source_artifact=source_artifact,
+            document=parsed_result.document,
+        )
         receipt["service_runtime_bindings"] = [
-            handoff.model_dump(mode="json")
-            for handoff in derive_jarvis_service_runtime_handoffs(
-                cluster=source_job.cluster,
-                source_job=source_job,
-                source_artifact=source_artifact,
-                document=parsed_result.document,
-            )
+            handoff.model_dump(mode="json") for handoff in service_runtime_handoffs
         ]
-    receipt["mcp_result"] = _bounded_mcp_result(parsed_result.public)
+        verified_jarvis_authorization_descriptors = True
+    receipt["mcp_result"] = _bounded_mcp_result(
+        parsed_result.public,
+        preserve_verified_jarvis_authorization_descriptors=(
+            verified_jarvis_authorization_descriptors
+        ),
+    )
 
 
 def _render_remote_mcp_context(catalog: VirtualRemoteMcpCatalog) -> str:

--- a/src/clio_relay/remote_mcp.py
+++ b/src/clio_relay/remote_mcp.py
@@ -50,7 +50,9 @@ from clio_relay.cluster_config import (
     read_bounded_configuration_bytes,
 )
 from clio_relay.errors import NotFoundError, RelayError
+from clio_relay.identifiers import durable_record_id_json_schema
 from clio_relay.models import (
+    REGISTERED_JARVIS_USER_CONTRACT,
     JobKind,
     JobState,
     McpAdmissionAuthority,
@@ -90,7 +92,7 @@ MAX_VIRTUAL_REMOTE_MCP_ALIAS_LENGTH = 64
 MAX_VIRTUAL_REMOTE_MCP_LOG_BYTES = 32_768
 REMOTE_MCP_REPLACE_ATTEMPTS = 25
 REMOTE_MCP_REPLACE_RETRY_SECONDS = 0.02
-CLIO_KIT_JARVIS_USER_CONTRACT_ID = "clio-kit-jarvis-user-v3.6"
+CLIO_KIT_JARVIS_USER_CONTRACT_ID = REGISTERED_JARVIS_USER_CONTRACT
 CLIO_KIT_JARVIS_USER_LEGACY_CONTRACT_ID = "clio-kit-jarvis-user-v3.5"
 CLIO_KIT_JARVIS_USER_CONTRACT_IDS = frozenset(
     {
@@ -139,7 +141,7 @@ CLIO_KIT_JARVIS_USER_TOOL_NAMES = frozenset(
         "jarvis_run",
     }
 )
-CLIO_KIT_SPACK_USER_WHEEL_VERSION = "2.6.2"
+CLIO_KIT_SPACK_USER_WHEEL_VERSION = "2.6.5"
 CLIO_KIT_SPACK_USER_CONTRACT_ID = "clio-kit-spack-user-v2.1"
 CLIO_KIT_SPACK_USER_LEGACY_CONTRACT_ID = "clio-kit-spack-user-v2"
 CLIO_KIT_SPACK_USER_CONTRACT_IDS = frozenset(
@@ -182,7 +184,7 @@ CLIO_KIT_SPACK_USER_CONTRACT_ARTIFACT_BY_ID = {
 CLIO_KIT_SPACK_USER_CONTRACT_SHA256 = CLIO_KIT_SPACK_USER_CONTRACT_SHA256_BY_ID[
     CLIO_KIT_SPACK_USER_CONTRACT_ID
 ]
-CLIO_KIT_SCIENTIFIC_CATALOG_USER_WHEEL_VERSION = "2.6.2"
+CLIO_KIT_SCIENTIFIC_CATALOG_USER_WHEEL_VERSION = "2.6.5"
 CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_ID = "clio-kit-scientific-catalog-user-v1.1"
 CLIO_KIT_SCIENTIFIC_CATALOG_USER_LEGACY_CONTRACT_ID = "clio-kit-scientific-catalog-user-v1"
 CLIO_KIT_SCIENTIFIC_CATALOG_USER_CONTRACT_IDS = frozenset(
@@ -411,6 +413,65 @@ VIRTUAL_REMOTE_MCP_JOB_OUTPUT_SCHEMA: JSON = {
     ],
     "additionalProperties": False,
 }
+
+
+def jarvis_service_runtime_handoff_json_schema(
+    *,
+    clusters: list[str] | None = None,
+) -> JSON:
+    """Return the exact agent-facing JARVIS service handoff schema."""
+    return {
+        "type": "object",
+        "properties": {
+            "cluster": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 256,
+                **({"enum": sorted(clusters)} if clusters is not None else {}),
+            },
+            "source_job_id": durable_record_id_json_schema(),
+            "source_artifact_id": durable_record_id_json_schema(),
+            "package_id": {"type": "string", "minLength": 1, "maxLength": 256},
+            "package_name": {"type": "string", "minLength": 1, "maxLength": 256},
+            "service_instance_id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 512,
+            },
+        },
+        "required": [
+            "cluster",
+            "source_job_id",
+            "source_artifact_id",
+            "package_id",
+            "package_name",
+            "service_instance_id",
+        ],
+        "additionalProperties": False,
+    }
+
+
+def virtual_jarvis_job_output_schema(
+    remote_tool: str,
+    *,
+    clusters: list[str] | None = None,
+) -> JSON:
+    """Return the exact relay job receipt schema for one verified JARVIS tool."""
+    if remote_tool not in CLIO_KIT_JARVIS_USER_TOOL_NAMES:
+        raise ValueError(f"unknown virtual JARVIS tool: {remote_tool}")
+    output_schema = deepcopy(VIRTUAL_REMOTE_MCP_JOB_OUTPUT_SCHEMA)
+    if remote_tool == "jarvis_get_execution":
+        output_properties = cast(JSON, output_schema["properties"])
+        output_properties["service_runtime_bindings"] = {
+            "type": "array",
+            "description": (
+                "Ready-service handoffs derived from the verified durable MCP result. "
+                "Pass one item unchanged as relay_bind_jarvis_runtime.binding."
+            ),
+            "items": jarvis_service_runtime_handoff_json_schema(clusters=clusters),
+            "maxItems": 4_096,
+        }
+    return output_schema
 
 
 class RemoteMcpToolSchema(BaseModel):
@@ -645,6 +706,25 @@ class RemoteMcpSchemaCache(BaseModel):
             )
             updated._write_atomic(path)
             return updated
+
+    @classmethod
+    def invalidate_cluster_entries(
+        cls,
+        path: Path,
+        cluster: str,
+    ) -> tuple[RemoteMcpSchemaCache, tuple[str, ...]]:
+        """Atomically invalidate every cached server schema for one cluster."""
+        ensure_private_configuration_directory(path.parent)
+        with FileLock(f"{path}.lock"):
+            cache = cls.load(path)
+            removed_server_names = tuple(
+                sorted(entry.server_name for entry in cache.entries if entry.cluster == cluster)
+            )
+            if not removed_server_names:
+                return cache, removed_server_names
+            updated = cls(entries=[entry for entry in cache.entries if entry.cluster != cluster])
+            updated._write_atomic(path)
+            return updated, removed_server_names
 
     def _write_atomic(self, path: Path) -> None:
         payload = (self.model_dump_json(indent=2) + "\n").encode("utf-8")
@@ -1394,7 +1474,12 @@ class VirtualRemoteMcpTool:
             "call; otherwise use relay job tools with the returned handle."
         )
         exact_v36_routes = bool(self.routes) and all(
-            route.contract == CLIO_KIT_JARVIS_USER_CONTRACT_ID for route in self.routes.values()
+            route.contract == REGISTERED_JARVIS_USER_CONTRACT for route in self.routes.values()
+        )
+        output_schema = (
+            virtual_jarvis_job_output_schema(self.remote_tool.name, clusters=clusters)
+            if exact_v36_routes and self.remote_tool.name in CLIO_KIT_JARVIS_USER_TOOL_NAMES
+            else deepcopy(VIRTUAL_REMOTE_MCP_JOB_OUTPUT_SCHEMA)
         )
         if exact_v36_routes and self.remote_tool.name == "jarvis_describe":
             properties = cast(JSON, input_schema["properties"])
@@ -1435,7 +1520,7 @@ class VirtualRemoteMcpTool:
                 f"as a durable relay job. {wait_guidance}"
             ),
             "inputSchema": input_schema,
-            "outputSchema": deepcopy(VIRTUAL_REMOTE_MCP_JOB_OUTPUT_SCHEMA),
+            "outputSchema": output_schema,
         }
         if self.remote_tool.title is not None:
             definition["title"] = self.remote_tool.title

--- a/src/clio_relay/session_lifecycle.py
+++ b/src/clio_relay/session_lifecycle.py
@@ -4251,36 +4251,17 @@ def _run_bounded_command(
 
 def _current_session_api_release_identity() -> SessionApiReleaseIdentity:
     """Return the exact locally installed release identity for an API child."""
-    from clio_relay.installation import installation_info
+    from clio_relay.installation import verified_session_api_install_receipt
 
-    info = installation_info()
-    raw_receipt = info.get("receipt")
-    receipt = (
-        {str(key): value for key, value in cast(dict[object, object], raw_receipt).items()}
-        if isinstance(raw_receipt, dict)
-        else None
+    receipt = verified_session_api_install_receipt()
+    artifact_sha256 = receipt.artifact_sha256
+    if artifact_sha256 is None:  # pragma: no cover - verified helper requires it
+        raise RelayError("session API installation identity is incomplete")
+    return SessionApiReleaseIdentity(
+        distribution_version=receipt.distribution_version,
+        artifact_sha256=artifact_sha256,
+        software=receipt.software,
     )
-    software = info.get("software")
-    identity: dict[str, object] = {
-        "schema_version": "clio-relay.session-api-release.v1",
-        "distribution_version": info.get("distribution_version"),
-        "artifact_sha256": (receipt.get("artifact_sha256") if receipt is not None else None),
-        "software": software,
-    }
-    try:
-        validated = SessionApiReleaseIdentity.model_validate(identity)
-    except ValueError as exc:
-        raise RelayError("session API installation identity is incomplete") from exc
-    if (
-        info.get("schema_version") != "clio-relay.installation-info.v1"
-        or info.get("receipt_matches_install") is not True
-        or receipt is None
-        or receipt.get("schema_version") != "clio-relay.install-receipt.v1"
-        or receipt.get("distribution_version") != validated.distribution_version
-        or receipt.get("software") != validated.software.model_dump(mode="json")
-    ):
-        raise RelayError("session API installation receipt does not match the running package")
-    return validated
 
 
 def _validated_start_registry(
@@ -7502,9 +7483,6 @@ def start_remote_session_durable(
         if observed.state != "ambiguous":
             return observed
         return observed.model_copy(update={"error": str(exc)[:_MAX_SESSION_START_ERROR_CHARS]})
-    except RelayError:
-        observed = query_remote_session_start(definition=definition, plan=plan)
-        return observed
     values: dict[str, str] = {}
     for line in lines:
         if "=" not in line:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -48,14 +48,14 @@ from tests.plugin_fakes import FakeEntryPoint, FakeEntryPoints
 
 def test_bootstrap_uses_exact_public_jarvis_cd_release_pin() -> None:
     """Keep bootstrap and the locked MCP child on the same public JARVIS wheel."""
-    assert JARVIS_CD_VERSION == "1.6.0"
-    assert JARVIS_CD_WHEEL_FILENAME == "jarvis_cd-1.6.0-py3-none-any.whl"
+    assert JARVIS_CD_VERSION == "1.7.0"
+    assert JARVIS_CD_WHEEL_FILENAME == "jarvis_cd-1.7.0-py3-none-any.whl"
     assert JARVIS_CD_WHEEL_URL == (
         "https://github.com/grc-iit/jarvis-cd/releases/download/"
-        "v1.6.0/jarvis_cd-1.6.0-py3-none-any.whl"
+        "v1.7.0/jarvis_cd-1.7.0-py3-none-any.whl"
     )
     assert JARVIS_CD_WHEEL_SHA256 == (
-        "c4853138f3263715e806fcd794233d89f4aa58161e3c5fbab59e7f96d24f0e98"
+        "f61d2c9b01af1794263013b9045916230c36c318c2984ba4f35d82d8c994e9bb"
     )
 
 
@@ -186,7 +186,8 @@ def test_linux_user_bootstrap_script_installs_required_components() -> None:
     assert f'JARVIS_CD_WHEEL="$JARVIS_CD_WHEEL_DIR/{JARVIS_CD_WHEEL_FILENAME}"' in script
     assert 'fetch --depth 1 origin "$JARVIS_UTIL_COMMIT"' in script
     assert 'fetch --depth 1 origin "$JARVIS_CD_COMMIT"' not in script
-    assert 'curl -L --fail --retry 3 -o "$JARVIS_CD_STAGING" "$JARVIS_CD_WHEEL_URL"' in script
+    assert "bootstrap_fetch_exact_artifact" in script
+    assert '"$JARVIS_CD_WHEEL_URL" "$JARVIS_CD_WHEEL_SHA256" "$JARVIS_CD_STAGING"' in script
     assert (
         'echo "$JARVIS_CD_WHEEL_SHA256 *$JARVIS_CD_STAGING" | sha256sum --check --strict -'
     ) in script

--- a/tests/test_bootstrap_fast_path.py
+++ b/tests/test_bootstrap_fast_path.py
@@ -17,12 +17,14 @@ from contextlib import nullcontext
 from datetime import UTC, datetime
 from io import BytesIO
 from pathlib import Path
+from types import SimpleNamespace
 from typing import NoReturn, cast
 
 import pytest
 from typer.testing import CliRunner
 
 import clio_relay.bootstrap as bootstrap
+import clio_relay.bootstrap_reconcile as bootstrap_reconcile
 import clio_relay.cli as cli
 from clio_relay import __version__
 from clio_relay.bootstrap_reconcile import (
@@ -34,6 +36,7 @@ from clio_relay.bootstrap_reconcile import (
     JarvisStateEvidence,
     execution_environment_identity,
     make_bootstrap_receipt,
+    proven_active_generation_mismatch,
 )
 from clio_relay.cluster_config import ClusterDefinition, ClusterRegistry
 from clio_relay.errors import ConfigurationError, RelayError
@@ -1413,6 +1416,160 @@ def test_exact_remote_bootstrap_never_reads_or_builds_payload(
     assert operations["payload_transfer_bytes"] == 0
 
 
+def test_bootstrap_preflight_quotes_its_multiline_remote_command(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SSH receives one quoted command whose Bash payload retains its line boundaries."""
+    identity = bootstrap.bootstrap_relay_identity(
+        source_root=tmp_path / "release",
+        relay_wheel=None,
+        relay_artifact_sha256="a" * 64,
+    )
+    desired = bootstrap._bootstrap_desired_state(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        identity=identity,
+        cluster="ares",
+        core_dir=bootstrap.DEFAULT_REMOTE_CORE_DIR,
+        spool_dir=bootstrap.DEFAULT_REMOTE_SPOOL_DIR,
+        frp_version=bootstrap.FRP_VERSION,
+        clio_kit_install_spec=bootstrap.CLIO_KIT_JARVIS_MCP_WHEEL_URL,
+        clio_kit_artifact_sha256=bootstrap.CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
+        agent_adapter="exec",
+        agent_npm_package=None,
+        agent_npm_bin=None,
+        agent_args=[],
+        jarvis_resource_graph_profile="ares",
+    )
+    observed: list[list[str]] = []
+
+    def run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        observed.append(command)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            "bootstrap_preflight_unsupported=not_installed\n",
+            "",
+        )
+
+    monkeypatch.setattr(bootstrap, "_run", run)
+    result = bootstrap._bootstrap_preflight_over_ssh(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        ssh_host="ares",
+        invocation_id="bootstrap_test",
+        desired=desired,
+        core_dir=bootstrap.DEFAULT_REMOTE_CORE_DIR,
+        spool_dir=bootstrap.DEFAULT_REMOTE_SPOOL_DIR,
+        repair=False,
+        timeout_seconds=30,
+    )
+
+    assert result.action == "payload_required"
+    assert len(observed) == 1
+    assert observed[0][:2] == ["ssh", "ares"]
+    assert len(observed[0]) == 3
+    ssh_remote_command = " ".join(observed[0][2:])
+    remote_argv = shlex.split(ssh_remote_command, posix=True)
+    exec_index = remote_argv.index("exec")
+    assert remote_argv[:4] == ["if", "[", "-n", "${BASH_VERSION-}"]
+    assert remote_argv[exec_index : exec_index + 3] == ["exec", "bash", "-c"]
+    assert len(remote_argv) == exec_index + 4
+    assert remote_argv[exec_index + 3].startswith("set -u\n")
+    assert remote_argv[exec_index + 3].endswith("printf '%s\\n' \"$BOOTSTRAP_PREFLIGHT_OUTPUT\"")
+
+
+def test_pinned_local_bootstrap_artifact_copy_is_bounded_and_digest_verified(
+    tmp_path: Path,
+) -> None:
+    """A pre-staged candidate is copied only from its managed digest-pinned root."""
+    candidate_root = tmp_path / "candidate-wheels"
+    candidate_root.mkdir()
+    source = candidate_root / "jarvis-candidate.whl"
+    payload = b"real candidate wheel bytes"
+    source.write_bytes(payload)
+    expected_sha256 = hashlib.sha256(payload).hexdigest()
+    destination = tmp_path / "staging.whl"
+    destination.touch()
+    program = bootstrap._BOOTSTRAP_PINNED_LOCAL_ARTIFACT_COPY_SOURCE  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-c",
+            program,
+            source.as_uri(),
+            expected_sha256,
+            str(destination),
+            str(candidate_root),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert destination.read_bytes() == payload
+
+    escaped_source = tmp_path / "outside.whl"
+    escaped_source.write_bytes(payload)
+    escaped_destination = tmp_path / "escaped-staging.whl"
+    escaped_destination.touch()
+    escaped = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-c",
+            program,
+            escaped_source.as_uri(),
+            expected_sha256,
+            str(escaped_destination),
+            str(candidate_root),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert escaped.returncode != 0
+    assert escaped_destination.read_bytes() == b""
+
+    mismatched_destination = tmp_path / "mismatched-staging.whl"
+    mismatched_destination.touch()
+    mismatched = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-c",
+            program,
+            source.as_uri(),
+            "f" * 64,
+            str(mismatched_destination),
+            str(candidate_root),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert mismatched.returncode != 0
+    assert mismatched_destination.read_bytes() == b""
+
+
+def test_bootstrap_uses_exact_fetcher_for_jarvis_artifacts() -> None:
+    """Rendered bootstrap accepts only HTTPS or managed file staging for JARVIS."""
+    script = bootstrap.render_linux_user_bootstrap_script(cluster="cluster-a")
+
+    assert "bootstrap_fetch_exact_artifact() {" in script
+    assert "file://*)" in script
+    assert "https://*)" in script
+    assert '"$HOME/.local/share/clio-relay/candidate-wheels"' in script
+    assert (
+        "bootstrap_fetch_exact_artifact \\\n"
+        '  "$JARVIS_CD_WHEEL_URL" "$JARVIS_CD_WHEEL_SHA256" "$JARVIS_CD_STAGING"' in script
+    )
+    assert 'curl -L --fail --retry 3 -o "$JARVIS_CD_STAGING"' not in script
+
+
 @pytest.mark.release_platform("posix")
 def test_legacy_preflight_classifies_receipt_before_invoking_old_relay(
     tmp_path: Path,
@@ -1469,8 +1626,10 @@ def test_legacy_preflight_classifies_receipt_before_invoking_old_relay(
     assert "bootstrap_preflight_unsupported=legacy_relay_provider" in remote_script
     assert 'if ! BOOTSTRAP_RELAY_RECEIPT_CLASS="$(' in remote_script
     assert "python3 -I -" in remote_script
-    sanitizer = remote_script.index("while IFS= read -r bootstrap_environment_name")
-    assert 'LD_*|PYTHON*|BASH_ENV|ENV) unset "$bootstrap_environment_name"' in remote_script
+    sanitizer = remote_script.index(
+        'for bootstrap_environment_name in "${!LD_@}" "${!PYTHON@}" BASH_ENV ENV'
+    )
+    assert 'unset "$bootstrap_environment_name"' in remote_script
     assert sanitizer < remote_script.index("python3 -I -")
     assert sanitizer < remote_script.index("timeout --signal=TERM")
     assert "env -u PYTHONPATH" not in remote_script
@@ -2011,6 +2170,251 @@ def test_payload_free_inspector_fails_closed_after_repair_does_not_converge(
 
     assert result.exit_code != 0
     assert "repair did not converge" in result.output
+    assert "bootstrap_preflight_json=" not in result.output
+
+
+def test_proven_active_generation_mismatch_requires_one_managed_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only a stable canonical generation directory can trigger the fast path."""
+    desired = bootstrap._bootstrap_desired_state(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        identity=bootstrap.BootstrapRelayIdentity(
+            install_spec=f"clio-relay=={__version__}",
+            transport_install_spec=f"clio-relay=={__version__}",
+            source_identity=f"release:clio-relay=={__version__}:sha256:{'a' * 64}",
+            deployment_artifact_sha256="a" * 64,
+        ),
+        cluster="cluster-a",
+        core_dir=bootstrap.DEFAULT_REMOTE_CORE_DIR,
+        spool_dir=bootstrap.DEFAULT_REMOTE_SPOOL_DIR,
+        frp_version=bootstrap.FRP_VERSION,
+        clio_kit_install_spec=bootstrap.CLIO_KIT_JARVIS_MCP_WHEEL_URL,
+        clio_kit_artifact_sha256=bootstrap.CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
+        agent_adapter="exec",
+        agent_npm_package=None,
+        agent_npm_bin=None,
+        agent_args=[],
+        jarvis_resource_graph_profile="ares",
+    )
+    share = tmp_path / ".local/share/clio-relay"
+    generations = share / "generations"
+    active = generations / ("b" * 64)
+    active.mkdir(parents=True)
+    current = share / "current"
+    current.write_text("test-only link placeholder", encoding="utf-8")
+    current_details = current.lstat()
+    simulated_link_details = SimpleNamespace(
+        st_dev=current_details.st_dev,
+        st_ino=current_details.st_ino,
+        st_mode=0o120777,
+        st_size=current_details.st_size,
+        st_mtime_ns=current_details.st_mtime_ns,
+        st_ctime_ns=current_details.st_ctime_ns,
+    )
+    path_type = type(current)
+    original_lstat = path_type.lstat
+    original_readlink = os.readlink
+    original_is_directory_alias = bootstrap_reconcile._path_is_directory_alias  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    raw_target = str(active)
+    simulate_current_race = False
+    current_lstat_calls = 0
+
+    def simulated_lstat(path: Path) -> os.stat_result:
+        nonlocal current_lstat_calls
+        if path == current:
+            current_lstat_calls += 1
+            if simulate_current_race and current_lstat_calls == 2:
+                return cast(
+                    os.stat_result,
+                    SimpleNamespace(
+                        **{
+                            **vars(simulated_link_details),
+                            "st_ino": simulated_link_details.st_ino + 1,
+                        }
+                    ),
+                )
+            return cast(os.stat_result, simulated_link_details)
+        return original_lstat(path)
+
+    def simulated_readlink(path: str | os.PathLike[str]) -> str:
+        if Path(path) == current:
+            return raw_target
+        return original_readlink(path)
+
+    monkeypatch.setattr(path_type, "lstat", simulated_lstat)
+    monkeypatch.setattr(bootstrap_reconcile.os, "readlink", simulated_readlink)
+
+    assert proven_active_generation_mismatch(desired, home=tmp_path) == "b" * 64
+
+    desired_generation = generations / desired.fingerprint
+    desired_generation.mkdir()
+    raw_target = str(desired_generation)
+    assert proven_active_generation_mismatch(desired, home=tmp_path) is None
+
+    malformed = generations / "not-a-generation"
+    malformed.mkdir()
+    raw_target = str(malformed)
+    assert proven_active_generation_mismatch(desired, home=tmp_path) is None
+
+    outside = tmp_path / ("c" * 64)
+    outside.mkdir()
+    raw_target = str(outside)
+    assert proven_active_generation_mismatch(desired, home=tmp_path) is None
+
+    raw_target = str(active)
+
+    def aliased_generations(path: Path) -> bool:
+        return path == generations or original_is_directory_alias(path)
+
+    monkeypatch.setattr(
+        bootstrap_reconcile,
+        "_path_is_directory_alias",
+        aliased_generations,
+    )
+    assert proven_active_generation_mismatch(desired, home=tmp_path) is None
+    monkeypatch.setattr(
+        bootstrap_reconcile,
+        "_path_is_directory_alias",
+        original_is_directory_alias,
+    )
+
+    current_lstat_calls = 0
+    simulate_current_race = True
+    assert proven_active_generation_mismatch(desired, home=tmp_path) is None
+
+
+@pytest.mark.parametrize("repair", [False, True])
+def test_payload_free_inspector_short_circuits_proven_generation_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    repair: bool,
+) -> None:
+    """A different managed generation requests payload without deep inspection."""
+    desired = bootstrap._bootstrap_desired_state(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        identity=bootstrap.BootstrapRelayIdentity(
+            install_spec=f"clio-relay=={__version__}",
+            transport_install_spec=f"clio-relay=={__version__}",
+            source_identity=f"release:clio-relay=={__version__}:sha256:{'a' * 64}",
+            deployment_artifact_sha256="a" * 64,
+        ),
+        cluster="cluster-a",
+        core_dir=bootstrap.DEFAULT_REMOTE_CORE_DIR,
+        spool_dir=bootstrap.DEFAULT_REMOTE_SPOOL_DIR,
+        frp_version=bootstrap.FRP_VERSION,
+        clio_kit_install_spec=bootstrap.CLIO_KIT_JARVIS_MCP_WHEEL_URL,
+        clio_kit_artifact_sha256=bootstrap.CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
+        agent_adapter="exec",
+        agent_npm_package=None,
+        agent_npm_bin=None,
+        agent_args=[],
+        jarvis_resource_graph_profile="ares",
+    )
+    monkeypatch.setenv(
+        "CLIO_RELAY_BOOTSTRAP_DESIRED_STATE_BASE64",
+        base64.b64encode(desired.model_dump_json().encode()).decode(),
+    )
+
+    def unexpected(*_args: object, **_kwargs: object) -> NoReturn:
+        pytest.fail("generation mismatch performed an expensive inspection")
+
+    def invocation_lock(**_kwargs: object) -> nullcontext[Path]:
+        return nullcontext(tmp_path / "bootstrap.lock")
+
+    def mismatched_generation(_desired: BootstrapDesiredState) -> str:
+        return "b" * 64
+
+    monkeypatch.setattr(cli, "bootstrap_invocation_lock", invocation_lock)
+    monkeypatch.setattr(
+        cli,
+        "proven_active_generation_mismatch",
+        mismatched_generation,
+    )
+    monkeypatch.setattr(cli, "installation_info", unexpected)
+    monkeypatch.setattr(cli, "ClioCoreQueue", unexpected)
+    monkeypatch.setattr(cli, "run_bounded_process", unexpected)
+    monkeypatch.setattr(cli, "worker_runtime_info", unexpected)
+    monkeypatch.setattr(cli, "inspect_exact_bootstrap_noop", unexpected)
+    monkeypatch.setattr(cli, "write_bootstrap_receipt", unexpected)
+    arguments = [
+        "bootstrap-inspect",
+        "--invocation-id",
+        f"bootstrap_mismatch_{repair}",
+        "--repair" if repair else "--inspect-only",
+    ]
+
+    result = CliRunner().invoke(cli.app, arguments)
+
+    assert result.exit_code == 0, result.output
+    payload_line = next(
+        line for line in result.output.splitlines() if line.startswith("bootstrap_preflight_json=")
+    )
+    payload = json.loads(payload_line.partition("=")[2])
+    assert payload == {
+        "action": "payload_required",
+        "desired_fingerprint": desired.fingerprint,
+        "exact_match": False,
+        "reasons": ["active generation differs from desired fingerprint"],
+        "receipt": None,
+        "schema_version": "clio-relay.bootstrap-preflight.v1",
+    }
+
+
+def test_payload_free_inspector_keeps_deep_verification_for_matching_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A matching pointer remains subject to the complete identity inspection."""
+    desired = bootstrap._bootstrap_desired_state(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        identity=bootstrap.BootstrapRelayIdentity(
+            install_spec=f"clio-relay=={__version__}",
+            transport_install_spec=f"clio-relay=={__version__}",
+            source_identity=f"release:clio-relay=={__version__}:sha256:{'a' * 64}",
+            deployment_artifact_sha256="a" * 64,
+        ),
+        cluster="cluster-a",
+        core_dir=bootstrap.DEFAULT_REMOTE_CORE_DIR,
+        spool_dir=bootstrap.DEFAULT_REMOTE_SPOOL_DIR,
+        frp_version=bootstrap.FRP_VERSION,
+        clio_kit_install_spec=bootstrap.CLIO_KIT_JARVIS_MCP_WHEEL_URL,
+        clio_kit_artifact_sha256=bootstrap.CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
+        agent_adapter="exec",
+        agent_npm_package=None,
+        agent_npm_bin=None,
+        agent_args=[],
+        jarvis_resource_graph_profile="ares",
+    )
+    monkeypatch.setenv(
+        "CLIO_RELAY_BOOTSTRAP_DESIRED_STATE_BASE64",
+        base64.b64encode(desired.model_dump_json().encode()).decode(),
+    )
+
+    def invocation_lock(**_kwargs: object) -> nullcontext[Path]:
+        return nullcontext(tmp_path / "bootstrap.lock")
+
+    def deep_inspection() -> dict[str, object]:
+        raise ConfigurationError("deep inspection reached")
+
+    def matching_generation(_desired: BootstrapDesiredState) -> None:
+        return None
+
+    monkeypatch.setattr(cli, "bootstrap_invocation_lock", invocation_lock)
+    monkeypatch.setattr(cli, "proven_active_generation_mismatch", matching_generation)
+    monkeypatch.setattr(cli, "installation_info", deep_inspection)
+
+    result = CliRunner().invoke(
+        cli.app,
+        [
+            "bootstrap-inspect",
+            "--invocation-id",
+            "bootstrap_matching_generation",
+            "--inspect-only",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "deep inspection reached" in result.output
     assert "bootstrap_preflight_json=" not in result.output
 
 
@@ -2799,8 +3203,10 @@ def test_staged_upgrade_uses_journal_bound_idempotent_forward_activation() -> No
     assert 'receipt_document.get("deployment_manifest")' in script
     assert "staged install receipt omitted its desired state" in script
     assert "journal-phase prepared_manifest" in script
-    assert provider_function.index("compgen -e") < provider_function.index("exec python3 -I -c")
-    assert 'LD_*|PYTHON*|BASH_ENV|ENV) unset "$bootstrap_environment_name"' in provider_function
+    assert provider_function.index(
+        'for bootstrap_environment_name in "${!LD_@}" "${!PYTHON@}" BASH_ENV ENV'
+    ) < provider_function.index("exec python3 -I -c")
+    assert 'unset "$bootstrap_environment_name"' in provider_function
     assert activation < finish < verify < activated < migration
     assert "bootstrap_candidate_action finish-activation" in recovery
     assert "phase_identities" in recovery

--- a/tests/test_ci_clio_kit_wheel.py
+++ b/tests/test_ci_clio_kit_wheel.py
@@ -21,16 +21,16 @@ from clio_relay.remote_mcp import (
 ROOT = Path(__file__).resolve().parents[1]
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
-WHEEL_FILENAME = "clio_kit-2.6.2-py3-none-any.whl"
-WHEEL_SHA256 = "96ce0f85bacad637b715704565be0c57df9d1891193c1c00c3c85dc2904725a4"
-WHEEL_URL = f"https://github.com/iowarp/clio-kit/releases/download/v2.6.2/{WHEEL_FILENAME}"
+WHEEL_FILENAME = "clio_kit-2.6.5-py3-none-any.whl"
+WHEEL_SHA256 = "15a24746453041009f5b3618a72ea8b1c044927def46395ba383eb444ee9c82d"
+WHEEL_URL = f"https://github.com/iowarp/clio-kit/releases/download/v2.6.5/{WHEEL_FILENAME}"
 
 
 def test_runtime_and_ci_share_one_exact_clio_kit_release_pin() -> None:
     """Keep bootstrap, JARVIS MCP, and CI on the same exact release wheel bytes."""
-    assert CLIO_KIT_JARVIS_MCP_VERSION == "2.6.2"
-    assert CLIO_KIT_SPACK_USER_WHEEL_VERSION == "2.6.2"
-    assert CLIO_KIT_SCIENTIFIC_CATALOG_USER_WHEEL_VERSION == "2.6.2"
+    assert CLIO_KIT_JARVIS_MCP_VERSION == "2.6.5"
+    assert CLIO_KIT_SPACK_USER_WHEEL_VERSION == "2.6.5"
+    assert CLIO_KIT_SCIENTIFIC_CATALOG_USER_WHEEL_VERSION == "2.6.5"
     assert CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME == WHEEL_FILENAME
     assert CLIO_KIT_JARVIS_MCP_WHEEL_SHA256 == WHEEL_SHA256
     assert CLIO_KIT_JARVIS_MCP_WHEEL_URL == WHEEL_URL
@@ -106,7 +106,7 @@ def test_ci_wheel_download_is_bounded_https_only_and_fail_closed() -> None:
         assert "pip install" not in script
         assert "uvx" not in script
         assert "|| true" not in script
-        assert "clio-kit-v2.6.2" in script
+        assert "clio-kit-v2.6.5" in script
         assert "clio-kit-v2.5.11" not in script
 
     assert 'if [ "$RUNNER_OS" = Windows ]' in scripts["validate"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import importlib
 import json
 import os
 import stat
@@ -4474,7 +4475,7 @@ def test_cli_api_start_verifies_process_bound_release_identity(
     events: list[str] = []
     bound_app = object()
     late_app = object()
-    http_api_module = sys.modules["clio_relay.http_api"]
+    http_api_module = importlib.import_module("clio_relay.http_api")
     monkeypatch.setattr(http_api_module, "app", bound_app)
     monkeypatch.setenv("CLIO_RELAY_SESSION_OWNER_TOKEN", "a" * 64)
 
@@ -4489,7 +4490,13 @@ def test_cli_api_start_verifies_process_bound_release_identity(
         events.append("serve")
         launches.append((host, port))
 
-    monkeypatch.setattr(cli, "installation_info", lambda: installation)
+    receipt = cli.InstallReceipt.model_validate(installation["receipt"])
+    monkeypatch.setattr(cli, "verified_session_api_install_receipt", lambda: receipt)
+
+    def unexpected_full_installation_probe() -> dict[str, object]:
+        raise AssertionError("API startup must not run full component installation probes")
+
+    monkeypatch.setattr(cli, "installation_info", unexpected_full_installation_probe)
     monkeypatch.setattr(cli, "publish_owned_session_api_startup_receipt", publish)
     monkeypatch.setattr(cli.uvicorn, "run", launch)
     monkeypatch.setenv("CLIO_RELAY_API_RELEASE_IDENTITY_SHA256", identity.sha256())
@@ -5897,6 +5904,17 @@ def test_cli_session_teardown_failure_writes_canonical_report(
         raise RelayError("remote process identity changed")
 
     monkeypatch.setattr(cli, "teardown_remote_session", fail_teardown)
+    monkeypatch.setattr(
+        cli,
+        "_observe_worker_before_cleanup",
+        _fake_no_worker_observation,
+    )
+    monkeypatch.setattr(cli, "status_remote_session", _fake_owned_session_status)
+    monkeypatch.setattr(
+        cli,
+        "_cleanup_owned_runtime_sessions",
+        _fake_empty_runtime_cleanup,
+    )
     report_path = tmp_path / "teardown-failed.json"
 
     result = CliRunner().invoke(
@@ -10313,6 +10331,135 @@ def test_cli_cluster_bootstrap_uses_package_source_root(
     assert captured["relay_wheel"] == wheel
     assert captured["jarvis_resource_graph_profile"] == "ares"
     assert captured["allow_jarvis_resource_graph_build"] is True
+
+
+def test_bootstrap_same_generation_preserves_remote_mcp_cache(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    def reject_invalidation(
+        _cls: type[object],
+        _path: Path,
+        _cluster: str,
+    ) -> tuple[object, tuple[str, ...]]:
+        raise AssertionError("same-generation bootstrap must preserve cached MCP schemas")
+
+    monkeypatch.setattr(
+        cli.RemoteMcpSchemaCache,
+        "invalidate_cluster_entries",
+        classmethod(reject_invalidation),
+    )
+
+    evidence = cli._invalidate_remote_mcp_cache_after_bootstrap(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        cluster="ares",
+        receipt={
+            "generation": {
+                "previous": "a" * 64,
+                "active": "a" * 64,
+            }
+        },
+        registry_path=tmp_path / "clusters.json",
+    )
+
+    assert evidence == {
+        "schema_version": "clio-relay.remote-mcp-cache-invalidation.v1",
+        "cluster": "ares",
+        "previous_generation": "a" * 64,
+        "active_generation": "a" * 64,
+        "generation_changed": False,
+        "action": "preserved",
+        "removed_server_count": 0,
+        "removed_server_names": [],
+    }
+
+
+def test_cluster_bootstrap_invalidates_cache_before_target_validation_and_records_evidence(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_test_cluster(tmp_path)
+    report_path = tmp_path / "bootstrap-report.json"
+    events: list[str] = []
+
+    def fake_bootstrap_cluster_over_ssh(**_kwargs: object) -> list[str]:
+        receipt = {
+            "schema_version": "clio-relay.bootstrap-receipt.v2",
+            "outcome": "reconciled",
+            "invocation_id": "bootstrap_generation_changed",
+            "generation": {
+                "previous": "a" * 64,
+                "active": "b" * 64,
+            },
+        }
+        return [
+            "bootstrap_receipt=/home/test/.local/share/clio-relay/bootstrap-receipt.json",
+            "bootstrap_receipt_json=" + json.dumps(receipt, sort_keys=True),
+        ]
+
+    def invalidate_cluster_entries(
+        cls: type[cli.RemoteMcpSchemaCache],
+        path: Path,
+        cluster: str,
+    ) -> tuple[cli.RemoteMcpSchemaCache, tuple[str, ...]]:
+        events.append("cache-invalidated")
+        assert path == (tmp_path / ".clio-relay" / "remote-mcp-cache.json").resolve()
+        assert cluster == "ares"
+        return cls(), ("__builtin_jarvis__", "jarvis-demo")
+
+    def fake_remote_target_identity(
+        _definition: ClusterDefinition,
+    ) -> dict[str, object]:
+        assert events == ["cache-invalidated"]
+        events.append("target-validated")
+        return {"verified": True}
+
+    monkeypatch.setattr(cli, "package_source_root", lambda: tmp_path / "package")
+    monkeypatch.setattr(cli, "bootstrap_cluster_over_ssh", fake_bootstrap_cluster_over_ssh)
+    monkeypatch.setattr(cli, "_remote_target_identity", fake_remote_target_identity)
+    monkeypatch.setattr(
+        cli.RemoteMcpSchemaCache,
+        "invalidate_cluster_entries",
+        classmethod(invalidate_cluster_entries),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "cluster",
+            "bootstrap",
+            "--cluster",
+            "ares",
+            "--report",
+            str(report_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert events == ["cache-invalidated", "target-validated"]
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    bootstrap_check = cast(dict[str, object], report["checks"][0])
+    evidence = cast(list[dict[str, object]], bootstrap_check["evidence"])
+    cache_evidence = next(
+        item for item in evidence if item["kind"] == "remote_mcp_cache_invalidation"
+    )
+    assert cache_evidence["metadata"] == {
+        "schema_version": "clio-relay.remote-mcp-cache-invalidation.v1",
+        "cluster": "ares",
+        "previous_generation": "a" * 64,
+        "active_generation": "b" * 64,
+        "generation_changed": True,
+        "action": "invalidated",
+        "removed_server_count": 2,
+        "removed_server_names": ["__builtin_jarvis__", "jarvis-demo"],
+    }
+    bootstrap_resource = next(
+        resource for resource in report["resources"] if resource["kind"] == "bootstrap_invocation"
+    )
+    assert (
+        bootstrap_resource["metadata"]["remote_mcp_cache_invalidation"]
+        == cache_evidence["metadata"]
+    )
 
 
 def test_cli_remote_task_event_passthrough_uses_cluster_core(

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -31,6 +31,7 @@ from clio_relay.installation import (
     installation_info,
     load_install_receipt,
     probe_clio_kit_native_execution_contract,
+    verified_session_api_install_receipt,
     verify_distribution_file_source,
     verify_remote_clio_kit_native_execution_component,
     verify_remote_native_jarvis_component,
@@ -753,6 +754,67 @@ def test_install_receipt_binds_running_package_to_wheel_bytes(tmp_path: Path) ->
     assert loaded.component_artifacts["clio-kit"].requested_source == "pypi"
     assert info["receipt_matches_install"] is True
     assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_session_api_receipt_skips_unrelated_component_runtime_probes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wheel = tmp_path / "clio_relay-session-api-py3-none-any.whl"
+    wheel.write_bytes(b"session-api-wheel")
+    receipt_path = tmp_path / "install-receipt.json"
+    expected = write_install_receipt(
+        install_spec=str(wheel),
+        artifact_path=wheel,
+        path=receipt_path,
+        component_artifacts={
+            "clio-kit": ComponentArtifactIdentity(
+                distribution="clio-kit",
+                distribution_version="2.4.7",
+                install_spec="clio-kit==2.4.7",
+                requested_source="pypi",
+                artifact_filename="clio_kit-2.4.7-py3-none-any.whl",
+                artifact_sha256="c" * 64,
+            )
+        },
+    )
+
+    def unexpected_probe(_receipt: InstallReceipt) -> dict[str, object]:
+        raise AssertionError("session API startup must not probe component runtimes")
+
+    monkeypatch.setattr(
+        installation_module,
+        "_component_runtime_identity",
+        unexpected_probe,
+    )
+
+    assert verified_session_api_install_receipt(receipt_path) == expected
+
+
+def test_session_api_receipt_remains_bound_to_running_software(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wheel = tmp_path / "clio_relay-session-api-py3-none-any.whl"
+    wheel.write_bytes(b"session-api-wheel")
+    receipt_path = tmp_path / "install-receipt.json"
+    write_install_receipt(
+        install_spec=str(wheel),
+        artifact_path=wheel,
+        path=receipt_path,
+    )
+    current = installation_module.detect_software_identity()
+    monkeypatch.setattr(
+        installation_module,
+        "detect_software_identity",
+        lambda: current.model_copy(update={"commit": "f" * 40}),
+    )
+
+    with pytest.raises(
+        ConfigurationError,
+        match="receipt does not match the running package",
+    ):
+        verified_session_api_install_receipt(receipt_path)
 
 
 def test_install_receipt_labels_exact_version_spec_as_pypi(tmp_path: Path) -> None:

--- a/tests/test_jarvis_service_runtime.py
+++ b/tests/test_jarvis_service_runtime.py
@@ -49,6 +49,7 @@ from clio_relay.jarvis_service_runtime import (
 )
 from clio_relay.mcp_server import handle_request
 from clio_relay.models import (
+    REGISTERED_JARVIS_USER_CONTRACT,
     ArtifactRef,
     GatewaySession,
     GatewaySessionState,
@@ -955,6 +956,142 @@ def test_model_facing_mcp_projection_redacts_runtime_bearer_token() -> None:
     assert token not in json.dumps(projected, sort_keys=True)
 
 
+@pytest.mark.parametrize(
+    "expected_registered_contract",
+    [None, REGISTERED_JARVIS_USER_CONTRACT],
+    ids=["built-in", "registered"],
+)
+def test_verified_jarvis_wait_preserves_public_bearer_fingerprint(
+    tmp_path: Path,
+    expected_registered_contract: str | None,
+) -> None:
+    """Exact built-in and registered JARVIS waits preserve the public runtime hash."""
+
+    _queue, _definition, job, _artifact, envelope = _source_result(
+        tmp_path,
+        expected_registered_contract=expected_registered_contract,
+    )
+    artifact = ArtifactRef.model_validate(envelope["artifact"])
+    parsed = mcp_server_module._decode_verified_mcp_result(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        envelope,
+        artifact=artifact.model_dump(mode="json"),
+        job_id=job.job_id,
+    )
+    receipt: dict[str, Any] = {}
+
+    mcp_server_module._attach_terminal_mcp_evidence(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        receipt,
+        source_job=job,
+        last_error=None,
+        artifacts=[artifact.model_dump(mode="json")],
+        parsed_result=parsed,
+    )
+
+    original = cast(
+        dict[str, Any],
+        parsed.document["structured_result"]["service_runtimes"]["service_runtimes"][0],
+    )
+    projected = cast(
+        dict[str, Any],
+        receipt["mcp_result"]["structured_result"]["service_runtimes"]["service_runtimes"][0],
+    )
+    assert (
+        projected["authorization"]
+        == original["authorization"]
+        == {
+            "scheme": "bearer",
+            "token_sha256": hashlib.sha256(("a" * 64).encode("ascii")).hexdigest(),
+        }
+    )
+    assert projected == original
+    assert (
+        hashlib.sha256(
+            json.dumps(projected, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        == hashlib.sha256(
+            json.dumps(original, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+    )
+    assert (
+        len(
+            json.dumps(
+                receipt["mcp_result"],
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
+        <= mcp_server_module.MAX_INLINE_MCP_RESULT_BYTES
+    )
+
+
+@pytest.mark.parametrize(
+    "authorization",
+    [
+        {"scheme": "bearer", "token": "a" * 64},
+        {
+            "scheme": "bearer",
+            "token_sha256": "b" * 64,
+            "audience": "paraview",
+        },
+        {"scheme": "bearer", "token_sha256": "not-a-canonical-sha256"},
+        {"scheme": "basic", "token_sha256": "b" * 64},
+    ],
+    ids=["raw-token", "extra-key", "wrong-hash", "wrong-scheme"],
+)
+def test_jarvis_authorization_restore_rejects_non_public_descriptors(
+    authorization: dict[str, str],
+) -> None:
+    """Even a trusted projection flag cannot restore a secret or widened shape."""
+
+    projected = mcp_server_module._bounded_mcp_result(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        {
+            "structured_result": {
+                "service_runtimes": {
+                    "service_runtimes": [
+                        {
+                            "schema_version": "jarvis.service-runtime.v2",
+                            "authorization": authorization,
+                        }
+                    ]
+                }
+            }
+        },
+        preserve_verified_jarvis_authorization_descriptors=True,
+    )
+
+    runtime = projected["structured_result"]["service_runtimes"]["service_runtimes"][0]
+    assert runtime["authorization"] == "<redacted>"
+    assert projected["sensitive_values_redacted"] is True
+    if "token" in authorization:
+        assert authorization["token"] not in json.dumps(projected, sort_keys=True)
+
+
+def test_arbitrary_mcp_cannot_expose_jarvis_shaped_authorization() -> None:
+    """A lookalike authorization stays redacted without exact JARVIS source proof."""
+
+    projected = mcp_server_module._bounded_mcp_result(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        {
+            "structured_result": {
+                "service_runtimes": {
+                    "service_runtimes": [
+                        {
+                            "schema_version": "jarvis.service-runtime.v2",
+                            "authorization": {
+                                "scheme": "bearer",
+                                "token_sha256": "b" * 64,
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    runtime = projected["structured_result"]["service_runtimes"]["service_runtimes"][0]
+    assert runtime["authorization"] == "<redacted>"
+    assert projected["sensitive_values_redacted"] is True
+
+
 def test_waited_execution_exposes_compact_verified_binding_before_large_result(
     tmp_path: Path,
 ) -> None:
@@ -1000,7 +1137,6 @@ def test_waited_execution_exposes_compact_verified_binding_before_large_result(
         receipt
     )
     assert "a" * 64 not in serialized
-    assert '"sensitive_values_redacted": true' in serialized
     assert serialized.index('"service_runtime_bindings":') < serialized.index(
         '"mcp_result_artifact":'
     )
@@ -1866,6 +2002,145 @@ def test_service_runtime_source_rejects_generic_unmarked_jarvis_call(
     monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
 
     with pytest.raises(ValueError, match="JARVIS-CD lock pin"):
+        resolve_jarvis_service_runtime(
+            queue=queue,
+            definition=definition,
+            source_job_id=job.job_id,
+            source_artifact_id=artifact.artifact_id,
+            package_id="paraview-1",
+            package_name="builtin.paraview",
+        )
+
+
+def test_registered_service_runtime_source_binds_exact_durable_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An operator-registered JARVIS route uses its contract and artifact proof."""
+    queue, definition, job, artifact, envelope = _source_result(
+        tmp_path,
+        server="/opt/operator/bin/registered-jarvis-mcp",
+        expected_registered_contract=REGISTERED_JARVIS_USER_CONTRACT,
+    )
+    monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
+
+    verified = resolve_jarvis_service_runtime(
+        queue=queue,
+        definition=definition,
+        source_job_id=job.job_id,
+        source_artifact_id=artifact.artifact_id,
+        package_id="paraview-1",
+        package_name="builtin.paraview",
+    )
+
+    assert verified.binding.source_relay_job_id == job.job_id
+    assert verified.binding.source_relay_artifact_id == artifact.artifact_id
+    assert verified.binding.jarvis_execution_id == "execution-1"
+    assert verified.runtime.service_instance_id == "paraview-live-1"
+
+
+def test_registered_service_runtime_source_rejects_wrong_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue, definition, job, artifact, envelope = _source_result(
+        tmp_path,
+        expected_registered_contract="clio-kit-jarvis-user-v3.5",
+    )
+    monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
+
+    with pytest.raises(ValueError, match="supported JARVIS contract"):
+        resolve_jarvis_service_runtime(
+            queue=queue,
+            definition=definition,
+            source_job_id=job.job_id,
+            source_artifact_id=artifact.artifact_id,
+            package_id="paraview-1",
+            package_name="builtin.paraview",
+        )
+
+
+def test_registered_service_runtime_source_rejects_mixed_builtin_lock_pin(
+    tmp_path: Path,
+) -> None:
+    _queue, definition, job, _artifact, _envelope = _source_result(
+        tmp_path,
+        expected_registered_contract=REGISTERED_JARVIS_USER_CONTRACT,
+    )
+    spec = cast(McpCallSpec, job.spec).model_copy(
+        update={"expected_jarvis_cd_lock_binding": jarvis_cd_lock_binding_expectation()}
+    )
+    mixed_job = job.model_copy(update={"spec": spec})
+
+    with pytest.raises(ValueError, match="also supplied a built-in JARVIS-CD lock pin"):
+        runtime_binding._validate_source_job(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            mixed_job,
+            cluster=definition.name,
+        )
+
+
+def test_registered_service_runtime_source_rejects_result_contract_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue, definition, job, artifact, envelope = _source_result(
+        tmp_path,
+        expected_registered_contract=REGISTERED_JARVIS_USER_CONTRACT,
+    )
+    document = json.loads(base64.b64decode(envelope["data"], validate=True).decode("utf-8"))
+    document["expected_registered_contract"] = None
+    _replace_envelope_document(envelope, document)
+    monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
+
+    with pytest.raises(ValueError, match="result registered contract"):
+        resolve_jarvis_service_runtime(
+            queue=queue,
+            definition=definition,
+            source_job_id=job.job_id,
+            source_artifact_id=artifact.artifact_id,
+            package_id="paraview-1",
+            package_name="builtin.paraview",
+        )
+
+
+def test_registered_service_runtime_source_rejects_mismatched_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue, definition, job, artifact, envelope = _source_result(
+        tmp_path,
+        expected_registered_contract=REGISTERED_JARVIS_USER_CONTRACT,
+    )
+    document = json.loads(base64.b64decode(envelope["data"], validate=True).decode("utf-8"))
+    document["server_artifact"]["install_artifact_sha256"] = "c" * 64
+    _replace_envelope_document(envelope, document)
+    monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
+
+    with pytest.raises(ValueError, match="not the immutable registered route"):
+        resolve_jarvis_service_runtime(
+            queue=queue,
+            definition=definition,
+            source_job_id=job.job_id,
+            source_artifact_id=artifact.artifact_id,
+            package_id="paraview-1",
+            package_name="builtin.paraview",
+        )
+
+
+def test_registered_service_runtime_source_rejects_unverified_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server_artifact = _registered_jarvis_server_artifact()
+    server_artifact["verified"] = False
+    queue, definition, job, artifact, envelope = _source_result(
+        tmp_path,
+        expected_registered_contract=REGISTERED_JARVIS_USER_CONTRACT,
+        server_artifact=server_artifact,
+    )
+    monkeypatch.setattr(runtime_binding, "read_artifact_bytes", _envelope_reader(envelope))
+
+    with pytest.raises(ValueError, match="not the immutable registered route"):
         resolve_jarvis_service_runtime(
             queue=queue,
             definition=definition,
@@ -4427,11 +4702,18 @@ def _source_result(
     include_service_runtimes: bool | None = True,
     server: str = "/home/cluster/.local/bin/clio-kit",
     bind_relay_jarvis: bool = True,
+    expected_registered_contract: str | None = None,
     server_artifact: dict[str, Any] | None = None,
 ) -> tuple[ClioCoreQueue, ClusterDefinition, RelayJob, ArtifactRef, dict[str, Any]]:
     queue = ClioCoreQueue(tmp_path / "core")
     resolved_server_artifact = (
-        verified_jarvis_server_artifact() if server_artifact is None else server_artifact
+        (
+            _registered_jarvis_server_artifact()
+            if expected_registered_contract is not None
+            else verified_jarvis_server_artifact()
+        )
+        if server_artifact is None
+        else server_artifact
     )
     digest = remote_mcp_server_artifact_digest(resolved_server_artifact)
     job = queue.submit_job(
@@ -4442,8 +4724,11 @@ def _source_result(
                 server=server,
                 server_args=["mcp-server", "jarvis"],
                 expected_server_artifact_digest=digest,
+                expected_registered_contract=expected_registered_contract,
                 expected_jarvis_cd_lock_binding=(
-                    jarvis_cd_lock_binding_expectation() if bind_relay_jarvis else None
+                    jarvis_cd_lock_binding_expectation()
+                    if bind_relay_jarvis and expected_registered_contract is None
+                    else None
                 ),
                 tool=tool,
                 arguments={
@@ -4574,6 +4859,7 @@ def _mcp_result_document(
         "server_args": spec.server_args,
         "env_from": spec.env_from,
         "expected_server_artifact_digest": digest,
+        "expected_registered_contract": spec.expected_registered_contract,
         "expected_jarvis_cd_lock_binding": spec.expected_jarvis_cd_lock_binding,
         "observed_server_artifact_digest": digest,
         "server_artifact": server_artifact,
@@ -4585,6 +4871,14 @@ def _mcp_result_document(
         "protocol_error": None,
         "structured_result": structured,
         "protocol_result": {"structuredContent": structured, "isError": False},
+    }
+
+
+def _registered_jarvis_server_artifact() -> dict[str, Any]:
+    """Return an immutable discovered artifact for an operator-registered route."""
+    return {
+        **verified_jarvis_server_artifact(),
+        "install_spec": "/releases/clio_kit-2.6.2-py3-none-any.whl",
     }
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3111,6 +3111,7 @@ def test_waited_owned_jarvis_call_returns_bounded_artifact_bound_failure(
     )
 
     assert response is not None and "error" not in response
+    assert response["result"]["isError"] is True
     result = response["result"]["structuredContent"]
     advertised = next(tool for tool in listed["result"]["tools"] if tool["name"] == "jarvis_run")
     cast(_SchemaValidator, Draft202012Validator(advertised["outputSchema"])).validate(result)
@@ -3244,6 +3245,39 @@ def test_under_limit_terminal_mcp_result_returns_complete_structured_result() ->
     assert bounded["structured_result"] == {"dataset_id": "asteroid-first-five"}
     assert bounded["protocol_result_omitted"] == "redundant_with_structured_result"
     assert "delivery" not in bounded
+
+
+def test_bounded_mcp_error_preserves_exact_protocol_content_with_structured_result() -> None:
+    """Structured failures retain the remote server's exact human-readable error."""
+
+    exact_error = (
+        "Error calling tool 'update_visualization': ParaView runtime returned HTTP 409 "
+        "(revision_conflict): expected_revision does not match authoritative state"
+    )
+    bounded = mcp_server_module._bounded_mcp_result(  # pyright: ignore[reportPrivateUsage]
+        {
+            "operation": "tools/call",
+            "tool": "update_visualization",
+            "returncode": 1,
+            "timed_out": False,
+            "protocol_error": "tools/call returned isError=true",
+            "structured_result": {
+                "error": {
+                    "code": "revision_conflict",
+                    "message": "the requested revision is stale",
+                }
+            },
+            "protocol_result": {
+                "content": [{"type": "text", "text": exact_error}],
+                "isError": True,
+            },
+        }
+    )
+
+    protocol_result = cast(dict[str, Any], bounded["protocol_result"])
+    assert protocol_result["isError"] is True
+    assert protocol_result["content"] == [{"type": "text", "text": exact_error}]
+    assert "protocol_result_omitted" not in bounded
 
 
 def test_oversized_terminal_mcp_result_fails_closed_without_partial_payload() -> None:
@@ -4011,6 +4045,8 @@ def test_virtual_remote_mcp_idempotency_replays_exactly_and_conflicts_on_drift(
     conflict = invoke(4, 2)
 
     assert first is not None and replay is not None and conflict is not None
+    assert first["result"]["isError"] is False
+    assert first["result"]["structuredContent"]["terminal"] is False
     first_job_id = first["result"]["structuredContent"]["job_id"]
     assert replay["result"]["structuredContent"]["job_id"] == first_job_id
     assert "idempotency" in conflict["error"]["message"].lower()
@@ -4019,6 +4055,121 @@ def test_virtual_remote_mcp_idempotency_replays_exactly_and_conflicts_on_drift(
     assert isinstance(job.spec, McpCallSpec)
     assert job.spec.arguments == {"value": 1}
     assert job.idempotency_key == "agent-retry-1"
+
+
+def test_generated_remote_mcp_alias_propagates_exact_fastmcp_tool_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A generated remote alias remains failed with the exact inner MCP error."""
+
+    route = RemoteMcpRoute(
+        cluster="ares",
+        server_name="vigil",
+        command="vigil-mcp",
+        args=("--stdio",),
+        env_from=(),
+        expected_server_artifact_digest="e" * 64,
+        remote_tool_name="update_visualization",
+        timeout_seconds=300,
+        contract=None,
+        cluster_route_revision="d" * 64,
+        registration_revision="c" * 64,
+    )
+    alias = "remote_vigil_update_visualization"
+    catalog = VirtualRemoteMcpCatalog(
+        revision="f" * 64,
+        tools={
+            alias: VirtualRemoteMcpTool(
+                alias=alias,
+                namespace="vigil",
+                remote_tool=RemoteMcpToolSchema(
+                    name="update_visualization",
+                    input_schema={
+                        "type": "object",
+                        "properties": {"expected_revision": {"type": "integer", "minimum": 0}},
+                        "required": ["expected_revision"],
+                        "additionalProperties": False,
+                    },
+                ),
+                routes={"ares": route},
+                arguments_wrapped=False,
+            )
+        },
+        issues=(),
+        cluster_route_revisions={"ares": "d" * 64},
+    )
+
+    def selected_catalog(*, profile: str, reserved_names: set[str]) -> VirtualRemoteMcpCatalog:
+        del profile, reserved_names
+        return catalog
+
+    exact_error = (
+        "Error calling tool 'update_visualization': ParaView runtime returned HTTP 409 "
+        "(revision_conflict): expected_revision does not match authoritative state"
+    )
+    mcp_result = mcp_server_module._bounded_mcp_result(  # pyright: ignore[reportPrivateUsage]
+        {
+            "operation": "tools/call",
+            "tool": "update_visualization",
+            "returncode": 1,
+            "timed_out": False,
+            "protocol_error": "tools/call returned isError=true",
+            "structured_result": None,
+            "protocol_result": {
+                "content": [{"type": "text", "text": exact_error}],
+                "isError": True,
+            },
+        }
+    )
+    receipt: dict[str, Any] = {
+        "cluster": "ares",
+        "job_id": "job_remote_fastmcp_error",
+        "state": "failed",
+        "kind": "mcp_call",
+        "terminal": True,
+        "remote": True,
+        "route_revision": "d" * 64,
+        "last_error": "exit code 1",
+        "mcp_result": mcp_result,
+    }
+
+    def submit(
+        arguments: dict[str, Any],
+        *,
+        queue: ClioCoreQueue,
+        settings: RelaySettings,
+    ) -> dict[str, Any]:
+        del queue, settings
+        assert arguments["tool"] == "update_visualization"
+        assert arguments["arguments"] == {"expected_revision": 1}
+        return receipt
+
+    monkeypatch.setattr(mcp_server_module, "_remote_mcp_catalog", selected_catalog)
+    monkeypatch.setattr(mcp_server_module, "_submit_mcp_call", submit)
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": alias,
+                "arguments": {"cluster": "ares", "expected_revision": 1},
+            },
+        },
+        queue=ClioCoreQueue(tmp_path / "core"),
+        settings=RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool"),
+        profile="user",
+    )
+
+    assert response is not None and "error" not in response, response
+    tool_result = cast(dict[str, Any], response["result"])
+    assert tool_result["isError"] is True
+    assert exact_error in cast(list[dict[str, str]], tool_result["content"])[0]["text"]
+    structured = cast(dict[str, Any], tool_result["structuredContent"])
+    protocol_result = cast(dict[str, Any], structured["mcp_result"]["protocol_result"])
+    assert protocol_result["isError"] is True
+    assert protocol_result["content"] == [{"type": "text", "text": exact_error}]
 
 
 def test_virtual_remote_mcp_wait_envelope_returns_same_call_result_without_leaking(
@@ -4194,6 +4345,7 @@ def test_virtual_remote_mcp_wait_envelope_returns_same_call_result_without_leaki
     )
 
     assert response is not None and "error" not in response, response
+    assert response["result"]["isError"] is False
     result = response["result"]["structuredContent"]
     cast(_SchemaValidator, Draft202012Validator(advertised["outputSchema"])).validate(result)
     assert result["terminal"] is True

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -336,7 +336,7 @@ def test_jarvis_release_requirement_enforces_unified_gray_scott_contract() -> No
     assert lock_binding["schema_version"] == "clio-relay.jarvis-cd-lock-binding.v1"
     assert lock_binding["dependency"] == "jarvis-cd"
     assert lock_binding["error"] is None
-    assert lock_binding["expected_version"] == "1.6.0"
+    assert lock_binding["expected_version"] == "1.7.0"
     assert lock_binding["expected_url"] == lock_binding["observed_source_url"]
     assert lock_binding["expected_url"] == lock_binding["observed_wheel_url"]
     assert lock_binding["expected_sha256"] == lock_binding["observed_wheel_sha256"]
@@ -358,11 +358,11 @@ def test_jarvis_release_requirement_enforces_unified_gray_scott_contract() -> No
         if resource["kind"] == "relay_worker"
     )
     clio_kit_component = worker["metadata_equals"]["component_artifacts"]["clio-kit"]
-    assert clio_kit_component["distribution_version"] == "2.6.2"
+    assert clio_kit_component["distribution_version"] == "2.6.5"
     assert clio_kit_component["persistent_tool"]["manager"] == "uv"
     assert clio_kit_component["persistent_tool"]["uv_version"] == "0.11.28"
     assert clio_kit_component["persistent_tool"]["source_artifact_sha256"] == (
-        "96ce0f85bacad637b715704565be0c57df9d1891193c1c00c3c85dc2904725a4"
+        "15a24746453041009f5b3618a72ea8b1c044927def46395ba383eb444ee9c82d"
     )
     native_execution = clio_kit_component["native_execution"]
     assert native_execution["contract_id"] == "clio-kit-jarvis-user-v3.6"
@@ -370,11 +370,11 @@ def test_jarvis_release_requirement_enforces_unified_gray_scott_contract() -> No
         "055c6697dc9a25fb033c949db92c928aee8d5673f7b2e3a4d90a237f4f87a40d"
     )
     jarvis_component = worker["metadata_equals"]["component_artifacts"]["jarvis-cd"]
-    assert jarvis_component["distribution_version"] == "1.6.0"
+    assert jarvis_component["distribution_version"] == "1.7.0"
     assert jarvis_component["requested_source"] == "github_release"
-    assert jarvis_component["install_spec"].endswith("/v1.6.0/jarvis_cd-1.6.0-py3-none-any.whl")
+    assert jarvis_component["install_spec"].endswith("/v1.7.0/jarvis_cd-1.7.0-py3-none-any.whl")
     assert jarvis_component["artifact_sha256"] == (
-        "c4853138f3263715e806fcd794233d89f4aa58161e3c5fbab59e7f96d24f0e98"
+        "f61d2c9b01af1794263013b9045916230c36c318c2984ba4f35d82d8c994e9bb"
     )
     runtime = worker["metadata_equals"]["component_runtime"]["jarvis-cd"]
     assert runtime["provider_interpreter_verified"] is True
@@ -424,10 +424,10 @@ def test_jarvis_release_requirement_enforces_unified_gray_scott_contract() -> No
         for resource in cast(list[dict[str, Any]], lammps["required_resources"])
         if resource["kind"] == "relay_worker"
     )
-    assert lammps_worker["metadata_equals"]["components"] == {"jarvis-cd": "1.6.0"}
+    assert lammps_worker["metadata_equals"]["components"] == {"jarvis-cd": "1.7.0"}
     assert (
         lammps_worker["metadata_equals"]["component_artifacts"]["jarvis-cd"]["artifact_sha256"]
-        == "c4853138f3263715e806fcd794233d89f4aa58161e3c5fbab59e7f96d24f0e98"
+        == "f61d2c9b01af1794263013b9045916230c36c318c2984ba4f35d82d8c994e9bb"
     )
     assert lammps.get("evidence_group_resource_kind") is None
 
@@ -583,7 +583,7 @@ def test_spack_release_requirements_split_existing_resolution_from_fresh_install
     )
     assert fresh_server["metadata_equals"]["server_name"] == "spack-fresh"
     assert fresh_server["metadata_equals"]["install_artifact_sha256"] == (
-        "96ce0f85bacad637b715704565be0c57df9d1891193c1c00c3c85dc2904725a4"
+        "15a24746453041009f5b3618a72ea8b1c044927def46395ba383eb444ee9c82d"
     )
     assert fresh_server["metadata_equals"]["contract_id"] == "clio-kit-spack-user-v2.1"
     assert fresh_server["metadata_equals"]["contract_sha256"] == (

--- a/tests/test_remote_mcp.py
+++ b/tests/test_remote_mcp.py
@@ -16,6 +16,7 @@ from typing import Any, Protocol, cast
 import pytest
 from click import unstyle
 from jsonschema import Draft4Validator, Draft201909Validator, Draft202012Validator
+from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
 from pydantic import ValidationError
 from pytest import MonkeyPatch
 from typer.testing import CliRunner
@@ -37,6 +38,7 @@ from clio_relay.jarvis_mcp import (
     CLIO_KIT_JARVIS_USER_CONTRACT_SHA256,
     JARVIS_MCP_CACHE_SERVER_NAME,
     jarvis_user_contract,
+    virtual_jarvis_job_output_schema,
 )
 from clio_relay.mcp_server import McpSessionState, handle_request, serve_stdio
 from clio_relay.mcp_stdio_validation import PackagedMcpStdioSession
@@ -933,6 +935,31 @@ def test_discovery_artifact_creates_fresh_provenance_cache_entry(tmp_path: Path)
     assert entry.tools[0].input_schema["required"] == ["path"]
 
 
+def test_remote_mcp_cache_invalidates_only_one_cluster_atomically(tmp_path: Path) -> None:
+    registration = _registration()
+    cache_path = tmp_path / "remote-mcp-cache.json"
+    alpha_science = _entry(registration, cluster="alpha", server_name="science")
+    alpha_jarvis = _entry(
+        registration,
+        cluster="alpha",
+        server_name=JARVIS_MCP_CACHE_SERVER_NAME,
+    )
+    beta_science = _entry(registration, cluster="beta", server_name="science")
+    for entry in (alpha_science, alpha_jarvis, beta_science):
+        RemoteMcpSchemaCache.update_entry(cache_path, entry)
+
+    updated, removed_server_names = RemoteMcpSchemaCache.invalidate_cluster_entries(
+        cache_path,
+        "alpha",
+    )
+
+    assert removed_server_names == (JARVIS_MCP_CACHE_SERVER_NAME, "science")
+    assert updated == RemoteMcpSchemaCache.load(cache_path)
+    assert updated.entry_for("alpha", "science") is None
+    assert updated.entry_for("alpha", JARVIS_MCP_CACHE_SERVER_NAME) is None
+    assert updated.entry_for("beta", "science") == beta_science
+
+
 def test_remote_mcp_cache_rejects_oversized_or_non_regular_files(tmp_path: Path) -> None:
     oversized = tmp_path / "oversized-cache.json"
     oversized.write_bytes(b" " * (MAX_REMOTE_MCP_CACHE_BYTES + 1))
@@ -1348,6 +1375,138 @@ def test_registered_jarvis_v36_describe_advertises_terminal_reconciliation_defau
 
     assert definition["inputSchema"]["properties"]["wait_for_terminal"]["default"] is True
     assert "transparently reconciled" in definition["description"]
+
+
+def test_registered_jarvis_get_execution_advertises_exact_runtime_handoff_schema() -> None:
+    """An audited registered JARVIS route accepts relay-derived service handoffs."""
+    contract_artifact = cast(
+        dict[str, object],
+        json.loads(
+            (Path(remote_mcp.__file__).with_name("_contracts") / "jarvis-user-v3.6.json").read_text(
+                encoding="utf-8"
+            )
+        ),
+    )
+    tools = cast(list[dict[str, object]], contract_artifact["tools"])
+    tool_names = [cast(str, tool["name"]) for tool in tools]
+    registration = RemoteMcpServerConfig(
+        command="uvx",
+        args=[
+            "--from",
+            "/opt/wheels/clio_kit-2.6.2-py3-none-any.whl",
+            "clio-kit",
+            "mcp-server",
+            "jarvis",
+        ],
+        namespace="jarvis-demo",
+        allow_tools=tool_names,
+        profiles=["user"],
+        contract="clio-kit-jarvis-user-v3.6",
+    )
+    registry = ClusterRegistry(
+        clusters={
+            "alpha": _cluster("alpha", {"jarvis": registration}),
+            "beta": _cluster("beta", {"jarvis": registration}),
+        }
+    )
+    cache = RemoteMcpSchemaCache(
+        entries=[
+            _entry(registration, cluster="alpha", server_name="jarvis", tools=tools),
+            _entry(registration, cluster="beta", server_name="jarvis", tools=tools),
+        ]
+    )
+
+    catalog = build_virtual_remote_mcp_catalog(registry, cache, profile="user", now=NOW)
+    reversed_catalog = build_virtual_remote_mcp_catalog(
+        ClusterRegistry(clusters=dict(reversed(list(registry.clusters.items())))),
+        RemoteMcpSchemaCache(entries=list(reversed(cache.entries))),
+        profile="user",
+        now=NOW,
+    )
+    advertised = catalog.tools["remote_jarvis_demo_jarvis_get_execution"].definition()[
+        "outputSchema"
+    ]
+    reversed_advertised = reversed_catalog.tools[
+        "remote_jarvis_demo_jarvis_get_execution"
+    ].definition()["outputSchema"]
+
+    assert advertised == virtual_jarvis_job_output_schema(
+        "jarvis_get_execution",
+        clusters=["alpha", "beta"],
+    )
+    assert advertised == reversed_advertised
+    assert catalog.revision == reversed_catalog.revision
+    assert (
+        hashlib.sha256(
+            json.dumps(advertised, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        == hashlib.sha256(
+            json.dumps(reversed_advertised, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+    )
+    cast(_SchemaValidator, Draft202012Validator(advertised)).validate(
+        {
+            "cluster": "alpha",
+            "job_id": "job_registered_jarvis_query",
+            "state": "succeeded",
+            "kind": "mcp_call",
+            "terminal": True,
+            "route_revision": "a" * 64,
+            "catalog_revision": catalog.revision,
+            "service_runtime_bindings": [
+                {
+                    "cluster": "alpha",
+                    "source_job_id": "job_registered_jarvis_query",
+                    "source_artifact_id": "artifact_registered_jarvis_query",
+                    "package_id": "paraview",
+                    "package_name": "builtin.paraview",
+                    "service_instance_id": "service-paraview-1",
+                }
+            ],
+        }
+    )
+
+
+def test_arbitrary_registered_remote_mcp_output_forbids_jarvis_runtime_handoffs() -> None:
+    """JARVIS-like server and tool names cannot grant JARVIS-specific result fields."""
+    registration = _registration(namespace="jarvis-demo", profiles=["user"]).model_copy(
+        update={"allow_tools": ["jarvis_get_execution"]}
+    )
+    catalog = build_virtual_remote_mcp_catalog(
+        ClusterRegistry(clusters={"alpha": _cluster("alpha", {"jarvis": registration})}),
+        RemoteMcpSchemaCache(
+            entries=[
+                _entry(
+                    registration,
+                    cluster="alpha",
+                    server_name="jarvis",
+                    tools=[_tool("jarvis_get_execution")],
+                )
+            ]
+        ),
+        profile="user",
+        now=NOW,
+    )
+    advertised = catalog.tools["remote_jarvis_demo_jarvis_get_execution"].definition()[
+        "outputSchema"
+    ]
+    result: dict[str, object] = {
+        "cluster": "alpha",
+        "job_id": "job_science_query",
+        "state": "succeeded",
+        "kind": "mcp_call",
+        "terminal": True,
+        "route_revision": "a" * 64,
+        "catalog_revision": catalog.revision,
+        "service_runtime_bindings": [],
+    }
+
+    assert advertised == VIRTUAL_REMOTE_MCP_JOB_OUTPUT_SCHEMA
+    validator = cast(_SchemaValidator, Draft202012Validator(advertised))
+    with pytest.raises(JsonSchemaValidationError) as error:
+        validator.validate(result)
+    assert "Additional properties are not allowed" in error.value.message
+    assert "service_runtime_bindings" in error.value.message
 
 
 def test_cluster_injection_wraps_nonempty_root_id_without_changing_remote_schema() -> None:

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -15,6 +15,7 @@ from typing import Literal, cast
 import pytest
 from pytest import MonkeyPatch
 
+import clio_relay.installation as installation_module
 import clio_relay.session_lifecycle as session_lifecycle
 from clio_relay import __version__
 from clio_relay.cluster_config import (
@@ -25,6 +26,7 @@ from clio_relay.cluster_config import (
 )
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.errors import RelayError
+from clio_relay.installation import InstallReceipt
 from clio_relay.session_lifecycle import (
     SESSION_CONNECTORS_CHECK_ID,
     SESSION_GATEWAY_CHECK_ID,
@@ -66,6 +68,40 @@ def _api_release_identity() -> SessionApiReleaseIdentity:
                 "dirty": False,
             },
         }
+    )
+
+
+def test_session_start_release_identity_uses_verified_relay_receipt(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    expected = _api_release_identity()
+    receipt = InstallReceipt(
+        installed_at=datetime.now(UTC),
+        install_spec=f"clio-relay=={expected.distribution_version}",
+        requested_source="pypi",
+        artifact_filename=(f"clio_relay-{expected.distribution_version}-py3-none-any.whl"),
+        artifact_sha256=expected.artifact_sha256,
+        distribution_version=expected.distribution_version,
+        software=expected.software,
+    )
+    monkeypatch.setattr(
+        installation_module,
+        "verified_session_api_install_receipt",
+        lambda: receipt,
+    )
+
+    def unexpected_full_installation_probe() -> dict[str, object]:
+        raise AssertionError("session start must not run full component installation probes")
+
+    monkeypatch.setattr(
+        installation_module,
+        "installation_info",
+        unexpected_full_installation_probe,
+    )
+
+    assert (
+        session_lifecycle._current_session_api_release_identity()  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        == expected
     )
 
 


### PR DESCRIPTION
## Summary
- complete the durable ParaView/JARVIS live-service bootstrap, binding, recovery, and teardown path
- preserve runtime authority and scheduler state across CLI, MCP, and owned-session lifecycle operations
- pin the released clio-kit 2.6.5 and JARVIS-CD 1.7.0 artifacts by exact public URL and SHA-256
- refresh the 1.5.5 release policy, operations documentation, and regression coverage

## Validation
- 84 focused clio-kit pin and release-workflow tests passed
- broad combined integration set passed after applying this commit to the exact PR #136 tree
- `uv run ruff check src tests jarvis-packages/clio_relay/clio_relay`
- `uv run ruff format --check src tests jarvis-packages/clio_relay/clio_relay` (193 files already formatted)
- `uv run pyright src/clio_relay jarvis-packages/clio_relay/clio_relay` (0 errors, 0 warnings)

The rebased commit tree exactly matches the combined tree used for validation.