### PR TITLE
fix: preserve lexical JARVIS repository paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.5.5` uses a release-first patch process. A maintainer builds the
+> Version `1.5.6` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.5.5"
+$Version = "1.5.6"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.5.5"
+release_version: "1.5.6"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: bb1f6d1f50f98a19c74700ab5dc4a36cc1749f033d5d4f434a6ffd584344fb7c
+acceptance_matrix_sha256: 782be193bf0e8e6bdb331161aa6fb97ad85e035ddb87d2cbe0c4bb4d6c234c30
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.5.5"
+$Tag = "v1.5.6"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.5" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.6" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.5.5",
-  "matrix_sha256": "bb1f6d1f50f98a19c74700ab5dc4a36cc1749f033d5d4f434a6ffd584344fb7c",
+  "release_version": "1.5.6",
+  "matrix_sha256": "782be193bf0e8e6bdb331161aa6fb97ad85e035ddb87d2cbe0c4bb4d6c234c30",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.5.5"
+version = "1.5.6"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.5.5"
+__version__ = "1.5.6"

--- a/src/clio_relay/bootstrap_reconcile.py
+++ b/src/clio_relay/bootstrap_reconcile.py
@@ -986,13 +986,15 @@ def inspect_jarvis_state(
     ):
         raise ConfigurationError("JARVIS repositories must contain a string list")
     managed_repo_path = _expand_home(desired.managed_jarvis_repo, lexical_home)
-    managed_repo = str(_canonical_path_preserving_final(managed_repo_path))
-    managed_aliases = {str(managed_repo_path.absolute()), managed_repo}
+    lexical_managed_repo = str(Path(os.path.abspath(managed_repo_path.expanduser())))
+    canonical_managed_repo = str(_canonical_path_preserving_final(managed_repo_path))
+    managed_aliases = {lexical_managed_repo, canonical_managed_repo}
     managed_builtin_path = jarvis_root / "builtin"
-    managed_builtin = str(_canonical_path_preserving_final(managed_builtin_path))
+    lexical_managed_builtin = str(Path(os.path.abspath(managed_builtin_path.expanduser())))
+    canonical_managed_builtin = str(_canonical_path_preserving_final(managed_builtin_path))
     managed_builtin_aliases = {
-        str(Path(os.path.abspath(managed_builtin_path.expanduser()))),
-        managed_builtin,
+        lexical_managed_builtin,
+        canonical_managed_builtin,
     }
     repo_values = cast(list[str], raw_repo_values)
     managed_matches = [value for value in repo_values if value in managed_aliases]
@@ -1012,8 +1014,8 @@ def inspect_jarvis_state(
         config_sha256=hashlib.sha256(raw_config).hexdigest(),
         repos_sha256=hashlib.sha256(raw_repos).hexdigest(),
         resource_graph_sha256=hashlib.sha256(raw_graph).hexdigest(),
-        managed_repo_registered=len(managed_matches) == 1,
-        managed_builtin_repo_registered=len(managed_builtin_matches) == 1,
+        managed_repo_registered=managed_matches == [lexical_managed_repo],
+        managed_builtin_repo_registered=managed_builtin_matches == [lexical_managed_builtin],
     )
 
 
@@ -1285,10 +1287,9 @@ def finish_staged_activation(
         expected=expected_managed_target,
         label="relay-managed repository",
     )
-    canonical_home = lexical_home.resolve(strict=True)
-    reported_managed_repo = _expand_home(desired.managed_jarvis_repo, canonical_home)
+    reported_managed_repo = _expand_home(desired.managed_jarvis_repo, lexical_home)
     reported_managed_target = (
-        canonical_home / ".local/share/clio-relay/current/source/jarvis-packages/clio_relay"
+        lexical_home / ".local/share/clio-relay/current/source/jarvis-packages/clio_relay"
     )
     actions = activation.get("actions")
     if not isinstance(actions, dict):  # pragma: no cover - produced above
@@ -2768,9 +2769,9 @@ def reconcile_managed_jarvis_repository(
         raise ConfigurationError(
             "relay-managed JARVIS repository basename must match its clio_relay namespace"
         )
-    lexical_managed = str(Path(os.path.abspath(managed_repo.expanduser())))
-    managed = str(_canonical_path_preserving_final(managed_repo))
-    managed_aliases = {lexical_managed, managed}
+    managed = str(Path(os.path.abspath(managed_repo.expanduser())))
+    canonical_managed = str(_canonical_path_preserving_final(managed_repo))
+    managed_aliases = {managed, canonical_managed}
     managed_builtin: str | None = None
     managed_builtin_aliases: set[str] = set()
     if managed_builtin_repo is not None:
@@ -2785,8 +2786,8 @@ def reconcile_managed_jarvis_repository(
             raise ConfigurationError(
                 "JARVIS-managed builtin repository must be the exact active root slot"
             )
-        managed_builtin = str(canonical_builtin_path)
-        managed_builtin_aliases = {str(lexical_builtin_path), managed_builtin}
+        managed_builtin = str(lexical_builtin_path)
+        managed_builtin_aliases = {managed_builtin, str(canonical_builtin_path)}
     managed_alias_union = managed_aliases | managed_builtin_aliases
     previous_aliases: dict[str, str] = {}
     previous_builtin_aliases: set[str] = set()
@@ -3029,12 +3030,11 @@ def repair_managed_jarvis_binding(
         ),
         exchange_identity=desired.fingerprint,
     )
-    canonical_home = lexical_home.resolve(strict=True)
     return {
         "link_action": link_action,
-        "link": str(_expand_home(desired.managed_jarvis_repo, canonical_home)),
+        "link": str(_expand_home(desired.managed_jarvis_repo, lexical_home)),
         "target": str(
-            canonical_home / ".local/share/clio-relay/current/source/jarvis-packages/clio_relay"
+            lexical_home / ".local/share/clio-relay/current/source/jarvis-packages/clio_relay"
         ),
         "repositories": repo_evidence,
     }

--- a/tests/test_bootstrap_fast_path.py
+++ b/tests/test_bootstrap_fast_path.py
@@ -1278,17 +1278,15 @@ with tempfile.TemporaryDirectory() as value:
         raise SystemExit("warm activation was not a no-op")
     if first_repository["action"] != "updated" or second_repository["action"] != "reused":
         raise SystemExit("repository alias did not converge exactly once")
-    canonical_managed = str(
-        canonical_home / ".local/share/clio-relay/clio_relay"
-    )
-    canonical_builtin = str(canonical_home / ".ppi-jarvis/builtin")
+    lexical_managed = str(home / ".local/share/clio-relay/clio_relay")
+    lexical_builtin = str(home / ".ppi-jarvis/builtin")
     if yaml.safe_load(repos_file.read_text(encoding="utf-8"))["repos"] != [
-        canonical_managed,
+        lexical_managed,
         "/operator/clio_relay",
-        canonical_builtin,
+        lexical_builtin,
     ]:
         raise SystemExit(
-            "repository registration did not retain canonical managed paths"
+            "repository registration did not retain stable lexical managed paths"
         )
 print("aliased-activation-noop-ok")
 """

--- a/tests/test_bootstrap_reconcile.py
+++ b/tests/test_bootstrap_reconcile.py
@@ -306,10 +306,10 @@ def test_exact_noop_is_read_only_and_preserves_operator_jarvis_bytes(
     assert {path: (path.read_bytes(), path.stat().st_mtime_ns) for path in before} == before
 
 
-def test_managed_repository_converges_home_alias_to_one_canonical_stable_path(
+def test_managed_repository_converges_home_alias_to_one_lexical_stable_path(
     tmp_path: Path,
 ) -> None:
-    """Repository migration neither loses nor duplicates a stable path through HOME aliases."""
+    """Repository migration retains the stable HOME spelling required at execution."""
     desired = _desired(uv_sha256="a" * 64, frpc_sha256="b" * 64, frps_sha256="c" * 64)
     canonical_home = tmp_path / "canonical-home"
     canonical_home.mkdir()
@@ -320,36 +320,54 @@ def test_managed_repository_converges_home_alias_to_one_canonical_stable_path(
     previous = lexical_home / ".local/src/clio-relay/jarvis-packages/clio_relay"
     previous.mkdir(parents=True)
     operator = "/operator/clio_relay"
+    lexical_managed = str(managed.absolute())
+    canonical_managed = str(canonical_home / ".local/share/clio-relay/clio_relay")
+    canonical_previous = str(canonical_home / ".local/src/clio-relay/jarvis-packages/clio_relay")
+    lexical_builtin = str((root / "builtin").absolute())
+    canonical_builtin = str(canonical_home / ".ppi-jarvis/builtin")
     repos_file = root / "repos.yaml"
     repos_file.write_text(
         yaml.safe_dump(
-            {"repos": [str(managed.absolute()), str(previous.absolute()), operator]},
+            {
+                "repos": [
+                    canonical_managed,
+                    canonical_previous,
+                    operator,
+                    canonical_builtin,
+                ]
+            },
             sort_keys=False,
         ),
         encoding="utf-8",
     )
+    before = inspect_jarvis_state(desired, home=lexical_home)
+    assert before.managed_repo_registered is False
+    assert before.managed_builtin_repo_registered is False
 
     evidence = reconcile_managed_jarvis_repository(
         repos_file,
         managed,
+        managed_builtin_repo=root / "builtin",
         previous_managed_repos=(previous,),
         exchange_identity=desired.fingerprint,
     )
 
-    canonical_managed = str(canonical_home / ".local/share/clio-relay/clio_relay")
-    canonical_previous = str(canonical_home / ".local/src/clio-relay/jarvis-packages/clio_relay")
     assert yaml.safe_load(repos_file.read_text(encoding="utf-8"))["repos"] == [
-        canonical_managed,
+        lexical_managed,
         operator,
+        lexical_builtin,
     ]
-    assert evidence["managed_repo"] == canonical_managed
-    assert evidence["added_managed_repos"] == [canonical_managed]
+    assert evidence["managed_repo"] == lexical_managed
+    assert evidence["added_managed_repos"] == [lexical_managed, lexical_builtin]
     assert evidence["removed_previous_managed_repos"] == [canonical_previous]
-    assert inspect_jarvis_state(desired, home=lexical_home).managed_repo_registered is True
+    after = inspect_jarvis_state(desired, home=lexical_home)
+    assert after.managed_repo_registered is True
+    assert after.managed_builtin_repo_registered is True
 
     repeated = reconcile_managed_jarvis_repository(
         repos_file,
         managed,
+        managed_builtin_repo=root / "builtin",
         previous_managed_repos=(previous,),
         exchange_identity=desired.fingerprint,
     )
@@ -357,13 +375,24 @@ def test_managed_repository_converges_home_alias_to_one_canonical_stable_path(
 
     repos_file.write_text(
         yaml.safe_dump(
-            {"repos": [str(managed.absolute()), canonical_managed, operator]},
+            {
+                "repos": [
+                    lexical_managed,
+                    canonical_managed,
+                    operator,
+                    lexical_builtin,
+                ]
+            },
             sort_keys=False,
         ),
         encoding="utf-8",
     )
     with pytest.raises(ConfigurationError, match="multiple path aliases"):
-        reconcile_managed_jarvis_repository(repos_file, managed)
+        reconcile_managed_jarvis_repository(
+            repos_file,
+            managed,
+            managed_builtin_repo=root / "builtin",
+        )
 
 
 def test_matching_receipt_with_tampered_runtime_is_not_a_noop(

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.5.5"
+    assert version == "1.5.6"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2499,7 +2499,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.5.5"
+    assert policy.release_version == "1.5.6"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.5.5"
+version = "1.5.6"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- preserve lexical `$HOME` paths for relay-managed JARVIS repositories
- migrate canonical symlink aliases back to the execution-compatible lexical spelling
- add symlinked-home migration and exact no-op regression coverage
- bump the release contract to `1.5.6`

## Root cause

On systems where the login home is a symlink, bootstrap canonicalized the managed JARVIS repository paths. JARVIS runtime validation requires the stable lexical home spelling, so bootstrap could report success while later JARVIS execution rejected the repository registration.

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- focused symlinked-home reconciliation regression
- release identity and machine-readable policy tests
- candidate wheel bootstrap and exact no-op on Ares
- real JARVIS/Slurm execution on Ares
- user-profile MCP over authenticated SSH before and after detach/reconnect