### PR TITLE
fix: stabilize control query concurrency validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.5.7` uses a release-first patch process. A maintainer builds the
+> Version `1.5.8` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.5.7"
+$Version = "1.5.8"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.5.7"
+release_version: "1.5.8"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: b192b36089aedb20797c01394e73eaa0cb6c3d8638cb5bc556ba02e1b82d8025
+acceptance_matrix_sha256: 1b976be950a7649715a63c2a7d8a312f864cceba01fe7ae7309f0af8319c3363
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.5.7"
+$Tag = "v1.5.8"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.7" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.8" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.5.7",
-  "matrix_sha256": "b192b36089aedb20797c01394e73eaa0cb6c3d8638cb5bc556ba02e1b82d8025",
+  "release_version": "1.5.8",
+  "matrix_sha256": "1b976be950a7649715a63c2a7d8a312f864cceba01fe7ae7309f0af8319c3363",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.5.7"
+version = "1.5.8"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.5.7"
+__version__ = "1.5.8"

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1791,7 +1791,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "b192b36089aedb20797c01394e73eaa0cb6c3d8638cb5bc556ba02e1b82d8025"
+        "1b976be950a7649715a63c2a7d8a312f864cceba01fe7ae7309f0af8319c3363"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_control_query_admission.py
+++ b/tests/test_control_query_admission.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import subprocess
-import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -321,33 +320,35 @@ def test_reserved_query_finishes_while_workload_keeps_lease_and_state(
     try:
         with ThreadPoolExecutor(max_workers=1) as executor:
             source_future = executor.submit(workload_worker.run_once)
-            assert provider.source_started.wait(timeout=10)
-            source_lease = _lease_for_job(queue, source.job_id)
-            assert source_lease is not None
-            assert queue.get_job(source.job_id).state is JobState.RUNNING
+            try:
+                assert provider.source_started.wait(timeout=10)
+                source_lease = _lease_for_job(queue, source.job_id)
+                assert source_lease is not None
+                assert queue.get_job(source.job_id).state is JobState.RUNNING
 
-            query_result = control_worker.run_once(
-                mcp_admission_class=McpAdmissionClass.CONTROL_QUERY,
-                mcp_admission_limit=1,
-            )
+                query_result = control_worker.run_once(
+                    mcp_admission_class=McpAdmissionClass.CONTROL_QUERY,
+                    mcp_admission_limit=1,
+                )
 
-            assert query_result is not None
-            assert query_result.job_id == query.job_id
-            assert query_result.state is JobState.SUCCEEDED
-            assert provider.query_started.is_set()
-            live_source = queue.get_job(source.job_id)
-            renewed_source_lease = _lease_for_job(queue, source.job_id)
-            assert live_source.state is JobState.RUNNING
-            assert live_source.leased_by == source_lease.endpoint_id
-            assert "cancellation_request" not in live_source.metadata
-            assert renewed_source_lease is not None
-            assert renewed_source_lease.lease_id == source_lease.lease_id
-            assert renewed_source_lease.expires_at >= source_lease.expires_at
-            assert _lease_for_job(queue, query.job_id) is None
+                assert query_result is not None
+                assert query_result.job_id == query.job_id
+                assert query_result.state is JobState.SUCCEEDED
+                assert provider.query_started.is_set()
+                live_source = queue.get_job(source.job_id)
+                renewed_source_lease = _lease_for_job(queue, source.job_id)
+                assert live_source.state is JobState.RUNNING
+                assert live_source.leased_by == source_lease.endpoint_id
+                assert "cancellation_request" not in live_source.metadata
+                assert renewed_source_lease is not None
+                assert renewed_source_lease.lease_id == source_lease.lease_id
+                assert renewed_source_lease.expires_at >= source_lease.expires_at
+                assert _lease_for_job(queue, query.job_id) is None
 
-            source_events, _ = queue.read_event_page(source.job_id, limit=100)
-            assert all("cancel" not in event.event_type for event in source_events)
-            provider.release_source.set()
+                source_events, _ = queue.read_event_page(source.job_id, limit=100)
+                assert all("cancel" not in event.event_type for event in source_events)
+            finally:
+                provider.release_source.set()
             source_result = source_future.result(timeout=10)
 
         assert source_result is not None
@@ -549,12 +550,9 @@ class _BlockingLaneProvider(JarvisCdProvider):
             return subprocess.CompletedProcess(["jarvis"], 0, "", "")
 
         self.source_started.set()
-        deadline = time.monotonic() + 10
         while not self.release_source.wait(0.01):
             if should_cancel is not None and should_cancel():
                 return subprocess.CompletedProcess(["jarvis"], -15, "", "")
-            if time.monotonic() >= deadline:
-                return subprocess.CompletedProcess(["jarvis"], 124, "", "timed out")
             if on_poll is not None:
                 on_poll()
         return subprocess.CompletedProcess(["jarvis"], 0, "", "")

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.5.7"
+    assert version == "1.5.8"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2499,7 +2499,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.5.7"
+    assert policy.release_version == "1.5.8"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.5.7"
+version = "1.5.8"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- remove the synthetic provider's 10-second wall-clock failure from the control-query overlap test
- guarantee release of the workload thread when an assertion exits the test body
- advance the release identity and matrix binding to v1.5.8

## Validation

- uv lock --check
- uv run ruff check --fix
- uv run ruff format
- uv run pyright
- 20 repeated Windows/Python 3.13 passes of the formerly failing test
- 40 focused tests, including the full control-query admission module and release-policy checks

The v1.5.7 tag matrix passed every Ubuntu leg and Windows 3.12/3.14; Windows 3.13 alone exceeded the test helper's artificial 10-second deadline and reported exit code 124.