### PR TITLE
feat: add relay-backed FastMCP background tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.5.8` uses a release-first patch process. A maintainer builds the
+> Version `1.5.9` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ clio-relay agent render-mcp-config --output .\clio-relay-agent.config.toml
 clio-relay agent run --cluster my-cluster --prompt /path/on/cluster/prompt.md --mcp-config /path/on/cluster/clio-relay-agent.config.toml
 ```
 
+The MCP server is native FastMCP and can project long-running relay operations
+through standard SEP-2663 task handles without introducing a second scheduler.
+Stdio is the default. Authenticated Streamable HTTP is also available:
+
+```powershell
+$env:CLIO_RELAY_API_TOKEN = "<random-secret>"
+clio-relay mcp-server --profile user --transport http --host 127.0.0.1 --port 8766 --path /mcp
+```
+
+See [MCP background tasks](docs/mcp-tasks.md) for official FastMCP client usage,
+reconnect, cancellation, input, and security semantics.
+
 Operators can expose selected tools from any cluster-side stdio MCP server
 through the same local relay MCP. Registration is allowlisted, and schema
 discovery is an explicit durable job:

--- a/docs/ai/interface-context.md
+++ b/docs/ai/interface-context.md
@@ -163,6 +163,13 @@ The MCP server exposes relay tools for:
 
 MCP tools operate on the same durable records as CLI and HTTP calls.
 
+`clio-relay mcp-server` uses native FastMCP over stdio or authenticated
+Streamable HTTP. On MCP `2026-07-28`, it advertises
+`io.modelcontextprotocol/tasks` and binds `tasks/get`, `tasks/update`, and
+`tasks/cancel`. Standard task IDs equal relay job IDs. Virtual remote/JARVIS
+operations may return tasks; low-level submit/status/read/cancel tools remain
+immediate. The server does not run Docket. See `docs/mcp-tasks.md`.
+
 `relay_artifact_lineage` is the single user-profile lineage query. Pass `job_id`
 to list that job's immutable input edges or `artifact_id` to list downstream
 consumer jobs; cluster routes use the normal `cluster` plus `route_revision`

--- a/docs/ai/system-context.md
+++ b/docs/ai/system-context.md
@@ -49,6 +49,13 @@ Job submission is asynchronous by default. Submit returns a `job_id`, state, kin
 Remote agent jobs should usually submit child cluster work asynchronously and return the child `job_id`. A cluster worker running a parent agent job cannot also execute a child job if it is waiting synchronously inside the parent.
 
 Cancellation is durable and cooperative. A cancel request records queue events and the worker terminates the running process group. For scheduler-backed packages, package code should capture scheduler job ids and cancel through the scheduler when needed.
+
+The native FastMCP server implements SEP-2663 with a custom
+`RelayTasksExtension`. Its task ID equals the existing relay job ID. The
+projection record is protocol state only; clio-core/relay remains the sole
+execution, scheduling, recovery, artifact, and cancellation authority.
+FastMCP's stock Docket-backed `TasksExtension` is not enabled and
+`FastMCP.docket` remains `None`.
 Session teardown quiesces the exact owner-session generation before discovery. With
 `--cancel-jobs`, it waits boundedly for worker cleanup acknowledgment of leased and
 running jobs before gateway or API cleanup. It stops the API to seal intake, rescans

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,6 +32,14 @@ generation converge.
 
 Tasks can also have structured timeline events. A remote agent can record discovery, planning, warnings, commands, scheduler decisions, and completion as resumable task-scoped records. These events are separate from raw stdout so a UI can show meaningful work before the final answer exists.
 
+The local MCP server exposes long-running relay operations through the
+SEP-2663 tasks extension. This is a protocol projection, not another task
+backend: the standardized task ID is the existing relay job ID, and canonical
+job, route, cancellation, event, and artifact records remain authoritative.
+The bounded `clio-relay.mcp-task-projection.v1` record retains only the protocol
+state needed for standard client polling, input updates, and reconnect.
+FastMCP's Docket-backed task executor is not started.
+
 Gateway sessions are durable records for scheduler-backed services such as interactive visualization servers, data streams, remote MCP servers, or long-running agent services. A session records the scheduler job, queue state, allocated node, logs, forwarded endpoint metadata, health hints, and close state. This lets the desktop detach, reconnect, and mark the session closed without treating it as an anonymous process. The package or scheduler integration remains responsible for stopping the actual remote service.
 
 Before a gateway launches scheduler or connector work, it records an exact

--- a/docs/mcp-tasks.md
+++ b/docs/mcp-tasks.md
@@ -1,0 +1,163 @@
+# MCP background tasks
+
+`clio-relay mcp-server` is a native FastMCP 4 server. It implements the
+[`io.modelcontextprotocol/tasks`](https://modelcontextprotocol.io/seps/2663-tasks-extension)
+extension so an MCP client can detach from a long-running relay operation and
+reattach through the standardized task methods.
+
+The protocol adapter does not create another execution system. A task is a
+projection of an existing durable relay job:
+
+- the MCP `taskId` is the relay `job_id`;
+- relay and clio-core job state remains authoritative;
+- relay routing, leasing, workers, JARVIS execution, artifacts, events,
+  recovery, and cancellation are unchanged;
+- task projections retain the exact tool, arguments, catalog revision, initial
+  receipt, input rounds, and final result needed for reconnect; and
+- a new MCP client can reconstruct a `ToolTask` from its retained task handle
+  while the same relay state remains available.
+
+FastMCP's stock `TasksExtension` is not enabled. The server has no Docket
+instance, Docket worker, Redis task queue, or second scheduler. The
+`fastmcp-tasks` package supplies the standard wire models, client support, and
+the currently required claimed-result serialization hook. Its Docket-backed
+execution path is installed as a dependency but remains inactive.
+
+## server transports
+
+Stdio remains the default:
+
+```powershell
+clio-relay mcp-server --profile user
+```
+
+Authenticated Streamable HTTP uses the existing relay API token:
+
+```powershell
+$env:CLIO_RELAY_API_TOKEN = "<random-secret>"
+clio-relay mcp-server --profile user --transport http --host 127.0.0.1 --port 8766 --path /mcp
+```
+
+HTTP startup fails when `CLIO_RELAY_API_TOKEN` is absent. Clients send
+`Authorization: Bearer <token>`. Binding beyond loopback changes network
+exposure and should be combined with the deployment's existing private
+transport and access controls.
+
+The tasks extension is available only on the modern MCP `2026-07-28` protocol.
+Older handshake connections continue to receive ordinary foreground tool
+results and cannot call `tasks/*`. Modern MCP removed the old core
+`Tool.execution` field; task support is therefore negotiated through the
+extension capability returned by `server/discover`, not through
+`tools/list.execution`.
+
+## client behavior
+
+Importing `fastmcp-tasks` registers its standard client extension with FastMCP.
+An ordinary `Client(mode="auto")` advertises the capability and transparently
+polls a tasked `call_tool` to its final `CallToolResult`:
+
+```python
+from fastmcp import Client
+import fastmcp_tasks  # noqa: F401
+
+async with Client("http://127.0.0.1:8766/mcp", auth=token, mode="auto") as client:
+    result = await client.call_tool("jarvis_run", arguments)
+```
+
+Client-only hosts can use the same wire support without installing
+`clio-relay`:
+
+```text
+pip install "fastmcp-slim[client]==4.0.0b1" "fastmcp-tasks==4.0.0b1"
+```
+
+`fastmcp-tasks` currently brings its server/task-runner dependencies even in a
+client-only environment, but the client path does not start Docket or a worker.
+This server remains interoperable with that official client package because it
+implements the same negotiated extension and standard methods.
+
+Use `call_tool_task` when the caller wants the handle immediately:
+
+```python
+from fastmcp import Client
+from fastmcp_tasks.client import call_tool_task
+
+async with Client("http://127.0.0.1:8766/mcp", auth=token, mode="auto") as client:
+    task = await call_tool_task(client, "jarvis_run", arguments)
+    print(task.task_id)
+    print((await task.status()).status)
+```
+
+The standard `ToolTask` surface supports `status()`, `wait()`, `result()`, and
+`cancel()`. A caller that reconnects can retain the returned
+`ClientCreateTaskResult` and construct a new `ToolTask` against a new client.
+The durable task ID remains sufficient for direct `tasks/get`,
+`tasks/update`, and `tasks/cancel` clients.
+
+## state mapping
+
+Relay state maps to SEP-2663 without changing relay semantics:
+
+| Relay observation | MCP task status |
+|---|---|
+| queued, leased, or running | `working` |
+| durable outstanding client input | `input_required` |
+| succeeded | `completed` with `isError: false` |
+| failed tool work | `completed` with `isError: true` |
+| protocol-level execution error | `failed` |
+| canceled | `cancelled` |
+
+A tool-level failure is a completed MCP task because the tool call itself
+finished and returned an error result. A JSON-RPC failure is a failed task.
+Cancellation is cooperative and eventually consistent: `tasks/cancel`
+acknowledges the relay cancellation request, while subsequent `tasks/get`
+observes canonical relay state.
+
+Low-level submission, status, read, and cancellation tools remain immediate.
+Task augmentation is enabled for the virtual remote-operation catalog and the
+JARVIS operation surface, where a durable job receipt already exists. The
+adapter creates a task only after relay admission succeeds; validation errors
+or calls that return no relay job remain ordinary synchronous results.
+
+## input and elicitation
+
+Foreground guard tools may return `InputRequiredResult`. The FastMCP client
+answers that request and re-enters the tool; only the leg that admits a durable
+relay job becomes a task.
+
+A running relay operation may expose a durable input round through
+`input_required`. Answers arrive through `tasks/update`. Unknown or stale keys
+are ignored, partial answers are retained, repeated answers are replay-safe,
+and concurrent updates use compare-and-swap retry. Input request identities,
+answers, arguments, and the complete projection are finite, depth-bounded, and
+size-bounded before persistence.
+
+The current built-in relay catalog does not originate a parked input round
+after admission. The durable projection and standard client update path are
+available for operation providers that add that state; built-in interactive
+validation currently exercises the pre-admission guard flow.
+
+Imperative `await ctx.elicit(...)` is not supported inside background work. It
+would hold a worker open for a client round trip. Background-capable tools use
+the guard pattern: return `InputRequiredResult`, then read
+`ctx.input_responses` and `ctx.request_state` on re-entry.
+
+## retention and security limits
+
+Task projections are immutable by identity and conflict when the same task ID
+is reused with different tool semantics. The current wire library requires a
+numeric `ttlMs`, so the server advertises 30 days rather than SEP-2663's
+nullable unlimited value. Relay job retention remains separately governed by
+relay policy.
+
+Arguments are limited to 512 KiB of canonical UTF-8 JSON. Input rounds are
+limited to 256 KiB, complete projections to 768 KiB, nesting to 64 levels, and
+JSON trees to 100,000 nodes. Non-finite numbers and non-JSON values are
+rejected. Dynamic tools remain bound to the exact catalog and cluster-route
+revision used at dispatch. An optional `Mcp-Name` header on task-management
+requests must equal the task ID.
+
+These controls protect the relay's protocol and durable-record boundaries.
+They do not expand tool authorization, grant a generated process new
+credentials, or replace the execution and artifact checks of the underlying
+relay operation.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -669,6 +669,32 @@ clio-relay job task-events <task-id> --cluster my-cluster --cursor 1
 
 Use timeline events for UI-visible agent work such as repository scans, dataset discovery, generated scripts, planned commands, scheduler submissions, warnings, and completion. Use normal job logs for stdout and stderr.
 
+## serve MCP background tasks
+
+The relay MCP server uses native FastMCP. Stdio remains the default:
+
+```powershell
+clio-relay mcp-server --profile user
+```
+
+To expose authenticated Streamable HTTP on loopback:
+
+```powershell
+$env:CLIO_RELAY_API_TOKEN = "<random-secret>"
+clio-relay mcp-server --profile user --transport http --host 127.0.0.1 --port 8766 --path /mcp
+```
+
+HTTP refuses to start without the relay API token. Modern FastMCP clients can
+use ordinary `call_tool` for transparent polling or `call_tool_task` for an
+immediate standard task handle. Closing the client does not cancel the relay
+job; reconnect with the retained task ID. Cancellation remains a separate
+explicit operation.
+
+The server implements SEP-2663 over existing relay jobs and does not start
+FastMCP's Docket execution backend. See [MCP background
+tasks](mcp-tasks.md) for status mapping, input rounds, limits, client examples,
+and protocol-version behavior.
+
 ## Use Remote JARVIS MCP
 
 Install the cluster-side server once, then launch its persistent executable:

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.5.8"
+$Version = "1.5.9"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.5.8"
+release_version: "1.5.9"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 1b976be950a7649715a63c2a7d8a312f864cceba01fe7ae7309f0af8319c3363
+acceptance_matrix_sha256: df909e16d44bcca69f46bf303902cd3e105c81c0f718962697dc1463b17f385a
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.5.8"
+$Tag = "v1.5.9"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.8" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.9" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/docs/remote-mcp-federation.md
+++ b/docs/remote-mcp-federation.md
@@ -389,6 +389,16 @@ relay's exact JARVIS-CD release pin. That dependency edge is recorded in the
 install receipt and call result. Operator-registered MCP servers remain bound
 by their own discovery artifact and are not constrained to the relay's
 JARVIS-CD version.
+
+For a verified `clio-kit.locked-server.v4` launcher, the worker withholds the
+MCP `initialize` message until clio-kit's typed post-build cache event proves
+that the locked environment sync has finished. This prevents a preparatory
+subprocess from consuming protocol input. The request-scoped launch sets
+`CLIO_KIT_UV_CACHE_PRUNE=0`: cache-wide pruning can wait behind another live
+clio-kit server and is not part of an individual MCP call's bounded startup.
+The locked sync and safe superseded-environment eviction still run; operators
+can perform explicit clio-kit cache GC outside a served MCP session.
+
 The release gate requires that exact 2.6.5 artifact to be rerun on every target
 selected by the release policy. Other servers use the operator registry and
 generated `remote_...` aliases.

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.5.8",
-  "matrix_sha256": "1b976be950a7649715a63c2a7d8a312f864cceba01fe7ae7309f0af8319c3363",
+  "release_version": "1.5.9",
+  "matrix_sha256": "df909e16d44bcca69f46bf303902cd3e105c81c0f718962697dc1463b17f385a",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/jarvis-packages/clio_relay/clio_relay/mcp_call/runner.py
+++ b/jarvis-packages/clio_relay/clio_relay/mcp_call/runner.py
@@ -24,6 +24,7 @@ import tomllib
 import zipfile
 from collections.abc import Callable, Generator, Iterator
 from contextlib import contextmanager
+from functools import partial
 from importlib import metadata
 from pathlib import Path, PurePosixPath
 from queue import Empty, Queue
@@ -160,6 +161,20 @@ _STREAM_READ_CHARS = 64 * 1024
 _TOOLS_LIST_PAGINATION_KEY = "_clioRelayPagination"
 _CLIO_KIT_LOCKED_SERVER_SCHEMA = "clio-kit.locked-server.v4"
 _CLIO_KIT_LOCKED_SERVER_RUNTIME_POLICY = "uv-run:materialized:frozen:no-editable:no-dev:v3"
+_CLIO_KIT_CACHE_EVENT_SCHEMA = "clio-kit.cache-event.v1"
+_CLIO_KIT_POST_BUILD_EVENTS = frozenset(
+    {
+        "uv_cache_prune",
+        "cache_maintenance_failed",
+        "cache_maintenance_skipped",
+    }
+)
+_CLIO_KIT_REQUEST_ENV_OVERRIDES = {
+    # A cache-wide uv prune waits behind other live clio-kit servers. It must not
+    # become part of one bounded relay request's startup path; explicit cache GC
+    # remains available outside the served MCP session.
+    "CLIO_KIT_UV_CACHE_PRUNE": "0",
+}
 _JARVIS_CD_LOCK_BINDING_SCHEMA = "clio-relay.jarvis-cd-lock-binding.v1"
 # These values intentionally mirror clio_relay.bootstrap. A focused release test
 # prevents either copy from moving independently. The JARVIS package also runs as
@@ -1857,12 +1872,19 @@ def run_mcp_call_from_params(params: dict[str, Any]) -> int:
             server_artifact=server_artifact,
         ) as prepared:
             launch_command, execution_artifact = prepared
+            wait_for_locked_launcher = _requires_locked_launcher_readiness(server_artifact)
+            run_session = _run_mcp_session
+            if wait_for_locked_launcher:
+                run_session = partial(
+                    _run_mcp_session,
+                    wait_for_locked_launcher=True,
+                )
             if (
                 operation == "tools/call"
                 and progress_bridge is None
                 and jarvis_input_manifest is None
             ):
-                process = _run_mcp_session(
+                process = run_session(
                     launch_command,
                     tool=tool,
                     arguments=arguments,
@@ -1870,7 +1892,7 @@ def run_mcp_call_from_params(params: dict[str, Any]) -> int:
                     env_from=env_from,
                 )
             elif operation == "tools/call" and jarvis_input_manifest is None:
-                process = _run_mcp_session(
+                process = run_session(
                     launch_command,
                     tool=tool,
                     arguments=arguments,
@@ -1879,7 +1901,7 @@ def run_mcp_call_from_params(params: dict[str, Any]) -> int:
                     progress_bridge=progress_bridge,
                 )
             elif operation == "tools/call":
-                process = _run_mcp_session(
+                process = run_session(
                     launch_command,
                     tool=tool,
                     arguments=arguments,
@@ -1889,7 +1911,7 @@ def run_mcp_call_from_params(params: dict[str, Any]) -> int:
                     jarvis_input_manifest=jarvis_input_manifest,
                 )
             else:
-                process = _run_mcp_session(
+                process = run_session(
                     launch_command,
                     tool=None,
                     arguments={},
@@ -4771,8 +4793,15 @@ def _run_mcp_session(
     env_from: dict[str, str] | None = None,
     progress_bridge: _McpProgressBridge | None = None,
     jarvis_input_manifest: dict[str, Any] | None = None,
+    wait_for_locked_launcher: bool = False,
 ) -> subprocess.CompletedProcess[str]:
-    process = _open_process(command, env_from=env_from or {})
+    process = _open_process(
+        command,
+        env_from=env_from or {},
+        environment_overrides=(
+            _CLIO_KIT_REQUEST_ENV_OVERRIDES if wait_for_locked_launcher else None
+        ),
+    )
     previous_handlers = _install_parent_termination_handlers(process)
     stdout_queue: Queue[_StreamEvent] = Queue()
     stderr_queue: Queue[_StreamEvent] = Queue()
@@ -4793,6 +4822,14 @@ def _run_mcp_session(
     started_at = time.monotonic()
     deadline = None if timeout is None else started_at + timeout
     try:
+        if wait_for_locked_launcher:
+            _wait_for_locked_launcher_readiness(
+                stderr_queue,
+                stderr_lines,
+                process=process,
+                deadline=deadline,
+                command=command,
+            )
         _write_message(process, _initialize_message())
         _wait_for_response(
             stdout_queue,
@@ -4887,6 +4924,60 @@ def _run_mcp_session(
         stdout="".join(stdout_lines),
         stderr="".join(stderr_lines),
     )
+
+
+def _requires_locked_launcher_readiness(server_artifact: dict[str, Any]) -> bool:
+    """Return whether a verified nested clio-kit launcher needs its stdin gate."""
+    raw_runtime = server_artifact.get("nested_runtime")
+    runtime = cast(dict[str, Any], raw_runtime) if isinstance(raw_runtime, dict) else None
+    return bool(
+        server_artifact.get("verified") is True
+        and server_artifact.get("nested_launcher") is True
+        and runtime is not None
+        and runtime.get("schema_version") == _CLIO_KIT_LOCKED_SERVER_SCHEMA
+        and runtime.get("locked_runtime_verified") is True
+    )
+
+
+def _wait_for_locked_launcher_readiness(
+    queue: Queue[_StreamEvent],
+    lines: list[str],
+    *,
+    process: subprocess.Popen[str],
+    deadline: float | None,
+    command: list[str],
+) -> None:
+    """Withhold MCP stdin until the verified clio-kit launcher finishes its build."""
+    while True:
+        remaining = None if deadline is None else deadline - time.monotonic()
+        if remaining is not None and remaining <= 0:
+            raise subprocess.TimeoutExpired(command, timeout=0)
+        try:
+            line = queue.get(timeout=0.2 if remaining is None else min(0.2, remaining))
+        except Empty:
+            continue
+        if line is None:
+            returncode = process.poll()
+            if returncode is None:
+                try:
+                    returncode = process.wait(timeout=0.2)
+                except subprocess.TimeoutExpired:
+                    returncode = None
+            detail = f" with return code {returncode}" if returncode is not None else ""
+            raise _McpProtocolFailure(
+                "verified clio-kit launcher stderr closed before its post-build "
+                f"readiness event{detail}"
+            )
+        if isinstance(line, _StreamLimit):
+            raise _McpProtocolFailure(line.message)
+        lines.append(line)
+        message = _decoded_json_object(line)
+        if (
+            message is not None
+            and message.get("schema_version") == _CLIO_KIT_CACHE_EVENT_SCHEMA
+            and message.get("event") in _CLIO_KIT_POST_BUILD_EVENTS
+        ):
+            return
 
 
 def _run_jarvis_input_reconciliation(
@@ -5170,9 +5261,14 @@ def _drain_available(queue: Queue[_StreamEvent], lines: list[str]) -> None:
 
 
 def _open_process(
-    command: list[str], *, env_from: dict[str, str] | None = None
+    command: list[str],
+    *,
+    env_from: dict[str, str] | None = None,
+    environment_overrides: dict[str, str] | None = None,
 ) -> subprocess.Popen[str]:
     child_env = _child_env(env_from) if env_from else _scrubbed_env()
+    if environment_overrides is not None:
+        child_env.update(environment_overrides)
     return subprocess.Popen(
         command,
         env=child_env,

--- a/jarvis-packages/clio_relay/clio_relay/process_containment.py
+++ b/jarvis-packages/clio_relay/clio_relay/process_containment.py
@@ -1474,14 +1474,26 @@ def _release_broker(
         daemon=True,
     )
     writer.start()
-    if not completed.wait(max(0.0, startup_deadline - time.monotonic())):
+    while not completed.is_set():
+        remaining = startup_deadline - time.monotonic()
+        if remaining > 0:
+            completed.wait(remaining)
+            continue
         if process.poll() is None:
             process.kill()
-        with suppress(OSError):
-            os.close(setup_channel.fileno())
-        process.stdin = None
         process.wait(timeout=TERMINATION_TIMEOUT_SECONDS)
+        writer.join(timeout=TERMINATION_TIMEOUT_SECONDS)
+        if writer.is_alive():
+            with suppress(OSError):
+                setup_channel.close()
+            writer.join(timeout=TERMINATION_TIMEOUT_SECONDS)
+        process.stdin = None
+        if writer.is_alive():
+            raise RuntimeError("containment broker setup writer remained active after timeout")
+        with suppress(OSError):
+            setup_channel.close()
         raise RuntimeError("containment broker setup write timed out")
+    writer.join()
     if errors:
         setup_channel.close()
         process.stdin = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ requires-python = ">=3.12,<3.15"
 license = { text = "MIT" }
 dependencies = [
     "fastapi>=0.115",
+    "fastmcp==4.0.0b1",
+    "fastmcp-slim[client,server]==4.0.0b1",
+    "fastmcp-tasks==4.0.0b1",
     "filelock>=3.15",
     "httpx>=0.27",
     "jsonschema>=4.23",
@@ -60,6 +63,9 @@ include = [
 
 [project.scripts]
 clio-relay = "clio_relay.cli:app"
+
+[tool.uv]
+prerelease = "allow"
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.5.8"
+version = "1.5.9"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.5.8"
+__version__ = "1.5.9"

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -86,6 +86,7 @@ from clio_relay.errors import (
     ObservationTimeoutError,
     RelayError,
 )
+from clio_relay.fastmcp_server import run_fastmcp_http, run_fastmcp_stdio
 from clio_relay.filesystem_paths import internal_filesystem_path
 from clio_relay.frp_check import run_frpc_connection_check
 from clio_relay.identifiers import validate_durable_record_id
@@ -120,7 +121,6 @@ from clio_relay.live_acceptance import LiveAcceptanceOptions, run_live_acceptanc
 from clio_relay.mcp_server import (
     load_registered_remote_mcp_catalog,
     render_agent_mcp_profile,
-    serve_stdio,
     static_mcp_tool_names,
 )
 from clio_relay.mcp_stdio_validation import PackagedMcpStdioSession, run_packaged_mcp_stdio_session
@@ -11649,9 +11649,28 @@ def mcp_server(
         str,
         typer.Option(help="MCP tool profile: user, admin, operator, or all."),
     ] = "user",
+    transport: Annotated[
+        Literal["stdio", "http"],
+        typer.Option(help="MCP transport: stdio or authenticated Streamable HTTP."),
+    ] = "stdio",
+    host: Annotated[
+        str,
+        typer.Option(help="HTTP bind address; ignored for stdio."),
+    ] = "127.0.0.1",
+    port: Annotated[
+        int,
+        typer.Option(help="HTTP bind port; ignored for stdio."),
+    ] = 8766,
+    path: Annotated[
+        str,
+        typer.Option(help="Streamable HTTP MCP path; ignored for stdio."),
+    ] = "/mcp",
 ) -> None:
-    """Serve relay job tools over stdio MCP."""
-    serve_stdio(profile=profile)
+    """Serve relay tools with native FastMCP and relay-backed SEP-2663 tasks."""
+    if transport == "stdio":
+        run_fastmcp_stdio(profile=profile)
+        return
+    run_fastmcp_http(profile=profile, host=host, port=port, path=path)
 
 
 @api_app.command("start")

--- a/src/clio_relay/cluster_config.py
+++ b/src/clio_relay/cluster_config.py
@@ -1728,18 +1728,52 @@ def open_private_configuration_windows_descriptor(
         ctypes.c_void_p,
     ]
     create_file.restype = ctypes.c_void_p
-    raw_handle = create_file(
-        str(storage_path),
-        _WINDOWS_GENERIC_READ | _WINDOWS_READ_CONTROL | _WINDOWS_WRITE_DAC | _WINDOWS_WRITE_OWNER,
-        0 if exclusive else _WINDOWS_FILE_SHARE_READ,
-        None,
-        _WINDOWS_OPEN_EXISTING,
-        _WINDOWS_FILE_FLAG_OPEN_REPARSE_POINT,
-        None,
+    full_access = (
+        _WINDOWS_GENERIC_READ | _WINDOWS_READ_CONTROL | _WINDOWS_WRITE_DAC | _WINDOWS_WRITE_OWNER
     )
-    if raw_handle in (None, ctypes.c_void_p(-1).value):
+    owner_preserving_access = full_access & ~_WINDOWS_WRITE_OWNER
+    raw_handle: int | None = None
+    for attempt in range(MAX_CONFIG_READ_ATTEMPTS):
+        candidate_handle = create_file(
+            str(storage_path),
+            full_access,
+            0 if exclusive else _WINDOWS_FILE_SHARE_READ,
+            None,
+            _WINDOWS_OPEN_EXISTING,
+            _WINDOWS_FILE_FLAG_OPEN_REPARSE_POINT,
+            None,
+        )
+        if candidate_handle not in (None, ctypes.c_void_p(-1).value):
+            raw_handle = cast(int, candidate_handle)
+            break
         error = _windows_last_error()
-        raise ConfigurationError(f"could not open private Windows file ({error}): {path}")
+        if error == 5:
+            candidate_handle = create_file(
+                str(storage_path),
+                owner_preserving_access,
+                0 if exclusive else _WINDOWS_FILE_SHARE_READ,
+                None,
+                _WINDOWS_OPEN_EXISTING,
+                _WINDOWS_FILE_FLAG_OPEN_REPARSE_POINT,
+                None,
+            )
+            if candidate_handle not in (None, ctypes.c_void_p(-1).value):
+                raw_handle = cast(int, candidate_handle)
+                break
+            error = _windows_last_error()
+        if error not in {5, 32, 33} or attempt + 1 >= MAX_CONFIG_READ_ATTEMPTS:
+            raise ConfigurationError(f"could not open private Windows file ({error}): {path}")
+        observed = os.lstat(storage_path)
+        if not (
+            stat.S_ISREG(observed.st_mode)
+            and not _is_reparse_stat(observed)
+            and observed.st_nlink == expected_nlink
+            and os.path.samestat(before, observed)
+        ):
+            raise ConfigurationError(f"private Windows file changed while awaiting access: {path}")
+        time.sleep(CONFIG_READ_RETRY_SECONDS)
+    if raw_handle is None:  # pragma: no cover - loop exits by success or exception
+        raise ConfigurationError(f"could not open private Windows file: {path}")
     handle = ctypes.c_void_p(raw_handle)
     try:
         get_information = kernel32.GetFileInformationByHandle
@@ -1772,7 +1806,7 @@ def open_private_configuration_windows_descriptor(
         if not os.path.samestat(after, confirmed) or confirmed.st_nlink != expected_nlink:
             raise ConfigurationError(f"private Windows file changed while securing: {path}")
         descriptor_flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
-        descriptor = _open_windows_os_file_handle(cast(int, raw_handle), descriptor_flags)
+        descriptor = _open_windows_os_file_handle(raw_handle, descriptor_flags)
         raw_handle = None
         return descriptor
     finally:

--- a/src/clio_relay/core_queue.py
+++ b/src/clio_relay/core_queue.py
@@ -71,6 +71,8 @@ from clio_relay.models import (
     ProgressRecord,
     RelayEvent,
     RelayJob,
+    RelayMcpTaskProjection,
+    RelayMcpTaskRecord,
     RelayTask,
     SchedulerCancelDisposition,
     SchedulerCancelDispositionState,
@@ -207,6 +209,7 @@ RECORD_FAMILY_MAX_BYTES: dict[str, int] = {
     "migrations": 262_144,
     "monitor_rules": 262_144,
     "monitor_rules_by_job": 262_144,
+    "mcp_tasks": 1_048_576,
     "owner_sessions": 65_536,
     "owner_session_jobs": 65_536,
     "owner_session_legacy_jobs": 65_536,
@@ -354,7 +357,7 @@ _INITIALIZED_QUEUE_FAMILIES = (
     "gc_trash",
     "global_order",
 )
-_ADDITIVE_QUEUE_FAMILIES = ("transforms",)
+_ADDITIVE_QUEUE_FAMILIES = ("transforms", "mcp_tasks")
 _LEGACY_ONLY_QUEUE_FAMILIES = ("cursors",)
 _GC_TERMINAL_SCHEDULER_PHASES = {
     SchedulerPhase.COMPLETED.value,
@@ -7449,6 +7452,87 @@ class ClioCoreQueue:
             )
         return saved
 
+    def put_mcp_task(self, task: RelayMcpTaskRecord) -> RelayMcpTaskRecord:
+        """Durably create or replay one MCP projection of a relay job."""
+        task = RelayMcpTaskRecord.model_validate(task.model_dump(mode="python"))
+        self._require_durable_record_id(task.task_id, field="task_id")
+        self._require_durable_record_id(task.job_id, field="job_id")
+        self.initialize()
+        with self._lock:
+            self._recover_pending_transitions_unlocked()
+            path = self._storage_root / "mcp_tasks" / f"{task.task_id}.json"
+            existing = self._read_optional(path, RelayMcpTaskRecord)
+            if existing is not None:
+                requested = task.projection
+                persisted = existing.projection
+                route_fields = ("remote", "cluster", "route_revision")
+                if (
+                    existing.task_id != task.task_id
+                    or existing.job_id != task.job_id
+                    or persisted.tool_name != requested.tool_name
+                    or persisted.profile != requested.profile
+                    or persisted.arguments != requested.arguments
+                    or persisted.catalog_revision != requested.catalog_revision
+                    or {field: persisted.initial_result.get(field) for field in route_fields}
+                    != {field: requested.initial_result.get(field) for field in route_fields}
+                ):
+                    raise QueueConflictError(
+                        f"MCP task identity was reused with different semantics: {task.task_id}"
+                    )
+                return existing
+            self._write(path, task)
+            return task
+
+    def update_mcp_task_projection(
+        self,
+        task_id: str,
+        projection: RelayMcpTaskProjection,
+        *,
+        expected_updated_at: datetime | None = None,
+        state: JobState | None = None,
+    ) -> RelayMcpTaskRecord:
+        """Atomically replace one typed MCP projection with optional CAS protection."""
+        projection = RelayMcpTaskProjection.model_validate(projection.model_dump(mode="python"))
+        task_id = self._require_durable_record_id(task_id, field="task_id")
+        self.initialize()
+        with self._lock:
+            self._recover_pending_transitions_unlocked()
+            path = self._storage_root / "mcp_tasks" / f"{task_id}.json"
+            task = self._read_optional(path, RelayMcpTaskRecord)
+            if task is None:
+                raise NotFoundError(f"MCP task not found: {task_id}")
+            if task.task_id != task_id or task.job_id != task_id:
+                raise QueueConflictError(f"canonical MCP task identity mismatch: {path}")
+            if expected_updated_at is not None and task.updated_at != expected_updated_at:
+                raise QueueConflictError(f"MCP task changed during update: {task_id}")
+            updates: dict[str, object] = {
+                "updated_at": utc_now(),
+                "projection": projection,
+            }
+            if state is not None:
+                updates["state"] = state
+            updated = RelayMcpTaskRecord.model_validate(
+                {
+                    **task.model_dump(mode="python"),
+                    **updates,
+                }
+            )
+            self._write(path, updated)
+            return updated
+
+    def get_mcp_task(self, task_id: str) -> RelayMcpTaskRecord:
+        """Return one durable MCP task projection by its relay job handle."""
+        task_id = self._require_durable_record_id(task_id, field="task_id")
+        task = self._read_optional(
+            self._storage_root / "mcp_tasks" / f"{task_id}.json",
+            RelayMcpTaskRecord,
+        )
+        if task is None:
+            raise NotFoundError(f"MCP task not found: {task_id}")
+        if task.task_id != task_id or task.job_id != task_id:
+            raise QueueConflictError(f"canonical MCP task identity mismatch: {task_id}")
+        return task
+
     def update_task_state(
         self,
         task_id: str,
@@ -12742,6 +12826,7 @@ class ClioCoreQueue:
                 ("jobs_queued", f"{job_id}.json"),
                 ("job_indexes", f"{safe_job_id}.json"),
                 ("transforms", f"{job_id}.json"),
+                ("mcp_tasks", f"{job_id}.json"),
             )
         )
         actions = 0

--- a/src/clio_relay/fastmcp_server.py
+++ b/src/clio_relay/fastmcp_server.py
@@ -47,6 +47,7 @@ from clio_relay import __version__
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.errors import NotFoundError, QueueConflictError
+from clio_relay.jarvis_mcp import is_virtual_jarvis_tool
 from clio_relay.mcp_server import (
     McpSessionState,
     call_mcp_tool,
@@ -548,8 +549,10 @@ class RelayToolProvider(Provider):
                 catalog_revision=(
                     None if cast(str, definition["name"]) in static_names else revision
                 ),
-                task_capable=cast(str, definition["name"]) not in static_names
-                or definition["name"] == "relay_call_jarvis_mcp",
+                task_capable=_task_capable_tool_name(
+                    cast(str, definition["name"]),
+                    static_names,
+                ),
             )
             for definition in definitions
         ]
@@ -570,9 +573,16 @@ class RelayToolProvider(Provider):
                 definition,
                 runtime=self._runtime,
                 catalog_revision=None if name in static_names else revision,
-                task_capable=name not in static_names or name == "relay_call_jarvis_mcp",
+                task_capable=_task_capable_tool_name(name, static_names),
             )
         return None
+
+
+def _task_capable_tool_name(name: str, static_names: set[str]) -> bool:
+    """Return whether one admitted-job tool supports SEP-2663 task projection."""
+    return (
+        name not in static_names or name == "relay_call_jarvis_mcp" or is_virtual_jarvis_tool(name)
+    )
 
 
 def _definitions_with_revision(profile: str) -> tuple[list[JSON], str]:

--- a/src/clio_relay/fastmcp_server.py
+++ b/src/clio_relay/fastmcp_server.py
@@ -1,0 +1,830 @@
+"""Native FastMCP server and relay-backed SEP-2663 task projection."""
+
+from __future__ import annotations
+
+import asyncio
+import hmac
+import json
+from collections.abc import AsyncGenerator, Sequence
+from contextlib import asynccontextmanager
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any, cast
+
+import mcp_types
+from fastmcp import FastMCP
+from fastmcp.exceptions import NotFoundError as FastMcpNotFoundError
+from fastmcp.server.auth import AccessToken, AuthProvider, TokenVerifier
+from fastmcp.server.dependencies import extract_version_spec, get_context, get_http_request
+from fastmcp.server.extensions import (
+    MethodBinding,
+    ServerExtension,
+    read_client_extension_settings,
+)
+from fastmcp.server.providers import Provider
+from fastmcp.tools import InputRequiredToolResult, Tool, ToolResult
+from fastmcp.utilities.tasks import TASKS_EXTENSION_ID, TaskConfig
+from fastmcp.utilities.versions import VersionSpec
+from fastmcp_tasks import wire_production
+from fastmcp_tasks.models import (
+    MISSING_REQUIRED_CLIENT_CAPABILITY,
+    CancelTaskParams,
+    CancelTaskResult,
+    CreateTaskResult,
+    GetTaskParams,
+    GetTaskResult,
+    UpdateTaskParams,
+    UpdateTaskResult,
+    missing_capability_error_data,
+)
+from mcp.server.context import ServerRequestContext
+from mcp.shared.exceptions import MCPError
+from mcp.shared.inbound import MCP_NAME_HEADER, decode_header_value
+from mcp_types.jsonrpc import HEADER_MISMATCH
+from mcp_types.version import MODERN_PROTOCOL_VERSIONS
+from pydantic import PrivateAttr
+
+from clio_relay import __version__
+from clio_relay.config import RelaySettings
+from clio_relay.core_queue import ClioCoreQueue
+from clio_relay.errors import NotFoundError, QueueConflictError
+from clio_relay.mcp_server import (
+    McpSessionState,
+    call_mcp_tool,
+    mcp_tool_definitions_and_remote_catalog,
+    mcp_tool_result_failed,
+    normalize_mcp_profile,
+    serialize_mcp_tool_result,
+    static_mcp_tool_names,
+    status_mcp_job,
+    wait_mcp_job,
+)
+from clio_relay.models import (
+    MAX_MCP_TASK_ARGUMENT_BYTES,
+    TERMINAL_STATES,
+    JobState,
+    RelayJob,
+    RelayMcpInputRound,
+    RelayMcpTaskProjection,
+    RelayMcpTaskRecord,
+)
+from clio_relay.storage_runtime import StorageManagedQueue, storage_managed_queue
+
+if TYPE_CHECKING:
+    from fastmcp.server.context import Context
+    from fastmcp.server.extensions import ToolCallContinuation, ToolCallOutcome
+
+JSON = dict[str, Any]
+SESSION_STATE_KEY = "clio-relay/mcp-session-state"
+TASK_POLL_INTERVAL_MS = 1_000
+TASK_TTL_MS = 30 * 24 * 60 * 60 * 1_000
+MAX_TASK_ARGUMENT_BYTES = MAX_MCP_TASK_ARGUMENT_BYTES
+_TASK_METHOD_VERSIONS = frozenset(MODERN_PROTOCOL_VERSIONS)
+
+
+def _session_to_json(session: McpSessionState) -> JSON:
+    """Serialize the compatibility session cache into FastMCP session state."""
+    return {
+        "remote_mcp_catalog_revisions": dict(session.remote_mcp_catalog_revisions),
+        "remote_job_routes": {
+            job_id: [list(route) for route in sorted(routes)]
+            for job_id, routes in session.remote_job_routes.items()
+        },
+    }
+
+
+def _session_from_json(value: object) -> McpSessionState:
+    """Restore a validated compatibility session cache."""
+    session = McpSessionState()
+    if value is None:
+        return session
+    if not isinstance(value, dict):
+        raise ValueError("stored MCP session state is not an object")
+    document = cast(JSON, value)
+    revisions_value = document.get("remote_mcp_catalog_revisions", {})
+    routes_value = document.get("remote_job_routes", {})
+    if not isinstance(revisions_value, dict) or not isinstance(routes_value, dict):
+        raise ValueError("stored MCP session state contains invalid collections")
+    revisions = cast(dict[str, object], revisions_value)
+    routes = cast(dict[str, object], routes_value)
+    session.remote_mcp_catalog_revisions = {
+        str(key): str(revision) for key, revision in revisions.items()
+    }
+    restored_routes: dict[str, set[tuple[str, str]]] = {}
+    for job_id, raw_routes in routes.items():
+        if not isinstance(raw_routes, list):
+            raise ValueError("stored MCP job routes are not a list")
+        route_items = cast(list[object], raw_routes)
+        parsed_routes: set[tuple[str, str]] = set()
+        for route in route_items:
+            if not isinstance(route, list):
+                raise ValueError("stored MCP job route is malformed")
+            route_parts = cast(list[object], route)
+            if len(route_parts) != 2:
+                raise ValueError("stored MCP job route is malformed")
+            parsed_routes.add((str(route_parts[0]), str(route_parts[1])))
+        restored_routes[str(job_id)] = parsed_routes
+        if len(restored_routes[str(job_id)]) != len(route_items):
+            raise ValueError("stored MCP job route is malformed")
+    session.remote_job_routes = restored_routes
+    return session
+
+
+async def _load_session() -> McpSessionState:
+    context = get_context()
+    return _session_from_json(await context.get_state(SESSION_STATE_KEY))
+
+
+async def _save_session(session: McpSessionState) -> None:
+    context = get_context()
+    await context.set_state(SESSION_STATE_KEY, _session_to_json(session))
+
+
+class RelayBearerTokenVerifier(TokenVerifier):
+    """Constant-time verifier for the existing clio-relay API bearer token."""
+
+    def __init__(self, token: str, *, base_url: str) -> None:
+        super().__init__(base_url=base_url, resource_base_url=base_url)
+        self._token = token
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        """Accept only the configured relay API token."""
+        if not hmac.compare_digest(token, self._token):
+            return None
+        return AccessToken(
+            token=token,
+            client_id="clio-relay-mcp",
+            scopes=[],
+            subject="clio-relay",
+        )
+
+
+class RelayMcpRuntime:
+    """Shared queue, profile, and projection operations for one MCP server."""
+
+    def __init__(
+        self,
+        *,
+        settings: RelaySettings,
+        profile: str,
+        queue: ClioCoreQueue | None = None,
+    ) -> None:
+        self.settings = settings
+        self.profile = normalize_mcp_profile(profile)
+        if queue is None:
+            owned_queue = storage_managed_queue(settings)
+            self.queue: ClioCoreQueue = owned_queue
+            self._owned_queue: StorageManagedQueue | None = owned_queue
+        else:
+            self.queue = queue
+            self._owned_queue = None
+
+    @asynccontextmanager
+    async def lifespan(self, _server: FastMCP[Any]) -> AsyncGenerator[dict[str, Any]]:
+        """Initialize and, when owned, close the relay queue."""
+        await asyncio.to_thread(self.queue.initialize)
+        try:
+            yield {"relay_runtime": self}
+        finally:
+            if self._owned_queue is not None:
+                await asyncio.to_thread(self._owned_queue.close)
+
+    async def call_tool(
+        self,
+        *,
+        name: str,
+        arguments: JSON,
+        catalog_revision: str | None,
+    ) -> ToolResult:
+        """Execute the established relay tool dispatcher behind FastMCP."""
+        session = await _load_session()
+        raw = await asyncio.to_thread(
+            lambda: call_mcp_tool(
+                {"name": name, "arguments": arguments},
+                queue=self.queue,
+                settings=self.settings,
+                profile=self.profile,
+                session=session,
+                observed_remote_mcp_catalog_revision=catalog_revision,
+                require_advertised_remote_mcp_catalog=catalog_revision is not None,
+            )
+        )
+        await _save_session(session)
+        content = [
+            mcp_types.TextContent.model_validate(item)
+            for item in cast(list[object], raw.get("content", []))
+        ]
+        structured = raw.get("structuredContent")
+        if not isinstance(structured, dict):
+            raise ValueError(f"relay tool {name!r} did not return structured content")
+        typed_structured = cast(JSON, structured)
+        return ToolResult(
+            content=content,
+            structured_content=typed_structured,
+            is_error=raw.get("isError") is True,
+        )
+
+    async def create_task(
+        self,
+        *,
+        tool: RelayTool,
+        arguments: JSON,
+        result: ToolResult,
+    ) -> RelayMcpTaskRecord | None:
+        """Create a durable SEP task when a tool returned a relay job receipt."""
+        structured = result.structured_content
+        if not isinstance(structured, dict):
+            return None
+        job_id = structured.get("job_id")
+        state_value = structured.get("state")
+        if not isinstance(job_id, str) or not isinstance(state_value, str):
+            return None
+        try:
+            state = JobState(state_value)
+        except ValueError:
+            return None
+        encoded_arguments = json.dumps(
+            arguments,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        if len(encoded_arguments) > MAX_TASK_ARGUMENT_BYTES:
+            raise ValueError("task arguments exceed the durable MCP projection limit")
+        projection = RelayMcpTaskProjection(
+            tool_name=tool.name,
+            profile=self.profile,
+            arguments=arguments,
+            catalog_revision=tool.catalog_revision,
+            initial_result=structured,
+        )
+        record = RelayMcpTaskRecord(
+            task_id=job_id,
+            job_id=job_id,
+            state=state,
+            projection=projection,
+        )
+        return await asyncio.to_thread(self.queue.put_mcp_task, record)
+
+    @staticmethod
+    def _route_arguments(record: RelayMcpTaskRecord) -> JSON:
+        arguments: JSON = {"job_id": record.job_id}
+        initial = record.projection.initial_result
+        if initial.get("remote") is True:
+            cluster = initial.get("cluster")
+            route_revision = initial.get("route_revision")
+            if not isinstance(cluster, str) or not isinstance(route_revision, str):
+                raise ValueError("remote MCP task omitted its immutable relay route")
+            arguments.update({"cluster": cluster, "route_revision": route_revision})
+        return arguments
+
+    async def task_status(self, record: RelayMcpTaskRecord) -> GetTaskResult:
+        """Project the current relay job state into a SEP-2663 task result."""
+        projection = record.projection
+        common: JSON = {
+            "task_id": record.task_id,
+            "created_at": record.created_at.isoformat(),
+            "last_updated_at": record.updated_at.isoformat(),
+            "ttl_ms": TASK_TTL_MS,
+            "poll_interval_ms": TASK_POLL_INTERVAL_MS,
+        }
+        if projection.protocol_error is not None:
+            return GetTaskResult(status="failed", error=projection.protocol_error, **common)
+        if projection.input_round is not None and projection.input_round.outstanding:
+            return GetTaskResult(
+                status="input_required",
+                input_requests=projection.input_round.outstanding,
+                **common,
+            )
+        if projection.completed_result is not None:
+            return GetTaskResult(
+                status="completed",
+                result=projection.completed_result,
+                **common,
+            )
+
+        route_arguments = self._route_arguments(record)
+        if projection.initial_result.get("remote") is True:
+            status = await asyncio.to_thread(
+                lambda: status_mcp_job(
+                    route_arguments,
+                    queue=self.queue,
+                    settings=self.settings,
+                )
+            )
+            raw_job = status.get("job")
+            if not isinstance(raw_job, dict):
+                raise ValueError("relay status omitted its durable job record")
+            job = RelayJob.model_validate(raw_job)
+        else:
+            job = await asyncio.to_thread(self.queue.get_job, record.job_id)
+        if job.state is JobState.CANCELED:
+            return GetTaskResult(
+                status="cancelled",
+                status_message=job.last_error,
+                last_updated_at=job.updated_at.isoformat(),
+                **{key: value for key, value in common.items() if key != "last_updated_at"},
+            )
+        if job.state not in TERMINAL_STATES:
+            return GetTaskResult(
+                status="working",
+                status_message=f"Relay job is {job.state.value}",
+                last_updated_at=job.updated_at.isoformat(),
+                **{key: value for key, value in common.items() if key != "last_updated_at"},
+            )
+
+        waited = await asyncio.to_thread(
+            lambda: wait_mcp_job(
+                {
+                    **route_arguments,
+                    "timeout_seconds": 0.01,
+                    "poll_seconds": 0.01,
+                    "include_logs": False,
+                },
+                queue=self.queue,
+                settings=self.settings,
+            )
+        )
+        final = _call_tool_result_document(waited)
+        completed_projection = RelayMcpTaskProjection.model_validate(
+            {
+                **projection.model_dump(mode="python"),
+                "completed_result": final,
+            }
+        )
+        try:
+            updated = await asyncio.to_thread(
+                lambda: self.queue.update_mcp_task_projection(
+                    record.task_id,
+                    completed_projection,
+                    expected_updated_at=record.updated_at,
+                    state=job.state,
+                )
+            )
+        except QueueConflictError:
+            updated = await asyncio.to_thread(self.queue.get_mcp_task, record.task_id)
+            if updated.projection.completed_result is None:
+                raise
+            final = updated.projection.completed_result
+        return GetTaskResult(
+            status="completed",
+            result=final,
+            status_message=f"Relay job {job.state.value}",
+            last_updated_at=job.updated_at.isoformat(),
+            **{key: value for key, value in common.items() if key != "last_updated_at"},
+        )
+
+    async def update_task(self, record: RelayMcpTaskRecord, responses: JSON) -> None:
+        """Apply replay-safe answers to the current durable input round."""
+        candidate = record
+        for _attempt in range(8):
+            current = candidate.projection.input_round
+            if current is None or not current.outstanding:
+                return
+            matched = {key: value for key, value in responses.items() if key in current.outstanding}
+            if not matched:
+                return
+            outstanding = {
+                key: value for key, value in current.outstanding.items() if key not in matched
+            }
+            updated_round = RelayMcpInputRound.model_validate(
+                {
+                    **current.model_dump(mode="python"),
+                    "outstanding": outstanding,
+                    "answered": {**current.answered, **matched},
+                }
+            )
+            projection = RelayMcpTaskProjection.model_validate(
+                {
+                    **candidate.projection.model_dump(mode="python"),
+                    "input_round": updated_round,
+                }
+            )
+            try:
+                await asyncio.to_thread(
+                    self.queue.update_mcp_task_projection,
+                    candidate.task_id,
+                    projection,
+                    expected_updated_at=candidate.updated_at,
+                )
+                return
+            except QueueConflictError:
+                candidate = await asyncio.to_thread(
+                    self.queue.get_mcp_task,
+                    candidate.task_id,
+                )
+        raise QueueConflictError(
+            f"MCP task input could not converge after concurrent updates: {record.task_id}"
+        )
+
+    async def cancel_task(self, record: RelayMcpTaskRecord) -> None:
+        """Request cancellation through the relay's existing cancellation path."""
+        from clio_relay.queue_management import cancel_queue_job
+
+        initial = record.projection.initial_result
+        if initial.get("remote") is True:
+            await asyncio.to_thread(
+                lambda: call_mcp_tool(
+                    {
+                        "name": "relay_cancel",
+                        "arguments": {
+                            **self._route_arguments(record),
+                            "cancel_scheduler_job": True,
+                        },
+                    },
+                    queue=self.queue,
+                    settings=self.settings,
+                    profile=self.profile,
+                    session=None,
+                    observed_remote_mcp_catalog_revision=None,
+                    require_advertised_remote_mcp_catalog=False,
+                )
+            )
+        else:
+            await asyncio.to_thread(
+                lambda: cancel_queue_job(
+                    self.queue,
+                    record.job_id,
+                    scheduler_policy="request-scheduler",
+                )
+            )
+
+
+def _call_tool_result_document(result: JSON) -> JSON:
+    """Build the exact CallToolResult wire object for one relay result."""
+    raw_job = result.get("job")
+    job_failed = (
+        isinstance(raw_job, dict)
+        and cast(dict[str, object], raw_job).get("state") == JobState.FAILED.value
+    )
+    call_result = mcp_types.CallToolResult(
+        content=[
+            mcp_types.TextContent(
+                type="text",
+                text=serialize_mcp_tool_result(result),
+            )
+        ],
+        structured_content=result,
+        is_error=(job_failed or mcp_tool_result_failed(result)),
+    )
+    return call_result.model_dump(by_alias=True, mode="json", exclude_none=True)
+
+
+class RelayTool(Tool):
+    """FastMCP component delegating to one existing relay MCP tool definition."""
+
+    _runtime: RelayMcpRuntime = PrivateAttr()
+    _catalog_revision: str | None = PrivateAttr(default=None)
+
+    def __init__(
+        self,
+        definition: JSON,
+        *,
+        runtime: RelayMcpRuntime,
+        catalog_revision: str | None,
+        task_capable: bool,
+    ) -> None:
+        meta = dict(cast(dict[str, Any], definition.get("_meta") or {}))
+        if catalog_revision is not None:
+            meta["clio-relay/catalog-revision"] = catalog_revision
+        raw_annotations = definition.get("annotations")
+        annotations = (
+            None
+            if raw_annotations is None
+            else mcp_types.ToolAnnotations.model_validate(raw_annotations)
+        )
+        super().__init__(
+            name=cast(str, definition["name"]),
+            title=cast(str | None, definition.get("title")),
+            description=cast(str | None, definition.get("description")),
+            parameters=cast(JSON, definition["inputSchema"]),
+            output_schema=cast(JSON | None, definition.get("outputSchema")),
+            annotations=annotations,
+            meta=meta or None,
+            task_config=TaskConfig(
+                mode="optional" if task_capable else "forbidden",
+                poll_interval=timedelta(milliseconds=TASK_POLL_INTERVAL_MS),
+            ),
+        )
+        self._runtime = runtime
+        self._catalog_revision = catalog_revision
+
+    @property
+    def catalog_revision(self) -> str | None:
+        """Return the exact dynamic catalog revision bound at dispatch."""
+        return self._catalog_revision
+
+    async def run(self, arguments: dict[str, Any]) -> ToolResult:
+        """Execute the established relay dispatcher without a second tool runtime."""
+        return await self._runtime.call_tool(
+            name=self.name,
+            arguments=arguments,
+            catalog_revision=self._catalog_revision,
+        )
+
+
+class RelayToolProvider(Provider):
+    """Expose the complete static and dynamic relay catalog through FastMCP."""
+
+    def __init__(self, runtime: RelayMcpRuntime) -> None:
+        super().__init__()
+        self._runtime = runtime
+
+    async def _definitions(self) -> tuple[list[JSON], str]:
+        return await asyncio.to_thread(lambda: _definitions_with_revision(self._runtime.profile))
+
+    async def _list_tools(self) -> Sequence[Tool]:
+        definitions, revision = await self._definitions()
+        session = await _load_session()
+        session.observe_remote_mcp_catalog(
+            profile=self._runtime.profile,
+            revision=revision,
+        )
+        await _save_session(session)
+        static_names = static_mcp_tool_names()
+        return [
+            RelayTool(
+                definition,
+                runtime=self._runtime,
+                catalog_revision=(
+                    None if cast(str, definition["name"]) in static_names else revision
+                ),
+                task_capable=cast(str, definition["name"]) not in static_names
+                or definition["name"] == "relay_call_jarvis_mcp",
+            )
+            for definition in definitions
+        ]
+
+    async def _get_tool(
+        self,
+        name: str,
+        version: VersionSpec | None = None,
+    ) -> Tool | None:
+        if version is not None:
+            return None
+        definitions, revision = await self._definitions()
+        static_names = static_mcp_tool_names()
+        for definition in definitions:
+            if definition.get("name") != name:
+                continue
+            return RelayTool(
+                definition,
+                runtime=self._runtime,
+                catalog_revision=None if name in static_names else revision,
+                task_capable=name not in static_names or name == "relay_call_jarvis_mcp",
+            )
+        return None
+
+
+def _definitions_with_revision(profile: str) -> tuple[list[JSON], str]:
+    definitions, catalog = mcp_tool_definitions_and_remote_catalog(profile=profile)
+    return definitions, catalog.revision
+
+
+class RelayTasksExtension(ServerExtension):
+    """SEP-2663 wire adapter projecting the relay's own durable jobs."""
+
+    identifier = TASKS_EXTENSION_ID
+
+    def __init__(self, runtime: RelayMcpRuntime) -> None:
+        self._runtime = runtime
+
+    def settings(self) -> dict[str, Any]:
+        """Advertise the standard tasks extension without private settings."""
+        return {}
+
+    def methods(self) -> Sequence[MethodBinding]:
+        """Bind the three SEP-2663 task-management methods."""
+        return (
+            MethodBinding(
+                method="tasks/get",
+                params_type=GetTaskParams,
+                handler=self._handle_get,
+                protocol_versions=_TASK_METHOD_VERSIONS,
+            ),
+            MethodBinding(
+                method="tasks/update",
+                params_type=UpdateTaskParams,
+                handler=self._handle_update,
+                protocol_versions=_TASK_METHOD_VERSIONS,
+            ),
+            MethodBinding(
+                method="tasks/cancel",
+                params_type=CancelTaskParams,
+                handler=self._handle_cancel,
+                protocol_versions=_TASK_METHOD_VERSIONS,
+            ),
+        )
+
+    @asynccontextmanager
+    async def lifespan(self) -> AsyncGenerator[None]:
+        """Install only the official task-result wire claim producer."""
+        wire_production.install()
+        try:
+            yield
+        finally:
+            wire_production.uninstall()
+
+    @staticmethod
+    def _require_capability(ctx: ServerRequestContext[Any, Any]) -> None:
+        if read_client_extension_settings(ctx, TASKS_EXTENSION_ID) is None:
+            raise MCPError(
+                code=MISSING_REQUIRED_CLIENT_CAPABILITY,
+                message=(
+                    "This request targets io.modelcontextprotocol/tasks, but the "
+                    "client did not declare that extension for this request."
+                ),
+                data=missing_capability_error_data(),
+            )
+
+    @staticmethod
+    def _require_matching_route(task_id: str) -> None:
+        try:
+            request = get_http_request()
+        except RuntimeError:
+            return
+        header = request.headers.get(MCP_NAME_HEADER)
+        if header is not None and decode_header_value(header) != task_id:
+            raise MCPError(
+                code=HEADER_MISMATCH,
+                message=(
+                    f"{MCP_NAME_HEADER} header does not match the request body's 'taskId' parameter"
+                ),
+            )
+
+    def _check_request(
+        self,
+        ctx: ServerRequestContext[Any, Any],
+        task_id: str,
+    ) -> None:
+        self._require_capability(ctx)
+        self._require_matching_route(task_id)
+
+    async def _record(self, task_id: str) -> RelayMcpTaskRecord:
+        try:
+            return await asyncio.to_thread(self._runtime.queue.get_mcp_task, task_id)
+        except NotFoundError as exc:
+            raise MCPError(
+                code=mcp_types.INVALID_PARAMS,
+                message=f"Task not found: {task_id}",
+            ) from exc
+
+    async def _handle_get(
+        self,
+        ctx: ServerRequestContext[Any, Any],
+        params: GetTaskParams,
+    ) -> GetTaskResult:
+        self._check_request(ctx, params.task_id)
+        return await self._runtime.task_status(await self._record(params.task_id))
+
+    async def _handle_update(
+        self,
+        ctx: ServerRequestContext[Any, Any],
+        params: UpdateTaskParams,
+    ) -> UpdateTaskResult:
+        self._check_request(ctx, params.task_id)
+        await self._runtime.update_task(
+            await self._record(params.task_id),
+            params.input_responses,
+        )
+        return UpdateTaskResult()
+
+    async def _handle_cancel(
+        self,
+        ctx: ServerRequestContext[Any, Any],
+        params: CancelTaskParams,
+    ) -> CancelTaskResult:
+        self._check_request(ctx, params.task_id)
+        await self._runtime.cancel_task(await self._record(params.task_id))
+        return CancelTaskResult()
+
+    async def intercept_tool_call(
+        self,
+        params: mcp_types.CallToolRequestParams,
+        context: Context,
+        call_next: ToolCallContinuation,
+    ) -> ToolCallOutcome:
+        """Materialize a task only after the relay has durably admitted its job."""
+        version_value = extract_version_spec(params.meta)
+        version = VersionSpec(eq=version_value) if version_value else None
+        try:
+            tool = await context.fastmcp.get_tool(params.name, version)
+        except FastMcpNotFoundError:
+            tool = None
+        if tool is None or not tool.task_config.supports_tasks():
+            return await call_next()
+
+        request_context = context.request_context
+        opted_in = (
+            request_context is not None
+            and request_context.protocol_version in MODERN_PROTOCOL_VERSIONS
+            and context.client_extension_settings(TASKS_EXTENSION_ID) is not None
+        )
+        if not opted_in:
+            if tool.task_config.mode == "required":
+                raise MCPError(
+                    code=MISSING_REQUIRED_CLIENT_CAPABILITY,
+                    message=f"Tool {tool.name!r} requires io.modelcontextprotocol/tasks.",
+                    data=missing_capability_error_data(),
+                )
+            return await call_next()
+
+        outcome = await call_next()
+        if isinstance(outcome, InputRequiredToolResult):
+            # SEP-2663 requires pre-creation MRTR to finish synchronously. The
+            # client re-enters this tools/call with answers; only the leg that
+            # durably admits a relay job is converted into a task.
+            return outcome
+        if not isinstance(outcome, ToolResult) or not isinstance(tool, RelayTool):
+            return outcome
+        task = await self._runtime.create_task(
+            tool=tool,
+            arguments=dict(params.arguments or {}),
+            result=outcome,
+        )
+        if task is None:
+            return outcome
+        return CreateTaskResult(
+            task_id=task.task_id,
+            status=(
+                "cancelled"
+                if task.state is JobState.CANCELED
+                else "completed"
+                if task.state in TERMINAL_STATES
+                else "working"
+            ),
+            status_message=f"Relay job is {task.state.value}",
+            created_at=task.created_at.isoformat(),
+            last_updated_at=task.updated_at.isoformat(),
+            ttl_ms=TASK_TTL_MS,
+            poll_interval_ms=TASK_POLL_INTERVAL_MS,
+        )
+
+
+def create_fastmcp_server(
+    *,
+    settings: RelaySettings | None = None,
+    profile: str = "user",
+    queue: ClioCoreQueue | None = None,
+    http_base_url: str | None = None,
+) -> FastMCP[dict[str, Any]]:
+    """Create the native FastMCP relay server without a second task backend."""
+    resolved = settings or RelaySettings.from_env()
+    runtime = RelayMcpRuntime(settings=resolved, profile=profile, queue=queue)
+    auth: AuthProvider | None = None
+    if http_base_url is not None:
+        if resolved.api_token is None:
+            raise ValueError("CLIO_RELAY_API_TOKEN is required for MCP HTTP transport")
+        auth = RelayBearerTokenVerifier(resolved.api_token, base_url=http_base_url)
+    server: FastMCP[dict[str, Any]] = FastMCP(
+        "clio-relay",
+        version=__version__,
+        instructions=(
+            "Durable relay operations. Long-running virtual remote and JARVIS tools "
+            "may be returned through io.modelcontextprotocol/tasks. Relay jobs remain "
+            "the sole execution and cancellation authority."
+        ),
+        providers=[RelayToolProvider(runtime)],
+        lifespan=runtime.lifespan,
+        auth=auth,
+        tasks=False,
+        strict_input_validation=True,
+    )
+    server.add_extension(RelayTasksExtension(runtime))
+    return server
+
+
+def run_fastmcp_stdio(
+    *,
+    settings: RelaySettings | None = None,
+    profile: str = "user",
+) -> None:
+    """Run the native FastMCP server over stdio."""
+    create_fastmcp_server(settings=settings, profile=profile).run(
+        transport="stdio",
+        show_banner=False,
+    )
+
+
+def run_fastmcp_http(
+    *,
+    settings: RelaySettings | None = None,
+    profile: str = "user",
+    host: str = "127.0.0.1",
+    port: int = 8766,
+    path: str = "/mcp",
+) -> None:
+    """Run authenticated Streamable HTTP with the existing relay API token."""
+    normalized_path = "/" + path.strip("/")
+    public_host = "127.0.0.1" if host in {"0.0.0.0", "::"} else host
+    base_url = f"http://{public_host}:{port}{normalized_path}"
+    create_fastmcp_server(
+        settings=settings,
+        profile=profile,
+        http_base_url=base_url,
+    ).run(
+        transport="http",
+        host=host,
+        port=port,
+        path=normalized_path,
+        show_banner=False,
+    )

--- a/src/clio_relay/http_api.py
+++ b/src/clio_relay/http_api.py
@@ -2676,9 +2676,14 @@ async def _monitor_stream_payloads(
             raise TypeError("monitor payload next_cursor was not an integer")
         next_cursor = raw_next_cursor
         yield _public_payload({"event": "monitor", "data": payload})
-        job = queue.get_job(job_id)
-        if stop_on_terminal and job.state.value in {"succeeded", "failed", "canceled"}:
-            yield {"event": "terminal", "data": {"job_id": job_id, "state": job.state.value}}
+        raw_job = payload.get("job")
+        if not isinstance(raw_job, dict):
+            raise TypeError("monitor payload job was not an object")
+        raw_state = raw_job.get("state")
+        if not isinstance(raw_state, str):
+            raise TypeError("monitor payload job state was not a string")
+        if stop_on_terminal and payload.get("terminal") is True:
+            yield {"event": "terminal", "data": {"job_id": job_id, "state": raw_state}}
             return
         await asyncio.sleep(poll_seconds)
 

--- a/src/clio_relay/http_api.py
+++ b/src/clio_relay/http_api.py
@@ -2679,7 +2679,7 @@ async def _monitor_stream_payloads(
         raw_job = payload.get("job")
         if not isinstance(raw_job, dict):
             raise TypeError("monitor payload job was not an object")
-        raw_state = raw_job.get("state")
+        raw_state = cast(dict[str, object], raw_job).get("state")
         if not isinstance(raw_state, str):
             raise TypeError("monitor payload job state was not a string")
         if stop_on_terminal and payload.get("terminal") is True:

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -354,6 +354,71 @@ class _VerifiedMcpResult:
     public: JSON
 
 
+def normalize_mcp_profile(profile: str) -> str:
+    """Normalize a public MCP tool-profile name."""
+    return _normalize_profile(profile)
+
+
+def mcp_tool_definitions_and_remote_catalog(
+    *,
+    profile: str,
+) -> tuple[list[JSON], VirtualRemoteMcpCatalog]:
+    """Return the complete static and dynamic MCP tool catalog."""
+    return _tool_definitions_and_remote_catalog(profile=profile)
+
+
+def call_mcp_tool(
+    params: JSON,
+    *,
+    queue: ClioCoreQueue,
+    settings: RelaySettings,
+    profile: str,
+    session: McpSessionState | None,
+    observed_remote_mcp_catalog_revision: str | None,
+    require_advertised_remote_mcp_catalog: bool,
+) -> JSON:
+    """Call one established relay MCP tool through its shared dispatcher."""
+    return _call_tool(
+        params,
+        queue=queue,
+        settings=settings,
+        profile=profile,
+        session=session,
+        observed_remote_mcp_catalog_revision=observed_remote_mcp_catalog_revision,
+        require_advertised_remote_mcp_catalog=require_advertised_remote_mcp_catalog,
+    )
+
+
+def status_mcp_job(
+    arguments: JSON,
+    *,
+    queue: ClioCoreQueue,
+    settings: RelaySettings,
+) -> JSON:
+    """Read one local or routed relay job through MCP handle semantics."""
+    return _status_job(arguments, queue=queue, settings=settings)
+
+
+def wait_mcp_job(
+    arguments: JSON,
+    *,
+    queue: ClioCoreQueue,
+    settings: RelaySettings,
+) -> JSON:
+    """Boundedly reconcile one local or routed MCP job."""
+    return _wait_job(arguments, queue=queue, settings=settings)
+
+
+def serialize_mcp_tool_result(result: JSON) -> str:
+    """Serialize a bounded human-readable relay tool result."""
+    return _serialize_tool_result(result)
+
+
+def mcp_tool_result_failed(result: JSON) -> bool:
+    """Return whether a relay result maps to CallToolResult.isError."""
+    return _mcp_tool_result_failed(result)
+
+
 def serve_stdio(
     *,
     stdin: TextIO = sys.stdin,

--- a/src/clio_relay/mcp_stdio_validation.py
+++ b/src/clio_relay/mcp_stdio_validation.py
@@ -17,6 +17,8 @@ from pathlib import Path
 from time import monotonic
 from typing import Any, BinaryIO, cast
 
+from mcp_types import ToolAnnotations
+
 from clio_relay import __version__
 from clio_relay.command_evidence import bounded_error_detail
 from clio_relay.errors import ObservationTimeoutError, RelayError
@@ -889,12 +891,24 @@ def _validate_protocol_contract(
 def _validate_initialize_contract(initialize_response: JSON) -> JSON:
     """Validate the exact packaged relay initialization contract before activation."""
     initialize_result = _required_result(initialize_response, label="initialize")
-    if set(initialize_result) != {"protocolVersion", "capabilities", "serverInfo"}:
+    if set(initialize_result) - {
+        "protocolVersion",
+        "capabilities",
+        "serverInfo",
+        "instructions",
+    }:
         raise RelayError("packaged MCP initialize result contained unexpected fields")
     if initialize_result.get("protocolVersion") != _EXPECTED_PROTOCOL_VERSION:
         raise RelayError("packaged MCP initialize protocol version did not match")
-    if initialize_result.get("capabilities") != {"tools": {}}:
+    capabilities = _mapping(initialize_result.get("capabilities"))
+    tools_capability = None if capabilities is None else _mapping(capabilities.get("tools"))
+    if capabilities is None or tools_capability is None:
         raise RelayError("packaged MCP initialize capabilities did not match")
+    if tools_capability.get("listChanged") is not True:
+        raise RelayError("packaged MCP initialize did not advertise live tool catalogs")
+    instructions = initialize_result.get("instructions")
+    if not isinstance(instructions, str) or "sole execution" not in instructions:
+        raise RelayError("packaged MCP initialize omitted relay execution authority")
     server_info = _mapping(initialize_result.get("serverInfo"))
     if server_info is None or server_info.get("name") != "clio-relay":
         raise RelayError("packaged MCP initialize serverInfo name did not match")
@@ -1005,9 +1019,72 @@ def _validate_pinned_jarvis_contract(tools: list[JSON]) -> str | None:
         cast(str, definition["name"]): definition
         for definition in virtual_jarvis_tool_definitions(clusters=clusters)
     }
-    if actual != expected:
-        raise RelayError("packaged MCP JARVIS v3.6 agent-facing schema did not match its pin")
+    contract_fields = (
+        "name",
+        "description",
+        "inputSchema",
+        "outputSchema",
+    )
+    normalized_expected_annotations = {
+        name: _normalized_tool_annotations(definition.get("annotations")) or {}
+        for name, definition in expected.items()
+    }
+    for name, definition in actual.items():
+        actual_annotations = _normalized_tool_annotations(definition.get("annotations")) or {}
+        expected_annotations = normalized_expected_annotations[name]
+        annotation_differences = {
+            key: {
+                "actual": actual_annotations.get(key),
+                "expected": value,
+            }
+            for key, value in expected_annotations.items()
+            if actual_annotations.get(key) != value
+        }
+        if annotation_differences:
+            raise RelayError(
+                "packaged MCP JARVIS v3.6 annotation semantics did not match its pin: "
+                f"{name} {annotation_differences}"
+            )
+    actual_contract = {
+        name: {
+            **{field: definition.get(field) for field in contract_fields},
+            "annotations": normalized_expected_annotations[name],
+        }
+        for name, definition in actual.items()
+    }
+    expected_contract = {
+        name: {
+            **{field: definition.get(field) for field in contract_fields},
+            "annotations": normalized_expected_annotations[name],
+        }
+        for name, definition in expected.items()
+    }
+    if actual_contract != expected_contract:
+        differing_fields = {
+            name: [
+                field
+                for field in (*contract_fields, "annotations")
+                if actual_contract[name].get(field) != expected_contract[name].get(field)
+            ]
+            for name in sorted(actual_contract)
+            if actual_contract[name] != expected_contract[name]
+        }
+        raise RelayError(
+            "packaged MCP JARVIS v3.6 agent-facing schema did not match its pin: "
+            f"{differing_fields}"
+        )
     return _tools_digest([actual[name] for name in sorted(actual)])
+
+
+def _normalized_tool_annotations(value: object) -> JSON | None:
+    """Normalize MCP annotation defaults before comparing a pinned catalog."""
+    if value is None:
+        return None
+    return ToolAnnotations.model_validate(value).model_dump(
+        by_alias=True,
+        mode="json",
+        exclude_none=True,
+    )
 
 
 def _required_result(response: JSON, *, label: str) -> JSON:

--- a/src/clio_relay/models.py
+++ b/src/clio_relay/models.py
@@ -8,7 +8,7 @@ import re
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from pathlib import Path
-from typing import Annotated, Any, Literal, Self
+from typing import Annotated, Any, Literal, Self, cast
 from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -34,6 +34,11 @@ MAX_JARVIS_RUN_INPUT_MANIFEST_BYTES = 1 * 1024 * 1024
 MAX_TRANSFORM_ENVIRONMENT_BYTES = 16 * 1024
 MAX_TRANSFORM_REF_BYTES = 192 * 1024
 MAX_TRANSFORM_USED_EVIDENCE = 1_000
+MAX_MCP_TASK_ARGUMENT_BYTES = 512 * 1024
+MAX_MCP_TASK_INPUT_ROUND_BYTES = 256 * 1024
+MAX_MCP_TASK_PROJECTION_BYTES = 768 * 1024
+MAX_MCP_TASK_JSON_DEPTH = 64
+MAX_MCP_TASK_JSON_NODES = 100_000
 REGISTERED_JARVIS_USER_CONTRACT = "clio-kit-jarvis-user-v3.6"
 
 
@@ -1590,6 +1595,147 @@ def prepare_owned_jarvis_run_submission(job: RelayJob) -> RelayJob:
             )
         }
     )
+
+
+def _require_bounded_mcp_task_json(
+    value: object,
+    *,
+    label: str,
+    maximum_bytes: int,
+) -> None:
+    """Require one finite, bounded JSON tree before durable task persistence."""
+    stack: list[tuple[object, int]] = [(value, 0)]
+    nodes = 0
+    while stack:
+        current, depth = stack.pop()
+        nodes += 1
+        if nodes > MAX_MCP_TASK_JSON_NODES:
+            raise ValueError(f"{label} exceeds {MAX_MCP_TASK_JSON_NODES} JSON nodes")
+        if depth > MAX_MCP_TASK_JSON_DEPTH:
+            raise ValueError(f"{label} exceeds {MAX_MCP_TASK_JSON_DEPTH} nesting levels")
+        if isinstance(current, dict):
+            for key, item in cast(dict[object, object], current).items():
+                if not isinstance(key, str):
+                    raise ValueError(f"{label} contains a non-string JSON object key")
+                stack.append((item, depth + 1))
+        elif isinstance(current, list):
+            stack.extend((item, depth + 1) for item in cast(list[object], current))
+        elif not isinstance(current, str | int | float | bool | None):
+            raise ValueError(f"{label} contains a non-JSON value")
+    try:
+        encoded = json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must contain finite JSON values") from exc
+    if len(encoded) > maximum_bytes:
+        raise ValueError(f"{label} exceeds {maximum_bytes} UTF-8 bytes")
+
+
+class RelayMcpInputRound(BaseModel):
+    """Durable outstanding input for one re-entrant MCP task leg."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    leg: int = Field(ge=1)
+    outstanding: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    answered: dict[str, Any] = Field(default_factory=dict)
+    request_state: str | None = Field(default=None, max_length=65_536)
+
+    @model_validator(mode="after")
+    def input_round_must_be_bounded(self) -> RelayMcpInputRound:
+        """Bound the complete round, including untrusted request payloads and answers."""
+        _require_bounded_mcp_task_json(
+            self.model_dump(mode="json"),
+            label="MCP task input round",
+            maximum_bytes=MAX_MCP_TASK_INPUT_ROUND_BYTES,
+        )
+        return self
+
+
+class RelayMcpTaskProjection(BaseModel):
+    """Typed SEP-2663 projection attached to an existing durable relay job."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["clio-relay.mcp-task-projection.v1"] = (
+        "clio-relay.mcp-task-projection.v1"
+    )
+    tool_name: str = Field(min_length=1, max_length=512)
+    profile: str = Field(min_length=1, max_length=64)
+    arguments: dict[str, Any] = Field(default_factory=dict)
+    catalog_revision: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")
+    initial_result: dict[str, Any]
+    issued_input_keys: list[str] = Field(default_factory=list, max_length=1_000)
+    input_round: RelayMcpInputRound | None = None
+    completed_result: dict[str, Any] | None = None
+    protocol_error: dict[str, Any] | None = None
+
+    @field_validator("issued_input_keys")
+    @classmethod
+    def input_keys_must_be_unique(cls, value: list[str]) -> list[str]:
+        """Reject ambiguous replay identities for task input requests."""
+        if len(value) != len(set(value)):
+            raise ValueError("issued_input_keys must be unique")
+        if any(not key or len(key) > 512 for key in value):
+            raise ValueError("issued_input_keys must contain bounded non-empty strings")
+        return value
+
+    @model_validator(mode="after")
+    def projection_must_be_bounded(self) -> RelayMcpTaskProjection:
+        """Require one unambiguous, finite projection below its record limit."""
+        if self.input_round is not None:
+            issued = set(self.issued_input_keys)
+            outstanding = set(self.input_round.outstanding)
+            answered = set(self.input_round.answered)
+            if not (outstanding | answered) <= issued:
+                raise ValueError("MCP task input round contains an unissued request key")
+            if outstanding & answered:
+                raise ValueError("MCP task input request cannot be outstanding and answered")
+        outcome_count = sum(
+            (
+                self.protocol_error is not None,
+                self.completed_result is not None,
+                self.input_round is not None and bool(self.input_round.outstanding),
+            )
+        )
+        if outcome_count > 1:
+            raise ValueError("MCP task projection contains conflicting result states")
+        _require_bounded_mcp_task_json(
+            self.arguments,
+            label="MCP task arguments",
+            maximum_bytes=MAX_MCP_TASK_ARGUMENT_BYTES,
+        )
+        _require_bounded_mcp_task_json(
+            self.model_dump(mode="json"),
+            label="MCP task projection",
+            maximum_bytes=MAX_MCP_TASK_PROJECTION_BYTES,
+        )
+        return self
+
+
+class RelayMcpTaskRecord(BaseModel):
+    """Durable MCP task handle projecting one local or federated relay job."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    task_id: DurableRecordId
+    job_id: DurableRecordId
+    state: JobState
+    created_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utc_now)
+    projection: RelayMcpTaskProjection
+
+    @model_validator(mode="after")
+    def task_id_must_project_job_id(self) -> RelayMcpTaskRecord:
+        """Keep the standardized task handle identical to the relay job handle."""
+        if self.task_id != self.job_id:
+            raise ValueError("MCP task_id must equal its projected relay job_id")
+        return self
 
 
 class RelayTask(BaseModel):

--- a/src/clio_relay/process_containment.py
+++ b/src/clio_relay/process_containment.py
@@ -1474,14 +1474,26 @@ def _release_broker(
         daemon=True,
     )
     writer.start()
-    if not completed.wait(max(0.0, startup_deadline - time.monotonic())):
+    while not completed.is_set():
+        remaining = startup_deadline - time.monotonic()
+        if remaining > 0:
+            completed.wait(remaining)
+            continue
         if process.poll() is None:
             process.kill()
-        with suppress(OSError):
-            os.close(setup_channel.fileno())
-        process.stdin = None
         process.wait(timeout=TERMINATION_TIMEOUT_SECONDS)
+        writer.join(timeout=TERMINATION_TIMEOUT_SECONDS)
+        if writer.is_alive():
+            with suppress(OSError):
+                setup_channel.close()
+            writer.join(timeout=TERMINATION_TIMEOUT_SECONDS)
+        process.stdin = None
+        if writer.is_alive():
+            raise RuntimeError("containment broker setup writer remained active after timeout")
+        with suppress(OSError):
+            setup_channel.close()
         raise RuntimeError("containment broker setup write timed out")
+    writer.join()
     if errors:
         setup_channel.close()
         process.stdin = None

--- a/src/clio_relay/storage_runtime.py
+++ b/src/clio_relay/storage_runtime.py
@@ -342,15 +342,22 @@ class StorageManagedQueue(ClioCoreQueue):
         lock_timeout_seconds: float = DEFAULT_CORE_LOCK_TIMEOUT_SECONDS,
     ) -> None:
         self._closed = False
-        if Path(root).absolute() != storage_runtime.config.core_root.absolute():
+        if logical_filesystem_path(Path(root).absolute()) != logical_filesystem_path(
+            storage_runtime.config.core_root.absolute()
+        ):
             raise ValueError("managed queue root must match the storage runtime core root")
         if owns_writer_lifetime_lock and writer_lifetime_lock is None:
             raise ValueError("an owned writer lifetime lock must be provided")
         if writer_lifetime_lock is not None:
             if not writer_lifetime_lock.acquired or writer_lifetime_lock.mode != "shared":
                 raise ValueError("managed queue writer lifetime lock must hold shared ownership")
-            root_stat = os.stat(root)
-            lock_stat = os.stat(writer_lifetime_lock.core_dir)
+            root_stat = os.stat(internal_filesystem_path(Path(root), force_extended=True))
+            lock_stat = os.stat(
+                internal_filesystem_path(
+                    writer_lifetime_lock.core_dir,
+                    force_extended=True,
+                )
+            )
             if (root_stat.st_dev, root_stat.st_ino) != (lock_stat.st_dev, lock_stat.st_ino):
                 raise ValueError("managed queue root must match its writer lifetime lock")
         super().__init__(root, lock_timeout_seconds=lock_timeout_seconds)
@@ -970,12 +977,13 @@ def storage_managed_queue(
 def initialize_queue_with_shared_writer_fencing(lifetime_lock: WorkerLifetimeLock) -> None:
     """Create a missing queue seal under exclusive ownership, then restore shared ownership."""
     core_dir = lifetime_lock.core_dir
+    internal_core_dir = internal_filesystem_path(core_dir, force_extended=True)
     try:
         ClioCoreQueue(core_dir).initialize(allow_exclusive_seal=False)
         return
     except QueueSealRequiresExclusive:
         try:
-            original_stat = os.stat(core_dir)
+            original_stat = os.stat(internal_core_dir)
         except OSError as exc:
             raise ConfigurationError(
                 f"queue root identity cannot be captured before seal fencing: {exc}"
@@ -1007,7 +1015,12 @@ def initialize_queue_with_shared_writer_fencing(lifetime_lock: WorkerLifetimeLoc
                 ) from exc
 
     try:
-        reacquired_stat = os.stat(lifetime_lock.core_dir)
+        reacquired_stat = os.stat(
+            internal_filesystem_path(
+                lifetime_lock.core_dir,
+                force_extended=True,
+            )
+        )
     except OSError as exc:
         raise ConfigurationError(
             f"queue root identity cannot be verified after seal fencing: {exc}"

--- a/src/clio_relay/worker_lifetime_lock.py
+++ b/src/clio_relay/worker_lifetime_lock.py
@@ -564,12 +564,16 @@ def exclusive_migration_lifetime(
             mode="exclusive",
             timeout_seconds=effective_timeout,
         ) as lifetime_lock:
-            locked_stat = os.stat(lifetime_lock.core_dir)
+            locked_root = internal_filesystem_path(
+                lifetime_lock.core_dir,
+                force_extended=True,
+            )
+            locked_stat = os.stat(locked_root)
             descriptor = lifetime_lock.descriptor
             if descriptor is None:
                 raise ConfigurationError("exclusive migration lifetime lock is not acquired")
             identity = _locked_core_identity(
-                lifetime_lock.core_dir,
+                locked_root,
                 locked_stat,
                 guard_fd=descriptor,
             )

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1791,7 +1791,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "1b976be950a7649715a63c2a7d8a312f864cceba01fe7ae7309f0af8319c3363"
+        "df909e16d44bcca69f46bf303902cd3e105c81c0f718962697dc1463b17f385a"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13412,3 +13412,50 @@ def test_execution_query_observations_compact_without_losing_milestones() -> Non
     assert [int(item.rsplit("-", 1)[1]) for item in retained_ids] == sorted(
         int(item.rsplit("-", 1)[1]) for item in retained_ids
     )
+
+
+def test_mcp_server_cli_dispatches_native_fastmcp_stdio(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    observed: list[str] = []
+
+    def run_stdio(*, profile: str) -> None:
+        observed.append(profile)
+
+    monkeypatch.setattr(cli, "run_fastmcp_stdio", run_stdio)
+
+    result = CliRunner().invoke(app, ["mcp-server", "--profile", "operator"])
+
+    assert result.exit_code == 0
+    assert observed == ["operator"]
+
+
+def test_mcp_server_cli_dispatches_authenticated_fastmcp_http(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    observed: list[tuple[str, str, int, str]] = []
+
+    def run_http(*, profile: str, host: str, port: int, path: str) -> None:
+        observed.append((profile, host, port, path))
+
+    monkeypatch.setattr(cli, "run_fastmcp_http", run_http)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "mcp-server",
+            "--profile",
+            "all",
+            "--transport",
+            "http",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "9876",
+            "--path",
+            "/relay-mcp",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert observed == [("all", "0.0.0.0", 9876, "/relay-mcp")]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6521,7 +6521,7 @@ def test_cli_session_teardown_waits_for_worker_acknowledged_cancellation(
             "session-1",
             "--cancel-jobs",
             "--relay-cancel-timeout-seconds",
-            "1",
+            "30",
             "--relay-cancel-poll-seconds",
             "0.01",
         ],

--- a/tests/test_clio_kit_mcp_contracts.py
+++ b/tests/test_clio_kit_mcp_contracts.py
@@ -1142,6 +1142,13 @@ def _exchange_tools_list(
     with tempfile.TemporaryFile() as stderr:
         process = subprocess.Popen(
             command,
+            env={
+                **os.environ,
+                # Contract probing validates the locked MCP surface, not
+                # cache-wide maintenance. A prune can wait behind another live
+                # clio-kit server and must not serialize independent probes.
+                "CLIO_KIT_UV_CACHE_PRUNE": "0",
+            },
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=stderr,

--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -243,6 +243,99 @@ def test_windows_atomic_create_captures_error_before_freeing_descriptor(
     assert events == ["create", "last-error", "free", "error"]
 
 
+def test_windows_private_descriptor_retries_transient_open_denial(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A stable file survives a bounded antivirus or sharing race."""
+    if os.name != "nt":
+        return
+    path = tmp_path / "private.json"
+    path.write_bytes(b"{}")
+    original_lstat = os.lstat
+    before = original_lstat(path)
+
+    class TransientCreateFile:
+        argtypes: list[object]
+        restype: object
+        attempts = 0
+        requested_access: list[int] = []
+
+        def __call__(
+            self,
+            _path: object,
+            desired_access: int,
+            *_args: object,
+        ) -> int | None:
+            self.attempts += 1
+            self.requested_access.append(desired_access)
+            if self.attempts < 3:
+                return ctypes.c_void_p(-1).value
+            return 123
+
+    transient_create = TransientCreateFile()
+
+    class GetFileInformation:
+        argtypes: list[object]
+        restype: object
+
+        def __call__(
+            self,
+            _handle: ctypes.c_void_p,
+            raw_information: Any,
+        ) -> int:
+            information = ctypes.cast(
+                raw_information,
+                ctypes.POINTER(cluster_config._WindowsFileInformation),  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            ).contents
+            information.attributes = 0
+            information.number_of_links = before.st_nlink
+            information.file_index_high = before.st_ino >> 32
+            information.file_index_low = before.st_ino & 0xFFFFFFFF
+            return 1
+
+    kernel32 = SimpleNamespace(
+        CreateFileW=transient_create,
+        GetFileInformationByHandle=GetFileInformation(),
+    )
+
+    def accept_private_acl(
+        _path: Path,
+        *,
+        handle: ctypes.c_void_p,
+        directory: bool,
+    ) -> None:
+        assert handle.value == 123
+        assert directory is False
+
+    def load_library(_name: str) -> object:
+        return kernel32
+
+    def open_os_file_handle(_handle: int, _flags: int) -> int:
+        return os.open(path, os.O_RDONLY)
+
+    monkeypatch.setattr(cluster_config, "_load_windows_library", load_library)
+    monkeypatch.setattr(cluster_config, "_windows_last_error", lambda: 5)
+    monkeypatch.setattr(
+        cluster_config,
+        "ensure_private_configuration_windows_handle",
+        accept_private_acl,
+    )
+    monkeypatch.setattr(
+        cluster_config,
+        "_open_windows_os_file_handle",
+        open_os_file_handle,
+    )
+
+    descriptor = cluster_config.open_private_configuration_windows_descriptor(path)
+    os.close(descriptor)
+
+    assert transient_create.attempts == 3
+    assert transient_create.requested_access[0] & cluster_config._WINDOWS_WRITE_OWNER  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    assert not transient_create.requested_access[1] & cluster_config._WINDOWS_WRITE_OWNER  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    assert transient_create.requested_access[2] & cluster_config._WINDOWS_WRITE_OWNER  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+
+
 def test_configuration_directory_is_created_with_private_protection(tmp_path: Path) -> None:
     path = tmp_path / "new-state" / "private"
 

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -2391,10 +2391,20 @@ def test_runtime_sidecar_failure_latches_until_exact_scheduler_reconciliation(
 
 def test_authenticated_direct_mode_pin_rejects_later_scheduler_identity(
     tmp_path: Path,
+    request: pytest.FixtureRequest,
 ) -> None:
     settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
     queue = ClioCoreQueue(settings.core_dir)
     scheduler = FakeSchedulerProvider()
+    owned_processes: list[subprocess.Popen[str]] = []
+
+    def cleanup_owned_processes() -> None:
+        for process in owned_processes:
+            if process.poll() is None:
+                process_containment.terminate_owned_process(process)
+            process_containment.release_owned_process(process)
+
+    request.addfinalizer(cleanup_owned_processes)
 
     class DirectThenSchedulerProvider(RecordingProvider):
         def run_named_pipeline_streaming(
@@ -2449,8 +2459,18 @@ def test_authenticated_direct_mode_pin_rejects_later_scheduler_identity(
                     + "\n"
                 )
             on_poll()
+            process = process_containment.spawn_owned_process(
+                [sys.executable, "-c", "import time;time.sleep(60)"],
+                env=process_containment.owner_environment(None),
+                text=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            owned_processes.append(process)
             if on_start is not None:
-                on_start(920)
+                on_start(process.pid)
+            process_containment.terminate_owned_process(process)
+            process.wait(timeout=5)
             return subprocess.CompletedProcess(["jarvis", "ppl", "run"], 0, "", "")
 
     job = queue.submit_job(
@@ -2487,15 +2507,27 @@ def test_authenticated_direct_mode_pin_rejects_later_scheduler_identity(
         and event.payload.get("scheduler_job_id") == "must-not-be-owned"
         for event in events
     )
+    assert len(owned_processes) == 1
+    owned_processes[0].wait(timeout=5)
 
 
 def test_corrupt_runtime_and_legacy_spoof_use_exact_durable_reconciliation(
     tmp_path: Path,
+    request: pytest.FixtureRequest,
 ) -> None:
     settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
     queue = ClioCoreQueue(settings.core_dir)
     scheduler = FakeSchedulerProvider()
     scheduler.reconciliation_matches = ["exact-owned-24680"]
+    owned_processes: list[subprocess.Popen[str]] = []
+
+    def cleanup_owned_processes() -> None:
+        for process in owned_processes:
+            if process.poll() is None:
+                process_containment.terminate_owned_process(process)
+            process_containment.release_owned_process(process)
+
+    request.addfinalizer(cleanup_owned_processes)
 
     class CorruptRuntimeWithSpoofProvider(RecordingProvider):
         def run_named_pipeline_streaming(
@@ -2523,8 +2555,18 @@ def test_corrupt_runtime_and_legacy_spoof_use_exact_durable_reconciliation(
             )
             document["runtime_metadata_hmac"] = "0" * 64
             runtime_path.write_text(json.dumps(document) + "\n", encoding="utf-8")
+            process = process_containment.spawn_owned_process(
+                [sys.executable, "-c", "import time;time.sleep(60)"],
+                env=process_containment.owner_environment(None),
+                text=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            owned_processes.append(process)
             if on_start is not None:
-                on_start(921)
+                on_start(process.pid)
+            process_containment.terminate_owned_process(process)
+            process.wait(timeout=5)
             if on_stdout is not None:
                 on_stdout("Submitted batch job spoofed-other-users-job\n")
             if on_poll is not None:
@@ -2561,6 +2603,8 @@ def test_corrupt_runtime_and_legacy_spoof_use_exact_durable_reconciliation(
     assert scheduler.reconciliation_markers
     assert scheduler.canceled == []
     _assert_no_execution_sidecars(settings, job.job_id)
+    assert len(owned_processes) == 1
+    owned_processes[0].wait(timeout=5)
 
 
 def test_worker_records_scheduler_status_from_polling(tmp_path: Path) -> None:

--- a/tests/test_fastmcp_server.py
+++ b/tests/test_fastmcp_server.py
@@ -278,6 +278,67 @@ def test_fastmcp_provider_exposes_dynamic_catalog_revision(
     asyncio.run(scenario())
 
 
+def test_fastmcp_factory_tasks_virtual_jarvis_tool(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+    definitions, catalog = mcp_tool_definitions_and_remote_catalog(profile="user")
+    submit_definition = next(item for item in definitions if item["name"] == "relay_submit_agent")
+    virtual_definition = {**submit_definition, "name": "jarvis_describe"}
+    original_call = fastmcp_server_module.call_mcp_tool
+
+    def virtual_catalog(*, profile: str) -> tuple[list[JSON], VirtualRemoteMcpCatalog]:
+        assert profile == "user"
+        return (
+            [virtual_definition],
+            VirtualRemoteMcpCatalog(
+                revision="b" * 64,
+                tools={},
+                issues=catalog.issues,
+            ),
+        )
+
+    def virtual_call(params: JSON, **kwargs: Any) -> JSON:
+        assert params["name"] == "jarvis_describe"
+        return original_call(
+            {
+                "name": "relay_submit_agent",
+                "arguments": params.get("arguments", {}),
+            },
+            **kwargs,
+        )
+
+    monkeypatch.setattr(
+        fastmcp_server_module,
+        "mcp_tool_definitions_and_remote_catalog",
+        virtual_catalog,
+    )
+    monkeypatch.setattr(fastmcp_server_module, "call_mcp_tool", virtual_call)
+
+    async def scenario() -> None:
+        server = create_fastmcp_server(settings=settings, queue=queue)
+        component = await server.get_tool("jarvis_describe")
+        assert component is not None
+        assert component.task_config.mode == "optional"
+        async with Client(
+            server,
+            mode="auto",
+        ) as client:
+            task = await call_tool_task(
+                client,
+                "jarvis_describe",
+                _submit_arguments(tmp_path, "factory-virtual"),
+            )
+            assert task.task_id == queue.list_jobs()[0].job_id
+
+    asyncio.run(scenario())
+
+
 def test_official_fastmcp_tool_task_projects_job_and_survives_reopen(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_fastmcp_server.py
+++ b/tests/test_fastmcp_server.py
@@ -1,0 +1,988 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import mcp_types
+import pytest
+from fastmcp import Client, FastMCP
+from fastmcp.client.transports import FastMCPTransport
+from fastmcp.server.dependencies import get_context
+from fastmcp.tools import InputRequiredToolResult, ToolResult
+from fastmcp.utilities.tests import asgi_server
+from fastmcp_tasks.client import (
+    ToolTask,
+    call_tool_task,  # pyright: ignore[reportUnknownVariableType]
+)
+from fastmcp_tasks.client_models import (
+    ClientGetTaskResult,
+    GetTaskRequest,
+    GetTaskRequestParams,
+)
+from fastmcp_tasks.models import MISSING_REQUIRED_CLIENT_CAPABILITY
+from mcp.shared.exceptions import MCPError
+
+import clio_relay.fastmcp_server as fastmcp_server_module
+from clio_relay.config import RelaySettings
+from clio_relay.core_queue import ClioCoreQueue
+from clio_relay.errors import NotFoundError, QueueConflictError
+from clio_relay.fastmcp_server import (
+    MAX_TASK_ARGUMENT_BYTES,
+    RelayMcpRuntime,
+    RelayTasksExtension,
+    RelayTool,
+    create_fastmcp_server,
+)
+from clio_relay.mcp_server import mcp_tool_definitions_and_remote_catalog
+from clio_relay.models import (
+    JobKind,
+    JobState,
+    RelayJob,
+    RelayMcpInputRound,
+    RelayMcpTaskProjection,
+    RelayMcpTaskRecord,
+    RemoteAgentTaskSpec,
+)
+from clio_relay.remote_mcp import VirtualRemoteMcpCatalog
+
+JSON = dict[str, Any]
+
+
+class _NoInternalExtensionsClient(Client[FastMCPTransport]):
+    """FastMCP client variant that deliberately omits built-in extensions."""
+
+    _auto_internal_extensions = False
+
+
+def _task_server(
+    settings: RelaySettings,
+    queue: ClioCoreQueue,
+) -> FastMCP[dict[str, Any]]:
+    runtime = RelayMcpRuntime(settings=settings, profile="user", queue=queue)
+    definitions, _catalog = mcp_tool_definitions_and_remote_catalog(profile="user")
+    definition = next(item for item in definitions if item["name"] == "relay_submit_agent")
+    tool = RelayTool(
+        definition,
+        runtime=runtime,
+        catalog_revision=None,
+        task_capable=True,
+    )
+    server: FastMCP[dict[str, Any]] = FastMCP(
+        "relay-task-test",
+        tools=[tool],
+        lifespan=runtime.lifespan,
+        tasks=False,
+        strict_input_validation=True,
+    )
+    server.add_extension(RelayTasksExtension(runtime))
+    return server
+
+
+def _submit_arguments(tmp_path: Path, suffix: str) -> dict[str, object]:
+    return {
+        "cluster": "test-cluster",
+        "prompt_path": str(tmp_path / f"prompt-{suffix}.md"),
+        "timeout_seconds": 45,
+        "idempotency_key": f"fastmcp-task-{suffix}",
+    }
+
+
+def _elicitation_request(message: str) -> mcp_types.ElicitRequest:
+    return mcp_types.ElicitRequest(
+        params=mcp_types.ElicitRequestFormParams(
+            message=message,
+            requested_schema={
+                "type": "object",
+                "properties": {"approved": {"type": "boolean"}},
+                "required": ["approved"],
+                "additionalProperties": False,
+            },
+        )
+    )
+
+
+def _elicitation_document(message: str) -> dict[str, Any]:
+    return _elicitation_request(message).model_dump(
+        by_alias=True,
+        mode="json",
+        exclude_none=True,
+    )
+
+
+def _put_input_round(
+    queue: ClioCoreQueue,
+    task_id: str,
+    *,
+    keys: tuple[str, ...],
+) -> None:
+    record = queue.get_mcp_task(task_id)
+    outstanding = {key: _elicitation_document(f"Approve {key}?") for key in keys}
+    projection = RelayMcpTaskProjection.model_validate(
+        {
+            **record.projection.model_dump(mode="python"),
+            "issued_input_keys": list(keys),
+            "input_round": RelayMcpInputRound(
+                leg=1,
+                outstanding=outstanding,
+                request_state="relay-input-round-v1",
+            ),
+        },
+    )
+    queue.update_mcp_task_projection(
+        task_id,
+        projection,
+        expected_updated_at=record.updated_at,
+    )
+
+
+class _GuardedRelayTool(RelayTool):
+    """Test-only relay tool proving a guard round precedes task creation."""
+
+    def __init__(
+        self,
+        definition: JSON,
+        *,
+        runtime: RelayMcpRuntime,
+        catalog_revision: str | None,
+        task_capable: bool,
+    ) -> None:
+        super().__init__(
+            definition,
+            runtime=runtime,
+            catalog_revision=catalog_revision,
+            task_capable=task_capable,
+        )
+
+    async def run(self, arguments: dict[str, Any]) -> ToolResult:
+        context = get_context()
+        responses = context.input_responses
+        if responses is None:
+            return InputRequiredToolResult(
+                input_required=mcp_types.InputRequiredResult(
+                    input_requests={"approval": _elicitation_request("Approve submission?")},
+                    request_state="guarded-submit-v1",
+                )
+            )
+        approval = responses.get("approval")
+        if not isinstance(approval, mcp_types.ElicitResult):
+            raise ValueError("guarded relay submission omitted its elicitation response")
+        if approval.action != "accept" or approval.content != {"approved": True}:
+            raise ValueError("guarded relay submission was not approved")
+        if context.request_state != "guarded-submit-v1":
+            raise ValueError("guarded relay submission lost its request state")
+        return await super().run(arguments)
+
+
+def _guarded_task_server(
+    settings: RelaySettings,
+    queue: ClioCoreQueue,
+) -> FastMCP[dict[str, Any]]:
+    runtime = RelayMcpRuntime(settings=settings, profile="user", queue=queue)
+    definitions, _catalog = mcp_tool_definitions_and_remote_catalog(profile="user")
+    definition = next(item for item in definitions if item["name"] == "relay_submit_agent")
+    server: FastMCP[dict[str, Any]] = FastMCP(
+        "relay-guarded-task-test",
+        tools=[
+            _GuardedRelayTool(
+                definition,
+                runtime=runtime,
+                catalog_revision=None,
+                task_capable=True,
+            )
+        ],
+        lifespan=runtime.lifespan,
+        tasks=False,
+        strict_input_validation=True,
+    )
+    server.add_extension(RelayTasksExtension(runtime))
+    return server
+
+
+def test_fastmcp_factory_advertises_tasks_and_preserves_user_catalog(
+    tmp_path: Path,
+) -> None:
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+
+    async def scenario() -> None:
+        server = create_fastmcp_server(settings=settings, queue=queue)
+        async with Client(server, mode="auto") as client:
+            tools = await client.list_tools()
+            tool_names = {tool.name for tool in tools}
+            assert "relay_submit_agent" in tool_names
+            assert "relay_status" in tool_names
+            capabilities = client.session.server_capabilities
+            assert capabilities is not None
+            extensions = capabilities.extensions or {}
+            assert "io.modelcontextprotocol/tasks" in extensions
+
+    asyncio.run(scenario())
+
+
+def test_fastmcp_provider_exposes_dynamic_catalog_revision(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+    definitions, catalog = mcp_tool_definitions_and_remote_catalog(profile="user")
+    revision = "a" * 64
+    dynamic_definition: JSON = {
+        "name": "remote_demo_echo",
+        "description": "One test-only dynamically discovered remote tool.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"cluster": {"type": "string"}},
+            "required": ["cluster"],
+            "additionalProperties": False,
+        },
+        "outputSchema": {
+            "type": "object",
+            "additionalProperties": True,
+        },
+    }
+
+    def dynamic_catalog(*, profile: str) -> tuple[list[JSON], VirtualRemoteMcpCatalog]:
+        assert profile == "user"
+        return (
+            [*definitions, dynamic_definition],
+            VirtualRemoteMcpCatalog(
+                revision=revision,
+                tools={},
+                issues=catalog.issues,
+            ),
+        )
+
+    monkeypatch.setattr(
+        fastmcp_server_module,
+        "mcp_tool_definitions_and_remote_catalog",
+        dynamic_catalog,
+    )
+
+    async def scenario() -> None:
+        server = create_fastmcp_server(settings=settings, queue=queue)
+        async with Client(server, mode="auto") as client:
+            tools = await client.list_tools()
+        dynamic = next(tool for tool in tools if tool.name == "remote_demo_echo")
+        assert dynamic.meta is not None
+        assert dynamic.meta["clio-relay/catalog-revision"] == revision
+
+    asyncio.run(scenario())
+
+
+def test_official_fastmcp_tool_task_projects_job_and_survives_reopen(
+    tmp_path: Path,
+) -> None:
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+
+    async def scenario() -> None:
+        async with Client(_task_server(settings, queue), mode="auto") as client:
+            task = await call_tool_task(
+                client,
+                "relay_submit_agent",
+                _submit_arguments(tmp_path, "complete"),
+            )
+            job = queue.get_job(task.task_id)
+            assert task.task_id == job.job_id
+            assert queue.get_mcp_task(task.task_id).projection.tool_name == ("relay_submit_agent")
+            assert (await task.status()).status == "working"
+
+            reopened = ClioCoreQueue(settings.core_dir)
+            restored = reopened.get_mcp_task(task.task_id)
+            assert restored.task_id == job.job_id
+            assert restored.projection.arguments["idempotency_key"] == ("fastmcp-task-complete")
+
+            queue.update_job_state(job.job_id, JobState.SUCCEEDED)
+            result = await task.result()
+            assert result.is_error is False
+            assert result.structured_content is not None
+            assert result.structured_content["job"]["job_id"] == job.job_id
+            assert (await task.status()).status == "completed"
+
+    asyncio.run(scenario())
+
+
+def test_official_fastmcp_tool_task_cancel_uses_relay_cancellation(
+    tmp_path: Path,
+) -> None:
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+
+    async def scenario() -> None:
+        async with Client(_task_server(settings, queue), mode="auto") as client:
+            task = await call_tool_task(
+                client,
+                "relay_submit_agent",
+                _submit_arguments(tmp_path, "cancel"),
+                raise_on_error=False,
+            )
+            await task.cancel()
+            assert queue.get_job(task.task_id).state is JobState.CANCELED
+            assert (await task.status()).status == "cancelled"
+            result = await task.result()
+            assert result.is_error is True
+
+    asyncio.run(scenario())
+
+
+def test_transparent_fastmcp_call_tool_polls_relay_task_to_completion(
+    tmp_path: Path,
+) -> None:
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+
+    async def scenario() -> None:
+        async with Client(_task_server(settings, queue), mode="auto") as client:
+            pending = asyncio.create_task(
+                client.call_tool(
+                    "relay_submit_agent",
+                    _submit_arguments(tmp_path, "transparent"),
+                )
+            )
+            for _attempt in range(1_000):
+                jobs = await asyncio.to_thread(queue.list_jobs)
+                if jobs:
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                raise AssertionError("relay job was not admitted")
+            queue.update_job_state(jobs[0].job_id, JobState.SUCCEEDED)
+            result = await asyncio.wait_for(pending, timeout=5)
+            assert result.is_error is False
+            assert result.structured_content is not None
+            assert result.structured_content["job"]["job_id"] == jobs[0].job_id
+
+    asyncio.run(scenario())
+
+
+def test_task_capability_is_visible_without_starting_docket(tmp_path: Path) -> None:
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+    server = _task_server(settings, queue)
+
+    async def scenario() -> None:
+        assert server.docket is None
+        async with Client(server, mode="auto") as client:
+            tools = await client.list_tools()
+            submit = next(tool for tool in tools if tool.name == "relay_submit_agent")
+            assert submit.execution is None
+            component = await server.get_tool("relay_submit_agent")
+            assert component is not None
+            assert component.task_config.mode == "optional"
+            capabilities = client.session.server_capabilities
+            assert capabilities is not None
+            assert "io.modelcontextprotocol/tasks" in (capabilities.extensions or {})
+            assert server.docket is None
+        assert server.docket is None
+
+    asyncio.run(scenario())
+
+
+def test_task_methods_require_the_client_extension_capability(tmp_path: Path) -> None:
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+    server = _task_server(settings, queue)
+
+    async def scenario() -> None:
+        async with Client(server, mode="auto") as client:
+            task = await call_tool_task(
+                client,
+                "relay_submit_agent",
+                _submit_arguments(tmp_path, "capability"),
+            )
+            task_id = task.task_id
+            with pytest.raises(MCPError) as missing:
+                await client.session.send_request(
+                    GetTaskRequest(params=GetTaskRequestParams(task_id="job-missing")),
+                    ClientGetTaskResult,
+                )
+            assert missing.value.code == mcp_types.INVALID_PARAMS
+
+        async with _NoInternalExtensionsClient(server, mode="auto") as client:
+            with pytest.raises(MCPError) as failure:
+                await client.session.send_request(
+                    GetTaskRequest(params=GetTaskRequestParams(task_id=task_id)),
+                    ClientGetTaskResult,
+                )
+            assert failure.value.code == MISSING_REQUIRED_CLIENT_CAPABILITY
+            assert failure.value.data == {
+                "requiredCapabilities": {"extensions": {"io.modelcontextprotocol/tasks": {}}}
+            }
+
+    asyncio.run(scenario())
+
+
+def test_task_methods_are_not_available_on_legacy_protocol(tmp_path: Path) -> None:
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+
+    async def scenario() -> None:
+        async with _NoInternalExtensionsClient(
+            _task_server(settings, queue),
+            mode="legacy",
+        ) as client:
+            with pytest.raises(MCPError) as failure:
+                await client.session.send_request(
+                    GetTaskRequest(params=GetTaskRequestParams(task_id="job-missing")),
+                    ClientGetTaskResult,
+                )
+            assert failure.value.code == mcp_types.METHOD_NOT_FOUND
+
+    asyncio.run(scenario())
+
+
+def test_streamable_http_requires_bearer_authentication(tmp_path: Path) -> None:
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        api_token="relay-http-secret",
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+    server = create_fastmcp_server(
+        settings=settings,
+        queue=queue,
+        http_base_url="http://127.0.0.1/mcp",
+    )
+
+    async def scenario() -> None:
+        async with asgi_server(server) as running:
+            async with running.http_client() as raw_client:
+                missing = await raw_client.post(running.url, json={})
+                assert missing.status_code == 401
+            async with running.http_client(
+                headers={"Authorization": "Bearer incorrect"}
+            ) as raw_client:
+                incorrect = await raw_client.post(running.url, json={})
+                assert incorrect.status_code == 401
+            async with Client(
+                running.transport(auth="relay-http-secret"),
+                mode="auto",
+            ) as client:
+                tools = await client.list_tools()
+                assert "relay_status" in {tool.name for tool in tools}
+
+    asyncio.run(scenario())
+
+
+def test_http_task_management_rejects_mcp_name_header_mismatch(
+    tmp_path: Path,
+) -> None:
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+
+    async def scenario() -> None:
+        async with (
+            asgi_server(_task_server(settings, queue)) as running,
+            Client(
+                running.transport(headers={"Mcp-Name": "not-the-relay-job-id"}),
+                mode="auto",
+            ) as client,
+        ):
+            task = await call_tool_task(
+                client,
+                "relay_submit_agent",
+                _submit_arguments(tmp_path, "header"),
+            )
+            with pytest.raises(MCPError) as failure:
+                await task.status()
+            assert failure.value.code == mcp_types.HEADER_MISMATCH
+
+    asyncio.run(scenario())
+
+
+def test_official_tool_task_reattaches_over_new_http_client(tmp_path: Path) -> None:
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+
+    async def scenario() -> None:
+        async with asgi_server(_task_server(settings, queue)) as running:
+            async with Client(
+                running.transport(),
+                mode="auto",
+            ) as first_client:
+                first = await call_tool_task(
+                    first_client,
+                    "relay_submit_agent",
+                    _submit_arguments(tmp_path, "reattach"),
+                )
+                create_result = first.create_result
+                task_id = first.task_id
+
+            queue.update_job_state(task_id, JobState.SUCCEEDED)
+
+            async with Client(
+                running.transport(),
+                mode="auto",
+            ) as second_client:
+                restored = ToolTask(
+                    second_client,
+                    "relay_submit_agent",
+                    create_result,
+                )
+                result = await restored.result()
+                assert result.is_error is False
+                assert result.structured_content is not None
+                assert result.structured_content["job"]["job_id"] == task_id
+
+    asyncio.run(scenario())
+
+
+def test_failed_relay_job_is_completed_task_with_tool_error(tmp_path: Path) -> None:
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+
+    async def scenario() -> None:
+        async with Client(_task_server(settings, queue), mode="auto") as client:
+            task = await call_tool_task(
+                client,
+                "relay_submit_agent",
+                _submit_arguments(tmp_path, "failed"),
+                raise_on_error=False,
+            )
+            queue.update_job_state(
+                task.task_id,
+                JobState.FAILED,
+                error="remote agent failed",
+            )
+            status = await task.status()
+            assert status.status == "completed"
+            assert status.result is not None
+            assert status.result["isError"] is True
+            result = await task.result()
+            assert result.is_error is True
+            assert result.structured_content is not None
+            assert result.structured_content["job"]["state"] == JobState.FAILED.value
+
+    asyncio.run(scenario())
+
+
+def test_official_client_answers_durable_input_required_task(tmp_path: Path) -> None:
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+    elicitation_messages: list[str] = []
+
+    async def approve(
+        message: str,
+        _response_type: type[Any] | None,
+        _params: mcp_types.ElicitRequestParams,
+        _context: Any,
+    ) -> dict[str, bool]:
+        elicitation_messages.append(message)
+        jobs = await asyncio.to_thread(queue.list_jobs)
+        assert len(jobs) == 1
+        await asyncio.to_thread(
+            queue.update_job_state,
+            jobs[0].job_id,
+            JobState.SUCCEEDED,
+        )
+        return {"approved": True}
+
+    async def scenario() -> None:
+        async with Client(
+            _task_server(settings, queue),
+            mode="auto",
+            elicitation_handler=approve,
+        ) as client:
+            task = await call_tool_task(
+                client,
+                "relay_submit_agent",
+                _submit_arguments(tmp_path, "input-required"),
+            )
+            _put_input_round(queue, task.task_id, keys=("approval",))
+            assert (await task.status()).status == "input_required"
+
+            result = await task.result()
+            assert result.is_error is False
+            assert elicitation_messages == ["Approve approval?"]
+            persisted = queue.get_mcp_task(task.task_id).projection.input_round
+            assert persisted is not None
+            assert persisted.outstanding == {}
+            answer = persisted.answered["approval"]
+            assert answer["action"] == "accept"
+            assert answer["content"] == {"approved": True}
+
+    asyncio.run(scenario())
+
+
+def test_task_input_updates_are_partial_replay_safe_and_cas_retrying(
+    tmp_path: Path,
+) -> None:
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+    runtime = RelayMcpRuntime(settings=settings, profile="user", queue=queue)
+
+    async def scenario() -> None:
+        async with Client(_task_server(settings, queue), mode="auto") as client:
+            task = await call_tool_task(
+                client,
+                "relay_submit_agent",
+                _submit_arguments(tmp_path, "input-cas"),
+            )
+        _put_input_round(queue, task.task_id, keys=("first", "second"))
+        original = queue.get_mcp_task(task.task_id)
+
+        await runtime.update_task(
+            original,
+            {
+                "unknown": {"ignored": True},
+                "first": {"action": "accept", "content": {"approved": True}},
+            },
+        )
+        after_first = queue.get_mcp_task(task.task_id)
+        first_round = after_first.projection.input_round
+        assert first_round is not None
+        assert set(first_round.outstanding) == {"second"}
+        first_updated_at = after_first.updated_at
+
+        await runtime.update_task(
+            after_first,
+            {"first": {"action": "accept", "content": {"approved": False}}},
+        )
+        assert queue.get_mcp_task(task.task_id).updated_at == first_updated_at
+
+        await runtime.update_task(
+            original,
+            {"second": {"action": "decline"}},
+        )
+        final_round = queue.get_mcp_task(task.task_id).projection.input_round
+        assert final_round is not None
+        assert final_round.outstanding == {}
+        assert set(final_round.answered) == {"first", "second"}
+        assert final_round.answered["first"]["content"] == {"approved": True}
+
+    asyncio.run(scenario())
+
+
+def test_task_projection_is_idempotent_bounded_and_conflict_checked(
+    tmp_path: Path,
+) -> None:
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+    runtime = RelayMcpRuntime(settings=settings, profile="user", queue=queue)
+    definitions, _catalog = mcp_tool_definitions_and_remote_catalog(profile="user")
+    definition = next(item for item in definitions if item["name"] == "relay_submit_agent")
+    tool = RelayTool(
+        definition,
+        runtime=runtime,
+        catalog_revision=None,
+        task_capable=True,
+    )
+    result = ToolResult(
+        content=[mcp_types.TextContent(type="text", text="accepted")],
+        structured_content={
+            "job_id": "job-projection-idempotency",
+            "state": JobState.QUEUED.value,
+            "terminal": False,
+        },
+    )
+
+    async def scenario() -> None:
+        first = await runtime.create_task(
+            tool=tool,
+            arguments={"value": "same"},
+            result=result,
+        )
+        replay = await runtime.create_task(
+            tool=tool,
+            arguments={"value": "same"},
+            result=result,
+        )
+        assert first is not None
+        assert replay == first
+
+        progressed_replay = await runtime.create_task(
+            tool=tool,
+            arguments={"value": "same"},
+            result=ToolResult(
+                content=result.content,
+                structured_content={
+                    "job_id": "job-projection-idempotency",
+                    "state": JobState.RUNNING.value,
+                    "terminal": False,
+                },
+            ),
+        )
+        assert progressed_replay is not None
+        assert progressed_replay == first
+        assert progressed_replay.projection.initial_result["state"] == JobState.QUEUED.value
+
+        with pytest.raises(QueueConflictError, match="different semantics"):
+            await runtime.create_task(
+                tool=tool,
+                arguments={"value": "different"},
+                result=result,
+            )
+
+        oversized = "x" * (MAX_TASK_ARGUMENT_BYTES + 1)
+        assert len(json.dumps({"value": oversized}).encode("utf-8")) > (MAX_TASK_ARGUMENT_BYTES)
+        with pytest.raises(ValueError, match="projection limit"):
+            await runtime.create_task(
+                tool=tool,
+                arguments={"value": oversized},
+                result=ToolResult(
+                    content=result.content,
+                    structured_content={
+                        "job_id": "job-projection-oversized",
+                        "state": JobState.QUEUED.value,
+                        "terminal": False,
+                    },
+                ),
+            )
+
+        with pytest.raises(ValueError, match="finite JSON"):
+            await runtime.create_task(
+                tool=tool,
+                arguments={"value": float("nan")},
+                result=ToolResult(
+                    content=result.content,
+                    structured_content={
+                        "job_id": "job-projection-nonfinite",
+                        "state": JobState.QUEUED.value,
+                        "terminal": False,
+                    },
+                ),
+            )
+
+        deep_arguments: JSON = {}
+        nested = deep_arguments
+        for _depth in range(66):
+            child: JSON = {}
+            nested["child"] = child
+            nested = child
+        with pytest.raises(ValueError, match="nesting levels"):
+            await runtime.create_task(
+                tool=tool,
+                arguments=deep_arguments,
+                result=ToolResult(
+                    content=result.content,
+                    structured_content={
+                        "job_id": "job-projection-deep",
+                        "state": JobState.QUEUED.value,
+                        "terminal": False,
+                    },
+                ),
+            )
+
+        errored_projection = RelayMcpTaskProjection.model_validate(
+            {
+                **first.projection.model_dump(mode="python"),
+                "protocol_error": {
+                    "code": mcp_types.INTERNAL_ERROR,
+                    "message": "relay protocol projection failed",
+                },
+            }
+        )
+        errored = await asyncio.to_thread(
+            lambda: queue.update_mcp_task_projection(
+                first.task_id,
+                errored_projection,
+                expected_updated_at=first.updated_at,
+            )
+        )
+        errored_status = await runtime.task_status(errored)
+        assert errored_status.status == "failed"
+        assert errored_status.error == {
+            "code": mcp_types.INTERNAL_ERROR,
+            "message": "relay protocol projection failed",
+        }
+        errored_replay = await runtime.create_task(
+            tool=tool,
+            arguments={"value": "same"},
+            result=result,
+        )
+        assert errored_replay == errored
+
+    asyncio.run(scenario())
+
+    projection_base: JSON = {
+        "tool_name": "relay_submit_agent",
+        "profile": "user",
+        "arguments": {},
+        "initial_result": {
+            "job_id": "job-projection-invariants",
+            "state": JobState.QUEUED.value,
+            "terminal": False,
+        },
+    }
+    with pytest.raises(ValueError, match="unissued request key"):
+        RelayMcpTaskProjection.model_validate(
+            {
+                **projection_base,
+                "input_round": {
+                    "leg": 1,
+                    "outstanding": {"unissued": _elicitation_document("Approve?")},
+                },
+            }
+        )
+    with pytest.raises(ValueError, match="outstanding and answered"):
+        RelayMcpTaskProjection.model_validate(
+            {
+                **projection_base,
+                "issued_input_keys": ["approval"],
+                "input_round": {
+                    "leg": 1,
+                    "outstanding": {"approval": _elicitation_document("Approve?")},
+                    "answered": {"approval": {"action": "accept", "content": {}}},
+                },
+            }
+        )
+    with pytest.raises(ValueError, match="conflicting result states"):
+        RelayMcpTaskProjection.model_validate(
+            {
+                **projection_base,
+                "issued_input_keys": ["approval"],
+                "input_round": {
+                    "leg": 1,
+                    "outstanding": {"approval": _elicitation_document("Approve?")},
+                },
+                "completed_result": {"isError": False},
+            }
+        )
+
+
+def test_mcp_task_family_is_additive_and_collected_with_its_job(tmp_path: Path) -> None:
+    core_dir = tmp_path / "core"
+    queue = ClioCoreQueue(core_dir)
+    queue.initialize()
+    task_dir = core_dir / "mcp_tasks"
+    assert task_dir.is_dir()
+
+    task_dir.rmdir()
+    queue = ClioCoreQueue(core_dir)
+    queue.initialize()
+    assert task_dir.is_dir()
+
+    job = queue.submit_job(
+        RelayJob(
+            cluster="test-cluster",
+            kind=JobKind.REMOTE_AGENT,
+            spec=RemoteAgentTaskSpec(prompt_path="/remote/prompt.md"),
+            idempotency_key="mcp-task-gc",
+        )
+    )
+    queue.put_mcp_task(
+        RelayMcpTaskRecord(
+            task_id=job.job_id,
+            job_id=job.job_id,
+            state=job.state,
+            projection=RelayMcpTaskProjection(
+                tool_name="relay_submit_agent",
+                profile="user",
+                arguments={"cluster": "test-cluster"},
+                initial_result={
+                    "job_id": job.job_id,
+                    "state": job.state.value,
+                    "terminal": False,
+                },
+            ),
+        )
+    )
+    queue.update_job_state(job.job_id, JobState.SUCCEEDED)
+
+    for _attempt in range(100):
+        collected = queue.collect_terminal_job(
+            job.job_id,
+            execute=True,
+            batch_size=3,
+            external_quarantine_id=f"test-quarantine:{job.job_id}",
+        )
+        if collected.complete:
+            break
+    else:
+        raise AssertionError("terminal MCP task GC did not complete")
+
+    with pytest.raises(NotFoundError):
+        queue.get_mcp_task(job.job_id)
+
+
+def test_guarded_input_round_completes_before_relay_task_creation(
+    tmp_path: Path,
+) -> None:
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+    elicitation_count = 0
+
+    async def approve(
+        _message: str,
+        _response_type: type[Any] | None,
+        _params: mcp_types.ElicitRequestParams,
+        _context: Any,
+    ) -> dict[str, bool]:
+        nonlocal elicitation_count
+        elicitation_count += 1
+        return {"approved": True}
+
+    async def scenario() -> None:
+        async with Client(
+            _guarded_task_server(settings, queue),
+            mode="auto",
+            elicitation_handler=approve,
+        ) as client:
+            pending = asyncio.create_task(
+                client.call_tool(
+                    "relay_submit_agent",
+                    _submit_arguments(tmp_path, "guarded"),
+                )
+            )
+            for _attempt in range(1_000):
+                jobs = await asyncio.to_thread(queue.list_jobs)
+                if jobs:
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                raise AssertionError("guarded relay job was not admitted")
+            assert elicitation_count == 1
+            queue.update_job_state(jobs[0].job_id, JobState.SUCCEEDED)
+            result = await asyncio.wait_for(pending, timeout=5)
+            assert result.is_error is False
+            assert queue.get_mcp_task(jobs[0].job_id).task_id == jobs[0].job_id
+
+    asyncio.run(scenario())

--- a/tests/test_mcp_call_runner.py
+++ b/tests/test_mcp_call_runner.py
@@ -494,6 +494,152 @@ for line in sys.stdin:
     assert result.stderr == ""
 
 
+def test_mcp_session_withholds_initialize_until_locked_launcher_is_ready(
+    tmp_path: Path,
+) -> None:
+    """A nested launcher's preparation phase cannot consume the MCP handshake."""
+    runner = _load_runner()
+    server_path = tmp_path / "locked_launcher.py"
+    server_path.write_text(
+        """import json
+import os
+import queue
+import sys
+import threading
+import time
+
+received = queue.Queue()
+
+def read_initialize():
+    received.put(sys.stdin.readline())
+
+reader = threading.Thread(target=read_initialize, daemon=True)
+reader.start()
+print(json.dumps({
+    "schema_version": "clio-kit.cache-event.v0",
+    "event": "uv_cache_prune",
+}), file=sys.stderr, flush=True)
+print(json.dumps({
+    "schema_version": "clio-kit.cache-event.v1",
+    "event": "cache_config_rejected",
+}), file=sys.stderr, flush=True)
+time.sleep(0.4)
+if not received.empty():
+    print("initialize arrived during locked environment preparation", file=sys.stderr, flush=True)
+    raise SystemExit(91)
+print(json.dumps({
+    "schema_version": "clio-kit.cache-event.v1",
+    "event": "uv_cache_prune",
+    "ran": False,
+    "ok": True,
+    "prune_config": os.environ.get("CLIO_KIT_UV_CACHE_PRUNE"),
+}), file=sys.stderr, flush=True)
+
+def respond(message):
+    method = message.get("method")
+    if method == "initialize":
+        result = {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "locked-test-server", "version": "1.0"},
+        }
+        print(json.dumps({"jsonrpc": "2.0", "id": message["id"], "result": result}), flush=True)
+    elif method == "tools/list":
+        result = {"tools": []}
+        print(json.dumps({"jsonrpc": "2.0", "id": message["id"], "result": result}), flush=True)
+        return True
+    return False
+
+first = received.get(timeout=5)
+if first:
+    respond(json.loads(first))
+for line in sys.stdin:
+    if respond(json.loads(line)):
+        break
+""",
+        encoding="utf-8",
+    )
+
+    result = cast(Any, runner)._run_mcp_session(
+        [sys.executable, str(server_path)],
+        tool=None,
+        arguments={},
+        timeout=10,
+        operation="tools/list",
+        env_from={},
+        wait_for_locked_launcher=True,
+    )
+
+    assert result.returncode == 0
+    assert "locked-test-server" in result.stdout
+    assert "arrived during locked environment preparation" not in result.stderr
+    assert '"schema_version": "clio-kit.cache-event.v0"' in result.stderr
+    assert '"schema_version": "clio-kit.cache-event.v1"' in result.stderr
+    assert '"prune_config": "0"' in result.stderr
+
+
+def test_mcp_session_locked_launcher_readiness_obeys_session_timeout(
+    tmp_path: Path,
+) -> None:
+    """The launch preparation gate remains inside the request timeout."""
+    runner = _load_runner()
+    server_path = tmp_path / "silent_locked_launcher.py"
+    server_path.write_text(
+        "import time\ntime.sleep(30)\n",
+        encoding="utf-8",
+    )
+
+    started = time.monotonic()
+    with raises(subprocess.TimeoutExpired):
+        cast(Any, runner)._run_mcp_session(
+            [sys.executable, str(server_path)],
+            tool=None,
+            arguments={},
+            timeout=1,
+            operation="tools/list",
+            env_from={},
+            wait_for_locked_launcher=True,
+        )
+
+    assert time.monotonic() - started < 5
+
+
+def test_locked_launcher_readiness_requires_verified_v4_nested_runtime() -> None:
+    """Only the exact verified nested-launcher identity enables the stdin gate."""
+    runner = _load_runner()
+    artifact: dict[str, Any] = {
+        "verified": True,
+        "nested_launcher": True,
+        "nested_runtime": {
+            "schema_version": "clio-kit.locked-server.v4",
+            "locked_runtime_verified": True,
+        },
+    }
+
+    assert cast(Any, runner)._requires_locked_launcher_readiness(artifact) is True
+    mutations: tuple[dict[str, Any], ...] = (
+        {"verified": False},
+        {"nested_launcher": False},
+        {"nested_runtime": None},
+        {
+            "nested_runtime": {
+                "schema_version": "clio-kit.locked-server.v5",
+                "locked_runtime_verified": True,
+            }
+        },
+        {
+            "nested_runtime": {
+                "schema_version": "clio-kit.locked-server.v4",
+                "locked_runtime_verified": False,
+            }
+        },
+    )
+    for mutation in mutations:
+        candidate = deepcopy(artifact)
+        candidate.update(mutation)
+        assert cast(Any, runner)._requires_locked_launcher_readiness(candidate) is False
+
+
 def test_mcp_session_materializes_input_manifest_before_jarvis_run(tmp_path: Path) -> None:
     """The worker edits exact resolved paths before it can submit the scheduler run."""
     runner = _load_runner()
@@ -1772,9 +1918,11 @@ def test_mcp_call_runner_executes_private_snapshot_during_swap_and_restore(
         arguments: dict[str, object],
         timeout: int | None,
         env_from: dict[str, str],
+        wait_for_locked_launcher: bool = False,
     ) -> subprocess.CompletedProcess[str]:
         nonlocal snapshot_path
         del tool, arguments, timeout, env_from
+        assert wait_for_locked_launcher is True
         from_index = command.index("--from")
         snapshot_path = Path(command[from_index + 1])
         assert snapshot_path != wheel

--- a/tests/test_mcp_stdio_validation.py
+++ b/tests/test_mcp_stdio_validation.py
@@ -85,8 +85,17 @@ def _fake_transcript(*, version: str = __version__, tools: list[JSON] | None = N
             "id": "clio-relay-validation-initialize",
             "result": {
                 "protocolVersion": "2024-11-05",
-                "capabilities": {"tools": {}},
+                "capabilities": {
+                    "logging": {},
+                    "prompts": {"listChanged": False},
+                    "resources": {"listChanged": False, "subscribe": False},
+                    "tools": {"listChanged": True},
+                },
                 "serverInfo": {"name": "clio-relay", "version": version},
+                "instructions": (
+                    "Durable relay operations. Relay jobs remain the sole execution "
+                    "and cancellation authority."
+                ),
             },
         },
         {
@@ -558,7 +567,9 @@ def test_packaged_stdio_session_requires_exact_initialize_capabilities(
     monkeypatch: MonkeyPatch,
 ) -> None:
     transcript = _fake_transcript().replace(
-        b'"capabilities":{"tools":{}}',
+        b'"capabilities":{"logging":{},"prompts":{"listChanged":false},'
+        b'"resources":{"listChanged":false,"subscribe":false},'
+        b'"tools":{"listChanged":true}}',
         b'"capabilities":{}',
     )
     executable = _write_fake_executable(

--- a/tests/test_process_containment.py
+++ b/tests/test_process_containment.py
@@ -75,6 +75,72 @@ def test_owned_process_forwards_exact_bounded_stdin_payload() -> None:
         process_containment.release_owned_process(process)
 
 
+def test_broker_setup_timeout_joins_writer_before_return(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A timed-out setup writer cannot survive to corrupt a reused pipe handle."""
+    private = cast(Any, process_containment)
+    read_descriptor, write_descriptor = os.pipe()
+    setup_channel = os.fdopen(write_descriptor, "wb", buffering=0)
+    kill_observed = threading.Event()
+    allow_writer_exit = threading.Event()
+
+    class TimedOutBroker:
+        pid = 424242
+        stdin = setup_channel
+        returncode: int | None = None
+
+        def poll(self) -> int | None:
+            return self.returncode
+
+        def kill(self) -> None:
+            self.returncode = -9
+            kill_observed.set()
+
+        def wait(self, *, timeout: float) -> int:
+            assert timeout == process_containment.TERMINATION_TIMEOUT_SECONDS
+            assert self.returncode == -9
+            return -9
+
+    broker = TimedOutBroker()
+    original_write = os.write
+
+    def blocked_write(descriptor: int, payload: object) -> int:
+        if descriptor != write_descriptor:
+            return original_write(descriptor, cast(bytes, payload))
+        assert kill_observed.wait(timeout=1)
+        assert allow_writer_exit.wait(timeout=1)
+        raise BrokenPipeError("simulated timed-out broker pipe")
+
+    def release_writer() -> None:
+        assert kill_observed.wait(timeout=1)
+        time.sleep(0.05)
+        allow_writer_exit.set()
+
+    releaser = threading.Thread(target=release_writer, daemon=True)
+    releaser.start()
+    monkeypatch.setattr(process_containment.os, "write", blocked_write)
+    try:
+        with pytest.raises(RuntimeError, match="broker setup write timed out"):
+            private._release_broker(
+                broker,
+                readiness=SimpleNamespace(token="test-readiness"),
+                startup_deadline=time.monotonic() + 0.01,
+            )
+        writer_alive_after_return = any(
+            thread.name == f"clio-relay-broker-release-{broker.pid}" and thread.is_alive()
+            for thread in threading.enumerate()
+        )
+    finally:
+        allow_writer_exit.set()
+        releaser.join(timeout=1)
+        setup_channel.close()
+        os.close(read_descriptor)
+
+    assert broker.stdin is None
+    assert not writer_alive_after_return
+
+
 def test_linux_containment_discovery_uses_one_absolute_startup_deadline(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.5.8"
+    assert version == "1.5.9"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2499,7 +2499,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.5.8"
+    assert policy.release_version == "1.5.9"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,25 @@
 version = 1
 revision = 3
 requires-python = ">=3.12, <3.15"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
+
+[options]
+prerelease-mode = "allow"
+
+[[package]]
+name = "aiofile"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/cd/0d76dfc5de72bde52f55f53e925c7d152d9c7906634ec1e0cbc7e8d4ad93/aiofile-3.11.1-py3-none-any.whl", hash = "sha256:ce77d14ac07f77bc2b757834a5c129321f3f705c474593deed5ab209079a52c9", size = 20446, upload-time = "2026-05-16T08:18:32.051Z" },
+]
 
 [[package]]
 name = "annotated-doc"
@@ -43,12 +62,50 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
+]
+
+[[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
 name = "boolean-py"
 version = "5.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
+]
+
+[[package]]
+name = "burner-redis"
+version = "0.1.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/6f/ec3eeb9e3e9d7fedc51fcb56dd09da0f164495ab6fdf4caaa3754ceed659/burner_redis-0.1.6.tar.gz", hash = "sha256:362091d98c09953ef99be8bd026d75fad42599a0f153211e1a22d3e3029c7cfb", size = 843118, upload-time = "2026-04-27T17:11:41.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/cc/061897380b88c637e4bea1f6715ffba851d10b16d6610f2832ab61fa15b5/burner_redis-0.1.6-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:5dc9c170b9994b8d57958041857f240d1b0b9ac1559d0d35473f03fb62386dea", size = 1275400, upload-time = "2026-04-27T17:11:27.07Z" },
+    { url = "https://files.pythonhosted.org/packages/db/24/e4c6fb37d059b268c2a26b173d3f84b49547e837340983d3d018c08191c6/burner_redis-0.1.6-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f29caae7f80fea2e47350df24264a049aeaa934454210cddcadc2336ee8b423a", size = 1223570, upload-time = "2026-04-27T17:11:28.782Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/be/718af7f42bbebbfbfd771ba43697526c922dff54d1b0d62654e21418b25e/burner_redis-0.1.6-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0ce82edea4ed1ec34448a8610c62665517b3d2030254f31af32828b070a92a8", size = 1325624, upload-time = "2026-04-27T17:11:30.648Z" },
+    { url = "https://files.pythonhosted.org/packages/06/8a/4f72de7f967532d3739caa461625dc9122f0ca0d46faa883c153a10d0117/burner_redis-0.1.6-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e3dff7d691ab0035468c17f51632e452b075065a30e026278ed1b297441ce93", size = 1356531, upload-time = "2026-04-27T17:11:32.201Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/22/369338d6372abd12dee51965566428c06f3badd95f668ff1c11680b99b30/burner_redis-0.1.6-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3b43f983b6e8fbc208734f04b0bae8cf95323fc43105f977d20f0993fc28c1b3", size = 1526049, upload-time = "2026-04-27T17:11:33.93Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/23/0651cf86bc5ed390fef09e30ff4a4664cc3c5b88ddf4c6b8d905acc0d60e/burner_redis-0.1.6-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5b6ba097d910effff00a4610160a4a759503ad590e2c47a580bdcdac9a325823", size = 1579068, upload-time = "2026-04-27T17:11:35.964Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8c/302638fdad4476d4760d477b0f3c6b96c0f88d3f278e5f14d06eb048f788/burner_redis-0.1.6-cp310-abi3-win_amd64.whl", hash = "sha256:98c6b6fc397617cd5a6778ac020e4ed9985c393ad204f9f5cf524b68ae16070b", size = 1103735, upload-time = "2026-04-27T17:11:38.38Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ba/18668d92e18210150f7f93e2930264ad77a82e4d3e5f74ca1aecc002f78f/burner_redis-0.1.6-cp310-abi3-win_arm64.whl", hash = "sha256:c2583e98f9a3836ac2c6243ea0c8d56b40e7017b46617991e329bc807c544bad", size = 1029386, upload-time = "2026-04-27T17:11:40.266Z" },
 ]
 
 [[package]]
@@ -70,6 +127,36 @@ filecache = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "7.1.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/af/861ebc2e318a5c3300e3eb63bc4d30f3d70a46d13b360093728ac0705eed/cachetools-7.1.6.tar.gz", hash = "sha256:c7a79e7f30ba9943c1cefd08cc36f006aaae086e017af9166f1d59d6170c47e1", size = 40572, upload-time = "2026-07-23T22:47:53.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/f2/2086ba18a925a73586c4d4e61d25f4a6058e56fd00d77ce8f1d361ab4c9b/cachetools-7.1.6-py3-none-any.whl", hash = "sha256:2c12e255780330af28b91bb7fb96cce4c766f04e38396b9a24510190a5827096", size = 16954, upload-time = "2026-07-23T22:47:52.397Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -87,28 +174,56 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/85/990925db5df586ec90beb97529c853497e7f85ba0234830447faf41c3057/cffi-2.1.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:df2b82571a1b30f58a87bf4e5a9e78d2b1eff6c6ce8fd3aa3757221f93f0863f", size = 184829, upload-time = "2026-07-06T21:32:44.324Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/92/e7bb136ad6b5352603732cf907ef862ca103f20f2031c1735a46300c20c9/cffi-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78474632761faa0fb96f30b1c928c84ebcf68713cbb80d15bab09dfe61640fde", size = 184728, upload-time = "2026-07-06T21:32:45.683Z" },
     { url = "https://files.pythonhosted.org/packages/c3/c0/d1ec30ffb370f748f2fb54425972bfef9871e0132e82fb589c46b6676049/cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d", size = 214815, upload-time = "2026-07-06T21:32:48.557Z" },
     { url = "https://files.pythonhosted.org/packages/1b/dc/5620cf930688be01f2d673804291de757a934c90b946dbdc3d84130c2ea4/cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7", size = 222429, upload-time = "2026-07-06T21:32:49.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a4/77b53abbf7a1e0beb9637edbef2a94d15f9c822f591e85d439ffd91519a6/cffi-2.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:46b1c8db8f6122420f32d02fffb924c2fe9bc772d228c7c711748fff56aabb2b", size = 210315, upload-time = "2026-07-06T21:32:51.221Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0c/f528df19cc94b675087324d4760d9e6d5bfae97d6217aa4fac43de4f5fcc/cffi-2.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9fafc5aa2e2a39aaf7f8cc0c1f044a9b07fca12e558dca53a3cc5c654ad67a7", size = 208859, upload-time = "2026-07-06T21:32:52.512Z" },
     { url = "https://files.pythonhosted.org/packages/62/f2/c9522a81c32132799a1972c39f5c5f8b4c8b9f00488a23feaa6c06f07741/cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66", size = 221844, upload-time = "2026-07-06T21:32:53.704Z" },
     { url = "https://files.pythonhosted.org/packages/6e/28/bd53988b9833e8f8ad539d26f4c07a6b3f6bcb1e9e02e7ca038250b3428d/cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe", size = 225287, upload-time = "2026-07-06T21:32:54.907Z" },
     { url = "https://files.pythonhosted.org/packages/79/99/0d0fd37f055224085f42bbb2c022d002e17dde4a97972822327b07d84101/cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b", size = 223681, upload-time = "2026-07-06T21:32:56.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/80/c138990aa2a70b1a269f6e06348729836d733d6f970867943f61d367f8cc/cffi-2.1.0-cp312-cp312-win32.whl", hash = "sha256:9b8f0f26ca4e7513c534d351eca551947d053fac438f2a04ac96d882909b0d3a", size = 175269, upload-time = "2026-07-06T21:32:57.777Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/eb/f636456ff21a83fc13c032b58cc5dde061691546ac79efa284b2989b7982/cffi-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:c97f080ea627e2863524c5af3836e2270b5f5dfff1f104392b959f8df0c5d384", size = 185881, upload-time = "2026-07-06T21:32:59.253Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/400ea43e721727dca8a65c4521390e9196757caba4a45643acb2b63271b8/cffi-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:6d194185eabd279f1c05ebe3504265ddfc5ad2b58d0714f7db9f01da592e9eb6", size = 180088, upload-time = "2026-07-06T21:33:02.278Z" },
     { url = "https://files.pythonhosted.org/packages/96/88/a996879e2eeccb815f6e3a5967b12a308257412acec882039d386bd2aa7b/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda", size = 194331, upload-time = "2026-07-06T21:33:03.697Z" },
     { url = "https://files.pythonhosted.org/packages/58/85/7ae00d5c8dd6266f4e944c3db630f3c5c9a98b61d469c714d848b1d8138a/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b", size = 196966, upload-time = "2026-07-06T21:33:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e9/45c3a76ad8d43ad9261f4c95436da61128d3ca545d72b9612c0ab5be0b1c/cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a", size = 184795, upload-time = "2026-07-06T21:33:06.699Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4c/82f132cb4418ee6d953d982b19191e87e2a6372c8a4ce36e50b69d6ade4a/cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea", size = 184746, upload-time = "2026-07-06T21:33:08.071Z" },
     { url = "https://files.pythonhosted.org/packages/a0/1c/4ed5a0e5bdca6cbc275556de3328dd1b76fd0c11cc13c88fe66d1d8715f2/cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db", size = 214747, upload-time = "2026-07-06T21:33:09.671Z" },
     { url = "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f", size = 222392, upload-time = "2026-07-06T21:33:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f6/01890cfd63c08f8eb96a8319b0443690197d240a8bd6346048cf7bde9190/cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d", size = 210285, upload-time = "2026-07-06T21:33:12.251Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cf/2b684132056f438567b61e19d690dd31cd0921ace051e0a458be6074369e/cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0", size = 208801, upload-time = "2026-07-06T21:33:13.617Z" },
     { url = "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224", size = 221808, upload-time = "2026-07-06T21:33:15.466Z" },
     { url = "https://files.pythonhosted.org/packages/38/37/04f54b8e63a02f3d908332c9effbf8c366167c6f733ed8a3d4f79b7e2a1e/cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c", size = 225241, upload-time = "2026-07-06T21:33:16.869Z" },
     { url = "https://files.pythonhosted.org/packages/a9/d6/c72eecca433cd3e681c65ed313ab4835d9d4a379704d0f628a6a05f51c2e/cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a", size = 223588, upload-time = "2026-07-06T21:33:18.239Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4b/e706f67279140f92939da3475ad610df18bfd52d50f14953a8e5fede71d5/cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2", size = 175248, upload-time = "2026-07-06T21:33:19.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/47/59eb7975cb0e4ef0afa764ea945b29a5bb4537a9f771cb7d6c8a5dd74c95/cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512", size = 185717, upload-time = "2026-07-06T21:33:21.47Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/af/34fee85c48f8d94efc8597bc09470c9dd274c145f1c12e0fbc6ab6d38d74/cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f", size = 180114, upload-time = "2026-07-06T21:33:22.515Z" },
     { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
     { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
+    { url = "https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d", size = 184965, upload-time = "2026-07-06T21:33:26.605Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac", size = 184952, upload-time = "2026-07-06T21:33:27.823Z" },
     { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a5/e8bbb1ce5b3ac2f53ad6a10bde44318a5a8d99d4f4a000d44a6e39aeb3e4/cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913", size = 210051, upload-time = "2026-07-06T21:33:30.534Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ed/c127d3ac36e899c965e3361357c3befacd6578c03f40125183e41c3b219e/cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d", size = 208630, upload-time = "2026-07-06T21:33:31.753Z" },
     { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
     { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
     { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6f/ade5ce9863a57992a6ea3d0d10d7e29b8749fc127204b3d493d667b2815f/cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd", size = 177723, upload-time = "2026-07-06T21:33:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb", size = 187937, upload-time = "2026-07-06T21:33:53.403Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/cc6ae6c2913a03aab8898eee57963cf1035b8df5872ed8b9115fcc7e2be8/cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804", size = 183001, upload-time = "2026-07-06T21:33:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f0/134c00ce0779ec86dea2aa1aac69339c2741a8045072676763512363a2ea/cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714", size = 188538, upload-time = "2026-07-06T21:33:36.792Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d8/3b86aba791cb610d24e8a3e1b2cd529e71fa15096b04e4d4e360049d4a4c/cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376", size = 188230, upload-time = "2026-07-06T21:33:38.011Z" },
     { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3d/f20f8b886b254e3ad10e15cd4186d3aed49f3e6a35ab37aab9f8f25f7c03/cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13", size = 211652, upload-time = "2026-07-06T21:33:40.851Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3b/fad54de07260b93ddeef4b96d0131d57ea900675df1d410ae1deee52d7a6/cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d", size = 210755, upload-time = "2026-07-06T21:33:42.183Z" },
     { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
     { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
     { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/78/aa01ac599a8a4322533d45a1f9bc93b338276d2d59dabbe7c6d92a775c81/cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76", size = 182857, upload-time = "2026-07-06T21:33:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/d00496b22de4d4228f32dde94ad996f350c8aad676d63bcca0743c8dea4d/cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5", size = 194065, upload-time = "2026-07-06T21:33:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dd/0c7dbf815a579ff005008a2d815a55d6bb047c349eef536d9dc53d3f0a8d/cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8", size = 186404, upload-time = "2026-07-06T21:33:50.309Z" },
 ]
 
 [[package]]
@@ -190,6 +305,9 @@ version = "1.5.8"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "fastmcp" },
+    { name = "fastmcp-slim", extra = ["client", "server"] },
+    { name = "fastmcp-tasks" },
     { name = "filelock" },
     { name = "httpx" },
     { name = "jsonschema" },
@@ -215,6 +333,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
+    { name = "fastmcp", specifier = "==4.0.0b1" },
+    { name = "fastmcp-slim", extras = ["client", "server"], specifier = "==4.0.0b1" },
+    { name = "fastmcp-tasks", specifier = "==4.0.0b1" },
     { name = "filelock", specifier = ">=3.15" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "jsonschema", specifier = ">=4.23" },
@@ -238,12 +359,29 @@ dev = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cronsim"
+version = "2.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/1a/02f105147f7f2e06ed4f734ff5a6439590bb275a53dd91fc73df6312298a/cronsim-2.7-py3-none-any.whl", hash = "sha256:1e1431fa08c51dc7f72e67e571c7c7a09af26420169b607badd4ca9677ffad1e", size = 14213, upload-time = "2025-10-21T16:38:20.431Z" },
 ]
 
 [[package]]
@@ -255,33 +393,45 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
     { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
     { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
     { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
     { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
     { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
     { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
     { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
     { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
     { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
     { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
     { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
     { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
     { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
     { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
     { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
     { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
     { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
     { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
     { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
     { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
     { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
     { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
     { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
     { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
     { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
     { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
     { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
 ]
 
 [[package]]
@@ -301,6 +451,21 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclopts"
+version = "5.0.0a7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/e0/2718af0353632bd92bad5c54e738f3364df3283b38cfa68c4e92e0edab86/cyclopts-5.0.0a7.tar.gz", hash = "sha256:1de3e5e0adb7bd03083e1be63a941f799b845d4fbd2141a83b080d7f57496359", size = 191043, upload-time = "2026-06-23T00:57:57.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e1/d6f8c1e1680c0084201dbad8ba2be2d685d96aaf14c6dc91af26a37a3c8a/cyclopts-5.0.0a7-py3-none-any.whl", hash = "sha256:1409e7de686e1c6c4d8c6fb9742ae2503026d43e99c7709c09ffb5968172c1b6", size = 229854, upload-time = "2026-06-23T00:57:56.157Z" },
+]
+
+[[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -310,12 +475,55 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.23"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/39/a4/5180d9afc57e8fca05601dd652bdff19604c218814037fe90ffc7625a50a/docutils-0.23.tar.gz", hash = "sha256:746f5060322511280a1e50eb76846ed6bf2342984b2ac04dc42caa1a8d78799e", size = 2303823, upload-time = "2026-05-27T17:41:06.934Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/91/30151a39f7570f448ed84529390628a651d7f27c87d73c9b887f8189695e/docutils-0.23-py3-none-any.whl", hash = "sha256:25d013af9bf23bc1c7b2b093dff4208166c53a94786c9e447808335ef1185fea", size = 634701, upload-time = "2026-05-27T17:40:58.442Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
 ]
 
 [[package]]
@@ -335,12 +543,99 @@ wheels = [
 ]
 
 [[package]]
+name = "fastmcp"
+version = "4.0.0b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastmcp-slim", extra = ["client", "server"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/fd/e513c524bb3e296203f65bd8e9e726e9236bd3b59315e7cbdeb095662c01/fastmcp-4.0.0b1.tar.gz", hash = "sha256:f98d69588a73e1672840558641d5d0f111e207baffe001f3465713a53ebb6b4c", size = 42065171, upload-time = "2026-07-28T21:18:15.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/66/41b503ef852eff83f3f0c04f46cd1fc738c5374fd509384fc6b96e45918f/fastmcp-4.0.0b1-py3-none-any.whl", hash = "sha256:d66eb7b0763ffff2ae0fc573778ea25604dcb7e59769e5afaf9851a806eb1129", size = 8064, upload-time = "2026-07-28T21:18:12.688Z" },
+]
+
+[[package]]
+name = "fastmcp-slim"
+version = "4.0.0b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mcp-types" },
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/33/f207166aac88c6d8be1b2a82c54fecd1e04b075ef12d027aa17b3134fc0f/fastmcp_slim-4.0.0b1.tar.gz", hash = "sha256:158efb25720e0cb301711146b2d05d181de95cd91fe70e87c251ad14b123d665", size = 660081, upload-time = "2026-07-28T21:17:50.171Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/5d/fbe192d2ab50bb31b284fd0eb6c72d4347df7a57d836bee4f1973ffd1d7d/fastmcp_slim-4.0.0b1-py3-none-any.whl", hash = "sha256:dd907a3db5a2f479ca958c30157e227b4f7b340a56d333eb91de95719254597a", size = 827975, upload-time = "2026-07-28T21:17:48.747Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx2" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "starlette" },
+]
+server = [
+    { name = "authlib" },
+    { name = "cyclopts" },
+    { name = "exceptiongroup" },
+    { name = "griffelib" },
+    { name = "httpx2" },
+    { name = "joserfc" },
+    { name = "jsonref" },
+    { name = "jsonschema-path" },
+    { name = "mcp" },
+    { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "pyperclip" },
+    { name = "python-multipart" },
+    { name = "pyyaml" },
+    { name = "starlette" },
+    { name = "uncalled-for" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "fastmcp-tasks"
+version = "4.0.0b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "burner-redis", marker = "sys_platform == 'win32'" },
+    { name = "fastmcp-slim", extra = ["server"] },
+    { name = "pydocket" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/69/0a5613519eddd08fe674635ecd88ddae3f435f643141b725bb32834d7945/fastmcp_tasks-4.0.0b1.tar.gz", hash = "sha256:44f3a70a4241f82ff81c9fce477969aeb8cc06430985d7c37cb393eba791360e", size = 50552, upload-time = "2026-07-28T21:18:08.329Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/d3/48a891e14819d7b94304a0f360ceef5731e6d69477a28ded54fc43c3e286/fastmcp_tasks-4.0.0b1-py3-none-any.whl", hash = "sha256:221f1cca93213baeeea79a02fe70a69fea7c1902ed42e3f7a0f7f01d0c704869", size = 61363, upload-time = "2026-07-28T21:18:07.396Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.5"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e3/ee/29c668c50888588c432a702f7c2e8ee8a0c9e5286028d91f170308d6b2e9/filelock-3.29.5.tar.gz", hash = "sha256:6e6034c57a00a020e767f2614a5539863f056de7e7991d6d1473aef7ff73f156", size = 68927, upload-time = "2026-07-03T03:50:31.818Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/e3/f1fae3647d170919c2cf2a898e77e7d1a4e5c7cae0aed7bb4bd3f5ebff6f/filelock-3.29.5-py3-none-any.whl", hash = "sha256:8af830889ba3a0ffcefbd6c7d2af8a54012058103771f2e10848222f476a1693", size = 45073, upload-time = "2026-07-03T03:50:30.445Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
 ]
 
 [[package]]
@@ -381,6 +676,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -393,6 +701,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
@@ -468,6 +792,27 @@ wheels = [
 ]
 
 [[package]]
+name = "joserfc"
+version = "1.7.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/e0/27a6a081ae25420eda6768ceae05d7022a7f2447f420588843f2a44e4298/joserfc-1.7.4.tar.gz", hash = "sha256:b3bc561672ae541b17a9237053b48a03dacddd92d68047b3ecdfb4b5714a88ed", size = 234027, upload-time = "2026-07-19T15:43:02.739Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/bf/249dcd99b3376375910b7fa922383b57792975c8758f50d44612e749226c/joserfc-1.7.4-py3-none-any.whl", hash = "sha256:32d46c2cd5e3203c13e87a6c61333cab310b1ba80cd54b4c4f386a848a122463", size = 71000, upload-time = "2026-07-19T15:43:01.299Z" },
+]
+
+[[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -480,6 +825,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-path"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/79/cd02a4df6d9270efdc7d3feefe6edd730b0820c39eeaa107a2faee8322d5/jsonschema_path-0.5.0.tar.gz", hash = "sha256:493b156ba895c97602655b620a8456caa2ce08c1aa389f5a7addec065e6e855c", size = 19597, upload-time = "2026-05-19T20:45:00.971Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/2c/9e69d73c4297508be9e3b64a970ea3971b3eb8db64ffc5802d40bd25981f/jsonschema_path-0.5.0-py3-none-any.whl", hash = "sha256:2790a070bc7abb08ea3dbe4d340ece4efadf639223001f020c7503229ba068e2", size = 24077, upload-time = "2026-05-19T20:44:59.225Z" },
 ]
 
 [[package]]
@@ -533,6 +893,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx2" },
+    { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -649,6 +1047,30 @@ wheels = [
 ]
 
 [[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
 name = "packageurl-python"
 version = "0.17.6"
 source = { registry = "https://pypi.org/simple" }
@@ -664,6 +1086,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathable"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/f3/5a20387de9bcd0607871bfc2198ee0e15836da7baa4592ccd7f24c27c986/pathable-0.6.0.tar.gz", hash = "sha256:6404b8b82aef5ff0fd478934137128b99b12212ba35afdde5525ca4f8388ea58", size = 18970, upload-time = "2026-05-19T18:15:11.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/e8/6d75ffd9784bce2e93d1ae4415649427e39a53bb172d4672b2b59c6f0a7b/pathable-0.6.0-py3-none-any.whl", hash = "sha256:82c4ca6c98c502ad12e0d4e9779b6210afee93c38990988c8c5d1b49bdcdf566", size = 18983, upload-time = "2026-05-19T18:15:10.728Z" },
 ]
 
 [[package]]
@@ -749,6 +1180,43 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/73/f1334c29c2af4cd9dba6c7817e61b611bd0215e2eb5565c6064a4de18802/prometheus_client-0.26.0.tar.gz", hash = "sha256:04a91bcf94e2cf74a44a1a874d651a2e853ed354b6e822f3b7487751465d5c2b", size = 92910, upload-time = "2026-07-24T19:36:41.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/a3/b69efbf4143b5b9859b977770bbbabcc2796b702fa69dc40271e45cd5a56/prometheus_client-0.26.0-py3-none-any.whl", hash = "sha256:fa93d06737aa02bacd05794768508bb97d2fbee28cb3bca04eaae92f0ca953d6", size = 64494, upload-time = "2026-07-24T19:36:40.854Z" },
+]
+
+[[package]]
+name = "py-key-value-aio"
+version = "0.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/e2/d689d922894a7ecde73b6daeaf9b13dab5aae06fe6aaaf7514722644d382/py_key_value_aio-0.4.5.tar.gz", hash = "sha256:c6563a2c6abe5da5e20f4f9e875c2a9b425a2244a54fadbf46cf140a9eea45d7", size = 107547, upload-time = "2026-05-27T16:37:08.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/95/b8ba862968712caa12a19666175334fa979e1f198b896a430adb3bacfe87/py_key_value_aio-0.4.5-py3-none-any.whl", hash = "sha256:ab862adbcb8c72547d1c57821f22cbbb71ab86509039c96f36e914e0336c8dd7", size = 170005, upload-time = "2026-05-27T16:37:06.629Z" },
+]
+
+[package.optional-dependencies]
+filetree = [
+    { name = "aiofile" },
+    { name = "anyio" },
+]
+keyring = [
+    { name = "keyring" },
+]
+memory = [
+    { name = "cachetools" },
+]
+redis = [
+    { name = "redis" },
+]
+
+[[package]]
 name = "py-serializable"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -782,6 +1250,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
 ]
 
 [[package]]
@@ -860,6 +1333,44 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+]
+
+[[package]]
+name = "pydocket"
+version = "0.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "burner-redis" },
+    { name = "cloudpickle" },
+    { name = "cronsim" },
+    { name = "opentelemetry-api" },
+    { name = "prometheus-client" },
+    { name = "py-key-value-aio", extra = ["memory", "redis"] },
+    { name = "python-json-logger" },
+    { name = "redis" },
+    { name = "rich" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "uncalled-for" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/bf/7f1134e990855f373e5ee6ba316db8fe654a2d7dd852b41ab890fcfb91e3/pydocket-0.20.1.tar.gz", hash = "sha256:d72b3784e4b5069b39e5f49f599d54a891e1b6222c27a8bcfbd4dee0f57d4895", size = 361993, upload-time = "2026-05-06T14:06:25.956Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/9d/1bd873a0ea480dec388c40ac1a7500c129efbb9d61e2fef6b97236703458/pydocket-0.20.1-py3-none-any.whl", hash = "sha256:c886ece90ac93018f069d1eef9443f888404081d7258955e16847752575c95ae", size = 102774, upload-time = "2026-05-06T14:06:24.548Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -869,12 +1380,35 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
 ]
 
 [[package]]
@@ -917,6 +1451,49 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-json-logger"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
 ]
 
 [[package]]
@@ -989,6 +1566,15 @@ wheels = [
 ]
 
 [[package]]
+name = "redis"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c3/928b290c2c0ca99ab96eea5b4ff8f30be8112b075301a7d3ba214a3c8c12/redis-8.0.1.tar.gz", hash = "sha256:afc5a7a2f5a084f5b1880dec548dd45be17db7e43c82a30d84f952aefb05cfb0", size = 5114170, upload-time = "2026-06-23T14:52:37.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/0a/c2345ebf1ebe70840ce3f6c6ee612f8fa749cfbd1b03069c53bf0c62aaad/redis-8.0.1-py3-none-any.whl", hash = "sha256:47daa35a058c23468d6437f17a8c76882cb316b838ef763036af99b96cedd743", size = 502406, upload-time = "2026-06-23T14:52:36.137Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1049,6 +1635,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rich-rst"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/d6/d0b9fafc73b65767200da027acab1db1bdb1048f4fea5ebf659df01c700e/rich_rst-2.1.0.tar.gz", hash = "sha256:f4d117b49697f338769759fa5cacf5197da4888b347b9fda2e50aef5cd8d93bd", size = 302732, upload-time = "2026-07-05T02:59:44.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/68/1fc93dd759605b5d00fc98b50200739e41ed32bd22d6ba35ca6c3932371b/rich_rst-2.1.0-py3-none-any.whl", hash = "sha256:7ecd1343ee12c879d0e7ae74c3eb6d263b023d2929c6d114212eb1fd91057255", size = 272987, upload-time = "2026-07-05T02:59:42.792Z" },
 ]
 
 [[package]]
@@ -1175,6 +1774,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/10/a34c656829ffc1c4b22ef36d70d9ebb6b99c020e2aeb17cee5485099f028/sse_starlette-3.4.6.tar.gz", hash = "sha256:725f8a1bd6d26ae1b2c9610c0ef5065dfdd496f3988d28adcf8c4b49dc25c627", size = 32542, upload-time = "2026-07-20T14:16:32.201Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/36/e10c1d1b7ca881d2625db2ec28508578499187bb1c389952c398474e1834/sse_starlette-3.4.6-py3-none-any.whl", hash = "sha256:56217ab4c9a9f9c5db7b21e08732d3e7c2b807f45231ad23de0551a24c4a41f6", size = 16516, upload-time = "2026-07-20T14:16:30.978Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1251,6 +1863,15 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "twine"
 version = "6.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1307,6 +1928,24 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "uncalled-for"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1326,6 +1965,81 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9f/f6/cc9aadc0e481344a42095d222bfa764122fb8cfba708d1922917bd8bfb01/uvicorn-0.50.2.tar.gz", hash = "sha256:b92bf03509b82bcb9d49e7335b4fd364518ad021c2dc18b4e6a2fec8c955a0bb", size = 93716, upload-time = "2026-07-06T10:38:31.984Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/f0/7c228ee10c7ab8fd3a21d06579a6f7c6075c6ce72594a20fb5d2f206ff24/uvicorn-0.50.2-py3-none-any.whl", hash = "sha256:4ae72a385630bcc17a0adb8290f26c993865e0b43a2114c2aab96420172c056a", size = 72846, upload-time = "2026-07-06T10:38:30.543Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/2f/e42c992d2afda3108ea1c02acecc991b9f31d05c14adc2a7cee9ee211fc4/watchfiles-1.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bc13eb17538be00c874699dc0abe4ee2bc8d50bb1166a6b9e175ef3fd7eb8f26", size = 400115, upload-time = "2026-05-18T04:32:02.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8f/6af2ea19065c91d8b0ea3516fdfc8c0d349f407e8e9fbf4e5a17360de8ad/watchfiles-1.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d95ddc1eb6914154253d239089900813f6a767e174b8e6a50e7fdacb7e4236c", size = 393659, upload-time = "2026-05-18T04:30:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f70d8b291ef6e88d19b1f297a6905ddb978888d9272b0d05e6f53309856bcfc", size = 453207, upload-time = "2026-05-18T04:31:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/04/98/97557a812180338cb1abd32e1cffcc4588f59b5f23e0cb006b2ba95ba64a/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56d8641cf834c2836922899105bd3ce3d0dfc69291d52edf0b4d0436829b34c0", size = 459273, upload-time = "2026-05-18T04:31:50.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a8/b4b08dcb7653b8087c6586f7ce649505900e866bbcfe40dc9587af02e686/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2581a94056e55d7d0a31a823ea92bf73749c489ca2285bfdc0fbe6b2bb49d50c", size = 489927, upload-time = "2026-05-18T04:31:42.485Z" },
+    { url = "https://files.pythonhosted.org/packages/50/94/3dceea03545d2e5ddfd839f0ddd5e1cecbf1697b5a428d5ba11cef6af95d/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:41bc1199f7523b3f82843c88cbb979180c949caef0342cf90968f178e5d49b01", size = 570476, upload-time = "2026-05-18T04:31:03.071Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f2/d39a5450c3532092b91f81d274360e613c2371bc874a89c7a1a3c5e8d138/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7571e4464cb6e434958f867f7f730b8ab0b75e3f8e5eac0499168486ab3c33a8", size = 465650, upload-time = "2026-05-18T04:30:12.701Z" },
+    { url = "https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e53a384f76b631c3ae5334ce6a52f0baa3a911eb94a4eac7f160079868b716d5", size = 456398, upload-time = "2026-05-18T04:30:13.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/64/982ef4a4e5bab5b6e5b6becc8cd5e732f6130a78b855f0abec6439a9a135/watchfiles-1.2.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:d20029a60a71a052a24c4db7673bc4de39ab89adbaccbfb5d67987c5d73f424d", size = 465140, upload-time = "2026-05-18T04:31:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0c/95282abf4ed680b6096010bcfc30c5fa7a041fc5aa5a2ad17a2cc6c75bba/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2cb93af48550faf1cea04c303107c8b75833de7013e57ce27d3b8d21d8d0f58c", size = 630259, upload-time = "2026-05-18T04:31:25.676Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/607c1de1530c4bdcf2cf1d1ecc2505ddba5d96bd43ba9f2b0e79876f850f/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2995c176de7692b86a2e4c58d9ec718f753150a979cb4a754e2b4ffa38e70906", size = 659859, upload-time = "2026-05-18T04:30:24.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/08/d9e2e0f9e8e6791d33aefc694ad7eefa7f901f63caff84a81ded38692f9c/watchfiles-1.2.0-cp312-cp312-win32.whl", hash = "sha256:7a2cffd17d27d2ecbb310c2b1d8174f222a5495b1a721894afa88ec11e25b898", size = 275480, upload-time = "2026-05-18T04:30:31.307Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e6/9d42569c0102645cc8cea5d8c7d8a1e9d4ada2cb7f05f75e554b8aa2202a/watchfiles-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:f155b3a1b2a5fc89cdc70d47ee5d54e3b75e88efa34982028a35daef9ba00379", size = 288718, upload-time = "2026-05-18T04:32:10.745Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/26/88e0dc6ee3898169d7fa22bb6a69cabf2502d2ee25cb8c876d1262d204f8/watchfiles-1.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:8fa585ede612ee9f9e91b18bebf9ba11b9ae29a4e3a0d0cf6fca3e382133f0d5", size = 281026, upload-time = "2026-05-18T04:30:22.23Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4d/70a7feced9f87e2ff26dba42667290f41694fc64646c67261fbb8cab5d5c/watchfiles-1.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:01ea8d66f0693b9b60a6541c8d10263091ca9a9060d242f3c1f3143f9aad2c98", size = 399730, upload-time = "2026-05-18T04:31:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/31/3a/0da302f2307aee316922806ebd5726c542cbd787c938271cf14a074c7daf/watchfiles-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ba0480b9a74af058f43b337e937a451e109295c420916d68ad24e3dc02f5e44", size = 392842, upload-time = "2026-05-18T04:30:27.051Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658", size = 452989, upload-time = "2026-05-18T04:31:11.945Z" },
+    { url = "https://files.pythonhosted.org/packages/71/29/5495f2c1661949ef7a35e4d71111d129cfe7606414a26887a919d0a55406/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4e77f6a55f858504069abd35d336a637555c09bca453dde1ee1e5ada8a6a1fb", size = 458978, upload-time = "2026-05-18T04:30:52.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/7f9c07c433811c2fffd93e13fdfb7135de9aab5f2ae41be08960fa0047dc/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cb4d80e212f116474a545c21c912b445f16bb0cef9e6a73a498164223e14e2f", size = 490248, upload-time = "2026-05-18T04:31:36.003Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/11/d93632febc52fbc21be90231bb7c17fd5387f46c9076fd40a5f9c2ae6910/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b974946a10af379d425e2eef5b62f5c6ebeaccf91d45eaad6f5b27ecd4f91aa0", size = 571847, upload-time = "2026-05-18T04:31:10.862Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b4/383173e73aabb07ad1d9c7aa859d95437ac46a6d6a1e11005facda0c9d19/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86bc13c25a8d1fcd70b51d0ce7c9b65e90de5666fcbfd3e34957cc73ee19aeb5", size = 465974, upload-time = "2026-05-18T04:30:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71", size = 454782, upload-time = "2026-05-18T04:30:35.656Z" },
+    { url = "https://files.pythonhosted.org/packages/24/62/1732118367cfff0a9fce3bf62ff4bfded09ef5df21d9d446b858b3f70a96/watchfiles-1.2.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:c525543d91961c6955b2636b308569e84a1d1c5f5f2932041ab9ef46422f43e3", size = 465182, upload-time = "2026-05-18T04:30:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/28/96/716f7e5f51339bf22963f3345f9f27d7f3b30e2eadc597e257c881dd3c53/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:a204794696ffb8f9b10fba6f7cb5216d42f3b2b71860ccac6b6e42f5f10973b0", size = 629841, upload-time = "2026-05-18T04:31:05.397Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/c40783950fd771ccf66ab3ec2722d188a9af1c7f96c6e811f36e40c6e03f/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:10d86db20695afe7997ac9e1717637d6714a8d0220458c33f3d2061f54cec427", size = 658028, upload-time = "2026-05-18T04:31:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/71/72/4508db1856d1d87fcbb3b63f4839bab1b5682cb0e8d224d122263c09654a/watchfiles-1.2.0-cp313-cp313-win32.whl", hash = "sha256:eb283ee99e21ad6443c8cdb06ac5b34b1308c329cbdf03fa02b445363714c799", size = 275183, upload-time = "2026-05-18T04:30:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/36/14b76ca57652e5cc5fd1c11f32a261292c08a0d19a00351013c2549cbfb2/watchfiles-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0f27f01bee51861392bb6b7c4fdb290b27d1eb194e9e28788d68102a0e898d9", size = 288059, upload-time = "2026-05-18T04:32:07.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8d/0a85e395398d8d20fadfe5c5d32c726eee17a519e78fb356f2cf7531bffe/watchfiles-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:3651aa7058595e9cfb75d35dd5ada2bf9f48a5b8a0f3562821d3e210c507e077", size = 280186, upload-time = "2026-05-18T04:31:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/37/68/36db056f1fdcc5f07302f56e631774d6835bcd6fa3ace402304621d5f9e5/watchfiles-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:faea288b6f0ab1902ef08f4ca6de005dccf856c4e0c4f21b8c5fce02d90a1b08", size = 399031, upload-time = "2026-05-18T04:30:44.576Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/01a9d6f66a82a5c101ce939274106cc72759d62427e153f01edd2b9f87c2/watchfiles-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01859b11fd9fbca670f4d5da00fbac282cfea9bd67a2125d8b2833a3b5617ea9", size = 391205, upload-time = "2026-05-18T04:30:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2c/0a44fe058cb4bb7b8ede6b6670698bbb7c0400740e378d00022189b7b31d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff610d7bb2256a317bb1e96f0d7862c7aa8076733ee5df0fd41bbe76a24a4f4", size = 451892, upload-time = "2026-05-18T04:32:14.005Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a1/351e0d56cd35e6488b5c8b4fb11a809a5bc923e8fe8fed9faf8920be0c89/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b141a4891c995a039cd89e9a49e62df1dc8a559a5d1a6e4c7106d16c12777a55", size = 458867, upload-time = "2026-05-18T04:31:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/9d09605187f1b838998624049fcf8bf47b73c1a3b76901fcac1782f62277/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22943b7770483f6ea0721c6b11d022947a98eb0acae14694de034f4d0d38925", size = 490217, upload-time = "2026-05-18T04:31:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5d/a17a16eccb182f04188cd308ec24b1a71a9b5c4e7098269cf35d9fa56d02/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bc6195825b7dcd217968bb1f801a60fd4c16e8eeab5bedc7fe917d7d5995ab4", size = 571458, upload-time = "2026-05-18T04:32:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/3d/4dd457062083ab1938e5dfd45032eb425cee2ac817287ca8ff4356183e5d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4a4b147f5dca2a5d325a06a832fb43f345751adfbc63204aec30e0d9ca965a2", size = 464707, upload-time = "2026-05-18T04:30:43.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/71/ea8c57b128f5383de74d0c7d2d9c57ad7c9a65a930c451bd25d524b295b7/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4543579a9bdb0c9560039b4ffddbdb39545707659fbc430ce4c10f3f68d557f9", size = 454663, upload-time = "2026-05-18T04:30:16.061Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload-time = "2026-05-18T04:31:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload-time = "2026-05-18T04:31:14.141Z" },
+    { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload-time = "2026-05-18T04:31:47.14Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/54/a9c7ea9a82a4ac65e7004c0a03920b5cdd2f9c3b678757d9cd425aa51d53/watchfiles-1.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8c8358484d5fa12ef34f05b7f4168eaf1932f408725ff6d023c33ec17bd79d4", size = 400205, upload-time = "2026-05-18T04:32:05.153Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5d/c9ab3534374a4a67450696905d6ef16a04405448b8dc52bd752ae50423d4/watchfiles-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f04b092229ad2c50126dd3c922c8822e51e605993764a33058d4a791ab42281", size = 392508, upload-time = "2026-05-18T04:30:54.849Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ca/1ad30103535cf0cecd7b993e8d50edc5351b1820e38f2d22e3df58962feb/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7ce236284f002a156f70add88efe5c70879cccbb658be0822c54b1306fc09d", size = 452448, upload-time = "2026-05-18T04:30:53.727Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/ceee2cdf2afbd715fa07758d39c9859513eae411b23196f7fd039e5feedd/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9909cc2b48468b575eefa944919e1fe8a36c5849d5c7c168f80a8c1db69398e", size = 459605, upload-time = "2026-05-18T04:30:23.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f6/421e30fd1cb3907a84ed92ab3f1983e37ba2dca015e9a894a048418417a2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a37faaed405c67e28e6be45a1fa4f206ef5a2860f27c237db9fa30704c38242", size = 490757, upload-time = "2026-05-18T04:30:47.358Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/55ed1b97ed08be7bba6f9a541cac15f2a858e1d74d2b07b6da70a82aab00/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9649193aa27bd9ff2e80ff29bfaa93085496c7a3a377592823cc58b77ee88add", size = 568672, upload-time = "2026-05-18T04:30:38.915Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/cf/d8ae8a80dd7bafab395ea7681c10237311bbf34d37704a8c744e7cf31fc7/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e4ff8e37f99cf1da89e255e07c9c4b37c214038c4283707bdec308cb1b0ea1f", size = 464197, upload-time = "2026-05-18T04:30:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/3076c496ca8dafe0e8cd03fcebdfc47be4b1174b4e5b24ff6e396e6b3af2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:054dc20fd2e3132b4c3883b4a00d72fd6e1f56fdaf89fccd12e8057d74cd74d7", size = 453181, upload-time = "2026-05-18T04:30:14.829Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/10/9745e17c98e7b8a86454df0a3c7b5686bd650383f1e9f26e4ebcbd6cc0c0/watchfiles-1.2.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e140ed30ebde76796b686e67c182cff10ea2fbab186fafd1560f74bb5a473a6e", size = 465109, upload-time = "2026-05-18T04:30:28.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/95/8ef4a95481d3e0cb52d62a06fa6e972e81424be2d9698b91a2fecca9904c/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:bb7e52ecf68ba46d22df23467b87cffeb2146908aa523ebfe803019618cfda06", size = 630653, upload-time = "2026-05-18T04:31:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e4/3b3bf36b0f829b50c6ebcb8d031583863c59f923d6a6af3d485e470d0fac/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:23282a321c8baf9b3a3c4afff673f9fe65eb7fdc2338d765ccad9d3d1916a5ba", size = 657838, upload-time = "2026-05-18T04:31:06.497Z" },
+    { url = "https://files.pythonhosted.org/packages/21/b1/6cbbb50c1f3002ab568777d44aa21206dfb8807a840990c4037523b51812/watchfiles-1.2.0-cp314-cp314-win32.whl", hash = "sha256:c0db965c5f79aa49fe672d297cf1febc5ad149b658594944f49a54a2b96270a7", size = 275108, upload-time = "2026-05-18T04:30:06.891Z" },
+    { url = "https://files.pythonhosted.org/packages/92/45/190ce6db8dcb4536682cf75d3889ff1a27182a58cb519d343cb6d9ea63d8/watchfiles-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:71283b39fd17e5408eb123bd37aeecfd9d54c81fc184421943208aadb879d103", size = 288441, upload-time = "2026-05-18T04:32:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/3eae1c2313ab08378431d907c3f8095ecca00f3eda33111cf4f0f2591799/watchfiles-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:c5c19526f4e54a00f2666a6c0e9e40d582c09e865055ea7378bf0009aab857b3", size = 280684, upload-time = "2026-05-18T04:31:26.902Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/75/fb64e6c25d6b5ca636d03df34ffb1c6e9873303e76d27967e045f8df088f/watchfiles-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d73a585accffa5ae39c17264c36ec3166d2fad7000c780f5ef83b2722afb9dd2", size = 398857, upload-time = "2026-05-18T04:32:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/9f7adf01754cbf81843722ccfec169d8f26c69778281a302855cecd2ee08/watchfiles-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae99b14c5f21e026e0e9d96f40e07d8570ebee6cafd9d8fc318354606daa7a28", size = 392413, upload-time = "2026-05-18T04:31:07.911Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c8/bec626bcc2d69f44b9acb24ce7d60ed7b16b73628eea747fcbd169d8edda/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4429f3b105524a10b72c3a819b091c495d2811d419c1e1e8df773a5a5974f831", size = 452409, upload-time = "2026-05-18T04:31:20.142Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b7/b6362068e81e7c556d155a34c35d40ac3ef42d747b06d7f6e5bf58e359c2/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43d818978d06062d9b22c4fab2ebe44cf5213d42dc8e62bda8c2760cfa2eeb33", size = 458827, upload-time = "2026-05-18T04:32:06.219Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/9a813fa42afb1e0b4625e75f0479826644d3ee8dc287e093799bc01f390c/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9f732dc58b2dbe69e464ccf8fff7a03b0dd0be439da4c0720d3558527d3d6b4", size = 490104, upload-time = "2026-05-18T04:31:56.034Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bf/27dfb6094ca4c9aad21298b5525b6c53cb36121ee454331d05161e58d130/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f200104103feb097de4cab8fe4f5dd18a2026934c7dea98c55a2f5fd6d5a33b", size = 571360, upload-time = "2026-05-18T04:31:57.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/39/44a096d67270ea93df91d33877dbe91fbda3aa4f8ec2edf799d93eda8736/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ac26eefbf4af1741247d6fb68b11c49a25b2f7413fbd318a83a12aaa9cf666", size = 464644, upload-time = "2026-05-18T04:30:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/80/c7472203bad6268e3ef1ad260739704847898938ad7ea8b63a5131f46b50/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4997d4e4a55f0d02b6cde327322daf3a0400e5df6c6b15948994bf72497925", size = 454771, upload-time = "2026-05-18T04:30:48.736Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -301,7 +301,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.5.8"
+version = "1.5.9"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- expose relay operations through FastMCP SEP-2663 task protocol without introducing a second scheduler
- preserve durable task identity, replay, cancellation, reconnect, and virtual JARVIS tool behavior
- gate locked MCP launcher startup on verified cache lifecycle events
- prepare release 1.5.9

## Validation

- focused FastMCP HTTP, stdio, task, reconnect, and cancellation checks passed
- exact candidate wheel smoke checks passed
- release identity check passed
- the complete regression matrix is intentionally running in GitHub CI