### PR TITLE
fix: constrain FastMCP HTTP client dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.5.9` uses a release-first patch process. A maintainer builds the
+> Version `1.5.10` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.5.9"
+$Version = "1.5.10"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }
@@ -925,7 +925,7 @@ Invoke-JarvisSetupTool "jarvis_add_step" "lammps-add" @{
   step_id = "lammps"
   config = @{
     deploy_mode = "default"; nprocs = 1; ppn = 1; script = $RemoteLammpsInput
-    lmp_bin = "lmp -nonbuf"; out = "$AresRemoteRoot/lammps/out"; kokkos_gpu = $false
+    out = "$AresRemoteRoot/lammps/out"; kokkos_gpu = $false
     progress = @{ adapter = "lammps"; log_visibility = "shared"; total_steps = 10000 }
   }
 }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.5.9"
+release_version: "1.5.10"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: df909e16d44bcca69f46bf303902cd3e105c81c0f718962697dc1463b17f385a
+acceptance_matrix_sha256: 4b140a6d634d91d98824c5d7c96d9555a91ca0703ebf3021a2bb19c47afbe8e2
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.5.9"
+$Tag = "v1.5.10"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.9" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.10" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/ares-lammps-long/pipeline.yaml
+++ b/examples/ares-lammps-long/pipeline.yaml
@@ -10,7 +10,6 @@ pkgs:
     nprocs: 1
     ppn: 1
     script: $HOME/.local/share/clio-relay/live-tests/{run_id}/in.lj
-    lmp_bin: lmp -nonbuf
     out: $HOME/.local/share/clio-relay/live-tests/{run_id}/lammps-out
     kokkos_gpu: false
     progress:

--- a/examples/ares-lammps-long/pipeline.yaml
+++ b/examples/ares-lammps-long/pipeline.yaml
@@ -9,8 +9,8 @@ pkgs:
     deploy_mode: default
     nprocs: 1
     ppn: 1
-    script: $HOME/.local/share/clio-relay/live-tests/{run_id}/in.lj
-    out: $HOME/.local/share/clio-relay/live-tests/{run_id}/lammps-out
+    script: /mnt/common/$USER/.local/share/clio-relay/live-tests/{run_id}/in.lj
+    out: /mnt/common/$USER/.local/share/clio-relay/live-tests/{run_id}/lammps-out
     kokkos_gpu: false
     progress:
       adapter: lammps

--- a/examples/ares-lammps/pipeline.yaml
+++ b/examples/ares-lammps/pipeline.yaml
@@ -10,7 +10,6 @@ pkgs:
     nprocs: 1
     ppn: 1
     script: $HOME/.local/share/clio-relay/live-tests/{run_id}/in.lj
-    lmp_bin: lmp -nonbuf
     out: $HOME/.local/share/clio-relay/live-tests/{run_id}/lammps-out
     kokkos_gpu: false
     progress:

--- a/examples/ares-lammps/pipeline.yaml
+++ b/examples/ares-lammps/pipeline.yaml
@@ -9,8 +9,8 @@ pkgs:
     deploy_mode: default
     nprocs: 1
     ppn: 1
-    script: $HOME/.local/share/clio-relay/live-tests/{run_id}/in.lj
-    out: $HOME/.local/share/clio-relay/live-tests/{run_id}/lammps-out
+    script: /mnt/common/$USER/.local/share/clio-relay/live-tests/{run_id}/in.lj
+    out: /mnt/common/$USER/.local/share/clio-relay/live-tests/{run_id}/lammps-out
     kokkos_gpu: false
     progress:
       adapter: lammps

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.5.9",
-  "matrix_sha256": "df909e16d44bcca69f46bf303902cd3e105c81c0f718962697dc1463b17f385a",
+  "release_version": "1.5.10",
+  "matrix_sha256": "4b140a6d634d91d98824c5d7c96d9555a91ca0703ebf3021a2bb19c47afbe8e2",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.5.9"
+version = "1.5.10"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"
@@ -11,7 +11,7 @@ dependencies = [
     "fastmcp-slim[client,server]==4.0.0b1",
     "fastmcp-tasks==4.0.0b1",
     "filelock>=3.15",
-    "httpx>=0.27",
+    "httpx>=0.27,<1",
     "jsonschema>=4.23",
     "packaging>=24.2",
     "pydantic>=2.8",

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.5.9"
+__version__ = "1.5.10"

--- a/src/clio_relay/live_acceptance.py
+++ b/src/clio_relay/live_acceptance.py
@@ -69,6 +69,7 @@ from clio_relay.runtime_metadata import (
     RUNTIME_METADATA_SCHEMA,
     JarvisRuntimeMetadata,
     RuntimeMetadataSource,
+    native_execution_documents,
 )
 from clio_relay.service_runtime import ServiceRuntimeStopResult, ServiceRuntimeSupervisor
 from clio_relay.session_api import (
@@ -4405,6 +4406,27 @@ def _verify_live_package_progress(
             ):
                 raise RelayError("package progress was recorded before job.running")
             return
+        status = _remote_clio_json(
+            definition,
+            ["job", "status", job_id],
+            runner=runner,
+        )
+        runtime_metadata = _runtime_metadata_from_job_status(status, job_id=job_id)
+        native_attestation = _native_progress_attestation(
+            runtime_metadata,
+            expected_adapter,
+            package_name=package_name,
+            require_nonterminal=True,
+        )
+        if native_attestation is not None:
+            if not saw_running and not _remote_job_has_event(
+                definition,
+                job_id,
+                "job.running",
+                runner=runner,
+            ):
+                raise RelayError("package progress was recorded before job.running")
+            return
         if event_types & {"job.succeeded", "job.failed", "job.canceled"}:
             break
         time.sleep(poll_seconds)
@@ -4617,6 +4639,18 @@ def _verify_completed_job(
             job_id=job_id,
             package_name=expected_progress_package,
         )
+        native_progress = (
+            None
+            if runtime_metadata is None
+            else _native_progress_attestation(
+                runtime_metadata.document,
+                expected_progress_adapter,
+                package_name=expected_progress_package,
+                require_nonterminal=False,
+            )
+        )
+        if provider_metadata is None:
+            provider_metadata = native_progress
         if provider_metadata is None:
             raise RelayError(
                 f"expected package progress adapter was not recorded: {expected_progress_adapter}"
@@ -4624,27 +4658,22 @@ def _verify_completed_job(
         lines.append(f"{line_prefix}.progress_adapter={expected_progress_adapter}")
         lines.append("package-progress.provider=verified")
         lines.append("package-progress.acceptance=verified")
-        lines.append(
-            "package-progress.identity="
-            f"{provider_metadata['provider_distribution']}:"
-            f"{provider_metadata['provider_distribution_version']}:"
-            f"{provider_metadata['provider_entry_point']}:"
-            f"{provider_metadata['adapter']}"
-        )
+        progress_identity = _progress_attestation_identity(provider_metadata)
+        lines.append(f"package-progress.identity={progress_identity}")
         if recorder is not None:
             recorder.add_resource(
                 ValidationResource(
                     kind="package_progress_provider",
-                    resource_id=(
-                        f"{provider_metadata['provider_distribution']}:"
-                        f"{provider_metadata['provider_distribution_version']}:"
-                        f"{provider_metadata['provider_entry_point']}:"
-                        f"{provider_metadata['adapter']}"
-                    ),
+                    resource_id=progress_identity,
                     role="jarvis_package_progress",
                     cluster=definition.name,
                     state="verified",
-                    provider=str(provider_metadata["provider_distribution"]),
+                    provider=str(
+                        provider_metadata.get(
+                            "provider_distribution",
+                            "jarvis-native-execution",
+                        )
+                    ),
                     metadata=dict(provider_metadata),
                 )
             )
@@ -4901,6 +4930,129 @@ def _progress_provider_attestation(
                 continue
             return dict(typed_metadata)
     return None
+
+
+def _runtime_metadata_from_job_status(
+    status: dict[str, Any],
+    *,
+    job_id: str,
+) -> dict[str, Any] | None:
+    """Return validated runtime metadata from one exact relay job status response."""
+    raw_job = status.get("job")
+    if not isinstance(raw_job, dict):
+        return None
+    typed_job = cast(dict[str, Any], raw_job)
+    if typed_job.get("job_id") != job_id:
+        return None
+    raw_job_metadata = typed_job.get("metadata")
+    if not isinstance(raw_job_metadata, dict):
+        return None
+    typed_job_metadata = cast(dict[str, Any], raw_job_metadata)
+    raw_runtime = typed_job_metadata.get("runtime_metadata")
+    if not isinstance(raw_runtime, dict):
+        return None
+    try:
+        validated = JarvisRuntimeMetadata.model_validate(raw_runtime)
+    except ValueError:
+        return None
+    return validated.model_dump(mode="json")
+
+
+def _native_progress_attestation(
+    runtime_metadata: dict[str, Any] | None,
+    expected_adapter: str,
+    *,
+    package_name: str | None,
+    require_nonterminal: bool,
+) -> dict[str, Any] | None:
+    """Return trusted JARVIS-native package progress from runtime metadata."""
+    if runtime_metadata is None:
+        return None
+    try:
+        runtime = JarvisRuntimeMetadata.model_validate(runtime_metadata)
+    except ValueError:
+        return None
+    if runtime.source not in {
+        RuntimeMetadataSource.JARVIS_MCP,
+        RuntimeMetadataSource.JARVIS_SIDECAR,
+    }:
+        return None
+    raw_contract = runtime.details.get("producer_contract")
+    if not isinstance(raw_contract, dict):
+        return None
+    typed_contract = cast(dict[str, Any], raw_contract)
+    if (
+        typed_contract.get("contract_kind") != "native_execution"
+        or typed_contract.get("trusted") is not True
+    ):
+        return None
+    raw_documents = runtime.details.get("native_execution")
+    if not isinstance(raw_documents, dict):
+        return None
+    try:
+        documents = native_execution_documents(cast(dict[str, Any], raw_documents))
+    except ValueError:
+        return None
+    if documents is None:
+        return None
+    snapshot = documents.progress
+    if require_nonterminal and snapshot.terminal:
+        return None
+    terminal_progress_states = {"completed", "failed", "canceled"}
+    for package in snapshot.packages:
+        latest = package.latest
+        if latest is None:
+            continue
+        if package_name is not None and package.package_name != package_name:
+            continue
+        if latest.metadata.get("adapter") != expected_adapter:
+            continue
+        if require_nonterminal and latest.state in terminal_progress_states:
+            continue
+        package_version = latest.metadata.get("package_version")
+        return {
+            "source": "jarvis_execution",
+            "adapter": expected_adapter,
+            "package_name": package.package_name,
+            "package_id": package.package_id,
+            "package_version": (
+                package_version
+                if isinstance(package_version, str) and package_version
+                else "native"
+            ),
+            "execution_id": snapshot.execution_id,
+            "pipeline_id": snapshot.pipeline_id,
+            "execution_state": snapshot.execution_state,
+            "execution_terminal": snapshot.terminal,
+            "progress_state": latest.state,
+            "progress_sequence": latest.sequence,
+            "progress_event_count": package.event_count,
+            "current": latest.current,
+            "total": latest.total,
+            "unit": latest.unit,
+            "producer_contract": "native_execution",
+            "producer_validated": True,
+            "acceptance_validated": True,
+        }
+    return None
+
+
+def _progress_attestation_identity(metadata: dict[str, Any]) -> str:
+    """Return a stable evidence identity for provider or native progress."""
+    if metadata.get("source") == "jarvis_execution":
+        return (
+            "jarvis-native:"
+            f"{metadata['package_version']}:"
+            f"{metadata['package_name']}:"
+            f"{metadata['package_id']}:"
+            f"{metadata['adapter']}"
+        )
+    return (
+        f"{metadata['provider_distribution']}:"
+        f"{metadata['provider_distribution_version']}:"
+        f"{metadata['provider_entry_point']}:"
+        f"{metadata['adapter']}"
+    )
 
 
 def _verify_progress_monitor(

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1791,7 +1791,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "df909e16d44bcca69f46bf303902cd3e105c81c0f718962697dc1463b17f385a"
+        "4b140a6d634d91d98824c5d7c96d9555a91ca0703ebf3021a2bb19c47afbe8e2"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_live_acceptance.py
+++ b/tests/test_live_acceptance.py
@@ -34,8 +34,11 @@ from clio_relay.live_acceptance import (
     _expected_progress_package,  # pyright: ignore[reportPrivateUsage]
     _find_agent_child_job,  # pyright: ignore[reportPrivateUsage]
     _http_json,  # pyright: ignore[reportPrivateUsage]
+    _native_progress_attestation,  # pyright: ignore[reportPrivateUsage]
     _packaged_mcp_acceptance_evidence,  # pyright: ignore[reportPrivateUsage]
+    _progress_attestation_identity,  # pyright: ignore[reportPrivateUsage]
     _require_secure_runtime_control_capacity,  # pyright: ignore[reportPrivateUsage]
+    _runtime_metadata_from_job_status,  # pyright: ignore[reportPrivateUsage]
     _secure_runtime_probe_config,  # pyright: ignore[reportPrivateUsage]
     _select_secure_runtime_handoff,  # pyright: ignore[reportPrivateUsage]
     _validated_secure_runtime_pending_bind,  # pyright: ignore[reportPrivateUsage]
@@ -138,6 +141,102 @@ def _structured_live_runtime_metadata() -> dict[str, object]:
             "pipeline_id": "jarvis_mcp",
             "scheduler_provider": "jarvis_mcp",
             "scheduler_job_id": "jarvis_mcp",
+        },
+    }
+
+
+def _native_progress_runtime_metadata(
+    *,
+    terminal: bool = False,
+) -> dict[str, object]:
+    """Build one strictly valid JARVIS-native progress observation."""
+    execution_state = "completed" if terminal else "running"
+    progress_state = "completed" if terminal else "running"
+    current = 10.0 if terminal else 3.0
+    return {
+        "schema_version": "clio-relay.jarvis-runtime.v1",
+        "source": "jarvis_sidecar",
+        "execution_id": "execution-native-41",
+        "pipeline_id": "pipeline-native-41",
+        "terminal": {
+            "state": execution_state,
+            "terminal": terminal,
+            "returncode": 0 if terminal else None,
+            "started_at": "2026-07-29T20:00:00Z",
+            "finished_at": "2026-07-29T20:01:00Z" if terminal else None,
+        },
+        "details": {
+            "native_execution": {
+                "execution_handle": {
+                    "schema_version": "jarvis.execution.handle.v1",
+                    "execution_id": "execution-native-41",
+                    "pipeline_id": "pipeline-native-41",
+                    "mode": "direct",
+                    "scheduler_provider": None,
+                    "scheduler_native_id": None,
+                    "cluster": None,
+                },
+                "execution_record": {
+                    "schema_version": "jarvis.execution.record.v1",
+                    "execution_id": "execution-native-41",
+                    "pipeline_id": "pipeline-native-41",
+                    "pipeline_name": "pipeline-native-41",
+                    "mode": "direct",
+                    "scheduler_provider": None,
+                    "scheduler_native_id": None,
+                    "cluster": None,
+                    "state": execution_state,
+                    "submitted": False,
+                    "terminal": terminal,
+                    "created_at": "2026-07-29T20:00:00Z",
+                    "updated_at": "2026-07-29T20:01:00Z",
+                    "return_code": 0 if terminal else None,
+                    "error": None,
+                    "metadata": {},
+                },
+                "progress": {
+                    "schema_version": "jarvis.execution.progress.v1",
+                    "execution_id": "execution-native-41",
+                    "pipeline_id": "pipeline-native-41",
+                    "execution_state": execution_state,
+                    "terminal": terminal,
+                    "packages": [
+                        {
+                            "package_id": "simulation",
+                            "package_name": "site.simulation",
+                            "event_count": 2,
+                            "latest": {
+                                "schema_version": "jarvis.progress.v1",
+                                "package_name": "site.simulation",
+                                "package_id": "simulation",
+                                "execution_id": "execution-native-41",
+                                "label": "timestep",
+                                "state": progress_state,
+                                "current": current,
+                                "total": 10.0,
+                                "unit": "step",
+                                "message": f"step {int(current)} of 10",
+                                "sequence": 2,
+                                "observed_at_epoch": 1785360000.0,
+                                "determinate": True,
+                                "metadata": {
+                                    "adapter": "site-progress",
+                                    "package_version": "3.4.5",
+                                },
+                            },
+                        }
+                    ],
+                },
+            },
+            "producer_contract": {
+                "requested_source": "jarvis_sidecar",
+                "contract_kind": "native_execution",
+                "producer_schema_version": "jarvis.execution.record.v1",
+                "handle_schema_version": "jarvis.execution.handle.v1",
+                "progress_schema_version": "jarvis.execution.progress.v1",
+                "trusted": True,
+                "reason": "exact native JARVIS execution documents matched",
+            },
         },
     }
 
@@ -1124,6 +1223,112 @@ def test_live_acceptance_accepts_durable_progress_after_terminal_observation() -
         timeout_seconds=1,
         poll_seconds=0.01,
         runner=fake_runner,
+    )
+
+
+def test_live_acceptance_accepts_nonterminal_native_jarvis_progress() -> None:
+    runtime = _native_progress_runtime_metadata()
+
+    def fake_runner(
+        command: list[str],
+        *,
+        input: bytes | None = None,
+    ) -> subprocess.CompletedProcess[bytes]:
+        del input
+        script = command[-1]
+        if "job monitor" in script:
+            return _completed(
+                command,
+                json.dumps(
+                    {
+                        "events": [
+                            {"event_type": "job.queued"},
+                            {"event_type": "job.running"},
+                            {"event_type": "jarvis.started"},
+                        ]
+                    }
+                ),
+            )
+        if "job progress" in script:
+            return _completed(command, json.dumps([]))
+        if "job status" in script:
+            return _completed(
+                command,
+                json.dumps(
+                    {
+                        "job": {
+                            "job_id": "job_test",
+                            "metadata": {"runtime_metadata": runtime},
+                        }
+                    }
+                ),
+            )
+        raise AssertionError(f"unexpected command: {command}")
+
+    _verify_live_package_progress(
+        ClusterDefinition(name="test-cluster", ssh_host="test-host"),
+        "job_test",
+        "site-progress",
+        package_name="site.simulation",
+        timeout_seconds=1,
+        poll_seconds=0.01,
+        runner=fake_runner,
+    )
+
+
+def test_native_jarvis_progress_requires_trusted_matching_nonterminal_documents() -> None:
+    runtime = _native_progress_runtime_metadata()
+    attestation = _native_progress_attestation(
+        cast(dict[str, Any], runtime),
+        "site-progress",
+        package_name="site.simulation",
+        require_nonterminal=True,
+    )
+
+    assert attestation is not None
+    assert attestation["source"] == "jarvis_execution"
+    assert attestation["progress_event_count"] == 2
+    assert (
+        _progress_attestation_identity(attestation)
+        == "jarvis-native:3.4.5:site.simulation:simulation:site-progress"
+    )
+    status_runtime = _runtime_metadata_from_job_status(
+        {
+            "job": {
+                "job_id": "job_test",
+                "metadata": {"runtime_metadata": runtime},
+            }
+        },
+        job_id="job_test",
+    )
+    assert status_runtime is not None
+    assert (
+        _native_progress_attestation(
+            status_runtime,
+            "wrong-adapter",
+            package_name="site.simulation",
+            require_nonterminal=True,
+        )
+        is None
+    )
+    terminal = _native_progress_runtime_metadata(terminal=True)
+    assert (
+        _native_progress_attestation(
+            cast(dict[str, Any], terminal),
+            "site-progress",
+            package_name="site.simulation",
+            require_nonterminal=True,
+        )
+        is None
+    )
+    assert (
+        _native_progress_attestation(
+            cast(dict[str, Any], terminal),
+            "site-progress",
+            package_name="site.simulation",
+            require_nonterminal=False,
+        )
+        is not None
     )
 
 

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.5.9"
+    assert version == "1.5.10"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_release_dependencies.py
+++ b/tests/test_release_dependencies.py
@@ -1,0 +1,17 @@
+"""Release dependency constraints that protect clean-wheel installs."""
+
+import tomllib
+from pathlib import Path
+
+from packaging.requirements import Requirement
+
+
+def test_httpx_stays_on_the_fastmcp_compatible_major_version() -> None:
+    """Prevent prerelease resolution from selecting incompatible httpx 1.x."""
+    project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]
+    requirements = {
+        requirement.name: requirement
+        for requirement in (Requirement(value) for value in project["dependencies"])
+    }
+
+    assert str(requirements["httpx"].specifier) == "<1,>=0.27"

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2499,7 +2499,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.5.9"
+    assert policy.release_version == "1.5.10"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -301,7 +301,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.5.9"
+version = "1.5.10"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -337,7 +337,7 @@ requires-dist = [
     { name = "fastmcp-slim", extras = ["client", "server"], specifier = "==4.0.0b1" },
     { name = "fastmcp-tasks", specifier = "==4.0.0b1" },
     { name = "filelock", specifier = ">=3.15" },
-    { name = "httpx", specifier = ">=0.27" },
+    { name = "httpx", specifier = ">=0.27,<1" },
     { name = "jsonschema", specifier = ">=4.23" },
     { name = "packaging", specifier = ">=24.2" },
     { name = "pydantic", specifier = ">=2.8" },


### PR DESCRIPTION
## What changed

- constrain the direct `httpx` dependency to `>=0.27,<1`;
- bump the release candidate to `1.5.10`;
- add a regression test over the published project dependency metadata;
- update live acceptance to recognize authenticated, schema-validated native JARVIS progress from `jarvis_sidecar` or `jarvis_mcp` runtime documents;
- refresh the uv lockfile and release acceptance fixtures.

## Why

Live validation from a clean PyPI-installed v1.5.9 environment exposed two release-only failures that source tests did not:

1. enabling FastMCP 4.0.0b1 prereleases allowed `httpx 1.0.dev3`, while FastMCP 4.0.0b1 still imports the 0.x `HTTPStatusError` API, so the installed `clio-relay` command failed before startup;
2. a real Ares LAMMPS job emitted trusted native JARVIS progress, but the older release observer only accepted the superseded provider-log projection and therefore reported a false acceptance failure after the application succeeded.

The upper bound keeps clean release installs on the FastMCP-compatible `httpx 0.28.x` line. The observer now accepts only exact native handle/record/progress documents from a trusted JARVIS producer contract and still requires a nonterminal observation for the live-progress gate.

## User impact

A clean wheel/tool installation can import and start the native FastMCP server. Real JARVIS-native application progress is accepted without falling back to scraped output, unblocking exact-released-wheel HTTP/stdio and Ares application acceptance.

## Live evidence found during validation

- Ares job `job_455ecec7f3234a8aad347fd26f32740f`: deployed LAMMPS execution completed 150/150 steps with return code 0 and six immutable artifacts.
- Ares job `job_8a29e4c457a54eb694a3e181b3951081`: deployed LAMMPS execution completed 10,000/10,000 steps with return code 0 and 22 native progress events. Its exact terminal runtime document is recognized as `jarvis-native:1.7.0:builtin.lammps:lammps:lammps` by this candidate.

These jobs ran against released v1.5.9 and exposed the two repair items. Exact v1.5.10 released-wheel acceptance will be rerun after CI and publication.

## Validation

- `uv run ruff check src/clio_relay/live_acceptance.py tests/test_live_acceptance.py`
- `uv run ruff format --check src/clio_relay/live_acceptance.py tests/test_live_acceptance.py`
- `uv run pyright src/clio_relay/live_acceptance.py tests/test_live_acceptance.py`
- `uv run pytest -q tests/test_live_acceptance.py`
- `uv run pytest -q tests/test_release_dependencies.py`
- clean candidate install resolves `httpx==0.28.1` and imports `FastMCP`
- `uv build`

The full test matrix is delegated to GitHub Actions while live acceptance continues.