### PR TITLE
feat: relay half of the cross-repo schema-equality CI (clio-agent#1121)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
           python-version: "3.12"
       - name: install dependencies
         run: uv sync --python "3.12" --locked --all-groups
+      - name: check committed cross-repo schema goldens
+        run: uv run --no-sync python -m tests.generate_schema_equality_goldens --check
       - name: stage exact clio-kit release wheel
         shell: bash
         env:

--- a/src/clio_relay/fastmcp_server.py
+++ b/src/clio_relay/fastmcp_server.py
@@ -8,7 +8,7 @@ import json
 from collections.abc import AsyncGenerator, Sequence
 from contextlib import asynccontextmanager
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
 import mcp_types
 from fastmcp import FastMCP
@@ -80,6 +80,39 @@ TASK_POLL_INTERVAL_MS = 1_000
 TASK_TTL_MS = 30 * 24 * 60 * 60 * 1_000
 MAX_TASK_ARGUMENT_BYTES = MAX_MCP_TASK_ARGUMENT_BYTES
 _TASK_METHOD_VERSIONS = frozenset(MODERN_PROTOCOL_VERSIONS)
+
+type McpTaskStatus = Literal[
+    "working",
+    "input_required",
+    "completed",
+    "failed",
+    "cancelled",
+]
+type RelayStateMapRow = tuple[tuple[str, ...], McpTaskStatus, bool | None]
+
+# Cross-repo federation contract: keep this table identical to clio-agent's
+# RELAY_STATE_MAP. The source rationale is docs/mcp-tasks.md:99-114.
+RELAY_STATE_MAP: Final[tuple[RelayStateMapRow, ...]] = (
+    (("queued", "leased", "running"), "working", None),
+    (("durable_input_round",), "input_required", None),
+    (("succeeded",), "completed", False),
+    (("tool_failure",), "completed", True),
+    (("protocol_error",), "failed", None),
+    (("canceled",), "cancelled", None),
+)
+_RELAY_STATE_PROJECTIONS: Final[dict[str, tuple[McpTaskStatus, bool | None]]] = {
+    observation: (status, is_error)
+    for observations, status, is_error in RELAY_STATE_MAP
+    for observation in observations
+}
+
+
+def _relay_state_projection(observation: str) -> tuple[McpTaskStatus, bool | None]:
+    """Return the committed MCP task projection for one relay observation."""
+    try:
+        return _RELAY_STATE_PROJECTIONS[observation]
+    except KeyError as exc:
+        raise ValueError(f"relay observation has no MCP task projection: {observation}") from exc
 
 
 def _session_to_json(session: McpSessionState) -> JSON:
@@ -289,16 +322,24 @@ class RelayMcpRuntime:
             "poll_interval_ms": TASK_POLL_INTERVAL_MS,
         }
         if projection.protocol_error is not None:
-            return GetTaskResult(status="failed", error=projection.protocol_error, **common)
+            status, _ = _relay_state_projection("protocol_error")
+            return GetTaskResult(status=status, error=projection.protocol_error, **common)
         if projection.input_round is not None and projection.input_round.outstanding:
+            status, _ = _relay_state_projection("durable_input_round")
             return GetTaskResult(
-                status="input_required",
+                status=status,
                 input_requests=projection.input_round.outstanding,
                 **common,
             )
         if projection.completed_result is not None:
+            observation = (
+                "tool_failure"
+                if projection.completed_result.get("isError") is True
+                else "succeeded"
+            )
+            status, _ = _relay_state_projection(observation)
             return GetTaskResult(
-                status="completed",
+                status=status,
                 result=projection.completed_result,
                 **common,
             )
@@ -319,15 +360,17 @@ class RelayMcpRuntime:
         else:
             job = await asyncio.to_thread(self.queue.get_job, record.job_id)
         if job.state is JobState.CANCELED:
+            status, _ = _relay_state_projection(job.state.value)
             return GetTaskResult(
-                status="cancelled",
+                status=status,
                 status_message=job.last_error,
                 last_updated_at=job.updated_at.isoformat(),
                 **{key: value for key, value in common.items() if key != "last_updated_at"},
             )
         if job.state not in TERMINAL_STATES:
+            status, _ = _relay_state_projection(job.state.value)
             return GetTaskResult(
-                status="working",
+                status=status,
                 status_message=f"Relay job is {job.state.value}",
                 last_updated_at=job.updated_at.isoformat(),
                 **{key: value for key, value in common.items() if key != "last_updated_at"},
@@ -366,8 +409,10 @@ class RelayMcpRuntime:
             if updated.projection.completed_result is None:
                 raise
             final = updated.projection.completed_result
+        observation = "tool_failure" if final.get("isError") is True else "succeeded"
+        status, _ = _relay_state_projection(observation)
         return GetTaskResult(
-            status="completed",
+            status=status,
             result=final,
             status_message=f"Relay job {job.state.value}",
             last_updated_at=job.updated_at.isoformat(),

--- a/tests/fixtures/relay_schema_equality_v1.json
+++ b/tests/fixtures/relay_schema_equality_v1.json
@@ -1,0 +1,1019 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "issue": "iowarp/clio-agent#1121 P2.3",
+  "models": {
+    "ArtifactRef": {
+      "disposition": "clio-schemas projection reference",
+      "json_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "artifact_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[a-z0-9][a-z0-9_-]{0,127}$",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "job_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[a-z0-9][a-z0-9_-]{0,127}$",
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "sha256": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "size_bytes": {
+            "anyOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "job_id",
+          "uri",
+          "kind"
+        ],
+        "type": "object"
+      },
+      "reference": "clio-schemas v0.2.0 ArtifactVersion.to_artifact_ref; tests/fixtures/clio_schemas_v0_2_0_projections.json"
+    },
+    "ArtifactUse": {
+      "disposition": "clio-schemas projection reference",
+      "json_schema": {
+        "$defs": {
+          "ArtifactUseEvidence": {
+            "enum": [
+              "schema-arg",
+              "hash-pair",
+              "lease-window",
+              "authority",
+              "assertion"
+            ],
+            "type": "string"
+          },
+          "ArtifactUseProvenance": {
+            "additionalProperties": false,
+            "properties": {
+              "arg": {
+                "default": "",
+                "maxLength": 512,
+                "type": "string"
+              },
+              "authority": {
+                "default": "",
+                "maxLength": 4096,
+                "type": "string"
+              },
+              "evidence": {
+                "$ref": "#/$defs/ArtifactUseEvidence"
+              },
+              "external_ref": {
+                "default": "",
+                "maxLength": 4096,
+                "type": "string"
+              },
+              "note": {
+                "default": "",
+                "maxLength": 512,
+                "type": "string"
+              },
+              "schema_version": {
+                "const": "clio-relay.artifact-use-provenance.v1",
+                "default": "clio-relay.artifact-use-provenance.v1",
+                "type": "string"
+              }
+            },
+            "required": [
+              "evidence"
+            ],
+            "type": "object"
+          }
+        },
+        "additionalProperties": false,
+        "properties": {
+          "artifact_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[a-z0-9][a-z0-9_-]{0,127}$",
+            "type": "string"
+          },
+          "provenance": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ArtifactUseProvenance"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "sha256": {
+            "maxLength": 64,
+            "minLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "artifact_id",
+          "sha256"
+        ],
+        "type": "object"
+      },
+      "reference": "clio-schemas v0.2.0 ProvEdge.to_artifact_use; tests/fixtures/clio_schemas_v0_2_0_projections.json"
+    },
+    "RelayJob": {
+      "disposition": "relay-owned committed golden",
+      "json_schema": {
+        "$defs": {
+          "ArtifactUse": {
+            "additionalProperties": false,
+            "properties": {
+              "artifact_id": {
+                "maxLength": 128,
+                "minLength": 1,
+                "pattern": "^[a-z0-9][a-z0-9_-]{0,127}$",
+                "type": "string"
+              },
+              "provenance": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/ArtifactUseProvenance"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "sha256": {
+                "maxLength": 64,
+                "minLength": 64,
+                "type": "string"
+              }
+            },
+            "required": [
+              "artifact_id",
+              "sha256"
+            ],
+            "type": "object"
+          },
+          "ArtifactUseEvidence": {
+            "enum": [
+              "schema-arg",
+              "hash-pair",
+              "lease-window",
+              "authority",
+              "assertion"
+            ],
+            "type": "string"
+          },
+          "ArtifactUseProvenance": {
+            "additionalProperties": false,
+            "properties": {
+              "arg": {
+                "default": "",
+                "maxLength": 512,
+                "type": "string"
+              },
+              "authority": {
+                "default": "",
+                "maxLength": 4096,
+                "type": "string"
+              },
+              "evidence": {
+                "$ref": "#/$defs/ArtifactUseEvidence"
+              },
+              "external_ref": {
+                "default": "",
+                "maxLength": 4096,
+                "type": "string"
+              },
+              "note": {
+                "default": "",
+                "maxLength": 512,
+                "type": "string"
+              },
+              "schema_version": {
+                "const": "clio-relay.artifact-use-provenance.v1",
+                "default": "clio-relay.artifact-use-provenance.v1",
+                "type": "string"
+              }
+            },
+            "required": [
+              "evidence"
+            ],
+            "type": "object"
+          },
+          "InputArtifactSpec": {
+            "additionalProperties": false,
+            "properties": {
+              "logical_name": {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              "schema_version": {
+                "const": "clio-relay.input-artifact.v1",
+                "default": "clio-relay.input-artifact.v1",
+                "type": "string"
+              },
+              "sha256": {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              },
+              "size_bytes": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "logical_name",
+              "size_bytes",
+              "sha256"
+            ],
+            "type": "object"
+          },
+          "JarvisPipelineInputBinding": {
+            "additionalProperties": false,
+            "properties": {
+              "accepted_names": {
+                "items": {
+                  "maxLength": 512,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "maxItems": 64,
+                "minItems": 1,
+                "type": "array"
+              },
+              "artifact_use": {
+                "$ref": "#/$defs/ArtifactUse"
+              },
+              "canonical_setting": {
+                "maxLength": 512,
+                "minLength": 1,
+                "type": "string"
+              },
+              "logical_name": {
+                "maxLength": 512,
+                "minLength": 1,
+                "type": "string"
+              },
+              "remote_path": {
+                "maxLength": 4096,
+                "minLength": 1,
+                "type": "string"
+              },
+              "sha256": {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              },
+              "size_bytes": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "step_id": {
+                "maxLength": 512,
+                "minLength": 1,
+                "type": "string"
+              },
+              "workspace_relative_path": {
+                "maxLength": 4096,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "step_id",
+              "canonical_setting",
+              "accepted_names",
+              "workspace_relative_path",
+              "logical_name",
+              "size_bytes",
+              "sha256",
+              "remote_path",
+              "artifact_use"
+            ],
+            "type": "object"
+          },
+          "JarvisPipelineInputRoute": {
+            "additionalProperties": false,
+            "properties": {
+              "cluster": {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "cluster_route_revision": {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              },
+              "contract": {
+                "const": "clio-kit-jarvis-user-v3.6",
+                "default": "clio-kit-jarvis-user-v3.6",
+                "type": "string"
+              },
+              "expected_server_artifact_digest": {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              },
+              "owner_session_generation_id": {
+                "maxLength": 128,
+                "minLength": 1,
+                "pattern": "^[a-z0-9][a-z0-9_-]{0,127}$",
+                "type": "string"
+              },
+              "owner_session_id": {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "pipeline_id": {
+                "maxLength": 512,
+                "minLength": 1,
+                "type": "string"
+              },
+              "registration_revision": {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              },
+              "schema_version": {
+                "const": "clio-relay.jarvis-pipeline-input-route.v1",
+                "default": "clio-relay.jarvis-pipeline-input-route.v1",
+                "type": "string"
+              },
+              "server_name": {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "cluster",
+              "server_name",
+              "cluster_route_revision",
+              "registration_revision",
+              "expected_server_artifact_digest",
+              "pipeline_id",
+              "owner_session_id",
+              "owner_session_generation_id"
+            ],
+            "type": "object"
+          },
+          "JarvisRunInputManifest": {
+            "additionalProperties": false,
+            "properties": {
+              "artifact_uses": {
+                "items": {
+                  "$ref": "#/$defs/ArtifactUse"
+                },
+                "maxItems": 1000,
+                "minItems": 1,
+                "type": "array"
+              },
+              "created_at": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "document_sha256": {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              },
+              "idempotency_key": {
+                "maxLength": 4096,
+                "minLength": 1,
+                "type": "string"
+              },
+              "manifest_sha256": {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              },
+              "resolutions": {
+                "items": {
+                  "$ref": "#/$defs/JarvisRunInputResolution"
+                },
+                "maxItems": 1000,
+                "minItems": 1,
+                "type": "array"
+              },
+              "route": {
+                "$ref": "#/$defs/JarvisPipelineInputRoute"
+              },
+              "route_sha256": {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              },
+              "schema_version": {
+                "const": "clio-relay.jarvis-run-input-manifest.v1",
+                "default": "clio-relay.jarvis-run-input-manifest.v1",
+                "type": "string"
+              }
+            },
+            "required": [
+              "route",
+              "route_sha256",
+              "idempotency_key",
+              "resolutions",
+              "artifact_uses",
+              "manifest_sha256",
+              "created_at",
+              "document_sha256"
+            ],
+            "type": "object"
+          },
+          "JarvisRunInputResolution": {
+            "additionalProperties": false,
+            "properties": {
+              "binding": {
+                "$ref": "#/$defs/JarvisPipelineInputBinding"
+              },
+              "disposition": {
+                "enum": [
+                  "reused",
+                  "updated"
+                ],
+                "type": "string"
+              },
+              "previous_sha256": {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "binding",
+              "disposition",
+              "previous_sha256"
+            ],
+            "type": "object"
+          },
+          "JarvisRunSpec": {
+            "additionalProperties": false,
+            "properties": {
+              "command": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "env": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "package": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "pipeline_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "pipeline_path": {
+                "anyOf": [
+                  {
+                    "format": "path",
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "pipeline_yaml": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "progress": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "timeout_seconds": {
+                "anyOf": [
+                  {
+                    "exclusiveMinimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "workdir": {
+                "anyOf": [
+                  {
+                    "format": "path",
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "type": "object"
+          },
+          "JobKind": {
+            "enum": [
+              "jarvis",
+              "remote_agent",
+              "mcp_call",
+              "input_ingest"
+            ],
+            "type": "string"
+          },
+          "JobState": {
+            "enum": [
+              "queued",
+              "leased",
+              "running",
+              "succeeded",
+              "failed",
+              "canceled"
+            ],
+            "type": "string"
+          },
+          "McpAdmissionClass": {
+            "enum": [
+              "workload",
+              "control_query"
+            ],
+            "type": "string"
+          },
+          "McpCallSpec": {
+            "additionalProperties": false,
+            "properties": {
+              "admission_class": {
+                "$ref": "#/$defs/McpAdmissionClass",
+                "default": "workload"
+              },
+              "arguments": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "env_from": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "expected_jarvis_cd_lock_binding": {
+                "anyOf": [
+                  {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "expected_registered_contract": {
+                "anyOf": [
+                  {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "expected_server_artifact_digest": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "jarvis_input_manifest": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/JarvisRunInputManifest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "operation": {
+                "$ref": "#/$defs/McpOperation",
+                "default": "tools/call"
+              },
+              "server": {
+                "type": "string"
+              },
+              "server_args": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "timeout_seconds": {
+                "anyOf": [
+                  {
+                    "exclusiveMinimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "tool": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "required": [
+              "server"
+            ],
+            "type": "object"
+          },
+          "McpOperation": {
+            "enum": [
+              "tools/call",
+              "tools/list"
+            ],
+            "type": "string"
+          },
+          "RemoteAgentTaskSpec": {
+            "additionalProperties": false,
+            "properties": {
+              "context": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "mcp_config_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "model": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "prompt_path": {
+                "type": "string"
+              },
+              "timeout_seconds": {
+                "anyOf": [
+                  {
+                    "exclusiveMinimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "workdir": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "required": [
+              "prompt_path"
+            ],
+            "type": "object"
+          },
+          "StorageReservationEstimate": {
+            "additionalProperties": false,
+            "properties": {
+              "core_bytes": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "spool_bytes": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "core_bytes",
+              "spool_bytes"
+            ],
+            "type": "object"
+          }
+        },
+        "additionalProperties": false,
+        "properties": {
+          "attempts": {
+            "default": 0,
+            "type": "integer"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "idempotency_key": {
+            "type": "string"
+          },
+          "job_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[a-z0-9][a-z0-9_-]{0,127}$",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/$defs/JobKind"
+          },
+          "last_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "leased_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "spec": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/JarvisRunSpec"
+              },
+              {
+                "$ref": "#/$defs/RemoteAgentTaskSpec"
+              },
+              {
+                "$ref": "#/$defs/McpCallSpec"
+              },
+              {
+                "$ref": "#/$defs/InputArtifactSpec"
+              }
+            ]
+          },
+          "state": {
+            "$ref": "#/$defs/JobState",
+            "default": "queued"
+          },
+          "storage_reservation": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/StorageReservationEstimate"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "submission_digest": {
+            "anyOf": [
+              {
+                "maxLength": 64,
+                "minLength": 64,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "used_artifact_refs": {
+            "items": {
+              "$ref": "#/$defs/ArtifactUse"
+            },
+            "maxItems": 1000,
+            "type": "array"
+          }
+        },
+        "required": [
+          "cluster",
+          "kind",
+          "spec",
+          "idempotency_key"
+        ],
+        "type": "object"
+      },
+      "reference": "clio_relay.models.RelayJob"
+    },
+    "TaskTimelineEvent": {
+      "disposition": "relay-owned committed golden",
+      "json_schema": {
+        "$defs": {
+          "TaskEventStatus": {
+            "enum": [
+              "planned",
+              "running",
+              "succeeded",
+              "warning",
+              "error",
+              "canceled"
+            ],
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "properties": {
+          "artifact_refs": {
+            "items": {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[a-z0-9][a-z0-9_-]{0,127}$",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "event_type": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "path_refs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "seq": {
+            "default": 0,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "status": {
+            "$ref": "#/$defs/TaskEventStatus",
+            "default": "running"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "task_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[a-z0-9][a-z0-9_-]{0,127}$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "task_id",
+          "event_type",
+          "label",
+          "summary"
+        ],
+        "type": "object"
+      },
+      "reference": "clio_relay.models.TaskTimelineEvent"
+    }
+  },
+  "runtime_dependency_policy": "No clio-schemas runtime dependency; release audit requires hashed requirements.",
+  "schema_version": "clio-relay.cross-repo-schema-equality.v1"
+}

--- a/tests/fixtures/relay_state_map_v1.json
+++ b/tests/fixtures/relay_state_map_v1.json
@@ -1,0 +1,35 @@
+{
+  "_source": "docs/mcp-tasks.md:99-114; cross-repo counterpart clio_agent.gact.agents.invoker.RELAY_STATE_MAP (iowarp/clio-agent#1121 P2.3)",
+  "rows": [
+    {
+      "relay_observations": ["queued", "leased", "running"],
+      "mcp_task_status": "working",
+      "isError": null
+    },
+    {
+      "relay_observations": ["durable_input_round"],
+      "mcp_task_status": "input_required",
+      "isError": null
+    },
+    {
+      "relay_observations": ["succeeded"],
+      "mcp_task_status": "completed",
+      "isError": false
+    },
+    {
+      "relay_observations": ["tool_failure"],
+      "mcp_task_status": "completed",
+      "isError": true
+    },
+    {
+      "relay_observations": ["protocol_error"],
+      "mcp_task_status": "failed",
+      "isError": null
+    },
+    {
+      "relay_observations": ["canceled"],
+      "mcp_task_status": "cancelled",
+      "isError": null
+    }
+  ]
+}

--- a/tests/generate_schema_equality_goldens.py
+++ b/tests/generate_schema_equality_goldens.py
@@ -1,0 +1,149 @@
+"""Generate the committed cross-repo relay JSON-Schema expectations.
+
+This generator deliberately imports relay models only. The shared-model source
+provenance is the committed clio-schemas v0.2.0 projection fixture, not a live
+``clio-schemas`` dependency, because release validation exports and audits
+hash-pinned requirements.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final, cast
+
+from pydantic import BaseModel
+
+from clio_relay.models import ArtifactRef, ArtifactUse, RelayJob, TaskTimelineEvent
+
+type JSONValue = dict[str, JSONValue] | list[JSONValue] | str | int | float | bool | None
+
+GOLDEN_PATH: Final = Path(__file__).parent / "fixtures" / "relay_schema_equality_v1.json"
+SCHEMA_MODELS: Final[dict[str, type[BaseModel]]] = {
+    "ArtifactUse": ArtifactUse,
+    "ArtifactRef": ArtifactRef,
+    "RelayJob": RelayJob,
+    "TaskTimelineEvent": TaskTimelineEvent,
+}
+MODEL_DISPOSITIONS: Final[dict[str, dict[str, str]]] = {
+    "ArtifactUse": {
+        "disposition": "clio-schemas projection reference",
+        "reference": (
+            "clio-schemas v0.2.0 ProvEdge.to_artifact_use; "
+            "tests/fixtures/clio_schemas_v0_2_0_projections.json"
+        ),
+    },
+    "ArtifactRef": {
+        "disposition": "clio-schemas projection reference",
+        "reference": (
+            "clio-schemas v0.2.0 ArtifactVersion.to_artifact_ref; "
+            "tests/fixtures/clio_schemas_v0_2_0_projections.json"
+        ),
+    },
+    "RelayJob": {
+        "disposition": "relay-owned committed golden",
+        "reference": "clio_relay.models.RelayJob",
+    },
+    "TaskTimelineEvent": {
+        "disposition": "relay-owned committed golden",
+        "reference": "clio_relay.models.TaskTimelineEvent",
+    },
+}
+_NON_WIRE_SCHEMA_KEYS: Final = frozenset({"description", "title"})
+
+
+def canonical_wire_schema(value: JSONValue) -> JSONValue:
+    """Remove documentation-only JSON-Schema annotations and sort mappings."""
+    if isinstance(value, dict):
+        return {
+            key: canonical_wire_schema(item)
+            for key, item in sorted(value.items())
+            if key not in _NON_WIRE_SCHEMA_KEYS
+        }
+    if isinstance(value, list):
+        return [canonical_wire_schema(item) for item in value]
+    return value
+
+
+def build_schema_equality_document(
+    models: Mapping[str, type[BaseModel]] = SCHEMA_MODELS,
+) -> dict[str, Any]:
+    """Build the canonical committed schema-equality document."""
+    if set(models) != set(MODEL_DISPOSITIONS):
+        raise ValueError("schema equality models must match the committed disposition catalog")
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "schema_version": "clio-relay.cross-repo-schema-equality.v1",
+        "issue": "iowarp/clio-agent#1121 P2.3",
+        "runtime_dependency_policy": (
+            "No clio-schemas runtime dependency; release audit requires hashed requirements."
+        ),
+        "models": {
+            name: {
+                **MODEL_DISPOSITIONS[name],
+                "json_schema": canonical_wire_schema(
+                    cast("JSONValue", model.model_json_schema(mode="serialization"))
+                ),
+            }
+            for name, model in sorted(models.items())
+        },
+    }
+
+
+def render_schema_equality_document(
+    models: Mapping[str, type[BaseModel]] = SCHEMA_MODELS,
+) -> str:
+    """Render the canonical schema document with stable bytes."""
+    return (
+        json.dumps(
+            build_schema_equality_document(models),
+            indent=2,
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+
+def assert_schema_equality_golden_current(
+    models: Mapping[str, type[BaseModel]] = SCHEMA_MODELS,
+) -> None:
+    """Raise with a unified diff when runtime wire schemas drift from the golden."""
+    expected = GOLDEN_PATH.read_text(encoding="utf-8")
+    actual = render_schema_equality_document(models)
+    if actual == expected:
+        return
+    diff = "".join(
+        difflib.unified_diff(
+            expected.splitlines(keepends=True),
+            actual.splitlines(keepends=True),
+            fromfile=str(GOLDEN_PATH),
+            tofile="generated relay wire schemas",
+        )
+    )
+    raise AssertionError(f"committed relay schema equality golden is stale:\n{diff}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Write the golden, or verify it without mutation with ``--check``."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="fail when the committed golden differs instead of rewriting it",
+    )
+    arguments = parser.parse_args(argv)
+    if arguments.check:
+        assert_schema_equality_golden_current()
+        print(f"OK: {GOLDEN_PATH} is canonical")
+        return 0
+    GOLDEN_PATH.write_text(render_schema_equality_document(), encoding="utf-8", newline="\n")
+    print(f"Wrote {GOLDEN_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_schema_equality.py
+++ b/tests/test_schema_equality.py
@@ -1,0 +1,91 @@
+"""Relay half of cross-repo schema and task-state equality CI (#1121, P2.3)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from clio_relay.fastmcp_server import RELAY_STATE_MAP
+from clio_relay.models import ArtifactUse, JobState
+from tests.generate_schema_equality_goldens import (
+    MODEL_DISPOSITIONS,
+    SCHEMA_MODELS,
+    assert_schema_equality_golden_current,
+)
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_relay_wire_schemas_match_committed_cross_repo_goldens() -> None:
+    """Every federated relay wire model must equal its committed expectation."""
+    assert_schema_equality_golden_current()
+
+
+def test_schema_equality_model_dispositions_are_explicit() -> None:
+    """Shared projections and relay-owned models must retain distinct provenance."""
+    assert {
+        name: disposition["disposition"] for name, disposition in MODEL_DISPOSITIONS.items()
+    } == {
+        "ArtifactUse": "clio-schemas projection reference",
+        "ArtifactRef": "clio-schemas projection reference",
+        "RelayJob": "relay-owned committed golden",
+        "TaskTimelineEvent": "relay-owned committed golden",
+    }
+
+
+def test_ci_checks_committed_schema_goldens_without_syncing() -> None:
+    """The primary CI leg must run the generator's read-only check mode."""
+    workflow = (Path(__file__).parents[1] / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "uv run --no-sync python -m tests.generate_schema_equality_goldens --check" in workflow
+
+
+def test_schema_equality_detector_rejects_one_field_model_sabotage() -> None:
+    """Adding one wire field must make equality fail before a golden contract rev."""
+
+    class SabotagedArtifactUse(ArtifactUse):
+        sabotage_field: str | None = None
+
+    sabotaged_models = {**SCHEMA_MODELS, "ArtifactUse": SabotagedArtifactUse}
+    with pytest.raises(AssertionError, match="sabotage_field"):
+        assert_schema_equality_golden_current(sabotaged_models)
+
+
+def test_relay_state_map_matches_documented_mcp_task_projection() -> None:
+    """Relay's implementation table must equal the committed cross-repo table."""
+    document = cast(
+        "dict[str, Any]",
+        json.loads((_FIXTURES / "relay_state_map_v1.json").read_text(encoding="utf-8")),
+    )
+    actual = [
+        {
+            "relay_observations": list(observations),
+            "mcp_task_status": status,
+            "isError": is_error,
+        }
+        for observations, status, is_error in RELAY_STATE_MAP
+    ]
+
+    assert actual == document["rows"]
+
+
+def test_relay_state_map_is_total_and_bijective_by_documented_row() -> None:
+    """Each relay observation occurs once and each semantic projection is distinct."""
+    observations = [
+        observation
+        for row_observations, _status, _is_error in RELAY_STATE_MAP
+        for observation in row_observations
+    ]
+    projections = [(status, is_error) for _observations, status, is_error in RELAY_STATE_MAP]
+
+    direct_job_states = set(JobState) - {JobState.FAILED}
+    assert direct_job_states <= set(observations)
+    assert {"tool_failure", "protocol_error"} <= set(observations)
+    assert JobState.FAILED.value not in observations
+    assert len(observations) == len(set(observations))
+    assert len(projections) == len(set(projections))


### PR DESCRIPTION
The relay half of the P2.3 schema-equality CI (clio-agent half merged as iowarp/clio-agent#1159): committed golden wire shapes for the four shared models with a scripted --check generator (no runtime clio-schemas dependency, per the #148 lesson), the RELAY_STATE_MAP projection as a typed Final table asserted by a bijection test — identical to the table clio-agent commits, so drift reds the drifting side — plus a permanent meta-sabotage test. Failing-first + sabotage shown. Focused suites + ruff/format/pyright strict green; full local suite green except the A/B-controlled box-environmental clio-kit contract fixtures and one unreproducible single-run flake in test_browser_attachment_queue (passed 3/3 standalone; noting honestly — CI matrix is the arbiter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)