### PR TITLE
feat: per-user/owner-session identity on jobs (#144)

### DIFF
--- a/src/clio_relay/http_api.py
+++ b/src/clio_relay/http_api.py
@@ -65,6 +65,14 @@ from clio_relay.jarvis_service_runtime import (
     resolve_local_verified_jarvis_service_runtime_authority,
     reverify_jarvis_service_runtime,
 )
+from clio_relay.job_identity import (
+    OWNER_SESSION_ID_HEADER,
+    SESSION_GENERATION_ID_HEADER,
+    JobOwnerSessionIdentity,
+    OwnerSessionIdentityError,
+    parse_job_owner_session_identity,
+    require_job_owner_session_identity,
+)
 from clio_relay.models import (
     INPUT_INGEST_POLICY_METADATA_KEY,
     MCP_ADMISSION_AUTHORITY_METADATA_KEY,
@@ -134,11 +142,7 @@ from clio_relay.remote_mcp import (
     resolve_registered_remote_mcp_admission,
 )
 from clio_relay.retention import TerminalRetentionCoordinator
-from clio_relay.session_api import (
-    OWNER_SESSION_ID_HEADER,
-    SESSION_GENERATION_ID_HEADER,
-    session_identity_document,
-)
+from clio_relay.session_api import session_identity_document
 from clio_relay.spool import JobSpool
 from clio_relay.storage_runtime import StorageAdmissionError, storage_managed_queue
 from clio_relay.validation_report import redact_sensitive_values
@@ -1046,6 +1050,10 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
     )
     auth_dependency = Depends(_require_api_token(resolved))
     session_submission_dependency = Depends(_require_session_submission_binding(resolved))
+    job_identity_parameter = cast(
+        JobOwnerSessionIdentity | None,
+        Depends(_job_owner_session_identity()),
+    )
 
     def ensure_intake_open() -> None:
         if resolved.owner_session_id is None:
@@ -1093,6 +1101,7 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
     def submit_owned(
         job: RelayJob,
         *,
+        owner_session_identity: JobOwnerSessionIdentity | None = None,
         mcp_admission_authority: McpAdmissionAuthority | None = None,
         input_ingest_policy: InputArtifactIngestPolicy | None = None,
     ) -> RelayJob:
@@ -1123,6 +1132,21 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
                     + ", ".join(protected)
                 ),
             )
+        if job.owner_session_id is not None or job.owner_session_generation_id is not None:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "job owner-session identity is server-managed and must be "
+                    "supplied through headers"
+                ),
+            )
+        try:
+            owner_session_identity = require_job_owner_session_identity(
+                job.kind,
+                owner_session_identity,
+            )
+        except OwnerSessionIdentityError as exc:
+            raise HTTPException(status_code=422, detail=exc.detail) from exc
         if job.kind is JobKind.MCP_CALL:
             if not isinstance(job.spec, McpCallSpec):
                 raise HTTPException(status_code=422, detail="MCP job has an invalid specification")
@@ -1171,7 +1195,17 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
         # Job ids crossing HTTP are caller-controlled, including on the raw
         # /jobs route. Generate new-admission entropy inside the server; an
         # idempotent retry is still canonicalized by the durable key record.
-        job = job.model_copy(update={"job_id": new_id("job")})
+        job_updates: dict[str, object] = {"job_id": new_id("job")}
+        if owner_session_identity is not None:
+            job_updates.update(
+                {
+                    "owner_session_id": owner_session_identity.owner_session_id,
+                    "owner_session_generation_id": (
+                        owner_session_identity.owner_session_generation_id
+                    ),
+                }
+            )
+        job = job.model_copy(update=job_updates)
         try:
             return _public_record(queue.submit_job(job.model_copy(update={"metadata": metadata})))
         except ValueError as exc:
@@ -1399,22 +1433,28 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
     @app.post(
         "/jobs",
         response_model=RelayJob,
-        dependencies=[auth_dependency, session_submission_dependency],
+        dependencies=[auth_dependency],
     )
-    def submit_job(job: RelayJob) -> RelayJob:
+    def submit_job(
+        job: RelayJob,
+        owner_session_identity: JobOwnerSessionIdentity | None = job_identity_parameter,
+    ) -> RelayJob:
         if job.kind in {JobKind.MCP_CALL, JobKind.INPUT_INGEST}:
             raise HTTPException(
                 status_code=422,
                 detail=("this job kind must use its dedicated authenticated internal route"),
             )
-        return submit_owned(job)
+        return submit_owned(job, owner_session_identity=owner_session_identity)
 
     @app.post(
         "/jobs/jarvis",
         response_model=RelayJob,
-        dependencies=[auth_dependency, session_submission_dependency],
+        dependencies=[auth_dependency],
     )
-    def submit_jarvis(request: JarvisSubmitRequest) -> RelayJob:
+    def submit_jarvis(
+        request: JarvisSubmitRequest,
+        owner_session_identity: JobOwnerSessionIdentity | None = job_identity_parameter,
+    ) -> RelayJob:
         return submit_owned(
             RelayJob(
                 cluster=request.cluster,
@@ -1422,15 +1462,19 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
                 spec=JarvisRunSpec(pipeline_yaml=request.pipeline_yaml),
                 idempotency_key=request.idempotency_key,
                 used_artifact_refs=request.used_artifact_refs,
-            )
+            ),
+            owner_session_identity=owner_session_identity,
         )
 
     @app.post(
         "/jobs/jarvis-pipeline",
         response_model=RelayJob,
-        dependencies=[auth_dependency, session_submission_dependency],
+        dependencies=[auth_dependency],
     )
-    def submit_jarvis_pipeline(request: JarvisPipelineSubmitRequest) -> RelayJob:
+    def submit_jarvis_pipeline(
+        request: JarvisPipelineSubmitRequest,
+        owner_session_identity: JobOwnerSessionIdentity | None = job_identity_parameter,
+    ) -> RelayJob:
         return submit_owned(
             RelayJob(
                 cluster=request.cluster,
@@ -1438,15 +1482,19 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
                 spec=JarvisRunSpec(pipeline_name=request.pipeline_name),
                 idempotency_key=request.idempotency_key,
                 used_artifact_refs=request.used_artifact_refs,
-            )
+            ),
+            owner_session_identity=owner_session_identity,
         )
 
     @app.post(
         "/jobs/remote-agent",
         response_model=RelayJob,
-        dependencies=[auth_dependency, session_submission_dependency],
+        dependencies=[auth_dependency],
     )
-    def submit_remote_agent(request: RemoteAgentSubmitRequest) -> RelayJob:
+    def submit_remote_agent(
+        request: RemoteAgentSubmitRequest,
+        owner_session_identity: JobOwnerSessionIdentity | None = job_identity_parameter,
+    ) -> RelayJob:
         return submit_owned(
             RelayJob(
                 cluster=request.cluster,
@@ -1460,15 +1508,19 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
                 ),
                 idempotency_key=request.idempotency_key,
                 used_artifact_refs=request.used_artifact_refs,
-            )
+            ),
+            owner_session_identity=owner_session_identity,
         )
 
     @app.post(
         "/jobs/mcp-call",
         response_model=RelayJob,
-        dependencies=[auth_dependency, session_submission_dependency],
+        dependencies=[auth_dependency],
     )
-    def submit_mcp_call(request: McpCallSubmitRequest) -> RelayJob:
+    def submit_mcp_call(
+        request: McpCallSubmitRequest,
+        owner_session_identity: JobOwnerSessionIdentity | None = job_identity_parameter,
+    ) -> RelayJob:
         registry_path = default_registry_path()
         try:
             definition = (
@@ -1516,15 +1568,19 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
                 idempotency_key=request.idempotency_key,
                 used_artifact_refs=request.used_artifact_refs,
             ),
+            owner_session_identity=owner_session_identity,
             mcp_admission_authority=admission_authority,
         )
 
     @app.post(
         "/jobs/jarvis-mcp-call",
         response_model=RelayJob,
-        dependencies=[auth_dependency, session_submission_dependency],
+        dependencies=[auth_dependency],
     )
-    def submit_jarvis_mcp_call(request: JarvisMcpCallSubmitRequest) -> RelayJob:
+    def submit_jarvis_mcp_call(
+        request: JarvisMcpCallSubmitRequest,
+        owner_session_identity: JobOwnerSessionIdentity | None = job_identity_parameter,
+    ) -> RelayJob:
         expected_digest = request.expected_server_artifact_digest
         try:
             admission_class, admission_authority = resolve_pinned_mcp_admission(
@@ -1591,6 +1647,7 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
                 idempotency_key=request.idempotency_key,
                 used_artifact_refs=request.used_artifact_refs,
             ),
+            owner_session_identity=owner_session_identity,
             mcp_admission_authority=admission_authority,
         )
 
@@ -2711,14 +2768,6 @@ def _require_api_token(settings: RelaySettings) -> Callable[..., Awaitable[None]
         expected_session_id = settings.owner_session_id
         expected_generation_id = settings.owner_session_generation_id
         if expected_session_id is None:
-            if (
-                x_clio_relay_owner_session_id is not None
-                or x_clio_relay_session_generation_id is not None
-            ):
-                raise HTTPException(
-                    status_code=409,
-                    detail="relay API is not bound to an owner session",
-                )
             return
         if x_clio_relay_owner_session_id is None or x_clio_relay_session_generation_id is None:
             raise HTTPException(
@@ -2736,6 +2785,30 @@ def _require_api_token(settings: RelaySettings) -> Callable[..., Awaitable[None]
                 status_code=409,
                 detail="owner session or generation does not match this API process",
             )
+
+    return dependency
+
+
+def _job_owner_session_identity() -> Callable[..., Awaitable[JobOwnerSessionIdentity | None]]:
+    """Parse optional attribution headers independently from bearer admission."""
+
+    async def dependency(
+        x_clio_relay_owner_session_id: Annotated[
+            str | None,
+            Header(alias=OWNER_SESSION_ID_HEADER),
+        ] = None,
+        x_clio_relay_session_generation_id: Annotated[
+            str | None,
+            Header(alias=SESSION_GENERATION_ID_HEADER),
+        ] = None,
+    ) -> JobOwnerSessionIdentity | None:
+        try:
+            return parse_job_owner_session_identity(
+                x_clio_relay_owner_session_id,
+                x_clio_relay_session_generation_id,
+            )
+        except OwnerSessionIdentityError as exc:
+            raise HTTPException(status_code=422, detail=exc.detail) from exc
 
     return dependency
 

--- a/src/clio_relay/job_identity.py
+++ b/src/clio_relay/job_identity.py
@@ -1,0 +1,99 @@
+"""Owner-session attribution for submitted relay jobs."""
+
+from __future__ import annotations
+
+from typing import Final, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from clio_relay.errors import RelayError
+from clio_relay.identifiers import DurableRecordId
+from clio_relay.models import JobKind
+
+OWNER_SESSION_ID_HEADER: Final = "X-Clio-Relay-Owner-Session-Id"
+SESSION_GENERATION_ID_HEADER: Final = "X-Clio-Relay-Session-Generation-Id"
+OWNER_SESSION_IDENTITY_ERROR_SCHEMA: Final = "clio-relay.owner-session-identity-error.v1"
+IDENTITY_REQUIRED_JOB_KINDS: Final = frozenset(
+    {
+        JobKind.JARVIS,
+        JobKind.REMOTE_AGENT,
+    }
+)
+
+OwnerSessionIdentityErrorCode = Literal[
+    "owner_session_identity_required",
+    "owner_session_identity_incomplete",
+    "owner_session_identity_invalid",
+]
+
+
+class JobOwnerSessionIdentity(BaseModel):
+    """A complete header-derived identity used only for job attribution."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    owner_session_id: str = Field(min_length=1, max_length=256)
+    owner_session_generation_id: DurableRecordId
+
+
+class OwnerSessionIdentityError(RelayError):
+    """A typed owner-session attribution refusal."""
+
+    def __init__(
+        self,
+        *,
+        code: OwnerSessionIdentityErrorCode,
+        job_kind: JobKind | None,
+        message: str,
+    ) -> None:
+        super().__init__(message)
+        self.detail: dict[str, object] = {
+            "schema": OWNER_SESSION_IDENTITY_ERROR_SCHEMA,
+            "code": code,
+            "job_kind": None if job_kind is None else job_kind.value,
+            "required_headers": [
+                OWNER_SESSION_ID_HEADER,
+                SESSION_GENERATION_ID_HEADER,
+            ],
+            "message": message,
+        }
+
+
+def parse_job_owner_session_identity(
+    owner_session_id: str | None,
+    session_generation_id: str | None,
+) -> JobOwnerSessionIdentity | None:
+    """Parse a complete optional header pair without treating it as authentication."""
+    if owner_session_id is None and session_generation_id is None:
+        return None
+    if owner_session_id is None or session_generation_id is None:
+        raise OwnerSessionIdentityError(
+            code="owner_session_identity_incomplete",
+            job_kind=None,
+            message="owner-session identity headers must be supplied together",
+        )
+    try:
+        return JobOwnerSessionIdentity(
+            owner_session_id=owner_session_id,
+            owner_session_generation_id=session_generation_id,
+        )
+    except ValidationError as exc:
+        raise OwnerSessionIdentityError(
+            code="owner_session_identity_invalid",
+            job_kind=None,
+            message="owner-session identity headers are invalid",
+        ) from exc
+
+
+def require_job_owner_session_identity(
+    kind: JobKind,
+    identity: JobOwnerSessionIdentity | None,
+) -> JobOwnerSessionIdentity | None:
+    """Refuse schedulable lanes without attribution and preserve optional identity."""
+    if kind in IDENTITY_REQUIRED_JOB_KINDS and identity is None:
+        raise OwnerSessionIdentityError(
+            code="owner_session_identity_required",
+            job_kind=kind,
+            message=f"{kind.value} submissions require owner-session identity headers",
+        )
+    return identity

--- a/src/clio_relay/models.py
+++ b/src/clio_relay/models.py
@@ -1501,6 +1501,8 @@ class RelayJob(BaseModel):
     state: JobState = JobState.QUEUED
     spec: JobSpec
     idempotency_key: str
+    owner_session_id: str | None = Field(default=None, min_length=1, max_length=256)
+    owner_session_generation_id: DurableRecordId | None = None
     used_artifact_refs: list[ArtifactUse] = Field(
         default_factory=_empty_artifact_uses,
         max_length=1_000,
@@ -1513,6 +1515,15 @@ class RelayJob(BaseModel):
     last_error: str | None = None
     storage_reservation: StorageReservationEstimate | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def owner_session_identity_must_be_complete(self) -> Self:
+        """Require the explicit scheduler-attribution identity as one complete pair."""
+        if (self.owner_session_id is None) != (self.owner_session_generation_id is None):
+            raise ValueError(
+                "owner_session_id and owner_session_generation_id must be supplied together"
+            )
+        return self
 
     @field_validator("used_artifact_refs")
     @classmethod

--- a/src/clio_relay/session_api.py
+++ b/src/clio_relay/session_api.py
@@ -23,6 +23,10 @@ from clio_relay.cluster_config import ClusterDefinition
 from clio_relay.config import RelaySettings
 from clio_relay.errors import ConfigurationError, ObservationTimeoutError, RelayError
 from clio_relay.jarvis_mcp import is_virtual_jarvis_control_query
+from clio_relay.job_identity import (
+    OWNER_SESSION_ID_HEADER,
+    SESSION_GENERATION_ID_HEADER,
+)
 from clio_relay.models import (
     MCP_ADMISSION_AUTHORITY_METADATA_KEY,
     REGISTERED_JARVIS_USER_CONTRACT,
@@ -46,8 +50,6 @@ from clio_relay.session_lifecycle import (
     status_remote_session,
 )
 
-OWNER_SESSION_ID_HEADER: Final = "X-Clio-Relay-Owner-Session-Id"
-SESSION_GENERATION_ID_HEADER: Final = "X-Clio-Relay-Session-Generation-Id"
 SESSION_IDENTITY_SCHEMA: Final = "clio-relay.session-identity.v1"
 MAX_SESSION_API_RESPONSE_BYTES: Final = 8 * 1024 * 1024
 # Leave part of clio-agent's ordinary 30-second transport budget available for
@@ -219,7 +221,9 @@ def submit_owned_session_job(
         raise RelayError("owned session API returned a job for a different cluster")
     _validate_submission_receipt(job, path=path, payload=payload)
     if (
-        job.metadata.get("owner") != "clio-relay"
+        job.owner_session_id != session_id
+        or job.owner_session_generation_id != generation_id
+        or job.metadata.get("owner") != "clio-relay"
         or job.metadata.get("owner_session_id") != session_id
         or job.metadata.get("owner_session_generation_id") != generation_id
         or "owner_session_admission_id" in job.metadata

--- a/tests/fixtures/relay_schema_equality_v1.json
+++ b/tests/fixtures/relay_schema_equality_v1.json
@@ -860,6 +860,33 @@
             "additionalProperties": true,
             "type": "object"
           },
+          "owner_session_generation_id": {
+            "anyOf": [
+              {
+                "maxLength": 128,
+                "minLength": 1,
+                "pattern": "^[a-z0-9][a-z0-9_-]{0,127}$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "owner_session_id": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
           "spec": {
             "anyOf": [
               {

--- a/tests/test_artifact_lineage.py
+++ b/tests/test_artifact_lineage.py
@@ -21,7 +21,11 @@ from clio_relay.cluster_config import (
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.errors import QueueConflictError
-from clio_relay.http_api import create_app
+from clio_relay.http_api import (
+    OWNER_SESSION_ID_HEADER,
+    SESSION_GENERATION_ID_HEADER,
+    create_app,
+)
 from clio_relay.mcp_server import handle_request
 from clio_relay.models import (
     ArtifactRef,
@@ -545,6 +549,10 @@ def test_http_submission_and_lineage_queries_share_the_content_pin(tmp_path: Pat
 
     submitted = client.post(
         "/jobs/jarvis",
+        headers={
+            OWNER_SESSION_ID_HEADER: "desktop-session-1",
+            SESSION_GENERATION_ID_HEADER: "generation-1",
+        },
         json={
             "cluster": "test-cluster",
             "pipeline_yaml": "name: lineage-http\npkgs: []\n",

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -381,9 +381,14 @@ def test_http_typed_submit_endpoints_create_real_jobs(tmp_path: Path) -> None:
     client = cast(Any, TestClient(create_app(settings)))
     prompt_path = tmp_path / "prompt.md"
     mcp_config_path = tmp_path / "mcp.toml"
+    identity_headers = {
+        OWNER_SESSION_ID_HEADER: "desktop-session-1",
+        SESSION_GENERATION_ID_HEADER: "generation-1",
+    }
 
     jarvis_response = client.post(
         "/jobs/jarvis",
+        headers=identity_headers,
         json={
             "cluster": "test-cluster",
             "pipeline_yaml": "name: generic\npkgs: []\n",
@@ -392,6 +397,7 @@ def test_http_typed_submit_endpoints_create_real_jobs(tmp_path: Path) -> None:
     )
     jarvis_pipeline_response = client.post(
         "/jobs/jarvis-pipeline",
+        headers=identity_headers,
         json={
             "cluster": "test-cluster",
             "pipeline_name": "site_simulation_4node",
@@ -400,6 +406,7 @@ def test_http_typed_submit_endpoints_create_real_jobs(tmp_path: Path) -> None:
     )
     agent_response = client.post(
         "/jobs/remote-agent",
+        headers=identity_headers,
         json={
             "cluster": "test-cluster",
             "prompt_path": str(prompt_path),
@@ -462,6 +469,211 @@ def test_http_typed_submit_endpoints_create_real_jobs(tmp_path: Path) -> None:
     assert jarvis_mcp.spec.server_args == ["mcp-server", "jarvis"]
     assert jarvis_mcp.spec.tool == "jarvis_describe"
     assert jarvis_mcp.spec.arguments == {"target": "packages"}
+
+
+def test_http_remote_agent_submission_requires_typed_owner_session_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A schedulable agent lane must refuse missing attribution as typed data."""
+    jobs: list[RelayJob] = []
+
+    class SubmissionQueue:
+        closed = False
+
+        def initialize(self) -> None:
+            pass
+
+        def close(self) -> None:
+            self.closed = True
+
+        def submit_job(self, job: RelayJob) -> RelayJob:
+            jobs.append(job)
+            return job
+
+    def submission_queue(_settings: RelaySettings) -> SubmissionQueue:
+        return SubmissionQueue()
+
+    monkeypatch.setattr(
+        http_api_module,
+        "storage_managed_queue",
+        submission_queue,
+    )
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        api_token="shared-admission-token",
+    )
+    client = cast(Any, TestClient(create_app(settings)))
+    payload = {
+        "cluster": "test-cluster",
+        "prompt_path": "/remote/prompt.md",
+        "idempotency_key": "missing-owner-session-identity",
+    }
+
+    response = client.post(
+        "/jobs/remote-agent",
+        headers={"Authorization": "Bearer shared-admission-token"},
+        json=payload,
+    )
+    jarvis_response = client.post(
+        "/jobs/jarvis-pipeline",
+        headers={"Authorization": "Bearer shared-admission-token"},
+        json={
+            "cluster": "test-cluster",
+            "pipeline_name": "site-simulation",
+            "idempotency_key": "missing-jarvis-owner-session-identity",
+        },
+    )
+    identity_without_bearer = client.post(
+        "/jobs/remote-agent",
+        headers={
+            OWNER_SESSION_ID_HEADER: "desktop-session-1",
+            SESSION_GENERATION_ID_HEADER: "generation-1",
+        },
+        json={**payload, "idempotency_key": "identity-is-not-admission"},
+    )
+
+    assert response.status_code == 422
+    assert jarvis_response.status_code == 422
+    assert jarvis_response.json()["detail"]["code"] == "owner_session_identity_required"
+    assert jarvis_response.json()["detail"]["job_kind"] == "jarvis"
+    assert identity_without_bearer.status_code == 401
+    assert response.json()["detail"] == {
+        "schema": "clio-relay.owner-session-identity-error.v1",
+        "code": "owner_session_identity_required",
+        "job_kind": "remote_agent",
+        "required_headers": [
+            OWNER_SESSION_ID_HEADER,
+            SESSION_GENERATION_ID_HEADER,
+        ],
+        "message": "remote_agent submissions require owner-session identity headers",
+    }
+    assert jobs == []
+
+
+def test_http_job_lanes_record_owner_session_identity_when_supplied(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Required and optional job lanes retain the exact attribution pair."""
+    jobs: list[RelayJob] = []
+
+    class SubmissionQueue:
+        closed = False
+
+        def initialize(self) -> None:
+            pass
+
+        def close(self) -> None:
+            self.closed = True
+
+        def submit_job(self, job: RelayJob) -> RelayJob:
+            jobs.append(job)
+            return job
+
+    queue = SubmissionQueue()
+
+    def submission_queue(_settings: RelaySettings) -> SubmissionQueue:
+        return queue
+
+    def resolve_admission(
+        **_kwargs: object,
+    ) -> tuple[McpAdmissionClass, None]:
+        return McpAdmissionClass.WORKLOAD, None
+
+    monkeypatch.setattr(
+        http_api_module,
+        "storage_managed_queue",
+        submission_queue,
+    )
+    monkeypatch.setattr(
+        http_api_module,
+        "resolve_registered_remote_mcp_admission",
+        resolve_admission,
+    )
+    monkeypatch.setattr(
+        http_api_module,
+        "default_registry_path",
+        lambda: tmp_path / "missing-clusters.json",
+    )
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        api_token="shared-admission-token",
+    )
+    client = cast(Any, TestClient(create_app(settings)))
+    identity_headers = {
+        "Authorization": "Bearer shared-admission-token",
+        OWNER_SESSION_ID_HEADER: "desktop-session-1",
+        SESSION_GENERATION_ID_HEADER: "generation-1",
+    }
+
+    jarvis = client.post(
+        "/jobs/jarvis-pipeline",
+        headers=identity_headers,
+        json={
+            "cluster": "test-cluster",
+            "pipeline_name": "site-simulation",
+            "idempotency_key": "attributed-jarvis",
+        },
+    )
+    agent = client.post(
+        "/jobs/remote-agent",
+        headers=identity_headers,
+        json={
+            "cluster": "test-cluster",
+            "prompt_path": "/remote/prompt.md",
+            "idempotency_key": "attributed-agent",
+        },
+    )
+    attributed_mcp = client.post(
+        "/jobs/mcp-call",
+        headers=identity_headers,
+        json={
+            "cluster": "test-cluster",
+            "server": "remote-server",
+            "tool": "inspect",
+            "idempotency_key": "attributed-mcp",
+        },
+    )
+    unattributed_mcp = client.post(
+        "/jobs/mcp-call",
+        headers={"Authorization": "Bearer shared-admission-token"},
+        json={
+            "cluster": "test-cluster",
+            "server": "remote-server",
+            "tool": "inspect",
+            "idempotency_key": "unattributed-mcp",
+        },
+    )
+    incomplete_mcp = client.post(
+        "/jobs/mcp-call",
+        headers={
+            "Authorization": "Bearer shared-admission-token",
+            OWNER_SESSION_ID_HEADER: "desktop-session-1",
+        },
+        json={
+            "cluster": "test-cluster",
+            "server": "remote-server",
+            "tool": "inspect",
+            "idempotency_key": "incomplete-mcp",
+        },
+    )
+
+    assert [
+        jarvis.status_code,
+        agent.status_code,
+        attributed_mcp.status_code,
+        unattributed_mcp.status_code,
+    ] == [200, 200, 200, 200]
+    for job in jobs[:3]:
+        assert job.owner_session_id == "desktop-session-1"
+        assert job.owner_session_generation_id == "generation-1"
+    assert jobs[3].owner_session_id is None
+    assert jobs[3].owner_session_generation_id is None
+    assert incomplete_mcp.status_code == 422
+    assert incomplete_mcp.json()["detail"]["code"] == "owner_session_identity_incomplete"
 
 
 def test_http_mcp_admission_is_server_owned_and_raw_bypass_is_closed(
@@ -1396,6 +1608,8 @@ def test_owned_session_api_stamps_jobs_and_gateways_with_server_ownership(
     assert submitted.status_code == 200
     assert forged.status_code == 422
     assert "server-managed" in forged.json()["detail"]
+    assert submitted.json()["owner_session_id"] == "desktop-session-1"
+    assert submitted.json()["owner_session_generation_id"] == "generation-1"
     assert submitted.json()["metadata"] == {
         "owner": "clio-relay",
         "owner_session_id": "desktop-session-1",
@@ -1411,7 +1625,7 @@ def test_owned_session_api_stamps_jobs_and_gateways_with_server_ownership(
     assert patched.json()["metadata"]["phase"] == "ready"
 
 
-def test_session_job_submission_rejects_missing_stale_and_unbound_identity(
+def test_session_job_submission_rejects_missing_and_stale_identity(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1509,8 +1723,9 @@ def test_session_job_submission_rejects_missing_stale_and_unbound_identity(
         },
         json=payload,
     )
-    assert unbound.status_code == 409
-    assert "not bound" in unbound.json()["detail"]
+    assert unbound.status_code == 200
+    assert unbound.json()["owner_session_id"] == "desktop-session-1"
+    assert unbound.json()["owner_session_generation_id"] == "generation-1"
 
 
 def test_owned_jarvis_mcp_submission_forwards_desktop_binding_without_remote_cache(

--- a/tests/test_production_admin_surfaces.py
+++ b/tests/test_production_admin_surfaces.py
@@ -11,7 +11,11 @@ from typer.testing import CliRunner
 from clio_relay.cli import app
 from clio_relay.cluster_config import ClusterDefinition, ClusterRegistry
 from clio_relay.config import RelaySettings
-from clio_relay.http_api import create_app
+from clio_relay.http_api import (
+    OWNER_SESSION_ID_HEADER,
+    SESSION_GENERATION_ID_HEADER,
+    create_app,
+)
 from clio_relay.mcp_server import handle_request
 from clio_relay.models import JarvisRunSpec, JobKind, JobState, RelayJob
 from clio_relay.storage_runtime import storage_managed_queue
@@ -104,6 +108,10 @@ def test_http_storage_status_and_507_decision_are_machine_readable(tmp_path: Pat
     status = client.get("/storage/status")
     first = client.post(
         "/jobs/jarvis",
+        headers={
+            OWNER_SESSION_ID_HEADER: "desktop-session-1",
+            SESSION_GENERATION_ID_HEADER: "generation-1",
+        },
         json={
             "cluster": "configured-target",
             "pipeline_yaml": "name: first\npkgs: []\n",
@@ -112,6 +120,10 @@ def test_http_storage_status_and_507_decision_are_machine_readable(tmp_path: Pat
     )
     denied = client.post(
         "/jobs/jarvis",
+        headers={
+            OWNER_SESSION_ID_HEADER: "desktop-session-1",
+            SESSION_GENERATION_ID_HEADER: "generation-1",
+        },
         json={
             "cluster": "configured-target",
             "pipeline_yaml": "name: second\npkgs: []\n",

--- a/tests/test_session_api.py
+++ b/tests/test_session_api.py
@@ -149,6 +149,8 @@ def _job(expected_digest: str) -> RelayJob:
             timeout_seconds=60,
         ),
         idempotency_key="owned-session-client",
+        owner_session_id="desktop-session-1",
+        owner_session_generation_id="generation-1",
         metadata={
             "owner": "clio-relay",
             "owner_session_id": "desktop-session-1",
@@ -187,6 +189,8 @@ def _admitted_jarvis_run_job(
             arguments={"pipeline_id": pipeline_id},
         ),
         idempotency_key="owned-session-client",
+        owner_session_id="desktop-session-1",
+        owner_session_generation_id="generation-1",
         metadata={
             "owner": "clio-relay",
             "owner_session_id": "desktop-session-1",
@@ -336,6 +340,8 @@ def test_owned_session_client_proves_identity_before_sending_credentials(
         payload=payload,
     )
 
+    assert job.owner_session_id == "desktop-session-1"
+    assert job.owner_session_generation_id == "generation-1"
     assert job.metadata["owner_session_generation_id"] == "generation-1"
     assert len(connections) == 1
     proof_headers = captured[0]["headers"]
@@ -429,6 +435,8 @@ def test_owned_session_submission_accepts_registered_jarvis_execution_identity(
             arguments={"pipeline_id": "science-pipeline"},
         ),
         idempotency_key="owned-session-client",
+        owner_session_id="desktop-session-1",
+        owner_session_generation_id="generation-1",
         metadata={
             "owner": "clio-relay",
             "owner_session_id": "desktop-session-1",


### PR DESCRIPTION
Closes #144 (P2.7). Owner-session identity (the existing header schema) defined + minimally enforced on job submissions: recorded onto RelayJob for scheduler attribution, typed refusal on identity-required lanes, bearer unchanged as the admission credential. Failing-first shown; existing HTTP tests updated to carry identity (one over-applied header injection during integration was caught by the ownership-rejection test and reverted — that test's 403 semantics are preserved). Full local suite green minus the A/B-controlled box-environmental clio-kit contract fixtures; statics green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)