### PR TITLE
feat: post-admission elicitation producer — agent lane (#145)

### DIFF
--- a/docs/ai/interface-context.md
+++ b/docs/ai/interface-context.md
@@ -124,6 +124,12 @@ owner-session-scoped APIs.
 
 When `CLIO_RELAY_API_TOKEN` is set and the API is started with `--require-token`, clients must send either `Authorization: Bearer <token>` or `X-Clio-Relay-Token: <token>`. `/healthz` stays open for local process checks.
 
+`jarvis` and `remote_agent` HTTP submissions require the complete
+`X-Clio-Relay-Owner-Session-Id` /
+`X-Clio-Relay-Session-Generation-Id` attribution pair. Generic `mcp_call`
+submissions accept the pair optionally and retain it when present. The pair is
+recorded in explicit `RelayJob` fields and is not an admission credential.
+
 Job POSTs to an owner-session-scoped API additionally require
 `X-Clio-Relay-Owner-Session-Id` and
 `X-Clio-Relay-Session-Generation-Id` for the exact live generation. The API

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,6 +60,26 @@ executes its bounded stdio request directly under relay-owned containment, with
 no outer JARVIS pipeline or scheduler allocation. If the called MCP tool then
 submits JARVIS work, that returned native execution remains JARVIS-owned.
 
+### job owner-session attribution
+
+HTTP job submissions use one complete attribution pair:
+`X-Clio-Relay-Owner-Session-Id` and
+`X-Clio-Relay-Session-Generation-Id`. The API records the pair directly as
+`RelayJob.owner_session_id` and `RelayJob.owner_session_generation_id`.
+These headers never replace `CLIO_RELAY_API_TOKEN`; the shared bearer remains
+the single admission credential.
+
+| job lane | identity policy | attribution rationale |
+|---|---|---|
+| `jarvis` | required | The job directly represents application work whose JARVIS execution may carry scheduler `native_id` provenance. |
+| `remote_agent` | required | The parent agent and any scheduler work it initiates need one durable owning session generation. |
+| `mcp_call` | optional, recorded when present | A generic call runs in endpoint containment without an outer scheduler allocation. If the called tool creates JARVIS work, its returned native handle and record remain the scheduler authority. |
+
+Supplying only one header is always a typed refusal. An owner-session-scoped
+API additionally verifies that the pair matches its exact live generation.
+Older lifecycle ownership metadata remains readable for teardown compatibility,
+but the direct `RelayJob` fields are the scheduler-attribution wire contract.
+
 Application behavior belongs in JARVIS packages or operator-selected application profiles. JARVIS core owns execution identity, durable progress events, and aggregate progress snapshots; an individual package owns only the application-specific interpretation used to produce those events. Generic bootstrap and worker code do not import application modules or infer application log paths. The generic bounded-command package stays generic.
 
 The production boundary is the native JARVIS contract. Every run returns exact

--- a/docs/mcp-tasks.md
+++ b/docs/mcp-tasks.md
@@ -125,17 +125,18 @@ Foreground guard tools may return `InputRequiredResult`. The FastMCP client
 answers that request and re-enters the tool; only the leg that admits a durable
 relay job becomes a task.
 
-A running relay operation may expose a durable input round through
-`input_required`. Answers arrive through `tasks/update`. Unknown or stale keys
-are ignored, partial answers are retained, repeated answers are replay-safe,
-and concurrent updates use compare-and-swap retry. Input request identities,
-answers, arguments, and the complete projection are finite, depth-bounded, and
-size-bounded before persistence.
+A remote-agent submission can opt into one post-admission message round with
+`request_followup_message: true`. The relay admits the job first, then the
+operation returns `InputRequiredResult` and durably projects the
+`agent_message` request as `input_required`. The matching `tasks/update`
+re-enters the guard with `ctx.input_responses` and `ctx.request_state`; after it
+consumes the answer, ordinary relay-state projection resumes. The JARVIS lane
+does not invent equivalent application input semantics.
 
-The current built-in relay catalog does not originate a parked input round
-after admission. The durable projection and standard client update path are
-available for operation providers that add that state; built-in interactive
-validation currently exercises the pre-admission guard flow.
+Unknown or stale keys are ignored, partial answers are retained, repeated
+answers are replay-safe, and concurrent updates use compare-and-swap retry.
+Input request identities, answers, arguments, and the complete projection are
+finite, depth-bounded, and size-bounded before persistence.
 
 Imperative `await ctx.elicit(...)` is not supported inside background work. It
 would hold a worker open for a client round trip. Background-capable tools use

--- a/src/clio_relay/fastmcp_server.py
+++ b/src/clio_relay/fastmcp_server.py
@@ -187,13 +187,10 @@ def _requests_document(result: mcp_types.InputRequiredResult) -> dict[str, JSON]
     """Serialize one bounded guard result for the durable task projection."""
     requests = result.input_requests or {}
     return {
-        key: cast(
-            JSON,
-            request.model_dump(
-                by_alias=True,
-                mode="json",
-                exclude_none=True,
-            ),
+        key: request.model_dump(
+            by_alias=True,
+            mode="json",
+            exclude_none=True,
         )
         for key, request in requests.items()
     }

--- a/src/clio_relay/fastmcp_server.py
+++ b/src/clio_relay/fastmcp_server.py
@@ -80,6 +80,10 @@ TASK_POLL_INTERVAL_MS = 1_000
 TASK_TTL_MS = 30 * 24 * 60 * 60 * 1_000
 MAX_TASK_ARGUMENT_BYTES = MAX_MCP_TASK_ARGUMENT_BYTES
 _TASK_METHOD_VERSIONS = frozenset(MODERN_PROTOCOL_VERSIONS)
+_AGENT_TASK_TOOL_NAMES = frozenset({"relay_submit_agent", "relay_submit_remote_agent"})
+_AGENT_INPUT_KEY = "agent_message"
+_AGENT_INPUT_REQUEST_STATE_SCHEMA = "clio-relay.agent-message-input.v1"
+_MAX_AGENT_INPUT_MESSAGE_BYTES = 128 * 1_024
 
 type McpTaskStatus = Literal[
     "working",
@@ -113,6 +117,91 @@ def _relay_state_projection(observation: str) -> tuple[McpTaskStatus, bool | Non
         return _RELAY_STATE_PROJECTIONS[observation]
     except KeyError as exc:
         raise ValueError(f"relay observation has no MCP task projection: {observation}") from exc
+
+
+def _agent_input_request_state(task_id: str) -> str:
+    """Bind one post-admission agent input round to its durable relay task."""
+    return json.dumps(
+        {
+            "schema_version": _AGENT_INPUT_REQUEST_STATE_SCHEMA,
+            "task_id": task_id,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _post_admission_agent_input_guard(
+    ctx: Context,
+    *,
+    task_id: str,
+) -> mcp_types.InputRequiredResult | mcp_types.ElicitResult:
+    """Ask for one follow-up agent message, then consume it on guarded re-entry."""
+    responses = ctx.input_responses
+    if responses is None:
+        return mcp_types.InputRequiredResult(
+            input_requests={
+                _AGENT_INPUT_KEY: mcp_types.ElicitRequest(
+                    params=mcp_types.ElicitRequestFormParams(
+                        message="Send a follow-up message to the running remote agent.",
+                        requested_schema={
+                            "type": "object",
+                            "properties": {
+                                "message": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 32_768,
+                                }
+                            },
+                            "required": ["message"],
+                            "additionalProperties": False,
+                        },
+                    )
+                )
+            },
+            request_state=_agent_input_request_state(task_id),
+        )
+    if ctx.request_state != _agent_input_request_state(task_id):
+        raise ValueError("post-admission agent input lost its durable request state")
+    raw_response = responses.get(_AGENT_INPUT_KEY)
+    if raw_response is None:
+        raise ValueError("post-admission agent input omitted its requested response")
+    response = (
+        raw_response
+        if isinstance(raw_response, mcp_types.ElicitResult)
+        else mcp_types.ElicitResult.model_validate(raw_response)
+    )
+    if response.action == "accept":
+        content = response.content
+        if not isinstance(content, dict):
+            raise ValueError("accepted post-admission agent input omitted its content")
+        message = content.get("message")
+        if not isinstance(message, str) or not message:
+            raise ValueError("accepted post-admission agent input omitted its message")
+        if len(message.encode("utf-8")) > _MAX_AGENT_INPUT_MESSAGE_BYTES:
+            raise ValueError("post-admission agent input message exceeds its byte limit")
+    return response
+
+
+def _requests_document(result: mcp_types.InputRequiredResult) -> dict[str, JSON]:
+    """Serialize one bounded guard result for the durable task projection."""
+    requests = result.input_requests or {}
+    return {
+        key: cast(
+            JSON,
+            request.model_dump(
+                by_alias=True,
+                mode="json",
+                exclude_none=True,
+            ),
+        )
+        for key, request in requests.items()
+    }
+
+
+def _agent_input_enabled(tool_name: str, arguments: JSON) -> bool:
+    """Return whether an agent task explicitly opted into one follow-up round."""
+    return tool_name in _AGENT_TASK_TOOL_NAMES and arguments.get("request_followup_message") is True
 
 
 def _session_to_json(session: McpSessionState) -> JSON:
@@ -263,6 +352,7 @@ class RelayMcpRuntime:
         tool: RelayTool,
         arguments: JSON,
         result: ToolResult,
+        context: Context | None = None,
     ) -> RelayMcpTaskRecord | None:
         """Create a durable SEP task when a tool returned a relay job receipt."""
         structured = result.structured_content
@@ -275,6 +365,11 @@ class RelayMcpRuntime:
         try:
             state = JobState(state_value)
         except ValueError:
+            return None
+        if tool.task_requires_post_admission_input and not _agent_input_enabled(
+            tool.name,
+            arguments,
+        ):
             return None
         encoded_arguments = json.dumps(
             arguments,
@@ -297,7 +392,56 @@ class RelayMcpRuntime:
             state=state,
             projection=projection,
         )
-        return await asyncio.to_thread(self.queue.put_mcp_task, record)
+        saved = await asyncio.to_thread(self.queue.put_mcp_task, record)
+        if not _agent_input_enabled(tool.name, arguments):
+            return saved
+        if context is None:
+            raise ValueError("post-admission agent input requires an MCP task context")
+        return await self._park_agent_input(saved, context)
+
+    async def _park_agent_input(
+        self,
+        record: RelayMcpTaskRecord,
+        context: Context,
+    ) -> RelayMcpTaskRecord:
+        """Persist the guard's first post-admission leg with CAS retry."""
+        candidate = record
+        for _attempt in range(8):
+            if candidate.projection.input_round is not None:
+                return candidate
+            outcome = _post_admission_agent_input_guard(context, task_id=candidate.task_id)
+            if not isinstance(outcome, mcp_types.InputRequiredResult):
+                raise ValueError("post-admission agent input did not originate an input round")
+            outstanding = _requests_document(outcome)
+            if set(outstanding) != {_AGENT_INPUT_KEY}:
+                raise ValueError("post-admission agent input produced an unexpected request set")
+            issued_keys = [*candidate.projection.issued_input_keys, *outstanding]
+            projection = RelayMcpTaskProjection.model_validate(
+                {
+                    **candidate.projection.model_dump(mode="python"),
+                    "issued_input_keys": issued_keys,
+                    "input_round": RelayMcpInputRound(
+                        leg=1,
+                        outstanding=outstanding,
+                        request_state=outcome.request_state,
+                    ),
+                }
+            )
+            try:
+                return await asyncio.to_thread(
+                    self.queue.update_mcp_task_projection,
+                    candidate.task_id,
+                    projection,
+                    expected_updated_at=candidate.updated_at,
+                )
+            except QueueConflictError:
+                candidate = await asyncio.to_thread(
+                    self.queue.get_mcp_task,
+                    candidate.task_id,
+                )
+        raise QueueConflictError(
+            f"MCP task input could not park after concurrent updates: {record.task_id}"
+        )
 
     @staticmethod
     def _route_arguments(record: RelayMcpTaskRecord) -> JSON:
@@ -439,6 +583,16 @@ class RelayMcpRuntime:
                     "answered": {**current.answered, **matched},
                 }
             )
+            if (
+                not outstanding
+                and current.leg == 1
+                and current.request_state is not None
+                and _agent_input_enabled(
+                    candidate.projection.tool_name,
+                    candidate.projection.arguments,
+                )
+            ):
+                updated_round = self._resume_agent_input(candidate.task_id, updated_round)
             projection = RelayMcpTaskProjection.model_validate(
                 {
                     **candidate.projection.model_dump(mode="python"),
@@ -460,6 +614,40 @@ class RelayMcpRuntime:
                 )
         raise QueueConflictError(
             f"MCP task input could not converge after concurrent updates: {record.task_id}"
+        )
+
+    @staticmethod
+    def _resume_agent_input(
+        task_id: str,
+        input_round: RelayMcpInputRound,
+    ) -> RelayMcpInputRound:
+        """Re-enter the guard with durable answers without blocking a worker."""
+        context = get_context()
+        task_context = cast(Any, context)
+        previous_task_id = task_context._task_id
+        previous_request_state = task_context._task_request_state
+        previous_input_responses = task_context._task_input_responses
+        typed_responses = {
+            key: mcp_types.ElicitResult.model_validate(value)
+            for key, value in input_round.answered.items()
+        }
+        try:
+            task_context._task_id = task_id
+            task_context._task_request_state = input_round.request_state
+            task_context._task_input_responses = typed_responses
+            outcome = _post_admission_agent_input_guard(context, task_id=task_id)
+        finally:
+            task_context._task_id = previous_task_id
+            task_context._task_request_state = previous_request_state
+            task_context._task_input_responses = previous_input_responses
+        if isinstance(outcome, mcp_types.InputRequiredResult):
+            raise ValueError("post-admission agent input did not consume its answer")
+        return RelayMcpInputRound.model_validate(
+            {
+                **input_round.model_dump(mode="python"),
+                "leg": input_round.leg + 1,
+                "request_state": None,
+            }
         )
 
     async def cancel_task(self, record: RelayMcpTaskRecord) -> None:
@@ -520,6 +708,7 @@ class RelayTool(Tool):
 
     _runtime: RelayMcpRuntime = PrivateAttr()
     _catalog_revision: str | None = PrivateAttr(default=None)
+    _task_requires_post_admission_input: bool = PrivateAttr(default=False)
 
     def __init__(
         self,
@@ -528,6 +717,7 @@ class RelayTool(Tool):
         runtime: RelayMcpRuntime,
         catalog_revision: str | None,
         task_capable: bool,
+        task_requires_post_admission_input: bool = False,
     ) -> None:
         meta = dict(cast(dict[str, Any], definition.get("_meta") or {}))
         if catalog_revision is not None:
@@ -553,11 +743,17 @@ class RelayTool(Tool):
         )
         self._runtime = runtime
         self._catalog_revision = catalog_revision
+        self._task_requires_post_admission_input = task_requires_post_admission_input
 
     @property
     def catalog_revision(self) -> str | None:
         """Return the exact dynamic catalog revision bound at dispatch."""
         return self._catalog_revision
+
+    @property
+    def task_requires_post_admission_input(self) -> bool:
+        """Return whether task admission requires the explicit agent-input opt-in."""
+        return self._task_requires_post_admission_input
 
     async def run(self, arguments: dict[str, Any]) -> ToolResult:
         """Execute the established relay dispatcher without a second tool runtime."""
@@ -598,6 +794,9 @@ class RelayToolProvider(Provider):
                     cast(str, definition["name"]),
                     static_names,
                 ),
+                task_requires_post_admission_input=(
+                    cast(str, definition["name"]) in _AGENT_TASK_TOOL_NAMES
+                ),
             )
             for definition in definitions
         ]
@@ -619,6 +818,7 @@ class RelayToolProvider(Provider):
                 runtime=self._runtime,
                 catalog_revision=None if name in static_names else revision,
                 task_capable=_task_capable_tool_name(name, static_names),
+                task_requires_post_admission_input=name in _AGENT_TASK_TOOL_NAMES,
             )
         return None
 
@@ -626,7 +826,10 @@ class RelayToolProvider(Provider):
 def _task_capable_tool_name(name: str, static_names: set[str]) -> bool:
     """Return whether one admitted-job tool supports SEP-2663 task projection."""
     return (
-        name not in static_names or name == "relay_call_jarvis_mcp" or is_virtual_jarvis_tool(name)
+        name not in static_names
+        or name == "relay_call_jarvis_mcp"
+        or name in _AGENT_TASK_TOOL_NAMES
+        or is_virtual_jarvis_tool(name)
     )
 
 
@@ -795,13 +998,17 @@ class RelayTasksExtension(ServerExtension):
             tool=tool,
             arguments=dict(params.arguments or {}),
             result=outcome,
+            context=context,
         )
         if task is None:
             return outcome
         return CreateTaskResult(
             task_id=task.task_id,
             status=(
-                "cancelled"
+                "input_required"
+                if task.projection.input_round is not None
+                and task.projection.input_round.outstanding
+                else "cancelled"
                 if task.state is JobState.CANCELED
                 else "completed"
                 if task.state in TERMINAL_STATES

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -695,6 +695,14 @@ def _all_tool_definitions(
                     "model": {"type": "string"},
                     "workdir": {"type": "string"},
                     "timeout_seconds": {"type": "integer", "minimum": 1},
+                    "request_followup_message": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": (
+                            "After durable admission, park one bounded message round that "
+                            "resumes through tasks/update."
+                        ),
+                    },
                     "idempotency_key": {"type": "string"},
                     "used_artifact_refs": _artifact_use_refs_json_schema(),
                     "wait_for_terminal": {"type": "boolean", "default": False},
@@ -931,6 +939,14 @@ def _all_tool_definitions(
                     "model": {"type": "string"},
                     "workdir": {"type": "string"},
                     "timeout_seconds": {"type": "integer", "minimum": 1},
+                    "request_followup_message": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": (
+                            "After durable admission, park one bounded message round that "
+                            "resumes through tasks/update."
+                        ),
+                    },
                     "idempotency_key": {"type": "string"},
                     "used_artifact_refs": _artifact_use_refs_json_schema(),
                     "wait_for_terminal": {"type": "boolean", "default": False},
@@ -4475,6 +4491,11 @@ def _submit_remote_agent(
     model = _optional_str(arguments, "model")
     workdir = _optional_str(arguments, "workdir")
     timeout_seconds = _optional_int(arguments, "timeout_seconds")
+    request_followup_message = _boolean_argument(
+        arguments,
+        "request_followup_message",
+        default=False,
+    )
     identity: dict[str, object] = {
         "cluster": cluster,
         "prompt_path": prompt_path,
@@ -4483,6 +4504,8 @@ def _submit_remote_agent(
         "workdir": workdir,
         "timeout_seconds": timeout_seconds,
     }
+    if request_followup_message:
+        identity["request_followup_message"] = True
     if used_artifact_refs:
         identity["used_artifact_refs"] = [artifact_use_payload(item) for item in used_artifact_refs]
     idempotency_key = str(

--- a/tests/test_fastmcp_server.py
+++ b/tests/test_fastmcp_server.py
@@ -409,9 +409,13 @@ def test_agent_task_parks_post_admission_input_and_resumes_with_answer(
         "clio_relay.core_queue.open_private_atomic_file",
         _open_atomic,
     )
+
+    def _no_cluster(_cluster: str) -> None:
+        return None
+
     monkeypatch.setattr(
         "clio_relay.mcp_server._optional_cluster_definition",
-        lambda _cluster: None,
+        _no_cluster,
     )
     settings = RelaySettings(
         core_dir=tmp_path / "core",

--- a/tests/test_fastmcp_server.py
+++ b/tests/test_fastmcp_server.py
@@ -20,6 +20,8 @@ from fastmcp_tasks.client_models import (
     ClientGetTaskResult,
     GetTaskRequest,
     GetTaskRequestParams,
+    UpdateTaskRequest,
+    UpdateTaskRequestParams,
 )
 from fastmcp_tasks.models import MISSING_REQUIRED_CLIENT_CAPABILITY
 from mcp.shared.exceptions import MCPError
@@ -371,6 +373,141 @@ def test_official_fastmcp_tool_task_projects_job_and_survives_reopen(
             assert result.structured_content is not None
             assert result.structured_content["job"]["job_id"] == job.job_id
             assert (await task.status()).status == "completed"
+
+    asyncio.run(scenario())
+
+
+def test_agent_task_parks_post_admission_input_and_resumes_with_answer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def create_test_directory(path: Path) -> None:
+        path.mkdir(parents=True, exist_ok=True)
+
+    def accept_test_path(path: Path, *, directory: bool) -> None:
+        if directory:
+            create_test_directory(path)
+
+    for module_name in (
+        "clio_relay.cluster_config",
+        "clio_relay.core_queue",
+        "clio_relay.worker_lifetime_lock",
+    ):
+        monkeypatch.setattr(
+            f"{module_name}.ensure_private_configuration_directory",
+            create_test_directory,
+        )
+        monkeypatch.setattr(
+            f"{module_name}.ensure_private_configuration_path",
+            accept_test_path,
+        )
+    monkeypatch.setattr(
+        "clio_relay.core_queue.open_private_atomic_file",
+        lambda path: path.open("xb"),
+    )
+    monkeypatch.setattr(
+        "clio_relay.mcp_server._optional_cluster_definition",
+        lambda _cluster: None,
+    )
+    settings = RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+
+    async def update_task(
+        client: Client[FastMCPTransport],
+        task_id: str,
+        responses: dict[str, Any],
+    ) -> None:
+        await client.session.send_request(
+            UpdateTaskRequest(
+                params=UpdateTaskRequestParams(
+                    task_id=task_id,
+                    input_responses=responses,
+                )
+            ),
+            mcp_types.Result,
+        )
+
+    async def scenario() -> None:
+        async with Client(
+            create_fastmcp_server(settings=settings, queue=queue),
+            mode="auto",
+        ) as client:
+            task = await call_tool_task(
+                client,
+                "relay_submit_agent",
+                {
+                    **_submit_arguments(tmp_path, "post-admission-input"),
+                    "request_followup_message": True,
+                },
+            )
+            assert queue.get_job(task.task_id).job_id == task.task_id
+
+            parked = await task.status()
+            assert parked.status == "input_required"
+            assert parked.input_requests is not None
+            assert set(parked.input_requests) == {"agent_message"}
+
+            accepted = {
+                "action": "accept",
+                "content": {"message": "Use the new boundary condition."},
+            }
+            update_projection = queue.update_mcp_task_projection
+            cas_attempts = 0
+
+            def conflict_once(*args: Any, **kwargs: Any) -> RelayMcpTaskRecord:
+                nonlocal cas_attempts
+                cas_attempts += 1
+                if cas_attempts == 1:
+                    raise QueueConflictError("forced acceptance CAS conflict")
+                return update_projection(*args, **kwargs)
+
+            monkeypatch.setattr(queue, "update_mcp_task_projection", conflict_once)
+            await update_task(client, task.task_id, {"agent_message": accepted})
+            assert cas_attempts == 2
+
+            resumed = await task.status()
+            assert resumed.status == "working"
+            persisted = queue.get_mcp_task(task.task_id)
+            input_round = persisted.projection.input_round
+            assert input_round is not None
+            assert input_round.leg == 2
+            assert input_round.outstanding == {}
+            assert input_round.answered == {"agent_message": accepted}
+            assert input_round.request_state is None
+
+            consumed_at = persisted.updated_at
+            await update_task(
+                client,
+                task.task_id,
+                {
+                    "agent_message": {
+                        "action": "accept",
+                        "content": {"message": "duplicate must not replace the answer"},
+                    },
+                    "unknown": {"action": "decline"},
+                },
+            )
+            replayed = queue.get_mcp_task(task.task_id)
+            assert replayed.updated_at == consumed_at
+            assert replayed.projection.input_round == input_round
+
+            queue.update_job_state(task.task_id, JobState.SUCCEEDED)
+            result = await task.result()
+            assert result.is_error is False
+
+            ordinary = await client.call_tool(
+                "relay_submit_agent",
+                _submit_arguments(tmp_path, "ordinary-agent"),
+            )
+            assert ordinary.is_error is False
+            assert ordinary.structured_content is not None
+            ordinary_job_id = ordinary.structured_content["job_id"]
+            assert queue.get_job(ordinary_job_id).job_id == ordinary_job_id
+            with pytest.raises(NotFoundError):
+                queue.get_mcp_task(ordinary_job_id)
 
     asyncio.run(scenario())
 

--- a/tests/test_fastmcp_server.py
+++ b/tests/test_fastmcp_server.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, BinaryIO
 
 import mcp_types
 import pytest
@@ -401,9 +401,12 @@ def test_agent_task_parks_post_admission_input_and_resumes_with_answer(
             f"{module_name}.ensure_private_configuration_path",
             accept_test_path,
         )
+    def _open_atomic(path: Path) -> BinaryIO:
+        return path.open("xb")
+
     monkeypatch.setattr(
         "clio_relay.core_queue.open_private_atomic_file",
-        lambda path: path.open("xb"),
+        _open_atomic,
     )
     monkeypatch.setattr(
         "clio_relay.mcp_server._optional_cluster_definition",

--- a/tests/test_fastmcp_server.py
+++ b/tests/test_fastmcp_server.py
@@ -401,6 +401,7 @@ def test_agent_task_parks_post_admission_input_and_resumes_with_answer(
             f"{module_name}.ensure_private_configuration_path",
             accept_test_path,
         )
+
     def _open_atomic(path: Path) -> BinaryIO:
         return path.open("xb")
 


### PR DESCRIPTION
Closes #145 (P2.15). The producer the durable input projection was missing: an agent-lane operation parks input_required post-admission through the existing projection + tasks/update CAS, guard-pattern only, with replay-safe/stale-rejection semantics pinned. Unblocks clio-agent#1128 (remote message-an-agent) and the P2 gate's remote-elicitation leg. Failing-first shown; full local suite green (contract fixtures deselected as box-environmental, A/B-controlled previously); statics green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)