### PR TITLE
fix: pin remote relay executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.5.11` uses a release-first patch process. A maintainer builds the
+> Version `1.5.12` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.5.11"
+$Version = "1.5.12"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.5.11"
+release_version: "1.5.12"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 52b34d7d816c6d970300a7f3a9342b965f8d543b754ad712cf84a3295dbdc260
+acceptance_matrix_sha256: 43720653bd005d57e1495d9fc5fd2c0b0c73c0cc88568eaa7a71f2e1c14ff1b8
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.5.11"
+$Tag = "v1.5.12"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.11" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.12" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.5.11",
-  "matrix_sha256": "52b34d7d816c6d970300a7f3a9342b965f8d543b754ad712cf84a3295dbdc260",
+  "release_version": "1.5.12",
+  "matrix_sha256": "43720653bd005d57e1495d9fc5fd2c0b0c73c0cc88568eaa7a71f2e1c14ff1b8",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.5.11"
+version = "1.5.12"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.5.11"
+__version__ = "1.5.12"

--- a/src/clio_relay/cluster_config.py
+++ b/src/clio_relay/cluster_config.py
@@ -431,6 +431,7 @@ class ClusterDefinition(BaseModel):
     bootstrap_profile: str = "linux-user"
     core_dir: str = "$HOME/.local/share/clio-relay/core"
     spool_dir: str = "$HOME/.local/share/clio-relay/spool"
+    relay_executable: str = "$HOME/.local/bin/clio-relay"
     jarvis_bin: str | None = None
     jarvis_resource_graph_profile: str | None = None
     allow_jarvis_resource_graph_build: bool = Field(default=False, strict=True)
@@ -539,6 +540,21 @@ class ClusterDefinition(BaseModel):
         if value != value.strip() or ".." in PurePosixPath(value).parts:
             raise ValueError(
                 "spack_executable must be one absolute remote path or start with $HOME/"
+            )
+        return value
+
+    @field_validator("relay_executable")
+    @classmethod
+    def _validate_relay_executable(cls, value: str) -> str:
+        try:
+            validate_remote_path(value, field="relay_executable")
+        except ConfigurationError as error:
+            raise ValueError(
+                "relay_executable must be one absolute remote path or start with $HOME/"
+            ) from error
+        if value != value.strip() or ".." in PurePosixPath(value).parts:
+            raise ValueError(
+                "relay_executable must be one absolute remote path or start with $HOME/"
             )
         return value
 

--- a/src/clio_relay/remote_cli.py
+++ b/src/clio_relay/remote_cli.py
@@ -90,7 +90,11 @@ def run_remote_clio(
             field="staged cluster registry path",
         )
         environment = f"{environment} export {CLUSTER_REGISTRY_ENV}={rendered_registry_path};"
-    return run_remote_shell(definition, f"{environment} clio-relay {rendered_args}")
+    relay_executable = render_remote_shell_value(
+        definition.relay_executable,
+        field="relay_executable",
+    )
+    return run_remote_shell(definition, f"{environment} {relay_executable} {rendered_args}")
 
 
 def run_remote_jarvis_runtime_authority(
@@ -102,7 +106,11 @@ def run_remote_jarvis_runtime_authority(
 ) -> str:
     """Resolve private JARVIS authority through a bounded, output-safe SSH transport."""
     rendered_args = " ".join(shlex.quote(arg) for arg in ["jarvis-runtime-authority", *args])
-    script = f"{remote_env(definition)} clio-relay {rendered_args}"
+    relay_executable = render_remote_shell_value(
+        definition.relay_executable,
+        field="relay_executable",
+    )
+    script = f"{remote_env(definition)} {relay_executable} {rendered_args}"
     command = ["ssh", definition.ssh_host, f"bash -lc {shlex.quote(script)}"]
     payload = _run_bounded_private_command(
         command,
@@ -337,13 +345,17 @@ def remote_env(definition: ClusterDefinition) -> str:
     agent_bin = _cluster_agent_bin(definition)
     rendered_core_dir = render_remote_shell_path(definition.core_dir, field="core_dir")
     rendered_spool_dir = render_remote_shell_path(definition.spool_dir, field="spool_dir")
+    rendered_relay_executable = render_remote_shell_value(
+        definition.relay_executable,
+        field="relay_executable",
+    )
     rendered_jarvis_bin = render_remote_shell_value(jarvis_bin, field="jarvis_bin")
     rendered_frpc_bin = render_remote_shell_value(frpc_bin, field="frpc_bin")
     rendered_agent_bin = render_remote_shell_value(agent_bin, field="agent_bin")
     exports = [
         'export PATH="$HOME/.local/bin:$PATH";',
         'export UV="$HOME/.local/bin/uv";',
-        'export CLIO_RELAY_VALIDATION_TOOL_EXECUTABLE="$HOME/.local/bin/clio-relay";',
+        f"export CLIO_RELAY_VALIDATION_TOOL_EXECUTABLE={rendered_relay_executable};",
         "export CLIO_RELAY_CLI_MODE=local;",
         f"export CLIO_RELAY_REMOTE_CLUSTER={shlex.quote(definition.name)};",
         f"export CLIO_RELAY_CORE_DIR={rendered_core_dir};",

--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -851,6 +851,22 @@ def test_cluster_spack_executable_is_explicit_site_configuration() -> None:
         )
 
 
+def test_cluster_relay_executable_is_an_exact_remote_path() -> None:
+    definition = ClusterDefinition(
+        name="site-cluster",
+        ssh_host="site-login",
+        relay_executable="/srv/releases/relay-1.5.12/bin/clio-relay",
+    )
+
+    assert definition.relay_executable == "/srv/releases/relay-1.5.12/bin/clio-relay"
+    with pytest.raises(ValueError, match="absolute remote path"):
+        ClusterDefinition(
+            name="site-cluster",
+            ssh_host="site-login",
+            relay_executable="clio-relay",
+        )
+
+
 def _registry(name: str) -> ClusterRegistry:
     return ClusterRegistry(
         clusters={name: ClusterDefinition(name=name, ssh_host=f"{name}.example.invalid")}

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.5.11"
+    assert version == "1.5.12"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_remote_cli.py
+++ b/tests/test_remote_cli.py
@@ -10,6 +10,7 @@ from clio_relay.remote_cli import (
     remote_command_timeout,
     remote_env,
     remove_remote_file,
+    run_remote_clio,
     run_remote_shell,
     write_remote_file,
 )
@@ -27,6 +28,31 @@ def test_remote_env_exports_operator_configured_jarvis_spack_executable() -> Non
     assert 'export JARVIS_MCP_SPACK_COMMAND="/home/operator/spack/bin/spack";' in rendered
     assert 'export UV="$HOME/.local/bin/uv";' in rendered
     assert 'export CLIO_RELAY_VALIDATION_TOOL_EXECUTABLE="$HOME/.local/bin/clio-relay";' in rendered
+
+
+def test_remote_clio_uses_the_configured_digest_bound_executable(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    definition = ClusterDefinition(
+        name="ares",
+        ssh_host="ares-login",
+        relay_executable="/srv/releases/relay-a1b2/bin/clio-relay",
+    )
+    observed: list[str] = []
+
+    def run_shell(_definition: ClusterDefinition, script: str) -> str:
+        observed.append(script)
+        return "{}"
+
+    monkeypatch.setattr("clio_relay.remote_cli.run_remote_shell", run_shell)
+
+    assert run_remote_clio(definition, ["queue", "list"]) == "{}"
+    assert observed == [
+        remote_env(definition) + ' "/srv/releases/relay-a1b2/bin/clio-relay" queue list'
+    ]
+    assert (
+        'export CLIO_RELAY_VALIDATION_TOOL_EXECUTABLE="/srv/releases/relay-a1b2/bin/clio-relay";'
+    ) in observed[0]
 
 
 def test_remote_env_forwards_nonsecret_validation_provenance(

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2499,7 +2499,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.5.11"
+    assert policy.release_version == "1.5.12"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -301,7 +301,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.5.11"
+version = "1.5.12"
 source = { editable = "." }
 dependencies = [
     { name = "clio-schemas" },


### PR DESCRIPTION
## What changed
- add an explicit, validated `relay_executable` to each cluster route
- invoke that exact executable for remote Relay commands and JARVIS runtime-authority queries
- bind validation provenance to the same executable
- advance the patch release to 1.5.12

## Root cause
Remote orchestration always resolved `clio-relay` from `$HOME/.local/bin`, even when the local coordinator and cluster worker were pinned to another immutable generation. During a rolling upgrade, the old remote CLI could not parse queue records written by the new version.

## Validation
- `uv run --no-sync --no-cache pytest -q tests/test_cluster_config.py tests/test_remote_cli.py tests/test_remote_value_contract.py`
- focused release policy and runbook tests
- `uv run --no-sync --no-cache ruff check ...`
- `uv run --no-sync --no-cache pyright src/clio_relay/cluster_config.py src/clio_relay/remote_cli.py`
- `uv lock --check --no-cache`