### PR TITLE
fix: bind remote relay install receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.5.12` uses a release-first patch process. A maintainer builds the
+> Version `1.5.13` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.5.12"
+$Version = "1.5.13"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.5.12"
+release_version: "1.5.13"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 43720653bd005d57e1495d9fc5fd2c0b0c73c0cc88568eaa7a71f2e1c14ff1b8
+acceptance_matrix_sha256: 5ac32749ebc6a8f5a62a86cfa984caf8b96db62fad13d31114d677e5488c84d0
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.5.12"
+$Tag = "v1.5.13"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.12" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.13" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.5.12",
-  "matrix_sha256": "43720653bd005d57e1495d9fc5fd2c0b0c73c0cc88568eaa7a71f2e1c14ff1b8",
+  "release_version": "1.5.13",
+  "matrix_sha256": "5ac32749ebc6a8f5a62a86cfa984caf8b96db62fad13d31114d677e5488c84d0",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.5.12"
+version = "1.5.13"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.5.12"
+__version__ = "1.5.13"

--- a/src/clio_relay/cluster_config.py
+++ b/src/clio_relay/cluster_config.py
@@ -432,6 +432,7 @@ class ClusterDefinition(BaseModel):
     core_dir: str = "$HOME/.local/share/clio-relay/core"
     spool_dir: str = "$HOME/.local/share/clio-relay/spool"
     relay_executable: str = "$HOME/.local/bin/clio-relay"
+    relay_install_receipt: str | None = None
     jarvis_bin: str | None = None
     jarvis_resource_graph_profile: str | None = None
     allow_jarvis_resource_graph_build: bool = Field(default=False, strict=True)
@@ -543,18 +544,20 @@ class ClusterDefinition(BaseModel):
             )
         return value
 
-    @field_validator("relay_executable")
+    @field_validator("relay_executable", "relay_install_receipt")
     @classmethod
-    def _validate_relay_executable(cls, value: str) -> str:
+    def _validate_relay_installation_path(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         try:
-            validate_remote_path(value, field="relay_executable")
+            validate_remote_path(value, field="relay installation path")
         except ConfigurationError as error:
             raise ValueError(
-                "relay_executable must be one absolute remote path or start with $HOME/"
+                "relay installation paths must be absolute or start with $HOME/"
             ) from error
         if value != value.strip() or ".." in PurePosixPath(value).parts:
             raise ValueError(
-                "relay_executable must be one absolute remote path or start with $HOME/"
+                "relay installation paths must be absolute or start with $HOME/"
             )
         return value
 

--- a/src/clio_relay/cluster_config.py
+++ b/src/clio_relay/cluster_config.py
@@ -556,9 +556,7 @@ class ClusterDefinition(BaseModel):
                 "relay installation paths must be absolute or start with $HOME/"
             ) from error
         if value != value.strip() or ".." in PurePosixPath(value).parts:
-            raise ValueError(
-                "relay installation paths must be absolute or start with $HOME/"
-            )
+            raise ValueError("relay installation paths must be absolute or start with $HOME/")
         return value
 
     @model_validator(mode="after")

--- a/src/clio_relay/remote_cli.py
+++ b/src/clio_relay/remote_cli.py
@@ -365,6 +365,15 @@ def remote_env(definition: ClusterDefinition) -> str:
         f"export CLIO_RELAY_AGENT_BIN={rendered_agent_bin};",
         f"export CLIO_RELAY_AGENT_ADAPTER={shlex.quote(definition.agent_adapter)};",
     ]
+    if definition.relay_install_receipt is not None:
+        exports.append(
+            "export CLIO_RELAY_INSTALL_RECEIPT="
+            + render_remote_shell_path(
+                definition.relay_install_receipt,
+                field="relay_install_receipt",
+            )
+            + ";"
+        )
     if definition.agent_args:
         exports.append(
             f"export CLIO_RELAY_AGENT_ARGS={shlex.quote(shlex.join(definition.agent_args))};"

--- a/tests/test_ci_validation.py
+++ b/tests/test_ci_validation.py
@@ -1791,7 +1791,7 @@ def test_release_report_asset_manifest_enforces_exact_ordered_matrix() -> None:
     ]
     matrix = validate_release_acceptance_matrix(raw_matrix)
     assert matrix["matrix_sha256"] == (
-        "52b34d7d816c6d970300a7f3a9342b965f8d543b754ad712cf84a3295dbdc260"
+        "5ac32749ebc6a8f5a62a86cfa984caf8b96db62fad13d31114d677e5488c84d0"
     )
     reports = cast(list[dict[str, object]], matrix["reports"])
     report_ids = [cast(str, item["id"]) for item in reports]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9300,7 +9300,7 @@ def test_cli_remote_mcp_call_stages_exact_route_authority_for_one_invocation(
     assert len(shell_scripts) == 1
     assert f'export CLIO_RELAY_CLUSTER_REGISTRY="$HOME/{registry_path}";' in shell_scripts[0]
     assert "export CLIO_RELAY_CLI_MODE=local;" in shell_scripts[0]
-    assert f"clio-relay mcp-call --cluster {definition.name}" in shell_scripts[0]
+    assert f'"$HOME/.local/bin/clio-relay" mcp-call --cluster {definition.name}' in shell_scripts[0]
     assert removals[-1] == ("registry", registry_path, True)
     if expected_tool_arguments is None:
         assert argument_writes == []
@@ -10071,7 +10071,7 @@ pkgs:
             remote_path = command[2].split("cat > ", maxsplit=1)[1].split(" &&", maxsplit=1)[0]
             writes[remote_path.strip("'")] = input or b""
             return subprocess.CompletedProcess(command, 0, b"", b"")
-        if "clio-relay job submit" in command[2]:
+        if '"$HOME/.local/bin/clio-relay" job submit' in command[2]:
             assert "CLIO_RELAY_CLI_MODE=local" in command[2]
             assert 'CLIO_RELAY_CORE_DIR="/remote/core"' in command[2]
             return subprocess.CompletedProcess(command, 0, b"job_remote\n", b"")
@@ -10102,7 +10102,7 @@ pkgs:
     )
     assert "x_clio_relay" not in staged_yaml
     assert ".local/share/clio-relay/live-tests/pipeline-" in staged_yaml
-    assert any("clio-relay job submit" in command[2] for command in commands)
+    assert any('"$HOME/.local/bin/clio-relay" job submit' in command[2] for command in commands)
 
 
 def test_cli_remote_wait_passthrough_uses_cluster_core(
@@ -10163,7 +10163,7 @@ def test_cli_remote_wait_passthrough_uses_cluster_core(
     assert observed["job_id"] == remote_job.job_id
     assert observed["observation"]["outcome"] == "observation_unknown"
     assert len(commands) == 1
-    assert f"clio-relay job wait {remote_job.job_id}" in commands[0][2]
+    assert f'"$HOME/.local/bin/clio-relay" job wait {remote_job.job_id}' in commands[0][2]
 
 
 def test_cli_remote_wait_transport_expiry_reobserves_exact_status(
@@ -10195,9 +10195,9 @@ def test_cli_remote_wait_transport_expiry_reobserves_exact_status(
         timeouts.append(timeout)
         assert capture_output is True
         assert check is False
-        if "clio-relay job wait" in command[2]:
+        if '"$HOME/.local/bin/clio-relay" job wait' in command[2]:
             raise subprocess.TimeoutExpired(command, timeout or 0)
-        if "clio-relay job status" in command[2]:
+        if '"$HOME/.local/bin/clio-relay" job status' in command[2]:
             return subprocess.CompletedProcess(
                 command,
                 0,
@@ -10627,7 +10627,7 @@ def test_cli_remote_task_event_passthrough_uses_cluster_core(
     assert json.loads(result.output)["seq"] == 1
     assert len(commands) == 1
     assert "CLIO_RELAY_CLI_MODE=local" in commands[0][2]
-    assert "clio-relay job record-task-event task_remote" in commands[0][2]
+    assert '"$HOME/.local/bin/clio-relay" job record-task-event task_remote' in commands[0][2]
     assert "--path-ref /mnt/common/datasets/example_001" in commands[0][2]
     assert "cli-file" in commands[0][2]
 
@@ -10698,10 +10698,10 @@ def test_cli_remote_gateway_passthrough_uses_cluster_core(
         "gateway_remote",
         "gateway_remote",
     ]
-    assert "clio-relay gateway create" in commands[0][2]
+    assert '"$HOME/.local/bin/clio-relay" gateway create' in commands[0][2]
     assert "remote_port" in commands[0][2]
-    assert "clio-relay gateway update gateway_remote" in commands[1][2]
-    assert "clio-relay gateway close gateway_remote" in commands[2][2]
+    assert '"$HOME/.local/bin/clio-relay" gateway update gateway_remote' in commands[1][2]
+    assert '"$HOME/.local/bin/clio-relay" gateway close gateway_remote' in commands[2][2]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -874,9 +874,7 @@ def test_cluster_relay_receipt_is_an_optional_exact_remote_path() -> None:
         relay_install_receipt="/srv/releases/relay-1.5.13/install-receipt.json",
     )
 
-    assert definition.relay_install_receipt == (
-        "/srv/releases/relay-1.5.13/install-receipt.json"
-    )
+    assert definition.relay_install_receipt == ("/srv/releases/relay-1.5.13/install-receipt.json")
     with pytest.raises(ValueError, match="absolute"):
         ClusterDefinition(
             name="site-cluster",

--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -855,15 +855,33 @@ def test_cluster_relay_executable_is_an_exact_remote_path() -> None:
     definition = ClusterDefinition(
         name="site-cluster",
         ssh_host="site-login",
-        relay_executable="/srv/releases/relay-1.5.12/bin/clio-relay",
+        relay_executable="/srv/releases/relay-1.5.13/bin/clio-relay",
     )
 
-    assert definition.relay_executable == "/srv/releases/relay-1.5.12/bin/clio-relay"
-    with pytest.raises(ValueError, match="absolute remote path"):
+    assert definition.relay_executable == "/srv/releases/relay-1.5.13/bin/clio-relay"
+    with pytest.raises(ValueError, match="absolute"):
         ClusterDefinition(
             name="site-cluster",
             ssh_host="site-login",
             relay_executable="clio-relay",
+        )
+
+
+def test_cluster_relay_receipt_is_an_optional_exact_remote_path() -> None:
+    definition = ClusterDefinition(
+        name="site-cluster",
+        ssh_host="site-login",
+        relay_install_receipt="/srv/releases/relay-1.5.13/install-receipt.json",
+    )
+
+    assert definition.relay_install_receipt == (
+        "/srv/releases/relay-1.5.13/install-receipt.json"
+    )
+    with pytest.raises(ValueError, match="absolute"):
+        ClusterDefinition(
+            name="site-cluster",
+            ssh_host="site-login",
+            relay_install_receipt="install-receipt.json",
         )
 
 

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.5.12"
+    assert version == "1.5.13"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_remote_cli.py
+++ b/tests/test_remote_cli.py
@@ -37,6 +37,7 @@ def test_remote_clio_uses_the_configured_digest_bound_executable(
         name="ares",
         ssh_host="ares-login",
         relay_executable="/srv/releases/relay-a1b2/bin/clio-relay",
+        relay_install_receipt="/srv/releases/relay-a1b2/install-receipt.json",
     )
     observed: list[str] = []
 
@@ -52,6 +53,9 @@ def test_remote_clio_uses_the_configured_digest_bound_executable(
     ]
     assert (
         'export CLIO_RELAY_VALIDATION_TOOL_EXECUTABLE="/srv/releases/relay-a1b2/bin/clio-relay";'
+    ) in observed[0]
+    assert (
+        'export CLIO_RELAY_INSTALL_RECEIPT="/srv/releases/relay-a1b2/install-receipt.json";'
     ) in observed[0]
 
 

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2499,7 +2499,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.5.12"
+    assert policy.release_version == "1.5.13"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -301,7 +301,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.5.12"
+version = "1.5.13"
 source = { editable = "." }
 dependencies = [
     { name = "clio-schemas" },


### PR DESCRIPTION
## What changed

- add an exact validated relay install-receipt path to cluster definitions
- export that receipt for every remote Relay CLI invocation
- bump the release candidate to 1.5.13 and refresh release metadata

## Why

An exact configured remote Relay executable could still consume the account-wide receipt from a different installation. This made the active worker and invoked CLI internally consistent but unable to prove the selected released artifact.

## Validation

- 52 focused tests passed
- Ruff passed
- Pyright passed
- release matrix self-digest and version contract passed