### PR TITLE
fix: pin owned session lifecycle executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.5.13` uses a release-first patch process. A maintainer builds the
+> Version `1.5.14` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -59,7 +59,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.5.13"
+$Version = "1.5.14"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.5.13"
+release_version: "1.5.14"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 5ac32749ebc6a8f5a62a86cfa984caf8b96db62fad13d31114d677e5488c84d0
+acceptance_matrix_sha256: 91caebfd62e2a9c4c43f86b95143875df0174f434d114367aa35fcf124457180
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.5.13"
+$Tag = "v1.5.14"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.13" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.5.14" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.5.13",
-  "matrix_sha256": "5ac32749ebc6a8f5a62a86cfa984caf8b96db62fad13d31114d677e5488c84d0",
+  "release_version": "1.5.14",
+  "matrix_sha256": "91caebfd62e2a9c4c43f86b95143875df0174f434d114367aa35fcf124457180",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.5.13"
+version = "1.5.14"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.5.13"
+__version__ = "1.5.14"

--- a/src/clio_relay/session_lifecycle.py
+++ b/src/clio_relay/session_lifecycle.py
@@ -46,6 +46,7 @@ from clio_relay.config import (
 from clio_relay.errors import RelayError
 from clio_relay.identifiers import DurableRecordId, validate_durable_record_id
 from clio_relay.remote_cli import remote_env
+from clio_relay.remote_values import render_remote_shell_value
 from clio_relay.validation_report import SoftwareIdentity
 
 if TYPE_CHECKING:
@@ -7880,6 +7881,15 @@ def detach_remote_session(
     )
 
 
+def _owned_session_relay_executable(definition: ClusterDefinition) -> str:
+    """Render the route-pinned Relay executable for cluster-local lifecycle calls."""
+
+    return render_remote_shell_value(
+        definition.relay_executable,
+        field="relay_executable",
+    )
+
+
 def _start_script(
     *,
     cluster: str,
@@ -7917,13 +7927,14 @@ def _start_script(
         else ""
     )
     request_json = request.model_dump_json()
+    relay_executable = _owned_session_relay_executable(definition)
     return (
         "set -euo pipefail\n"
         "umask 077\n"
         f"{remote_env(definition)}\n"
         f"{token_export}"
         f"printf '%s' {_shell_single_quote(request_json)} | "
-        "clio-relay session start-owned\n"
+        f"{relay_executable} session start-owned\n"
     )
 
 
@@ -7961,10 +7972,11 @@ def _owned_status_script(
 ) -> str:
     """Use the bounded, lock-coordinated recovery contract for public status."""
     probe_argument = " --pre-start-cleanup-probe" if pre_start_cleanup_probe else ""
+    relay_executable = _owned_session_relay_executable(definition)
     return (
         "set -euo pipefail\n"
         f"{remote_env(definition)}\n"
-        f"clio-relay session recovery-status --cluster {shlex.quote(cluster)} "
+        f"{relay_executable} session recovery-status --cluster {shlex.quote(cluster)} "
         f"--session-id {shlex.quote(session_id)}{probe_argument}\n"
     )
 
@@ -7975,10 +7987,12 @@ def _owned_start_status_script(
     selector: OwnedSessionStartStatusSelector,
 ) -> str:
     """Render the nonblocking exact-operation start-status command."""
+    relay_executable = _owned_session_relay_executable(definition)
     return (
         "set -euo pipefail\n"
         f"{remote_env(definition)}\n"
-        f"clio-relay session start-status-owned --cluster {shlex.quote(selector.cluster)} "
+        f"{relay_executable} session start-status-owned "
+        f"--cluster {shlex.quote(selector.cluster)} "
         f"--session-id {shlex.quote(selector.session_id)} "
         f"--start-operation-id {shlex.quote(selector.start_operation_id)} "
         "--cluster-route-revision "
@@ -8000,12 +8014,13 @@ def _owned_identity_challenge_script(
         session_generation_id=session_generation_id,
         nonce=nonce,
     )
+    relay_executable = _owned_session_relay_executable(definition)
     return (
         "set -euo pipefail\n"
         "umask 077\n"
         f"{remote_env(definition)}\n"
         f"printf '%s' {_shell_single_quote(request.model_dump_json())} | "
-        "clio-relay session challenge-owned\n"
+        f"{relay_executable} session challenge-owned\n"
     )
 
 
@@ -8014,21 +8029,23 @@ def _owned_cleanup_finalize_script(
     definition: ClusterDefinition,
 ) -> str:
     """Run the bounded coordinator-report finalizer with SSH stdin left intact."""
+    relay_executable = _owned_session_relay_executable(definition)
     return (
         "set -euo pipefail\n"
         "umask 077\n"
         f"{remote_env(definition)}\n"
-        "clio-relay session finalize-cleanup-owned\n"
+        f"{relay_executable} session finalize-cleanup-owned\n"
     )
 
 
 def _owned_cleanup_report_read_script(*, definition: ClusterDefinition) -> str:
     """Run the pinned coordinator-report reader with SSH stdin left intact."""
+    relay_executable = _owned_session_relay_executable(definition)
     return (
         "set -euo pipefail\n"
         "umask 077\n"
         f"{remote_env(definition)}\n"
-        "clio-relay session read-cleanup-report-owned\n"
+        f"{relay_executable} session read-cleanup-report-owned\n"
     )
 
 
@@ -8056,12 +8073,13 @@ def _owned_teardown_script(
         cancel_jobs=cancel_jobs,
         cancel_scheduler_jobs=cancel_scheduler_jobs,
     )
+    relay_executable = _owned_session_relay_executable(definition)
     return (
         "set -euo pipefail\n"
         "umask 077\n"
         f"{remote_env(definition)}\n"
         f"printf '%s' {_shell_single_quote(request.model_dump_json())} | "
-        "clio-relay session teardown-owned\n"
+        f"{relay_executable} session teardown-owned\n"
     )
 
 

--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -855,10 +855,10 @@ def test_cluster_relay_executable_is_an_exact_remote_path() -> None:
     definition = ClusterDefinition(
         name="site-cluster",
         ssh_host="site-login",
-        relay_executable="/srv/releases/relay-1.5.13/bin/clio-relay",
+        relay_executable="/srv/releases/relay-1.5.14/bin/clio-relay",
     )
 
-    assert definition.relay_executable == "/srv/releases/relay-1.5.13/bin/clio-relay"
+    assert definition.relay_executable == "/srv/releases/relay-1.5.14/bin/clio-relay"
     with pytest.raises(ValueError, match="absolute"):
         ClusterDefinition(
             name="site-cluster",
@@ -871,10 +871,10 @@ def test_cluster_relay_receipt_is_an_optional_exact_remote_path() -> None:
     definition = ClusterDefinition(
         name="site-cluster",
         ssh_host="site-login",
-        relay_install_receipt="/srv/releases/relay-1.5.13/install-receipt.json",
+        relay_install_receipt="/srv/releases/relay-1.5.14/install-receipt.json",
     )
 
-    assert definition.relay_install_receipt == ("/srv/releases/relay-1.5.13/install-receipt.json")
+    assert definition.relay_install_receipt == ("/srv/releases/relay-1.5.14/install-receipt.json")
     with pytest.raises(ValueError, match="absolute"):
         ClusterDefinition(
             name="site-cluster",

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.5.13"
+    assert version == "1.5.14"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -4168,7 +4168,7 @@ def test_start_remote_session_writes_owned_pid_and_metadata(monkeypatch: MonkeyP
     assert "session_started=session-1" in lines
     script = scripts[0]
     assert "CLIO_RELAY_API_TOKEN='token'" in script
-    assert "clio-relay session start-owned" in script
+    assert '"$HOME/.local/bin/clio-relay" session start-owned' in script
     assert "umask 077" in script
     assert '"cluster":"ares"' in script
     assert '"session_id":"session-1"' in script
@@ -4186,6 +4186,76 @@ def test_start_remote_session_writes_owned_pid_and_metadata(monkeypatch: MonkeyP
     assert "last_cleanup" not in script
     assert "\x00" not in script
     assert "pkill" not in script
+
+
+def test_owned_session_scripts_use_the_route_pinned_relay_executable() -> None:
+    pinned = "/opt/clio-relay/releases/1.5.14/bin/clio-relay"
+    definition = ClusterDefinition(
+        name="ares",
+        ssh_host="ares",
+        relay_executable=pinned,
+    )
+    release = _api_release_identity()
+    plan = session_lifecycle.plan_remote_session_start(
+        cluster="ares",
+        definition=definition,
+        session_id="session-pinned",
+        remote_api_port=18_765,
+        replace=False,
+        require_token=True,
+        start_operation_id="start_pinned",
+        expected_api_release_identity_sha256=release.sha256(),
+    )
+    scripts = (
+        session_lifecycle._start_script(  # pyright: ignore[reportPrivateUsage]
+            cluster="ares",
+            definition=definition,
+            session_id="session-pinned",
+            start_operation_id=plan.start_operation_id,
+            remote_api_port=plan.remote_api_port,
+            api_token="pinned-token",
+            expected_api_release_identity=release,
+            input_policy=plan.input_policy,
+            replace=False,
+            expected_cluster_route_revision=plan.cluster_route_revision,
+        ),
+        session_lifecycle._owned_status_script(  # pyright: ignore[reportPrivateUsage]
+            definition=definition,
+            cluster="ares",
+            session_id="session-pinned",
+        ),
+        session_lifecycle._owned_start_status_script(  # pyright: ignore[reportPrivateUsage]
+            definition=definition,
+            selector=plan.status_selector,
+        ),
+        session_lifecycle._owned_identity_challenge_script(  # pyright: ignore[reportPrivateUsage]
+            definition=definition,
+            cluster="ares",
+            session_id="session-pinned",
+            session_generation_id="generation-pinned",
+            nonce="1" * 64,
+        ),
+        session_lifecycle._owned_cleanup_finalize_script(  # pyright: ignore[reportPrivateUsage]
+            definition=definition,
+        ),
+        session_lifecycle._owned_cleanup_report_read_script(  # pyright: ignore[reportPrivateUsage]
+            definition=definition,
+        ),
+        session_lifecycle._owned_teardown_script(  # pyright: ignore[reportPrivateUsage]
+            definition=definition,
+            session_id="session-pinned",
+            expected_session_generation_id="generation-pinned",
+            expected_cleanup_operation_id="cleanup_pinned",
+            stop_worker=False,
+            cancel_jobs=False,
+            cancel_scheduler_jobs=False,
+            cluster="ares",
+        ),
+    )
+
+    assert all(pinned in script for script in scripts)
+    assert all("\nclio-relay session" not in script for script in scripts)
+    assert all("| clio-relay session" not in script for script in scripts)
 
 
 def test_start_remote_session_checks_existing_api_release_before_reuse(
@@ -4210,7 +4280,7 @@ def test_start_remote_session_checks_existing_api_release_before_reuse(
     )
 
     script = scripts[0]
-    assert "clio-relay session start-owned" in script
+    assert '"$HOME/.local/bin/clio-relay" session start-owned' in script
     assert '"replace":false' in script
     assert '"expected_api_release_identity"' in script
     assert "exec 9>" not in script
@@ -4248,7 +4318,7 @@ def test_start_remote_session_stages_large_registry_without_python_argv(
     script = scripts[0]
     assert len(script.encode("utf-8")) > 128 * 1024
     assert "printf '%s'" in script
-    assert "clio-relay session start-owned" in script
+    assert '"$HOME/.local/bin/clio-relay" session start-owned' in script
     assert "python3 -" not in script
 
 
@@ -4301,7 +4371,7 @@ def test_status_remote_session_returns_json(monkeypatch: MonkeyPatch) -> None:
 
     assert status == {"session_id": "session-1", "running": True}
     script = scripts[0]
-    command_index = script.index("clio-relay session recovery-status")
+    command_index = script.index('"$HOME/.local/bin/clio-relay" session recovery-status')
     for export in (
         'export PATH="$HOME/.local/bin:$PATH";',
         "export CLIO_RELAY_CLI_MODE=local;",
@@ -4340,7 +4410,7 @@ def test_status_remote_session_marks_pre_start_cleanup_probe_explicitly(
     assert status["cleanup_receipt"] is False
     assert status["recovery_verified"] is False
     assert (
-        "clio-relay session recovery-status --cluster ares "
+        '"$HOME/.local/bin/clio-relay" session recovery-status --cluster ares '
         "--session-id fresh-session --pre-start-cleanup-probe"
     ) in scripts[0]
 
@@ -4371,7 +4441,7 @@ def test_remote_session_start_status_uses_cluster_environment(
 
     assert observed == expected
     script = scripts[0]
-    command_index = script.index("clio-relay session start-status-owned")
+    command_index = script.index('"$HOME/.local/bin/clio-relay" session start-status-owned')
     for export in (
         'export PATH="$HOME/.local/bin:$PATH";',
         "export CLIO_RELAY_CLI_MODE=local;",
@@ -4411,7 +4481,7 @@ def test_remote_session_identity_challenge_binds_process_cluster_and_nonce(
 
     assert observed == expected
     script = scripts[0]
-    assert "clio-relay session challenge-owned" in script
+    assert '"$HOME/.local/bin/clio-relay" session challenge-owned' in script
     assert '"session_generation_id":"generation-1"' in script
     assert f'"nonce":"{nonce}"' in script
     assert "metadata.json" not in script
@@ -4724,7 +4794,7 @@ def test_teardown_remote_session_kills_owned_pid_and_optional_worker(
     assert report.resources[0].outcome == "stopped"
     assert report.resources[1].resource_id == "clio-relay-worker-ares.service"
     assert report.to_cleanup_evidence(stop_worker=True).stop_worker is True
-    assert "clio-relay session teardown-owned" in scripts[0]
+    assert '"$HOME/.local/bin/clio-relay" session teardown-owned' in scripts[0]
     assert '"expected_cleanup_operation_id":"cleanup-test"' in scripts[0]
     assert '"expected_session_generation_id":"generation-1"' in scripts[0]
     assert '"stop_worker":true' in scripts[0]
@@ -4754,7 +4824,7 @@ def test_owned_teardown_delegates_to_pinned_cluster_local_executor() -> None:
         cluster="ares",
     )
 
-    assert "clio-relay session teardown-owned" in script
+    assert '"$HOME/.local/bin/clio-relay" session teardown-owned' in script
     assert '"expected_session_generation_id":"generation-1"' in script
     assert '"expected_cleanup_operation_id":"cleanup-test"' in script
     assert "os.killpg" not in script

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2499,7 +2499,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.5.13"
+    assert policy.release_version == "1.5.14"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -301,7 +301,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.5.13"
+version = "1.5.14"
 source = { editable = "." }
 dependencies = [
     { name = "clio-schemas" },


### PR DESCRIPTION
## What changed

- execute every cluster-local owned-session lifecycle command through the route-pinned Relay executable
- add regression coverage for start, recovery, status, identity challenge, cleanup, and teardown
- bump the patch release to 1.5.14 and refresh the acceptance-matrix digest

## Root cause

The route carried an exact digest-bound Relay executable, but lifecycle scripts invoked bare `clio-relay` through `PATH`. A worker with an older default installation could therefore run a different schema than the selected release.

## Validation

- `tests/test_session_lifecycle.py`: 100 passed, zero skips
- focused release/version tests: 5 passed, zero skips
- Ruff check and format: passed
- focused Pyright: 0 errors, 0 warnings