### PR TITLE
rc: restore the one-link control plane and relay-owned input staging (#182)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,15 @@ Lease admission uses a crash-replayed aggregate for constant-read capacity
 checks, while an explicit full audit retains exact canonical and operational
 index verification for repair and production diagnostics.
 
-Transport is replaceable because it only carries HTTP bytes between endpoints:
+A connection is the desktop relay and the cluster relay joined by exactly one persistent link. Every operation for that connection rides it — submission, status, events, logs, artifact content, input staging, watch, cancellation, teardown — and the link is established once at bring-up and held. Transport is replaceable because it only carries HTTP bytes between endpoints:
 
-- Relay mode uses frp through a public relay host. It supports WebSocket/TLS for Cloudflare-style HTTPS infrastructure and raw TCP for environments that provide a direct public port.
+- Relay mode is the primary path. Both relays dial outbound to a public relay host, which brokers a handshake joining them; neither side accepts inbound. It supports WebSocket/TLS for Cloudflare-style HTTPS infrastructure and raw TCP for environments that provide a direct public port.
 - NAT bypass uses frp XTCP to try a direct peer path between desktop and cluster. It is an optimization for lower-latency or higher-volume traffic, with fallback to relay mode and the durable queue.
-- SSH forwarding uses local port forwarding through an existing SSH or VPN path. It is useful for closed environments that do not want a public relay.
+- SSH forwarding is the fallback for closed environments that permit no other path. One local port forward is established at bring-up and held for the life of the connection.
 
-Remote agent tasks, remote MCP calls, JARVIS pipelines, and gateway sessions all use the same queue and observation model. The transport can change without changing where state lives.
+SSH is a bootstrap mechanism or that one held forward. A connection opens at most one ssh connection in the frp modes — deploying the cluster relay, skipped when it is already there — and at most two in the SSH fallback. After bring-up it opens none, for any number of operations, because a protected cluster asks for interactive 2FA and the user is present only for the first connection. One desktop relay manages many cluster connections at once, behind one MCP endpoint.
+
+Remote agent tasks, remote MCP calls, JARVIS pipelines, and gateway sessions all use the same queue and observation model. The transport can change without changing where state lives. See [connection model](docs/connection-model.md) for the normative statement, including how run inputs reach the cluster.
 
 ## Install
 
@@ -92,6 +94,11 @@ Expose relay tools to an agent:
 clio-relay agent render-mcp-config --output .\clio-relay-agent.config.toml
 clio-relay agent run --cluster my-cluster --prompt /path/on/cluster/prompt.md --mcp-config /path/on/cluster/clio-relay-agent.config.toml
 ```
+
+`--prompt` and `--mcp-config` name cluster-side paths for operator material
+placed once at bootstrap. They are not a transfer channel: run inputs reach the
+cluster through relay's schema-declared input staging, which snapshots a file
+from the desktop workspace and records its lineage on the job.
 
 The MCP server is native FastMCP and can project long-running relay operations
 through standard SEP-2663 task handles without introducing a second scheduler.
@@ -205,6 +212,8 @@ single-node `BatchHost` rather than guessing an allocation node.
 
 ## Choose Transport
 
+Choose the mode that builds the connection's one link. The primary path is frp through a public relay point; SSH forwarding is the fallback for infrastructure that permits nothing else. Both carry the same traffic afterwards.
+
 For a public relay through Cloudflare or another HTTPS edge, use frp with `transport.protocol = "wss"`:
 
 ```powershell
@@ -216,7 +225,7 @@ clio-relay relay-host render-frpc-visitor-config --cluster my-cluster --bind-por
 clio-relay relay-host test-http-transport --cluster my-cluster --local-bind-port 18765
 ```
 
-For closed environments where SSH or VPN already exists, use SSH local forwarding:
+For closed environments where no relay point is reachable, use SSH local forwarding. The forward is established once and held; nothing re-dials ssh for status, polling, recovery, or staging afterwards:
 
 ```powershell
 clio-relay relay-host test-ssh-transport --cluster my-cluster --local-bind-port 18766 --remote-api-port 8766 --session-id relay-ssh-test
@@ -241,6 +250,7 @@ Use `session teardown --stop-worker` only when the user chooses to clean up the 
 
 ## Documentation
 
+- [connection model](docs/connection-model.md) — normative
 - [architecture](docs/architecture.md)
 - [operations](docs/operations.md)
 - [release](docs/release.md)

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -4,12 +4,23 @@ These files are for coding agents and review agents. Human-facing docs should st
 
 Read in this order:
 
-1. `system-context.md`
-2. `testing-context.md`
-3. `interface-context.md`
-4. `release-validation-0.9.17.md`
-5. `../../README.md`
-6. `../architecture.md`
-7. `../operations.md`
+1. `../connection-model.md`
+2. `system-context.md`
+3. `testing-context.md`
+4. `interface-context.md`
+5. `release-validation-0.9.17.md`
+6. `../../README.md`
+7. `../architecture.md`
+8. `../operations.md`
+
+`../connection-model.md` is normative and comes first: one link per connection,
+the ssh budget, the 2FA operating assumption, reconnect, one local relay for
+many remotes, and relay-owned input staging. Where another page or the shipped
+code disagrees with it, it is the other page or the code that is wrong.
 
 Do not treat examples as hardcoded product semantics. Examples show one configured target or workload.
+
+Live evidence files under this directory record what one run of one release
+actually did. Their commands are evidence, not interface guidance; an `ssh` or
+`scp` invocation in a validation transcript is harness scaffolding and must
+never be copied into product code, agent instructions, or a benchmark harness.

--- a/docs/ai/interface-context.md
+++ b/docs/ai/interface-context.md
@@ -2,6 +2,82 @@
 
 This file is a dense map for coding agents. Keep the README shorter than this file.
 
+## Connection model — read this before using any surface below
+
+The surfaces in this file only make sense on top of one model. Misreading it has
+already produced an ssh/scp-driven substitute system built around the relay,
+which invalidated months of benchmark results. The normative statement is
+[`docs/connection-model.md`](../connection-model.md). The short form:
+
+**One connection is one local relay and one remote relay joined by exactly one
+persistent link.** All control-plane and data-plane traffic rides that channel:
+status, identity, submission, events, logs, artifact content, input ingest,
+watch, cancellation, gateway operations, teardown. The link is established once
+at bring-up and held. An operation never establishes transport; it uses the
+transport that already exists.
+
+**Three transport modes, one ssh budget.** (a) frp TCP through an
+internet-accessible relay point that brokers two outbound connections — primary;
+(b) frp XTCP UDP NAT-bypass to a direct peer link, falling back to (a); (c) one
+held ssh port forward — fallback only. New ssh connections for the entire
+lifetime of a connection: **at most one** in (a)/(b) (deploying the cluster
+relay, skipped when already deployed), **at most two** in (c) (deploy plus the
+held forward). After bring-up the count is **zero**, across any number of
+operations, watches, recoveries, and staging transfers.
+
+**The 2FA assumption is why.** A protected cluster requires interactive 2FA to
+open an ssh connection. The user is present for the first connection and for
+none after. Any path that could dial unattended is a violation even when it
+succeeds — passwordless ssh on your test box is a property of that box, not a
+licence to design around a prompt the real user will never see.
+
+**One local relay manages many remote relays**, behind **one** virtual MCP
+endpoint. Reaching a second cluster means naming it in the `cluster` argument,
+never opening a second connection, tunnel, MCP registration, or shell.
+
+**Run inputs are staged by the relay, never copied.** A file-typed package
+setting declares `jarvis.configuration-input-binding.v1`; the caller passes a
+path relative to `CLIO_RELAY_INPUT_WORKSPACE_ROOT` on the **client** machine;
+the local door snapshots and hashes the bytes; they ingest through the owned
+session over the one link; the cluster materializes a content-addressed copy;
+relay rewrites the configuration to the staged reference; the job records
+lineage. **`used_artifact_refs` non-empty, with a digest matching the client's
+bytes, is the proof it engaged.** Empty on a declared file-typed setting means
+the input arrived out of band: the run is not reproducible and is not evidence,
+however successful it looks.
+
+### Never do this
+
+- Never `scp`/`rsync`/`sftp` a run input to the cluster. If it is an input, it
+  goes through the staging contract or it does not go.
+- Never pass a cluster-absolute path for a binding-declared setting. The value
+  is a workspace-relative client path. A cluster path silently disables staging
+  and empties `used_artifact_refs` while the job may still report success.
+- Never re-dial ssh for status, polling, recovery, watch, cancellation, or
+  staging. All of those are HTTP over the established link.
+- Never treat relay as an ssh convenience wrapper, and never build a parallel
+  ssh/scp path beside it. That substitutes an unrecorded system with no lineage,
+  no provenance, no cancellation, and no reconnect, and anything measured
+  through it describes the substitute rather than the product.
+- Never host the client-facing door on the cluster and reach it through a
+  tunnel. The door is local because the workspace it snapshots is the client's.
+- Never assume the local relay can read cluster storage. It reads the client
+  workspace and speaks HTTP to the remote relay; reading a cluster file means
+  asking the remote side over the link, not `ssh <host> cat`.
+- Never add a second local relay, MCP endpoint, or client config per cluster.
+
+### Deviations you will see in the shipped code
+
+State the design, not the deviation, in anything you write. These are tracked
+defects, not the contract: per-operation ssh dialing in the owned-session control
+plane ([#179](https://github.com/iowarp/clio-relay/issues/179)); cluster-targeted
+CLI dispatch opening an ssh connection per invocation under
+`CLIO_RELAY_CLI_MODE=auto`; the built-in JARVIS door skipping input staging
+([#176](https://github.com/iowarp/clio-relay/issues/176)); the outstanding
+end-to-end staging proof ([#177](https://github.com/iowarp/clio-relay/issues/177)).
+`ControlMaster` multiplexing and forward pooling are explicitly not fixes for
+any of them.
+
 ## CLI Surfaces
 
 Core setup:
@@ -262,6 +338,12 @@ The three input-limit variables configure policy at the desktop planning
 boundary. They are not ambient cluster defaults: the selected values are
 serialized into the durable start contract and projected into the exact owned
 API generation.
+
+`CLIO_RELAY_INPUT_WORKSPACE_ROOT` names a directory on the **client** machine —
+the only place the local door is allowed to read run inputs from. It is never a
+cluster path. `CLIO_RELAY_CLI_MODE` selects how a cluster-targeted CLI command
+is executed: `local` keeps it in-process, and `auto`/`ssh` currently open an ssh
+connection for that invocation, which is the tracked deviation noted above.
 
 Local cluster registry data lives under `.clio-relay/clusters.json` by default. Secrets for unattended local runs can live in ignored `.clio-relay/secrets.json`.
 

--- a/docs/ai/interface-context.md
+++ b/docs/ai/interface-context.md
@@ -69,14 +69,27 @@ however successful it looks.
 ### Deviations you will see in the shipped code
 
 State the design, not the deviation, in anything you write. These are tracked
-defects, not the contract: per-operation ssh dialing in the owned-session control
-plane ([#179](https://github.com/iowarp/clio-relay/issues/179)); cluster-targeted
-CLI dispatch opening an ssh connection per invocation under
-`CLIO_RELAY_CLI_MODE=auto`; the built-in JARVIS door skipping input staging
-([#176](https://github.com/iowarp/clio-relay/issues/176)); the outstanding
-end-to-end staging proof ([#177](https://github.com/iowarp/clio-relay/issues/177)).
-`ControlMaster` multiplexing and forward pooling are explicitly not fixes for
-any of them.
+defects, not the contract.
+
+Two are closed by this release and survive only in older deployments:
+per-operation ssh dialing in the owned-session control plane
+([#179](https://github.com/iowarp/clio-relay/issues/179)), which now rides one
+channel held per remote connection, and the built-in JARVIS door skipping input
+staging ([#176](https://github.com/iowarp/clio-relay/issues/176)), which now
+stages through the same plane as the registered route.
+
+Still deviating: `relay_bind_jarvis_runtime` admission dialing four fresh ssh
+per call; the `jarvis_service_runtime` scheduler bridge dialing ssh per
+operation; cluster-targeted CLI dispatch opening an ssh connection per
+invocation under `CLIO_RELAY_CLI_MODE=auto`; no production surface calling
+`reconnect()` on a dropped channel; only the ssh-forward transport mode being
+implemented; compute-node-side `frpc` carrying live service streams; and the
+outstanding end-to-end staging proof
+([#177](https://github.com/iowarp/clio-relay/issues/177)). `ControlMaster`
+multiplexing and forward pooling are explicitly not fixes for any of them. The
+full residual checklist is on
+[#182](https://github.com/iowarp/clio-relay/issues/182); `docs/connection-model.md`
+carries the same list in normative form.
 
 ## CLI Surfaces
 

--- a/docs/ai/system-context.md
+++ b/docs/ai/system-context.md
@@ -6,7 +6,10 @@
 
 - `clio-core` is the authoritative queue and state boundary.
 - The file-backed queue in this repository is a development backend for the same record contract.
-- frp and SSH forwarding are byte transports only.
+- frp and SSH forwarding are byte transports only. A connection has exactly one
+  such link, established at bring-up and held; every control-plane and
+  data-plane operation rides it. See `docs/connection-model.md`, which is
+  normative for transport, ssh budget, reconnect, and input staging.
 - JARVIS-CD owns cluster execution, scheduler integration, package behavior, output collection, and provenance.
 - Application-specific behavior belongs in JARVIS packages or package-aware adapters, not in generic relay core code.
 
@@ -61,11 +64,13 @@ Session teardown quiesces the exact owner-session generation before discovery. W
 running jobs before gateway or API cleanup. It stops the API to seal intake, rescans
 for pre-quiescence in-flight submissions, and acknowledges those before gateway
 cleanup. A timeout leaves intake quiesced and the remaining resources explicit.
-Default scheduler retention remains evidence-bearing without opening one SSH
-process per job: exact scheduler identities are de-duplicated, grouped by
-provider, and queried in bounded batches of at most 256. Every job still emits
-its own validated cleanup resource and status; batching changes transport cost,
-not ownership or preservation semantics.
+Default scheduler retention remains evidence-bearing without a per-job remote
+round trip: exact scheduler identities are de-duplicated, grouped by provider,
+and queried in bounded batches of at most 256 over the connection's established
+link. Every job still emits its own validated cleanup resource and status;
+batching changes transport cost, not ownership or preservation semantics. Per-job
+dialing is not the baseline this improves on — no relay operation opens
+transport of its own.
 
 JARVIS-owned execution is authoritative only when it supplies the exact `jarvis.execution.handle.v1`, `jarvis.execution.record.v1`, and `jarvis.execution.progress.v1` documents. The relay preserves those documents and projects them into `clio-relay.jarvis-runtime.v1` for job/task metadata, events, artifacts, and provenance. The older `jarvis.runtime.v1`, flexible structured payloads, and stdout scheduler patterns are compatibility evidence only and cannot authorize polling or cancellation or satisfy the 1.0 gate.
 
@@ -120,6 +125,15 @@ manifest before the worker materializes those settings and calls JARVIS.
 Idempotent retries reuse that manifest without rescanning Host state. Other
 schemas and path-looking arguments are pass-through.
 
+This is the only way a run input reaches the cluster. The declared value is a
+workspace-relative path on the client machine and the bytes ride the
+connection's one link; relay never copies a run input with `scp` or `rsync`, and
+a cluster-absolute path in a binding-declared setting disables staging rather
+than performing it. Non-empty `used_artifact_refs` with a digest matching the
+client's bytes is the proof that staging engaged. An empty list on a declared
+file-typed setting means the input arrived out of band: that run is not
+reproducible and cannot serve as evidence, whatever its terminal state says.
+
 Input file, aggregate-byte, and count limits are part of the immutable owned
 session start plan, status selector, retry selector, attempt journal, and ready
 session metadata. The cluster-local launcher projects that exact policy into
@@ -134,14 +148,37 @@ contains both forms.
 
 ## Transports
 
-Supported paths:
+One connection is one local relay and one remote relay joined by exactly one
+persistent link. The mode below decides how that link is built; it never gives
+an individual operation its own transport. Modes, in order of preference:
 
-- frp STCP over WebSocket/TLS for Cloudflare-backed or HTTPS-edge relay hosts.
-- frp STCP over TCP for public or institutional relay hosts.
-- SSH local port forwarding for closed environments that already have SSH or VPN access.
-- frp XTCP probing as an optional optimization with fallback.
+- frp STCP over WebSocket/TLS for Cloudflare-backed or HTTPS-edge relay hosts,
+  and over TCP for public or institutional relay hosts. Both relays dial
+  outbound and the relay point brokers the handshake that joins them; neither
+  side accepts inbound. This is the primary path.
+- frp XTCP probing as the UDP NAT-bypass variant, yielding a direct peer link
+  and falling back to the relay-point path.
+- SSH local port forwarding as the fallback for infrastructure that permits no
+  other path. One forward is established at bring-up and held for the lifetime
+  of the connection.
+
+The ssh budget is per connection lifetime: at most one connection in the frp
+modes (deploying the cluster relay, skipped when already deployed) and at most
+two in the ssh fallback (deploy plus the held forward). After bring-up, zero.
+The operating assumption is that a protected cluster requires interactive 2FA
+and the user is present only for the first connection, so no path may dial ssh
+unattended for status, polling, recovery, reconnect, or staging. SSH
+multiplexing and forward pooling are not fixes for exceeding the budget.
+
+Reconnect is first class: durable state lives in the core and the link is only
+transport, so the link is re-establishable without loss and a reconnect is never
+a new deployment. One local relay manages connections to many remote relays
+concurrently, behind one stable client-facing MCP endpoint.
 
 Transport failure must not corrupt queue state. Direct transport and NAT punching are optimizations, not reliability requirements.
+
+`docs/connection-model.md` is normative for this section and records the
+deviations currently tracked in #179, #176, and #177.
 
 ## Sessions
 

--- a/docs/ai/system-context.md
+++ b/docs/ai/system-context.md
@@ -177,8 +177,14 @@ concurrently, behind one stable client-facing MCP endpoint.
 
 Transport failure must not corrupt queue state. Direct transport and NAT punching are optimizations, not reliability requirements.
 
-`docs/connection-model.md` is normative for this section and records the
-deviations currently tracked in #179, #176, and #177.
+`docs/connection-model.md` is normative for this section. The owned-session
+control plane (#179) and the built-in JARVIS door's input staging (#176) meet it
+as of this release; `docs/one-link-control-plane.md` describes the implemented
+transport. The deviations that remain — per-operation ssh in
+`owner_session_admission.py` and the `jarvis_service_runtime` bridge, cluster-
+targeted CLI dispatch, the missing reconnect surface, the two unbuilt transport
+modes, compute-node-side live-stream `frpc`, and the outstanding #177 staging
+proof — are listed on that page and tracked on #182.
 
 ## Sessions
 

--- a/docs/ai/testing-context.md
+++ b/docs/ai/testing-context.md
@@ -2,6 +2,14 @@
 
 Local tests are necessary but not sufficient for transport or cluster behavior.
 
+A harness may place fixtures on an evidence cluster at bring-up, but it must
+never move a run input out of band. Copying scientific inputs to the cluster
+before a run masks the staging seam and makes the results describe the harness
+rather than relay; that bypass has already invalidated a benchmark campaign and
+is tracked as [#177](https://github.com/iowarp/clio-relay/issues/177). Every
+harness that submits work asserts the invariants in `docs/connection-model.md`,
+not the ones its own scaffolding happens to satisfy.
+
 ## local gates
 
 Run:
@@ -62,7 +70,12 @@ evidence must also prove the relevant boundary before it is claimed:
 - a generic remote MCP call runs in endpoint containment with
   `outer_jarvis_pipeline=false` and creates no scheduler allocation;
 - a package-declared v3.6 local file is hash-pinned, ingested, rewritten, and
-  inherited by the exact later JARVIS run after an MCP reconnect; and
+  inherited by the exact later JARVIS run after an MCP reconnect, with a
+  non-empty `used_artifact_refs` whose digest matches the client's bytes and no
+  out-of-band copy anywhere in the proven path;
+- the connection opens no new ssh connections after bring-up: zero in the frp
+  modes and one held forward in the ssh fallback, counted two-sided across an
+  arbitrary number of operations, watches, and recoveries; and
 - a nondefault input policy survives session start, status/retry reconstruction,
   API launch, and reconnect, while a changed policy is rejected without explicit
   replacement;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,6 +157,16 @@ restart and is keyed by the complete route, server artifact, pipeline, and
 owner-session identity. Unannotated path-like strings and other contracts are
 never interpreted as upload requests.
 
+Run inputs move only this way. The declared value is a path on the client
+machine, relative to the configured workspace root; the bytes travel through the
+owned session over the connection's one link. Relay never copies a run input
+with `scp` or `rsync`, and a cluster-absolute path supplied for a
+binding-declared setting is not staging — it disables it, leaving the job with
+an empty `used_artifact_refs`. A non-empty `used_artifact_refs` whose digest
+matches the client's bytes is the proof that staging engaged; an empty one on a
+declared file-typed setting means the input arrived out of band and the run is
+not reproducible.
+
 ## provenance records
 
 An `ArtifactUse` content pin may carry additive, bounded
@@ -175,14 +185,38 @@ the agent-facing MCP surface, and are garbage-collected with their job.
 
 ## Transport
 
-Transport is replaceable:
+A connection is one local relay process and one remote relay process joined by
+exactly one persistent link. All control-plane and data-plane traffic for that
+connection rides that single channel: owned-session status and identity, job
+submission, events, logs, artifact content, input-artifact ingest, watch,
+cancellation, gateway operations, and teardown. The link is established once at
+bring-up and held for the lifetime of the connection; an operation uses the
+transport that already exists and never establishes its own.
 
-- frp over WebSocket/TLS for Cloudflare or other HTTPS edges.
-- frp over TCP for public hosts or institutional relay hosts.
-- SSH local port forwarding for closed environments that already have SSH or VPN access.
-- frp XTCP probing as an optional direct path optimization.
+The mode decides how the one link is built:
+
+- frp through an internet-accessible relay point is the primary path. Both
+  relays dial outbound — WebSocket/TLS for Cloudflare or other HTTPS edges, TCP
+  for a public or institutional host — and the relay point brokers a handshake
+  that joins them. Neither side accepts inbound.
+- frp XTCP is the UDP NAT-bypass variant. The relays end with a direct peer
+  link and fall back to the relay-point path when hole punching fails.
+- SSH local port forwarding is the fallback for infrastructure that permits no
+  other path. One forward is established at bring-up and held; every message
+  rides the mapped port.
+
+SSH is a bootstrap mechanism or that single held forward. The connection's ssh
+budget is at most one connection in the frp modes (deploying the cluster relay,
+skipped when it is already deployed) and at most two in the ssh fallback (deploy
+plus the held forward). After bring-up, the count of new ssh connections is
+zero, for any number of operations. One local relay manages many such
+connections concurrently, behind one client-facing MCP endpoint.
 
 Every transport carries local HTTP between endpoints. No job submission, cursor, artifact, cancellation, progress, or provenance record depends on a particular tunnel.
+
+`docs/connection-model.md` is the normative statement of this model, including
+the 2FA operating constraint, reconnect semantics, the input-staging contract,
+and the tracked deviations. Read it before implementing against relay.
 
 ## Detach and Teardown
 

--- a/docs/brand.md
+++ b/docs/brand.md
@@ -14,7 +14,7 @@ Context:
 - clio-relay is part of the federation layer for clio-agent, but it is usable by any CLI, HTTP, or MCP client.
 - It submits remote scientific and engineering work, follows progress, and returns logs, artifacts, and provenance.
 - It keeps job state in durable records while network transports only carry bytes.
-- It supports cluster work, JARVIS-CD pipelines, SSH forwarding, and frp relay paths.
+- It supports cluster work and JARVIS-CD pipelines over one held relay path per connection, primarily frp, with SSH forwarding as the fallback.
 
 Visual direction:
 - Clear, technical, calm, and trustworthy.

--- a/docs/connect-desktop-homelab-cluster.md
+++ b/docs/connect-desktop-homelab-cluster.md
@@ -11,6 +11,12 @@ This guide starts from three machines that are not already connected through
 The homelab relay does not store job state. It only joins outbound `frp`
 connections from the desktop and the cluster.
 
+This walkthrough builds one connection: the desktop-local relay and the
+cluster-side relay joined by exactly one persistent link, which then carries
+every later operation. `docs/connection-model.md` is the normative statement of
+that model — the transport modes, the ssh budget, reconnect, and how run inputs
+reach the cluster. Read it before adapting these steps into automation.
+
 Install the released relay as a persistent tool on each operator host that runs
 `clio-relay`. Replace `<released-version>` with the exact version being deployed:
 
@@ -98,12 +104,25 @@ clio-relay agent render-mcp-config `
   --output .\clio-relay-agent.config.toml
 ```
 
-Copy the MCP config and prompt to the cluster:
+Place the MCP config and prompt on the cluster. This is **bootstrap-time file
+placement**: it happens once, at bring-up, alongside the deploy step that the
+mode's ssh budget already covers, because `agent run` takes cluster-side paths
+for both and relay has no channel for placing them today. Any file placement
+mechanism the site already trusts is acceptable here; the point is that it
+happens once, before the connection carries work:
 
 ```powershell
 scp .\clio-relay-agent.config.toml my-cluster-login:/home/<user>/relay/clio-relay-agent.config.toml
 scp .\prompt.md my-cluster-login:/home/<user>/relay/prompt.md
 ```
+
+This step is not a pattern to generalize. It does not repeat per run, per job,
+or per operation, and it never carries run inputs. A file that a job reads —
+a simulation input deck, a script a package executes, a dataset descriptor —
+reaches the cluster through relay's input staging, described under
+"Move a run input to the cluster" below. Copying such a file out of band leaves
+the job with an empty `used_artifact_refs` and no lineage, and the run stops
+being reproducible even when it succeeds.
 
 The prompt should tell the agent to use the relay tools rather than bypassing
 the relay. For example:
@@ -111,7 +130,9 @@ the relay. For example:
 ```text
 Use the clio-relay MCP tools. Submit the requested runtime or JARVIS pipeline
 through clio-relay. Return the child job id or gateway session id. Do not run
-the workload directly outside clio-relay.
+the workload directly outside clio-relay. Do not use ssh, scp, or rsync to move
+files or run commands on the cluster; relay staging is the only path for run
+inputs.
 ```
 
 ## Submit a remote agent run
@@ -144,6 +165,47 @@ clio-relay job list-artifacts <agent-job-id> --cluster my-cluster
 
 If the agent submits child work, it should return the child `job_id` or gateway
 session id. Monitor the child separately.
+
+## Move a run input to the cluster
+
+Files that a job reads are staged by the relay over the connection's one link.
+Nothing is copied to the cluster by hand after bootstrap.
+
+Point the desktop MCP process at the workspace it may read, on the desktop:
+
+```powershell
+$env:CLIO_RELAY_INPUT_WORKSPACE_ROOT = "$PWD\my-workspace"
+```
+
+Then configure the step with the path **relative to that workspace**, not a
+cluster path:
+
+```text
+jarvis_add_step(cluster="my-cluster", pipeline_id=..., step_id=...,
+                config={"script": "inputs/run.in"}, wait_for_terminal=true)
+```
+
+Staging is authorized by the package's own schema: the setting must declare
+`jarvis.configuration-input-binding.v1` with `kind="local_file"`, discovered
+through `jarvis_describe(target="package", ...)` on the same connection. Relay
+snapshots the bytes from the desktop workspace, hashes them, ingests them
+through the owned session, materializes a content-addressed copy on the cluster,
+rewrites the setting to that staged reference, and records lineage.
+
+Verify it engaged before trusting the run:
+
+```powershell
+clio-relay job used-artifacts <job-id> --cluster my-cluster
+```
+
+A non-empty result whose digest matches the desktop file is the proof. An empty
+result on a package that declared a file-typed setting means the bytes never
+travelled through relay: the run has no lineage and is not reproducible. Fix the
+staging path rather than copying the file to the cluster.
+
+Settings that declare no binding are passed through unchanged. A path-looking
+value is never enough on its own to make relay read a local file, so a
+cluster-absolute path in that slot is forwarded verbatim and stages nothing.
 
 ## Connect to a live service
 

--- a/docs/connect-desktop-homelab-cluster.md
+++ b/docs/connect-desktop-homelab-cluster.md
@@ -212,15 +212,24 @@ cluster-absolute path in that slot is forwarded verbatim and stages nothing.
 For scheduler-backed services, use a managed runtime. The runtime starts the
 application on a compute node and connects it to the desktop through `frp`.
 
-The data path is:
+The data path is the same as every other kind of traffic — the compute node
+talks to the cluster relay over cluster-internal connectivity, and the cluster
+relay carries the stream over the connection's one link:
 
 ```text
 application service on cluster compute node
-  -> cluster-side frpc outbound to relay host
-  -> frps relay host
-  -> desktop-side frpc visitor
+  -> cluster relay on the master node (cluster-internal connectivity)
+  -> the connection's link (relay point TCP, or the held ssh forward)
+  -> local relay
   -> http://127.0.0.1:<desktop-port>/<stream-path>
 ```
+
+A compute node never opens transport of its own: it needs no outbound internet
+reachability, and the stream's semantics are identical in every transport mode.
+(The current implementation deviates — it launches a compute-node-side `frpc`
+that dials the relay host directly, which both bypasses the cluster relay and
+demands outbound internet access from compute nodes; tracked on the
+connection-model restoration, issue #179.)
 
 The stream is pushed over the live transport. The relay core stores session,
 job, scheduler, lifecycle, and artifact metadata. It does not store bulk image

--- a/docs/connection-model.md
+++ b/docs/connection-model.md
@@ -307,34 +307,80 @@ no reader can rationally construct the wrong one.
 
 These are tracked defects. The sections above state the design; this section
 records where the shipped implementation does not yet meet it, so no reader
-mistakes current behavior for the contract.
+mistakes current behavior for the contract. The campaign that restores the
+implementation to this page is
+[#182](https://github.com/iowarp/clio-relay/issues/182), which carries the
+residual checklist.
 
-- **Owned-session control plane dials ssh per operation**
+### Closed by this release
+
+Both entries describe deployments older than this release, which still behave
+this way. They are kept because a reader meeting a 1.5.x deployment needs to
+recognise the shape.
+
+- **Owned-session control plane dialed ssh per operation**
   ([#179](https://github.com/iowarp/clio-relay/issues/179)). On 1.5.x, owned
-  session status, identity challenge, and watch open fresh ssh connections per
-  client context, and a per-context `-L` forward is created and torn down around
+  session status, identity challenge, and watch opened fresh ssh connections per
+  client context, and a per-context `-L` forward was created and torn down around
   each call. A two-sided measurement of one `jarvis_describe` recorded nine
-  fresh ssh connections. The fix is to ride the established link; multiplexing
-  and forward pooling are explicitly out of scope as fixes.
+  fresh ssh connections. The owned-session control plane now rides one channel
+  held per remote connection — see
+  [the one-link control plane](one-link-control-plane.md) for the implemented
+  shape and the two-sided measurement the deployment gate re-runs. Multiplexing
+  and forward pooling were never in scope as fixes and still are not. #179 stays
+  open for the residuals listed below.
+- **The built-in JARVIS door skipped input staging**
+  ([#176](https://github.com/iowarp/clio-relay/issues/176)). Virtual `jarvis_*`
+  tools reached through the built-in door forwarded a declared file-typed setting
+  verbatim and returned an empty `used_artifact_refs`, so the binding's promise
+  was silently skipped. Both doors now stage through one plane
+  (`src/clio_relay/jarvis_input_plane.py`), so an empty `used_artifact_refs` on
+  either route means what this page says it means everywhere else: staging did
+  not engage, and the run is not evidence.
+
+### Still deviating
+
+- **`relay_bind_jarvis_runtime` admission dials ssh per call.**
+  `owner_session_admission.py` opens four fresh ssh connections per invocation.
+  It sits outside the owned-session control plane restored above and needs a
+  server-side admission endpoint.
+- **The `jarvis_service_runtime` scheduler bridge dials ssh per operation** at
+  roughly twenty sites. Same shape, separate subsystem, restored separately.
 - **Cluster-targeted CLI dispatch dials ssh per invocation.** With
   `CLIO_RELAY_CLI_MODE=auto`, a cluster-targeted CLI command whose cluster has a
   non-local `ssh_host` is executed by opening an ssh connection for that
-  invocation. This is the same shape as #179 and the same rule applies to it.
-  `CLIO_RELAY_CLI_MODE=local` keeps the command in-process.
-- **The built-in JARVIS door skips input staging**
-  ([#176](https://github.com/iowarp/clio-relay/issues/176)). Virtual `jarvis_*`
-  tools reached through the built-in door forward a declared file-typed setting
-  verbatim and return an empty `used_artifact_refs`, so the binding's promise is
-  silently skipped. Until it lands, an empty `used_artifact_refs` on that route
-  is expected, and it still means the run is not evidence.
+  invocation. This is the same shape as the entries above and the same rule
+  applies to it. `CLIO_RELAY_CLI_MODE=local` keeps the command in-process.
+- **No production surface re-establishes a dropped channel.**
+  `RemoteConnection.reconnect()`, `RemoteConnectionRegistry.reconnect()`,
+  `event_report()`, and `close_all()` exist and are covered by tests, but no
+  door calls them, so a dropped channel surfaces as a typed failure rather than
+  a recovery a user can authorize.
+- **Only mode (c) is implemented.** `brokered_tcp` and `udp_rendezvous` are
+  declared and refuse with `TransportModeUnavailable` rather than degrading into
+  per-operation ssh. Until they are built, the primary modes are design, not
+  shipped behavior.
+- **Live service streams still ride a compute-node-side `frpc`** that dials the
+  relay host directly, instead of reaching the cluster relay over
+  cluster-internal connectivity and riding the connection's link. It also
+  requires outbound internet reachability from compute nodes, which most sites do
+  not grant.
+- **The connection-lifetime identity nonce is weaker than a per-operation
+  proof.** Streams are re-proven against the same out-of-band bring-up identity
+  document; a client-verifiable per-operation challenge is still owed.
+- **`--wait-seconds` is a wire-compatibility break** against cluster relays older
+  than this release. It fails loudly, but without naming the version mismatch as
+  the cause.
 - **End-to-end client-local staging to a remote cluster is not yet proven**
-  ([#177](https://github.com/iowarp/clio-relay/issues/177)). The capability
-  exists on the registered JARVIS route; the release-gating proof is outstanding
-  because harness-side `scp` had been masking the seam. Acceptance requires no
-  out-of-band copying anywhere in the proven path.
+  ([#177](https://github.com/iowarp/clio-relay/issues/177)). The capability now
+  exists on both JARVIS routes; the release-gating proof is outstanding because
+  harness-side `scp` had been masking the seam. Acceptance requires no
+  out-of-band copying anywhere in the proven path, through both doors.
 
 ## Related pages
 
+- [the one-link control plane](one-link-control-plane.md) — the implemented
+  transport, its configuration, and the two-sided ssh measurement.
 - [architecture](architecture.md) — roles, durable records, execution boundary.
 - [connect a desktop, homelab relay, and cluster](connect-desktop-homelab-cluster.md)
   — the first-connection walkthrough.

--- a/docs/connection-model.md
+++ b/docs/connection-model.md
@@ -76,9 +76,20 @@ handshake. When hole punching fails, the connection falls back to (a)'s
 relay-point-carried TCP. This is a latency and throughput optimization; it is
 never a reliability requirement, and a failed bypass is not a failed connection.
 
-### (c) SSH port forward — fallback
+### (c) SSH port forward — the configured pathway for secure environments
 
-For infrastructure that permits no other path, such as DOE-class clusters:
+"Fallback" here is a statement about which mode is the default, not about
+runtime behavior. The transport mode is a per-connection **configuration
+choice**: TCP through a relay point is what a user configures by default, and
+the ssh pathway is what a user configures for secure environments that permit
+no other path, such as DOE-class clusters. The relay never switches modes on
+its own — a connection whose configured link fails reports a typed link
+failure and re-establishes the **same** configured mode; it does not try
+another transport. (The one sanctioned in-mode degradation is (b)'s
+hole-punch handshake falling back to (a)'s relay-point-carried TCP, which
+stays within the same configured rendezvous.)
+
+For a connection configured on this pathway:
 
 1. One ssh connection deploys the cluster relay. Skipped when it is already
    deployed.

--- a/docs/connection-model.md
+++ b/docs/connection-model.md
@@ -1,0 +1,332 @@
+# Connection model
+
+This page is normative. It states how a `clio-relay` connection is designed to
+behave, and every other document in this repository is subordinate to it. Where
+shipped code currently deviates, the deviation is named in
+[Known deviations](#known-deviations) with its tracking issue. A deviation is a
+defect to be fixed, never a description of how the system works and never a
+pattern to copy.
+
+Read this before designing any integration, harness, benchmark, or agent
+instruction that uses relay.
+
+## What a connection is
+
+A connection is one local relay process and one remote relay process joined by
+exactly one persistent relay-protocol link.
+
+- The **local relay** runs next to the client. It manages every remote
+  connection, holds the durable client-facing surfaces (CLI, HTTP, MCP), and
+  projects the remote interfaces into one local MCP endpoint.
+- The **remote relay** runs on the cluster. It owns the cluster-side endpoint
+  worker, JARVIS execution, and the cluster's local state.
+- A cluster entry in `.clio-relay/clusters.json` names one such connection.
+
+The relay point (`frps`) in the modes below is not a third party to the
+connection. It joins two outbound connections and stores nothing.
+
+## The one-link rule
+
+All traffic for a connection rides that one channel. Control plane and data
+plane are the same channel:
+
+owned-session status, owned-session identity challenge, job submission, job
+state, events and cursors, log reads by offset, artifact listing, artifact
+content, input-artifact ingest, progress, watch, cancellation, gateway session
+operations, queue inspection, detach, and teardown.
+
+There is no second channel, no side channel, and no per-operation dial. Every
+one of those operations is plain local HTTP over the mapped port.
+
+The link is established once, at connection bring-up, and is held for the
+lifetime of the connection. **An operation never establishes transport. It uses
+transport that already exists.** Anything that would open a new connection to
+perform a status check, a poll, a recovery, or a transfer is a design violation
+rather than an optimization opportunity, and lowering its cost does not make it
+conforming.
+
+## Transport modes
+
+Three modes, in order of preference. The mode decides how the single link is
+built. It never changes the one-link rule, and no mode gives an operation its
+own transport.
+
+### (a) TCP through an internet-accessible relay point — primary
+
+1. One ssh connection deploys the relay on the cluster. Skipped when the cluster
+   relay is already deployed.
+2. The cluster relay connects **outbound** to the internet-accessible relay
+   point over TCP.
+3. The local relay is started on the client machine.
+4. The local relay connects outbound to the same relay point.
+5. The relay point brokers a handshake that joins the two outbound connections
+   into one relay-to-relay link.
+
+Neither side accepts an inbound connection. The relay point is a dumb joiner and
+holds no job, session, or application state. `CLIO_RELAY_STCP_SECRET` is this
+mode's pairing secret; `CLIO_RELAY_FRP_TOKEN` authenticates to the relay point.
+WebSocket/TLS on port 443 serves Cloudflare-style HTTPS edges; raw TCP serves a
+public or institutional host.
+
+### (b) UDP NAT-bypass rendezvous
+
+The same rendezvous, with the handshake attempting NAT traversal over UDP. The
+two relays end with a direct peer link and the relay point is used only for the
+handshake. When hole punching fails, the connection falls back to (a)'s
+relay-point-carried TCP. This is a latency and throughput optimization; it is
+never a reliability requirement, and a failed bypass is not a failed connection.
+
+### (c) SSH port forward — fallback
+
+For infrastructure that permits no other path, such as DOE-class clusters:
+
+1. One ssh connection deploys the cluster relay. Skipped when it is already
+   deployed.
+2. The local relay is started on the client machine.
+3. A **second** ssh connection establishes one port forward. The user is present
+   for its interactive authorization.
+4. The local relay connects to the cluster relay through that mapped port, for
+   the lifetime of the connection.
+
+Every subsequent message rides the mapped port. The forward is the connection.
+
+## The SSH budget
+
+| mode | ssh connections for the whole connection lifetime | what they are |
+|---|---|---|
+| (a) TCP through relay point | at most 1 | deploy the cluster relay; skipped when already deployed |
+| (b) UDP NAT bypass | at most 1 | deploy the cluster relay; skipped when already deployed |
+| (c) SSH port forward | at most 2 | deploy (skippable) plus the one held forward |
+
+The budget is per connection lifetime. It is not per operation, per session, per
+job, per client context, per poll, or per hour. After bring-up the count of new
+ssh connections is **zero**, across any number of operations, watches,
+recoveries, cancellations, and staging transfers.
+
+A build that opens a third ssh connection in mode (c), or a second in (a)/(b),
+is broken even when every dial succeeds.
+
+SSH multiplexing (`ControlMaster`/`ControlPersist`), forward caching, and
+connection pooling are explicitly **not** fixes for exceeding the budget. They
+preserve per-operation ssh semantics at lower cost, which reinforces the wrong
+model. The design has one link, and everything rides it.
+
+## The 2FA operating assumption
+
+Establishing an ssh connection to a protected cluster requires interactive
+two-factor authorization. This is the operating constraint the whole design is
+built on:
+
+**The user is present to approve the first connection at bring-up, and is
+present for none after.**
+
+Any code path that could dial ssh unattended — a retry, a reconnect loop, a
+per-context probe, an ephemeral forward, a status poll, a recovery scan — is a
+violation even when it happens to succeed. Key-based access on a test machine is
+a property of that machine, not permission to design around a prompt the real
+user will never see. A path that works only because the tester had passwordless
+ssh is unshippable.
+
+This is why the ssh budget is a hard number and not a performance target.
+
+## Reconnect
+
+Reconnect is a first-class client behavior, not an error path.
+
+The local relay can disconnect and connect again, and the link is
+re-establishable without loss: durable state lives in the core, and the link is
+only transport. No mode may treat a reconnect as a new deployment, re-run
+bootstrap, or demand authorization beyond what its own handshake requires.
+
+- In modes (a) and (b), a reconnect costs zero ssh connections. Both relays dial
+  out again and the relay point rejoins them.
+- In mode (c), the held forward *is* the connection, so re-establishing it
+  re-enters bring-up with the user present. That is precisely why unattended
+  reconnect machinery is forbidden in this mode: an automatic retry loop spends
+  a budget only a present human can authorize.
+
+Losing the link never loses queue state, job state, session state, or lineage. A
+transport failure must not corrupt or invent durable state, and an observation
+timeout is never proof of a terminal outcome.
+
+## One local relay, many remote relays
+
+A single local relay process manages connections to multiple remote relays
+concurrently. It is the manager of all connections, not a per-connection
+sidecar.
+
+- One held channel per connected cluster, all owned by that one local process.
+- The client-facing MCP endpoint stays single and stable across the connect,
+  disconnect, and reconnect cycles of any individual remote.
+- Adding a second cluster adds a connection inside the same local relay. It does
+  not add a second local relay, a second MCP server, or a second client
+  configuration.
+
+## The virtual MCP layer
+
+Focalization is the point of the product, not a convenience feature.
+
+Multiple remote servers, across multiple clusters, focalize into **one** virtual
+MCP endpoint on the client. The agent speaks to a single MCP surface and the
+local relay fans out behind it. That is exactly why the projection layer exists:
+virtual tools carry per-cluster identity, and the local-only `cluster` selector
+chooses the route.
+
+Consequences a client or agent can rely on:
+
+- One MCP registration serves every cluster. There is never one registration per
+  cluster.
+- The way to reach a second cluster is to name it in the `cluster` argument. It
+  is never to open a second connection, a second tunnel, or a shell.
+- A tool alias is stable across clusters when the namespace, tool name, schema,
+  and declared contract are equivalent; the cluster route is an argument, not a
+  different tool.
+
+See [remote MCP federation](remote-mcp-federation.md) for alias generation,
+schema cache, profile, and freshness rules.
+
+## Input staging is relay-owned
+
+Run inputs that live on the client machine reach the cluster **through the
+relay, over the one link**. Nothing copies files around the transport.
+
+The contract for a file-typed package setting:
+
+1. The package description declares the binding — exactly
+   `jarvis.configuration-input-binding.v1` with `kind="local_file"`. Staging is
+   schema-driven, never filename-driven; a path-looking argument is never
+   sufficient authority to read a local file.
+2. The caller passes a path **relative to the client workspace root**
+   (`CLIO_RELAY_INPUT_WORKSPACE_ROOT`), naming a file on the client machine.
+3. The local door snapshots those bytes from the workspace and hashes them,
+   enforcing the per-file, aggregate, and count bounds before any remote
+   mutation.
+4. The bytes ingest through the authenticated owned session over the one link
+   (`POST /input-artifacts/ingest`).
+5. The cluster materializes a content-addressed copy in the run's staging area.
+6. Relay rewrites the package configuration to that cluster-local staged
+   reference.
+7. The job records immutable `ArtifactUse` lineage for the staged artifact.
+
+Every genuinely new run re-snapshots the tracked logical paths: unchanged
+content reuses its immutable artifact, changed content is ingested as a new one,
+and an idempotent retry reuses the already admitted manifest without rescanning
+the workspace.
+
+### used_artifact_refs is the proof of engagement
+
+A job whose package declared a file-typed setting must come back with a
+**non-empty `used_artifact_refs`**, each entry pinning an artifact id and its
+SHA-256.
+
+- Non-empty, with a digest matching the client's bytes: staging engaged. The run
+  is reproducible and its inputs are attributable.
+- Empty: staging did **not** engage. Whatever the job read on the cluster got
+  there some other way, the run is not reproducible, and its result is not
+  evidence of anything. Treat that run as failed even when the job reports
+  success and the output looks right.
+
+This is the single check that distinguishes a real relay run from a run that was
+set up out of band. Any harness, benchmark, or acceptance procedure that reports
+success without asserting it is measuring the wrong system.
+
+## Bootstrap-time file placement
+
+One bounded exception exists, and it is not a channel.
+
+Before a connection exists there is nothing to carry bytes, so the deploy step
+of each mode places what the cluster needs to become a relay peer: the relay
+artifact itself, and operator-owned material such as the remote agent's prompt
+file, its MCP profile, and site fixtures. This happens **once, at bring-up, over
+the deploy connection the mode already budgets**.
+
+Rules that make it bounded:
+
+- It is bootstrap only. It never repeats per run, per job, or per operation.
+- It never carries run inputs. Run inputs use the staging contract above, for
+  the whole lifetime of the deployment.
+- It is not a template. A step marked bootstrap-only in a runbook must not be
+  generalized into a way of getting files to the cluster.
+
+There is currently no product channel for placing the remote agent's prompt and
+MCP profile on the cluster: `clio-relay agent run --prompt` and `--mcp-config`
+take cluster-side paths, and `agent render-mcp-config` writes locally or to
+stdout. That is a limitation of that surface at bring-up time, not permission to
+move run inputs the same way.
+
+## Never do this
+
+Each item below is a concrete way the model has been misread. They are listed so
+no reader can rationally construct the wrong one.
+
+- **Never copy files around the transport.** `scp`, `rsync`, or `sftp` of a run
+  input is always wrong. If a file is an input to a run, it reaches the cluster
+  through the input-staging contract or it does not reach it at all.
+- **Never pass a cluster-absolute path for a binding-declared setting.** The
+  correct value is a workspace-relative client path. A cluster path in that slot
+  silently disables staging, empties `used_artifact_refs`, and destroys lineage,
+  and the job may still appear to succeed.
+- **Never re-dial ssh for status, polling, recovery, watch, cancellation, or
+  staging.** All of those are HTTP over the established link. If an
+  implementation seems to require a new dial, the implementation is wrong, not
+  the requirement.
+- **Never treat the relay as an ssh convenience wrapper.** Relay is not a nicer
+  way to run remote commands. It is a durable queue, a lineage boundary, and one
+  held link. A design that reduces to "shell out to the cluster, but through
+  relay" has removed everything relay provides.
+- **Never build a substitute path around relay.** Driving the cluster with ssh
+  or scp beside relay does not extend relay; it replaces it with an unrecorded
+  system that produces no lineage, no provenance, no cancellation, and no
+  reconnect. Results collected that way describe the substitute, not the
+  product.
+- **Never host the client-facing door on the cluster and reach it through a
+  tunnel.** The door is local, next to the client, because the workspace it
+  snapshots is the client's. A cluster-hosted door has no path to the client's
+  bytes.
+- **Never assume the local relay can read cluster storage.** It cannot. It reads
+  the client workspace and speaks HTTP to the remote relay. Reading a cluster
+  file means asking the remote side over the link, never `ssh <host> cat`.
+- **Never add a second local relay, MCP endpoint, or client configuration per
+  cluster.** One local relay manages many remotes behind one virtual MCP
+  surface.
+- **Never dial unattended because the test machine has passwordless ssh.** See
+  the 2FA assumption.
+
+## Known deviations
+
+These are tracked defects. The sections above state the design; this section
+records where the shipped implementation does not yet meet it, so no reader
+mistakes current behavior for the contract.
+
+- **Owned-session control plane dials ssh per operation**
+  ([#179](https://github.com/iowarp/clio-relay/issues/179)). On 1.5.x, owned
+  session status, identity challenge, and watch open fresh ssh connections per
+  client context, and a per-context `-L` forward is created and torn down around
+  each call. A two-sided measurement of one `jarvis_describe` recorded nine
+  fresh ssh connections. The fix is to ride the established link; multiplexing
+  and forward pooling are explicitly out of scope as fixes.
+- **Cluster-targeted CLI dispatch dials ssh per invocation.** With
+  `CLIO_RELAY_CLI_MODE=auto`, a cluster-targeted CLI command whose cluster has a
+  non-local `ssh_host` is executed by opening an ssh connection for that
+  invocation. This is the same shape as #179 and the same rule applies to it.
+  `CLIO_RELAY_CLI_MODE=local` keeps the command in-process.
+- **The built-in JARVIS door skips input staging**
+  ([#176](https://github.com/iowarp/clio-relay/issues/176)). Virtual `jarvis_*`
+  tools reached through the built-in door forward a declared file-typed setting
+  verbatim and return an empty `used_artifact_refs`, so the binding's promise is
+  silently skipped. Until it lands, an empty `used_artifact_refs` on that route
+  is expected, and it still means the run is not evidence.
+- **End-to-end client-local staging to a remote cluster is not yet proven**
+  ([#177](https://github.com/iowarp/clio-relay/issues/177)). The capability
+  exists on the registered JARVIS route; the release-gating proof is outstanding
+  because harness-side `scp` had been masking the seam. Acceptance requires no
+  out-of-band copying anywhere in the proven path.
+
+## Related pages
+
+- [architecture](architecture.md) — roles, durable records, execution boundary.
+- [connect a desktop, homelab relay, and cluster](connect-desktop-homelab-cluster.md)
+  — the first-connection walkthrough.
+- [remote MCP federation](remote-mcp-federation.md) — the virtual layer and the
+  staging contract in operational detail.
+- [operations](operations.md) — operator paths for each mode.

--- a/docs/connection-model.md
+++ b/docs/connection-model.md
@@ -316,7 +316,7 @@ residual checklist.
 
 Both entries describe deployments older than this release, which still behave
 this way. They are kept because a reader meeting a 1.5.x deployment needs to
-recognise the shape.
+recognize the shape.
 
 - **Owned-session control plane dialed ssh per operation**
   ([#179](https://github.com/iowarp/clio-relay/issues/179)). On 1.5.x, owned

--- a/docs/connection-model.md
+++ b/docs/connection-model.md
@@ -341,9 +341,10 @@ recognize the shape.
 ### Still deviating
 
 - **`relay_bind_jarvis_runtime` admission dials ssh per call.**
-  `owner_session_admission.py` opens four fresh ssh connections per invocation.
-  It sits outside the owned-session control plane restored above and needs a
-  server-side admission endpoint.
+  `owner_session_admission.py` reads its status through
+  `remote_cli.run_remote_clio`, which opens one ssh connection per call; the bind
+  flow was measured at four. It sits outside the owned-session control plane
+  restored above and needs a server-side admission endpoint.
 - **The `jarvis_service_runtime` scheduler bridge dials ssh per operation** at
   roughly twenty sites. Same shape, separate subsystem, restored separately.
 - **Cluster-targeted CLI dispatch dials ssh per invocation.** With

--- a/docs/one-link-control-plane.md
+++ b/docs/one-link-control-plane.md
@@ -1,0 +1,148 @@
+# The one-link control plane
+
+The relay transport design is a single persistent link between the local relay
+process and each remote relay it is connected to. The link is established once,
+at connection bring-up, and every owned-session operation rides it as plain HTTP
+against the mapped port.
+
+This document describes the implemented shape, the transport modes, and the
+two-sided measurement the deployment gate re-runs.
+
+## Modes
+
+| Mode | Bring-up | Runtime transport connections |
+| --- | --- | --- |
+| `brokered_tcp` | one SSH to deploy the cluster relay (skipped when already deployed); both relays dial out to an internet-accessible server, which brokers the handshake | 0 |
+| `udp_rendezvous` | same rendezvous, UDP hole-punching handshake, falling back to `brokered_tcp`'s server-carried TCP | 0 |
+| `ssh_forward` | one SSH to deploy (skipped when already deployed); one SSH holding the port forward, which the present user authorizes | 1 |
+
+Only `ssh_forward` is implemented. `brokered_tcp` and `udp_rendezvous` are
+declared and slot in as sibling implementations of `RelayTransport`
+(`src/clio_relay/control_channel.py`). Asking for one today raises
+`TransportModeUnavailable` — an unbuilt mode must never quietly degrade into
+per-operation SSH.
+
+## How bring-up spends exactly one connection
+
+In `ssh_forward` mode a single SSH process does both jobs:
+
+```
+ssh -T -o ExitOnForwardFailure=yes -o ServerAliveInterval=15 \
+    -L 127.0.0.1:<local>:127.0.0.1:<remote_api_port> <ssh_host> bash -lc '<bootstrap>'
+```
+
+The `<bootstrap>` command runs the two cluster-local executors that used to be
+separate `ssh ... bash -s` dials — `session recovery-status` and
+`session challenge-owned` — prints their exact output as one JSON line, and then
+blocks on stdin (`exec cat >/dev/null`). Closing the local end of that pipe is
+how the channel is torn down.
+
+Carrying the identity challenge on the bring-up command is not an optimization,
+it is required: the owner token that signs the identity document is minted
+cluster-side and never leaves the cluster, so the local relay cannot compute the
+expected document itself. The proof therefore has to arrive over the same
+authenticated act that establishes the channel.
+
+`BatchMode` is deliberately **not** set for bring-up: the user is present to
+approve exactly this one connection's two-factor prompt. A non-interactive
+deployment can opt out with `allow_interactive_authorization=False`, which adds
+`BatchMode=yes` and makes an unattended dial fail rather than hang.
+
+## Configuration
+
+The forward has to be pointed at the remote owned-session API port before the
+channel exists, so the port is connection configuration rather than a
+per-operation discovery:
+
+1. an explicit `remote_api_port` argument,
+2. `CLIO_RELAY_OWNER_SESSION_API_PORT`,
+3. the default, `8765`.
+
+Whatever is resolved is cross-checked against the remote relay's own report in
+the bring-up document. A wrong port fails with a typed error naming both values
+instead of binding to a stranger.
+
+## Reconnect
+
+Reconnect is explicit. If the held channel drops, the next operation raises
+`ChannelDropped` and records a typed `dropped` event; it never redials. Calling
+`RemoteConnection.reconnect()` opens exactly one new transport and records
+`reestablishing` → `authorization_required` → `establishing` → `reestablished`.
+In `ssh_forward` mode that call is what the user authorizes.
+
+A broken *TCP stream* is not a broken *channel*. Re-opening the stream through
+the forward that is already held costs no new transport and is recorded as
+`stream_reproven`; the re-opened stream is re-proven against the same
+out-of-band bring-up identity document before any credential is sent.
+
+## One local relay, many remote relays
+
+`RemoteConnectionRegistry` maps each cluster to its own held connection. The
+client-facing MCP endpoint stays single and stable while connections come and
+go: connecting, disconnecting, or reconnecting one cluster leaves every other
+cluster's channel untouched.
+
+## The two-sided acceptance measurement
+
+The gate measures the same quantity from both ends and requires them to agree.
+
+**Client side (desktop).** The local relay's own typed record:
+
+```python
+from clio_relay.remote_connection import connection_registry
+
+report = connection_registry().event_report()
+report["transport_connections_opened"]   # established + reestablished, all clusters
+report["clusters"]["<cluster>"]["events"]  # the full typed lifecycle record
+```
+
+Out of process, the desktop sampler counts live `ssh` children of the door
+process across the window under test (the `ssh-sampler.ps1` shape used during
+the 1.5.10 measurement):
+
+```powershell
+Get-CimInstance Win32_Process -Filter "Name='ssh.exe'" |
+  Select-Object ProcessId, CreationDate, CommandLine
+```
+
+Sample at a fixed interval for the duration of the call and count **distinct
+ProcessIds**, not concurrent ones — the deviation's signature was many
+short-lived processes, not many simultaneous ones.
+
+**Server side (cluster).** Count new `sshd` sessions attributable to the run:
+
+```bash
+journalctl --user-unit ssh -S "<window start>" | grep -c "Accepted "
+# or, without journal access:
+last -F -n 200 "$USER" | awk '$0 ~ /still logged in|<date>/'
+```
+
+**Acceptance.**
+
+| Mode | Bring-up | Any number of later operations |
+| --- | --- | --- |
+| `ssh_forward` | exactly 1 new `sshd` session | 0 new |
+| `brokered_tcp` / `udp_rendezvous` | 0 (after deployment) | 0 new; passes with SSH unavailable entirely |
+
+The reference deviation, for comparison: on 1.5.10 a single `jarvis_describe`
+call opened **9** fresh SSH connections and about 35 seconds of pure handshake,
+and the cluster recorded 9 matching new `sshd` sessions.
+
+The unit tests assert the same invariant in-process by counting calls to the
+injected channel-process factory — one call is one SSH connection — in
+`tests/test_owned_session_channel.py`.
+
+## What is legitimately still SSH
+
+Deployment and lifecycle, not the runtime control plane:
+
+- cluster bootstrap (`bootstrap.py`) and endpoint-service install/restart
+  (`deployment.py`);
+- `session start` / `session teardown` / cleanup finalize and report read, which
+  must work when the owned API is not running and therefore cannot ride a
+  channel that depends on it;
+- `session start-watch`, which observes a start transition that by definition
+  precedes the owned API. It is no longer a redial loop: the desktop sends its
+  remaining deadline as `--wait-seconds` and the cluster-local command blocks
+  against durable state, so one watch is one connection regardless of how long
+  the start takes.

--- a/docs/one-link-control-plane.md
+++ b/docs/one-link-control-plane.md
@@ -192,8 +192,9 @@ deviations from `connection-model.md`, not sanctioned exceptions, and the
 campaign issue [#182](https://github.com/iowarp/clio-relay/issues/182) carries
 them:
 
-- `relay_bind_jarvis_runtime` admission (`owner_session_admission.py`) opens four
-  fresh SSH connections per call; it needs a server-side admission endpoint.
+- `relay_bind_jarvis_runtime` admission reads its status through
+  `remote_cli.run_remote_clio`, which opens one SSH connection per call; the
+  bind flow was measured at four. It needs a server-side admission endpoint.
 - the `jarvis_service_runtime` scheduler bridge dials SSH per operation at
   roughly twenty sites.
 - cluster-targeted CLI dispatch under `CLIO_RELAY_CLI_MODE=auto` opens one SSH

--- a/docs/one-link-control-plane.md
+++ b/docs/one-link-control-plane.md
@@ -70,10 +70,16 @@ Reconnect is explicit. If the held channel drops, the next operation raises
 `reestablishing` → `authorization_required` → `establishing` → `reestablished`.
 In `ssh_forward` mode that call is what the user authorizes.
 
-A broken *TCP stream* is not a broken *channel*. Re-opening the stream through
-the forward that is already held costs no new transport and is recorded as
-`stream_reproven`; the re-opened stream is re-proven against the same
-out-of-band bring-up identity document before any credential is sent.
+`RemoteConnectionRegistry.reconnect(cluster)` is the single entry point for it,
+so an operator action can reach it and a retry cannot.
+
+A broken *TCP stream* is not a broken *channel*. HTTP streams are pooled over
+the one held channel — a long poll on one operation must not block every other
+operation on the same cluster — and opening another stream is another TCP
+connection *through the forward that is already held*, so it costs no new
+transport. Each stream is proven against the same out-of-band bring-up identity
+document before any credential is sent, and extra streams are recorded as
+`stream_reproven`.
 
 ## One local relay, many remote relays
 

--- a/docs/one-link-control-plane.md
+++ b/docs/one-link-control-plane.md
@@ -22,6 +22,35 @@ declared and slot in as sibling implementations of `RelayTransport`
 `TransportModeUnavailable` — an unbuilt mode must never quietly degrade into
 per-operation SSH.
 
+**The mode is configuration, not a runtime decision.** SSH is not a fallback in
+the "try TCP, fail, degrade" sense: an operator configures which pathway a
+connection uses, per connection, at deployment time. Nothing probes a mode and
+nothing switches between them. A link failure re-establishes the *same*
+configured mode or reports a typed failure. Set it with
+`CLIO_RELAY_REMOTE_TRANSPORT_MODE` (`brokered_tcp` | `udp_rendezvous` |
+`ssh_forward`, default `ssh_forward`); an unrecognised value is refused at
+configuration load, not at first use. `CLIO_RELAY_REMOTE_TRANSPORT_INTERACTIVE=0`
+declares a headless deployment, which adds `BatchMode=yes` so bring-up fails
+fast instead of waiting for a prompt no one can answer.
+
+## What rides the link
+
+The link, not the owned-session API, is the unit the design holds open.
+Owned-session request/response rides its control endpoint today. Live
+application service streams must ride the *same* link: a compute node reaches
+the cluster relay over cluster-internal connectivity, the cluster relay carries
+that traffic across the link, and the local relay serves it — identically in
+every mode, because a compute node on a real HPC cluster has no route to the
+internet and cannot dial a relay host itself. (The current gateway
+implementation, where a compute-node-side `frpc` dials the relay host directly,
+is a deviation from this and is recorded on #179.)
+
+No mode carries multiplexed stream channels yet. What holds today is the shape:
+`ChannelLink` names its `control_endpoint` and a `stream_channels` capability
+flag, and `RelayTransport.open_stream_channel` exists and refuses with
+`StreamChannelsUnavailable` rather than opening a second connection. Adding
+streams later extends this interface instead of breaking it.
+
 ## How bring-up spends exactly one connection
 
 In `ssh_forward` mode a single SSH process does both jobs:

--- a/docs/one-link-control-plane.md
+++ b/docs/one-link-control-plane.md
@@ -148,7 +148,10 @@ Deployment and lifecycle, not the runtime control plane:
   must work when the owned API is not running and therefore cannot ride a
   channel that depends on it;
 - `session start-watch`, which observes a start transition that by definition
-  precedes the owned API. It is no longer a redial loop: the desktop sends its
-  remaining deadline as `--wait-seconds` and the cluster-local command blocks
-  against durable state, so one watch is one connection regardless of how long
-  the start takes.
+  precedes the owned API and therefore cannot ride a channel that depends on it.
+  It is no longer a redial loop: the desktop sends its remaining deadline as
+  `--wait-seconds` and the cluster-local command blocks against durable state.
+  The remote wait is capped at `MAX_REMOTE_SESSION_START_WAIT_SECONDS` (120s,
+  the ordinary remote-command budget) so a silent SSH command stays bounded, so
+  the cost is one connection per 120 seconds watched rather than one per 0.5s
+  interval. The CLI's default 120-second watch is exactly one connection.

--- a/docs/one-link-control-plane.md
+++ b/docs/one-link-control-plane.md
@@ -184,3 +184,26 @@ Deployment and lifecycle, not the runtime control plane:
   the ordinary remote-command budget) so a silent SSH command stays bounded, so
   the cost is one connection per 120 seconds watched rather than one per 0.5s
   interval. The CLI's default 120-second watch is exactly one connection.
+
+## What still dials and should not
+
+These are outside the owned-session control plane restored here. They are
+deviations from `connection-model.md`, not sanctioned exceptions, and the
+campaign issue [#182](https://github.com/iowarp/clio-relay/issues/182) carries
+them:
+
+- `relay_bind_jarvis_runtime` admission (`owner_session_admission.py`) opens four
+  fresh SSH connections per call; it needs a server-side admission endpoint.
+- the `jarvis_service_runtime` scheduler bridge dials SSH per operation at
+  roughly twenty sites.
+- cluster-targeted CLI dispatch under `CLIO_RELAY_CLI_MODE=auto` opens one SSH
+  connection per invocation.
+- no production surface calls `RemoteConnectionRegistry.reconnect()`,
+  `event_report()`, or `close_all()`, so a dropped channel has no door-side
+  recovery path today.
+- `brokered_tcp` and `udp_rendezvous` are declared but unbuilt, so the primary
+  transport modes are design rather than shipped behavior.
+- gateway live streams still run a compute-node-side `frpc` that dials the relay
+  host directly instead of riding this channel via the cluster relay.
+- `--wait-seconds` is a wire-compatibility break against cluster relays older
+  than this release: it fails loudly, but without naming the version mismatch.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -6,6 +6,12 @@ For a complete first-connection walkthrough from a local desktop through a
 homelab relay to a cluster worker and remote agent, see
 `docs/connect-desktop-homelab-cluster.md`.
 
+`docs/connection-model.md` is normative for everything transport-related on this
+page: one held link per connection, the ssh budget, the 2FA operating
+assumption, reconnect, and relay-owned input staging. The operator paths below
+are ways to build and drive that one connection, not independent ways to reach
+the cluster.
+
 ## Add a Cluster
 
 ```powershell
@@ -590,10 +596,12 @@ that membership through verified generation closure.
 The user MCP profile exposes the read-only `relay_queue_list`,
 `relay_queue_diagnose`, and `relay_queue_stale` tools. The admin profile also
 exposes `relay_queue_cleanup_stale`, `relay_cancel_job`, and worker status.
-When `cluster` names a configured SSH target, these tools operate on that
-cluster's queue and return a `route_revision`; exact follow-up operations can
-echo that revision so a changed cluster route is rejected instead of silently
-acting on a different queue.
+When `cluster` names a configured remote cluster, these tools operate on that
+cluster's queue over its established connection and return a `route_revision`;
+exact follow-up operations can echo that revision so a changed cluster route is
+rejected instead of silently acting on a different queue. The `cluster` argument
+selects a connection the local relay already holds. It is not an instruction to
+open one.
 
 For release evidence, configure at least three live worker slots and the exact
 per-kind cap `jarvis=2`, then run during a quiet window with an otherwise empty
@@ -657,6 +665,13 @@ whether fresh worker registrations agree, and active leases by kind.
 clio-relay agent render-mcp-config --output .\clio-relay-agent.config.toml
 clio-relay agent run --cluster my-cluster --prompt /path/on/cluster/prompt.md --mcp-config /path/on/cluster/clio-relay-agent.config.toml
 ```
+
+The `--prompt` and `--mcp-config` values are cluster-side paths for operator
+material placed once at bootstrap, before the connection carries work. They are
+not a transfer channel and must not be used as a precedent for getting other
+files onto the cluster. A file that a job reads is staged by relay from the
+desktop workspace through the connection's one link; see `stage declared local
+package inputs` in `docs/remote-mcp-federation.md`.
 
 Agents should submit child cluster work asynchronously and return the child `job_id`. A single cluster worker cannot execute a child job while it is blocked inside a parent agent job waiting for that child to finish.
 
@@ -1126,7 +1141,11 @@ runtime until `stop-runtime` has proven connector cleanup.
 
 ## Use FRP Transport
 
-Use frp when the desktop and cluster cannot directly SSH to each other but can both reach a relay host.
+frp is the primary transport. Use it whenever the desktop and cluster can both
+reach a relay host, including when SSH between them also happens to work. Both
+sides dial outbound and the relay host brokers a handshake that joins them into
+the connection's one link; neither side accepts inbound, and the relay host
+stores nothing. After bring-up this mode opens no ssh connections at all.
 
 ```powershell
 $env:CLIO_RELAY_FRP_TOKEN = "<shared-frp-token>"
@@ -1141,7 +1160,18 @@ For Cloudflare-backed homelab deployments, configure the cluster transport as `w
 
 ## Use SSH Forwarding
 
-Use SSH forwarding when the desktop already has SSH or VPN access to the cluster.
+SSH forwarding is the fallback. Use it when no relay host is reachable from both
+sides, as on DOE-class infrastructure. One local port forward is established at
+bring-up, with the user present for its interactive authorization, and is held
+for the lifetime of the connection; every later message rides the mapped port.
+
+The connection's ssh budget in this mode is two: deploying the cluster relay
+(skipped when it is already deployed) and that one forward. Nothing re-dials ssh
+afterwards for status, watch, polling, recovery, cancellation, or staging. A
+protected cluster asks for interactive 2FA on each connection and the user is
+present only at bring-up, so an unattended dial is a defect even when it
+succeeds on a key-based test host. `ControlMaster` multiplexing and forward
+pooling are not remedies; they keep the wrong shape at lower cost.
 
 ```powershell
 clio-relay relay-host test-ssh-transport --cluster my-cluster --local-bind-port 18766 --remote-api-port 8766 --session-id relay-ssh-test
@@ -1196,8 +1226,11 @@ for an attached API. Automation should persist the returned secret-free status
 selector.
 
 There is deliberately no aggregate start wait deadline in the relay contract.
-Each SSH/status observation is bounded so a client remains responsive, but a
+Each status observation is bounded so a client remains responsive, but a
 deadline produces `starting` or `ambiguous`, never a fabricated terminal failure.
+A status observation is a request over the connection's established link; it
+never opens transport of its own, and a bounded deadline is never a reason to
+dial again.
 The same operation id and immutable route/port/auth/release policy must be reused
 until it becomes terminal. A changed route or policy fails closed before mutation.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1087,7 +1087,7 @@ writes a revocation marker before
 stopping the owned proxy; same-id retries return an idempotent revoked result, while
 a different attachment id is refused.
 
-Use `transport_mode: "frp-stcp-wss"` for the relay path and `transport_mode: "frp-xtcp-wss"` for direct NAT-bypass attempts. The application stream still flows through the relay/bypass transport to the desktop-local bind port, not through an SSH port forward.
+Use `transport_mode: "frp-stcp-wss"` for the relay path and `transport_mode: "frp-xtcp-wss"` for direct NAT-bypass attempts. By design the application stream rides the connection's one link like all other traffic — compute node to the cluster relay over cluster-internal connectivity, then the cluster relay to the local relay over whatever link the connection is configured with (relay-point TCP, or the held ssh forward; the stream's semantics are identical in every mode). The current `transport_mode` implementation deviates: it opens a compute-node-side frp transport that bypasses the cluster relay and has no ssh-pathway equivalent — tracked on the connection-model restoration, issue #179.
 
 The default service contract is push-based. A desktop client subscribes once to `stream_url`, and the remote application pushes data, images, frames, or domain records as they are emitted. The relay does not assume any application-specific endpoint shape. Pull-style endpoints are represented only as named `compatibility_paths`, such as `snapshot`, `render_once`, or `state_dump`.
 

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -27,12 +27,16 @@ input** out of band: the LAMMPS input deck and the secure-runtime dataset
 descriptor are copied to the cluster and then referenced by cluster-absolute
 path. That is the bypass tracked by
 [#177](https://github.com/iowarp/clio-relay/issues/177), whose acceptance
-requires no out-of-band copying anywhere in the proven path, and it depends on
-[#176](https://github.com/iowarp/clio-relay/issues/176) for the built-in JARVIS
-door to engage staging. Both steps are marked in place. They are recorded here
-as the current state of the harness, not as a supported pattern; a run input
-belongs in the relay's input staging, which leaves a non-empty
-`used_artifact_refs` on the job.
+requires no out-of-band copying anywhere in the proven path. The capability
+those steps were waiting on has landed:
+[#176](https://github.com/iowarp/clio-relay/issues/176) makes the built-in
+JARVIS door stage declared inputs through the same plane as the registered
+route, so both steps can now be rewritten to pass a workspace-relative client
+path. Rewriting them is tracked on
+[#182](https://github.com/iowarp/clio-relay/issues/182) and has not been done
+yet; both steps are marked in place. They are recorded here as the current state
+of the harness, not as a supported pattern; a run input belongs in the relay's
+input staging, which leaves a non-empty `used_artifact_refs` on the job.
 
 ## Required report matrix
 
@@ -928,11 +932,13 @@ Invoke-RelayReport -Id "ares-jarvis-gray-scott" -ReportOption "--report" -Comman
   "--wait-timeout-seconds", "900", "--poll-seconds", "2"
 )
 
-# NON-CONFORMING, tracked by #177 and #176. The LAMMPS deck is a run input and
-# must reach the cluster through relay input staging: a path relative to
-# CLIO_RELAY_INPUT_WORKSPACE_ROOT in config.script, leaving a non-empty
-# used_artifact_refs on the job. The out-of-band copy and cluster-absolute path
-# below are the bypass those issues remove. Do not copy this pattern.
+# NON-CONFORMING, acceptance tracked by #177, rewrite tracked by #182. The
+# LAMMPS deck is a run input and must reach the cluster through relay input
+# staging: a path relative to CLIO_RELAY_INPUT_WORKSPACE_ROOT in config.script,
+# leaving a non-empty used_artifact_refs on the job. #176 landed the built-in
+# door's half of that capability; this step has not been rewritten onto it yet.
+# The out-of-band copy and cluster-absolute path below are the bypass. Do not
+# copy this pattern.
 $RemoteLammpsInput = "$AresRemoteRoot/lammps/in.lj"
 & $OpenSsh $AresSshHost "install -d -m 700 '$AresRemoteRoot/lammps'"
 Copy-RemoteTextFile `
@@ -1639,9 +1645,11 @@ if ($SecureDatasetRecords.Count -ne 1 -or $null -eq $SecureDatasetRecords[0].des
 }
 $SecureDescriptorLocal = Write-JsonFile `
   "ares-secure-runtime-dataset-descriptor.json" $SecureDatasetRecords[0].descriptor
-# NON-CONFORMING, tracked by #177 and #176. The descriptor is a run input for
-# the submitted pipeline; it belongs in relay input staging rather than an
-# out-of-band copy referenced by cluster-absolute path. Do not copy this pattern.
+# NON-CONFORMING, acceptance tracked by #177, rewrite tracked by #182. The
+# descriptor is a run input for the submitted pipeline; it belongs in relay input
+# staging rather than an out-of-band copy referenced by cluster-absolute path.
+# #176 landed the capability this step was waiting on; the step itself has not
+# been rewritten onto it yet. Do not copy this pattern.
 $SecureDescriptorRemote = "$AresRemoteRoot/secure-runtime/dataset-descriptor.json"
 & $OpenSsh $AresSshHost "install -d -m 700 '$AresRemoteRoot/secure-runtime'"
 if ($LASTEXITCODE -ne 0) { throw "secure-runtime fixture directory creation failed" }

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -13,6 +13,27 @@ by the 1.0 release policy. They are not product allowlists. Any operator can
 register other cluster names, and a later policy can select other evidence
 instances without a core-code change.
 
+## This runbook is harness scaffolding, not the relay interface
+
+The `ssh` and `scp` invocations below belong to the gate harness. They place
+build scripts, provider fixtures, and site material on an evidence cluster
+before any connection carries work. They are not how a client, an agent, or an
+application uses relay, and they must never be copied into product code, agent
+instructions, or a benchmark harness. `docs/connection-model.md` is normative
+for what relay actually does.
+
+Two steps below currently go further than fixture placement and stage a **run
+input** out of band: the LAMMPS input deck and the secure-runtime dataset
+descriptor are copied to the cluster and then referenced by cluster-absolute
+path. That is the bypass tracked by
+[#177](https://github.com/iowarp/clio-relay/issues/177), whose acceptance
+requires no out-of-band copying anywhere in the proven path, and it depends on
+[#176](https://github.com/iowarp/clio-relay/issues/176) for the built-in JARVIS
+door to engage staging. Both steps are marked in place. They are recorded here
+as the current state of the harness, not as a supported pattern; a run input
+belongs in the relay's input staging, which leaves a non-empty
+`used_artifact_refs` on the job.
+
 ## Required report matrix
 
 Each stage produces exactly these 19 policy reports. The tracked
@@ -907,6 +928,11 @@ Invoke-RelayReport -Id "ares-jarvis-gray-scott" -ReportOption "--report" -Comman
   "--wait-timeout-seconds", "900", "--poll-seconds", "2"
 )
 
+# NON-CONFORMING, tracked by #177 and #176. The LAMMPS deck is a run input and
+# must reach the cluster through relay input staging: a path relative to
+# CLIO_RELAY_INPUT_WORKSPACE_ROOT in config.script, leaving a non-empty
+# used_artifact_refs on the job. The out-of-band copy and cluster-absolute path
+# below are the bypass those issues remove. Do not copy this pattern.
 $RemoteLammpsInput = "$AresRemoteRoot/lammps/in.lj"
 & $OpenSsh $AresSshHost "install -d -m 700 '$AresRemoteRoot/lammps'"
 Copy-RemoteTextFile `
@@ -1592,6 +1618,12 @@ the descriptor from the same operator-owned catalog record that the released
 Scientific Catalog MCP already validated. This lightweight preparation may run
 on the login node; ParaView itself runs only in the submitted SLURM allocation.
 
+The `ssh ... cat` below is harness convenience for reading operator-owned site
+metadata while assembling a fixture. It is not a relay capability: the local
+relay cannot read cluster storage, and a client asking for cluster-side content
+does so over the connection's link. Never write product code, or instruct an
+agent, to read a cluster file by shelling out.
+
 ```powershell
 $SecureDatasetId = "deep-water-impact-2018-yb31-first5"
 $CatalogText = (& $OpenSsh $AresSshHost "cat '$AresScientificCatalogFile'" | Out-String)
@@ -1607,6 +1639,9 @@ if ($SecureDatasetRecords.Count -ne 1 -or $null -eq $SecureDatasetRecords[0].des
 }
 $SecureDescriptorLocal = Write-JsonFile `
   "ares-secure-runtime-dataset-descriptor.json" $SecureDatasetRecords[0].descriptor
+# NON-CONFORMING, tracked by #177 and #176. The descriptor is a run input for
+# the submitted pipeline; it belongs in relay input staging rather than an
+# out-of-band copy referenced by cluster-absolute path. Do not copy this pattern.
 $SecureDescriptorRemote = "$AresRemoteRoot/secure-runtime/dataset-descriptor.json"
 & $OpenSsh $AresSshHost "install -d -m 700 '$AresRemoteRoot/secure-runtime'"
 if ($LASTEXITCODE -ne 0) { throw "secure-runtime fixture directory creation failed" }

--- a/docs/remote-mcp-federation.md
+++ b/docs/remote-mcp-federation.md
@@ -375,13 +375,21 @@ has no input lineage, and it is not evidence of anything even when it reports
 success and the output looks correct. Treat an empty list as a failed run and
 fix the staging path; do not work around it by placing the file on the cluster.
 
-Two configurations produce an empty list without any error. A cluster-absolute
+One configuration produces an empty list without any error: a cluster-absolute
 path in the setting is forwarded verbatim, because a path-looking value carries
-no authority to read a local file. And the built-in JARVIS door does not engage
-staging at all today, so a declared binding reached through it is silently
-skipped — that is tracked as
-[#176](https://github.com/iowarp/clio-relay/issues/176), with the end-to-end
-proof tracked as [#177](https://github.com/iowarp/clio-relay/issues/177).
+no authority to read a local file. Pass a workspace-relative client path
+instead.
+
+The built-in JARVIS door used to produce an empty list for a declared binding
+too, because it never entered the staging plane
+([#176](https://github.com/iowarp/clio-relay/issues/176)). As of this release it
+shares the plane with the registered route, so the check above means the same
+thing on both doors. One deliberate, typed difference remains: the built-in door
+engages staging only when the JARVIS MCP runs on another machine, and a built-in
+run whose staged content changed is refused by name (`jarvis_run_input_drift`)
+rather than run against bytes the configuration never received. The end-to-end
+proof through both doors is still outstanding and tracked as
+[#177](https://github.com/iowarp/clio-relay/issues/177).
 
 ## Keep the compact JARVIS surface
 

--- a/docs/remote-mcp-federation.md
+++ b/docs/remote-mcp-federation.md
@@ -5,6 +5,12 @@ register stdio MCP servers that exist in a cluster environment, discover their
 real schemas through durable relay jobs, and expose selected remote tools as
 normal local tools with a `cluster` argument.
 
+This focalization is the point of the layer, not a convenience. Servers on any
+number of clusters collapse into one MCP surface: the agent calls one endpoint
+and the local relay fans out behind it over each connection's single held link.
+Adding a cluster adds a value to the `cluster` enum, never a second MCP
+registration, endpoint, tunnel, or shell.
+
 The desktop agent does not need one MCP registration per cluster. A virtual
 call follows the normal relay path:
 
@@ -256,9 +262,15 @@ which immutable evidence backs the `relay_wait` projection.
 
 ## stage declared local package inputs
 
-Registered JARVIS contract v3.6 can move a small caller-local file without
-adding an upload tool to the agent surface. Configure the desktop MCP process
-with a workspace it is allowed to read:
+This is the only way a run input reaches the cluster. Registered JARVIS contract
+v3.6 moves a small caller-local file without adding an upload tool to the agent
+surface: the bytes travel through the owned session over the connection's one
+link, exactly like every other relay operation. Nothing is copied around the
+transport — `scp` and `rsync` of a run input are always wrong, and the value
+supplied for a binding-declared setting is a path on the **caller's** machine,
+never a cluster-absolute path.
+
+Configure the desktop MCP process with a workspace it is allowed to read:
 
 ```powershell
 $env:CLIO_RELAY_INPUT_WORKSPACE_ROOT = "$PWD\science-workspace"
@@ -325,6 +337,34 @@ path-looking name is never sufficient authority to read a local file. Legacy or
 other remote MCP contracts also remain pass-through and cannot opt into staging.
 Large collections should use a separately managed data-staging service or
 shared storage rather than raising these control-plane limits without review.
+That is a data-management decision made by the site with its own transfer
+service; it is not permission for a client, harness, or agent to `scp` run
+inputs to the cluster beside the relay.
+
+### verify that staging engaged
+
+A job whose package declared a file-typed setting must return a non-empty
+`used_artifact_refs`, each entry pinning an artifact id and its SHA-256:
+
+```powershell
+clio-relay job used-artifacts <job-id> --cluster my-cluster
+```
+
+Non-empty, with a digest matching the caller's file, is the proof of engagement:
+the bytes travelled through relay, the configuration was rewritten to the staged
+reference, and the run is reproducible from its lineage. Empty means staging did
+not happen. Whatever the job read on the cluster arrived some other way, the run
+has no input lineage, and it is not evidence of anything even when it reports
+success and the output looks correct. Treat an empty list as a failed run and
+fix the staging path; do not work around it by placing the file on the cluster.
+
+Two configurations produce an empty list without any error. A cluster-absolute
+path in the setting is forwarded verbatim, because a path-looking value carries
+no authority to read a local file. And the built-in JARVIS door does not engage
+staging at all today, so a declared binding reached through it is silently
+skipped — that is tracked as
+[#176](https://github.com/iowarp/clio-relay/issues/176), with the end-to-end
+proof tracked as [#177](https://github.com/iowarp/clio-relay/issues/177).
 
 ## Keep the compact JARVIS surface
 

--- a/docs/remote-mcp-federation.md
+++ b/docs/remote-mcp-federation.md
@@ -274,14 +274,24 @@ must be at least the per-file bound. Relative paths are resolved under the
 workspace. Absolute paths are accepted only when the verified file remains
 inside it.
 
+Both JARVIS doors stage through the same plane. A registered route reaches it
+through its `clio-kit-jarvis-user-v3.6` registration; the built-in `jarvis_*`
+tools reach it through the relay's own pinned clio-kit release, whose contract
+digest and JARVIS-CD lock take the place of a registration revision in the
+staged route identity. The built-in door engages staging only when the JARVIS
+MCP runs on another machine: when it runs on this host the configured path is
+already the path the package reads, so nothing is transferred.
+
 Staging is schema-driven, not filename-driven. It is enabled only when all of
 these statements are true:
 
-- the registration declares exactly `contract: clio-kit-jarvis-user-v3.6` and
-  its immutable server artifact and discovered schemas match that contract;
-- the same MCP connection first completes
+- the door is the built-in JARVIS route, or a registration declares exactly
+  `contract: clio-kit-jarvis-user-v3.6` and its immutable server artifact and
+  discovered schemas match that contract;
+- the same route first completes
   `jarvis_describe(target="package", package_name=...,
-  wait_for_terminal=true)` on the same route;
+  wait_for_terminal=true)`, in this MCP connection or in an earlier one that
+  recorded the durable contract;
 - the selected package setting contains exactly
   `jarvis.configuration-input-binding.v1` with `kind="local_file"` and
   `structure="regular_file"`;
@@ -317,12 +327,19 @@ idempotency key reuses the already admitted manifest without rescanning the
 mutable workspace. A missing, unsafe, oversized, or concurrently changing file
 fails before run submission.
 
+The cluster-side materialization of a per-run manifest is accepted only for the
+registered contract. The built-in route therefore compares every tracked path
+against its staged digest before it ingests anything and refuses the run with a
+typed error naming each changed `step.setting`; call `jarvis_edit_step` on that
+setting to stage the new content, then run again.
+
 A changed route, registration, artifact, pipeline, session generation,
 checksum, or provenance fails closed rather than reusing stale bytes.
 
-Settings without the exact declaration are passed through unchanged; a
-path-looking name is never sufficient authority to read a local file. Legacy or
-other remote MCP contracts also remain pass-through and cannot opt into staging.
+Settings without the exact declaration are passed through unchanged, so a
+package that means a cluster-side absolute path keeps working; a path-looking
+name is never sufficient authority to read a local file. Legacy or other remote
+MCP contracts also remain pass-through and cannot opt into staging.
 Large collections should use a separately managed data-staging service or
 shared storage rather than raising these control-plane limits without review.
 

--- a/jarvis-packages/clio_relay/clio_relay/_jarvis_api.py
+++ b/jarvis-packages/clio_relay/clio_relay/_jarvis_api.py
@@ -16,7 +16,16 @@ if TYPE_CHECKING:
 
         config: dict[str, Any]
 
+    class ConfigurationInputBinding:
+        """Static shape of the JARVIS-CD configuration input binding used here."""
+
+        def __init__(self, *, kind: str, structure: str) -> None: ...
+
+        def to_dict(self) -> dict[str, Any]:
+            """Return the serialized binding a package menu entry publishes."""
+
 else:
     from jarvis_cd.core.pkg import Application
+    from jarvis_cd.deployment import ConfigurationInputBinding
 
-__all__ = ["Application"]
+__all__ = ["Application", "ConfigurationInputBinding"]

--- a/jarvis-packages/clio_relay/clio_relay/_jarvis_api.py
+++ b/jarvis-packages/clio_relay/clio_relay/_jarvis_api.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
         def to_dict(self) -> dict[str, Any]:
             """Return the serialized binding a package menu entry publishes."""
+            ...
 
 else:
     from jarvis_cd.core.pkg import Application

--- a/jarvis-packages/clio_relay/clio_relay/bounded_command/pkg.py
+++ b/jarvis-packages/clio_relay/clio_relay/bounded_command/pkg.py
@@ -66,22 +66,71 @@ class BoundedCommand(Application):
         """Initialize package state."""
 
     def _configure_menu(self) -> list[dict[str, Any]]:
-        """Return JARVIS configurator options."""
-        return []
+        """Return the JARVIS configurator options this package accepts.
+
+        JARVIS validates every configuration key against this menu before a
+        package is added to a pipeline, so an undeclared setting is rejected
+        even though the package would consume it.  Each option that may be
+        omitted declares a concrete default: JARVIS treats a menu entry whose
+        default is ``None`` as a required parameter.
+        """
+        return [
+            {
+                "name": "command",
+                "msg": (
+                    "Argument vector to execute, starting with the program. No shell is "
+                    "interposed, so shell syntax needs an explicit interpreter entry."
+                ),
+                "type": list,
+            },
+            {
+                "name": "workdir",
+                "msg": (
+                    "Working directory for the command. An empty string runs it in the "
+                    "directory JARVIS selected for the package."
+                ),
+                "type": str,
+                "default": "",
+            },
+            {
+                "name": "env",
+                "msg": (
+                    "Environment variables added to the inherited environment. Relay-owned "
+                    "capability variables are always removed before the command starts."
+                ),
+                "type": dict,
+                "default": {},
+            },
+            {
+                "name": "timeout_seconds",
+                "msg": (
+                    "Wall-clock limit in seconds after which the command tree is terminated. "
+                    "Zero means no limit."
+                ),
+                "type": int,
+                "default": 0,
+            },
+            {
+                "name": "progress",
+                "msg": (
+                    "Structured progress extraction from stdout: {'adapter': 'regex', "
+                    "'pattern': ...} publishes progress records, {'adapter': 'none'} "
+                    "publishes none."
+                ),
+                "type": dict,
+                "default": {"adapter": "none"},
+            },
+        ]
 
     def _configure(self, **kwargs: Any) -> None:
-        """Store configuration provided by the pipeline YAML."""
+        """Store configuration provided by the pipeline YAML or the configurator."""
+        if "command" in kwargs:
+            _command_arguments(kwargs["command"])
         self.config.update(kwargs)
 
     def start(self) -> None:
         """Run the configured command."""
-        command = self.config.get("command")
-        if not isinstance(command, list):
-            raise ValueError("command must be a string array")
-        raw_command = cast(list[object], command)
-        if not all(isinstance(item, str) for item in raw_command):
-            raise ValueError("command must be a string array")
-        command_args = [cast(str, item) for item in raw_command]
+        command_args = _command_arguments(self.config.get("command"))
         env = os.environ.copy()
         supplied_env = self.config.get("env", {})
         if isinstance(supplied_env, dict):
@@ -89,9 +138,8 @@ class BoundedCommand(Application):
             env.update({str(key): str(value) for key, value in typed_env.items()})
         env = _scrub_relay_environment(env)
         workdir_value = self.config.get("workdir")
-        workdir = Path(workdir_value) if isinstance(workdir_value, str) else None
-        timeout_value = self.config.get("timeout_seconds")
-        timeout = int(timeout_value) if timeout_value is not None else None
+        workdir = Path(workdir_value) if isinstance(workdir_value, str) and workdir_value else None
+        timeout = _optional_timeout(self.config.get("timeout_seconds"))
         result = _run_streaming(
             command_args,
             cwd=workdir,
@@ -107,6 +155,31 @@ class BoundedCommand(Application):
 
     def clean(self) -> None:
         """Clean hook for bounded commands."""
+
+
+def _command_arguments(value: object) -> list[str]:
+    """Return the configured command as an argument vector."""
+    if not isinstance(value, list):
+        raise ValueError("command must be a string array")
+    raw_command = cast(list[object], value)
+    if not raw_command:
+        raise ValueError("command must be a non-empty string array")
+    if not all(isinstance(item, str) for item in raw_command):
+        raise ValueError("command must be a string array")
+    return [cast(str, item) for item in raw_command]
+
+
+def _optional_timeout(value: object) -> int | None:
+    """Return the configured wall-clock limit, or None when no limit applies."""
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        raise ValueError("timeout_seconds must be an integer number of seconds")
+    try:
+        seconds = int(value)
+    except ValueError as exc:
+        raise ValueError("timeout_seconds must be an integer number of seconds") from exc
+    return seconds if seconds > 0 else None
 
 
 def _run_streaming(

--- a/jarvis-packages/clio_relay/clio_relay/bounded_command/pkg.py
+++ b/jarvis-packages/clio_relay/clio_relay/bounded_command/pkg.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, TextIO, cast
 
-from clio_relay._jarvis_api import Application
+from clio_relay._jarvis_api import Application, ConfigurationInputBinding
 from clio_relay.bounded_command.progress import adapter_from_config, append_progress_record
 from clio_relay.process_containment import nested_popen_kwargs, terminate_nested_process
 
@@ -120,6 +120,21 @@ class BoundedCommand(Application):
                 "type": dict,
                 "default": {"adapter": "none"},
             },
+            {
+                "name": "script",
+                "msg": (
+                    "Caller-local script staged onto the cluster and appended to 'command' "
+                    "as its final argument. The relay snapshots this file, ingests it as an "
+                    "immutable input artifact, and rewrites this setting to the staged "
+                    "cluster path before JARVIS records the step."
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file",
+                    structure="regular_file",
+                ).to_dict(),
+            },
         ]
 
     def _configure(self, **kwargs: Any) -> None:
@@ -131,6 +146,9 @@ class BoundedCommand(Application):
     def start(self) -> None:
         """Run the configured command."""
         command_args = _command_arguments(self.config.get("command"))
+        staged_script = _optional_script(self.config.get("script"))
+        if staged_script is not None:
+            command_args = [*command_args, staged_script]
         env = os.environ.copy()
         supplied_env = self.config.get("env", {})
         if isinstance(supplied_env, dict):
@@ -167,6 +185,15 @@ def _command_arguments(value: object) -> list[str]:
     if not all(isinstance(item, str) for item in raw_command):
         raise ValueError("command must be a string array")
     return [cast(str, item) for item in raw_command]
+
+
+def _optional_script(value: object) -> str | None:
+    """Return the staged script path appended to the command, or None when unset."""
+    if value is None or value == "":
+        return None
+    if not isinstance(value, str):
+        raise ValueError("script must be a path string")
+    return value
 
 
 def _optional_timeout(value: object) -> int | None:

--- a/jarvis-packages/clio_relay/clio_relay/bounded_command/pkg.py
+++ b/jarvis-packages/clio_relay/clio_relay/bounded_command/pkg.py
@@ -1,4 +1,13 @@
-"""JARVIS-CD package for bounded relay commands."""
+"""Run a bounded command on the cluster, optionally from a staged local script.
+
+The command is an explicit argument vector executed with no shell interposed,
+under a wall-clock limit, with optional structured progress extraction from
+stdout. Its script setting declares a local-file input binding: the relay
+stages one file from the caller's own machine, ingesting it as an immutable
+input artifact and appending the staged cluster path to the command as its
+final argument, so a shell script or any other interpreted file written on the
+caller's machine can be executed here without being copied by hand.
+"""
 
 from __future__ import annotations
 

--- a/jarvis-packages/clio_relay/clio_relay/mcp_call/runner.py
+++ b/jarvis-packages/clio_relay/clio_relay/mcp_call/runner.py
@@ -175,6 +175,14 @@ _CLIO_KIT_REQUEST_ENV_OVERRIDES = {
     # remains available outside the served MCP session.
     "CLIO_KIT_UV_CACHE_PRUNE": "0",
 }
+# The relay composes one site runtime identity for a JARVIS run from the Spack
+# executable its cluster registered, and publishes it to this runner under a
+# relay-owned name. The JARVIS MCP server reads JARVIS_MCP_SPACK_COMMAND before
+# it searches PATH, SPACK_ROOT/bin, ~/.local/spack or /opt/spack, so mapping the
+# composed value onto that variable makes `spack load` resolve the registered
+# executable rather than whichever one a search happens to reach.
+_RELAY_JARVIS_SPACK_COMMAND_ENV = "CLIO_RELAY_JARVIS_SPACK_COMMAND"
+_JARVIS_MCP_SPACK_COMMAND_CHILD_ENV = "JARVIS_MCP_SPACK_COMMAND"
 _JARVIS_CD_LOCK_BINDING_SCHEMA = "clio-relay.jarvis-cd-lock-binding.v1"
 # These values intentionally mirror clio_relay.bootstrap. A focused release test
 # prevents either copy from moving independently. The JARVIS package also runs as
@@ -4795,12 +4803,11 @@ def _run_mcp_session(
     jarvis_input_manifest: dict[str, Any] | None = None,
     wait_for_locked_launcher: bool = False,
 ) -> subprocess.CompletedProcess[str]:
+    overrides = _child_environment_overrides(wait_for_locked_launcher=wait_for_locked_launcher)
     process = _open_process(
         command,
         env_from=env_from or {},
-        environment_overrides=(
-            _CLIO_KIT_REQUEST_ENV_OVERRIDES if wait_for_locked_launcher else None
-        ),
+        environment_overrides=overrides or None,
     )
     previous_handlers = _install_parent_termination_handlers(process)
     stdout_queue: Queue[_StreamEvent] = Queue()
@@ -5258,6 +5265,30 @@ def _drain_available(queue: Queue[_StreamEvent], lines: list[str]) -> None:
             lines.append(f"\n[{line.message}]\n")
         elif line is not None:
             lines.append(line)
+
+
+def _child_environment_overrides(*, wait_for_locked_launcher: bool) -> dict[str, str]:
+    """Return every relay-owned value applied on top of the referenced child env."""
+    overrides: dict[str, str] = {}
+    if wait_for_locked_launcher:
+        overrides.update(_CLIO_KIT_REQUEST_ENV_OVERRIDES)
+    overrides.update(_relay_composed_run_environment())
+    return overrides
+
+
+def _relay_composed_run_environment() -> dict[str, str]:
+    """Map the relay-composed site Spack identity onto the JARVIS child variable.
+
+    Returns:
+        The child overrides, empty when the relay composed no site identity for
+        this call. The relay publishes the variable only for a JARVIS run whose
+        cluster registered a Spack executable, so an unregistered cluster keeps
+        the previous child environment exactly.
+    """
+    composed = os.environ.get(_RELAY_JARVIS_SPACK_COMMAND_ENV)
+    if not composed:
+        return {}
+    return {_JARVIS_MCP_SPACK_COMMAND_CHILD_ENV: composed}
 
 
 def _open_process(

--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -279,7 +279,6 @@ from clio_relay.session_lifecycle import (
     execute_owned_session_teardown,
     finalize_remote_session_cleanup_report,
     inspect_owned_session_recovery_status,
-    inspect_owned_session_start_status,
     open_owned_session_transaction,
     plan_remote_session_start,
     publish_owned_session_api_startup_receipt,
@@ -291,6 +290,7 @@ from clio_relay.session_lifecycle import (
     start_remote_session_durable,
     status_remote_session,
     teardown_remote_session,
+    wait_owned_session_start_status,
     watch_remote_session_start,
 )
 from clio_relay.storage_runtime import (
@@ -5449,16 +5449,26 @@ def session_start_status_owned(
         str,
         typer.Option(help="Exact cluster route revision selected by the start plan."),
     ],
+    wait_seconds: Annotated[
+        float,
+        typer.Option(
+            help=(
+                "Block here against durable start state until the observation is terminal "
+                "or this bound elapses. Zero returns one nonblocking observation."
+            )
+        ),
+    ] = 0.0,
 ) -> None:
-    """Return one nonblocking cluster-local start observation."""
+    """Return one cluster-local start observation, optionally waiting for terminal."""
 
     def action() -> None:
-        status = inspect_owned_session_start_status(
+        status = wait_owned_session_start_status(
             cluster=cluster,
             session_id=session_id,
             start_operation_id=start_operation_id,
             cluster_route_revision=cluster_route_revision,
             core_dir=RelaySettings.from_env().core_dir,
+            wait_seconds=wait_seconds,
         )
         typer.echo(status.model_dump_json(indent=2))
 

--- a/src/clio_relay/config.py
+++ b/src/clio_relay/config.py
@@ -7,7 +7,7 @@ import shlex
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Self
+from typing import Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -30,6 +30,26 @@ DEFAULT_INPUT_FILE_MAX_COUNT = 16
 MAX_INPUT_FILE_MAX_BYTES = 64 * 1024 * 1024
 MAX_INPUT_TOTAL_MAX_BYTES = 256 * 1024 * 1024
 ALLOW_UNAUTHENTICATED_OWNED_SESSION_ENV = "CLIO_RELAY_ALLOW_UNAUTHENTICATED_OWNED_SESSION"
+REMOTE_TRANSPORT_MODE_ENV = "CLIO_RELAY_REMOTE_TRANSPORT_MODE"
+REMOTE_TRANSPORT_INTERACTIVE_ENV = "CLIO_RELAY_REMOTE_TRANSPORT_INTERACTIVE"
+
+TransportMode = Literal["brokered_tcp", "udp_rendezvous", "ssh_forward"]
+"""How one remote connection reaches its remote relay.
+
+The mode is a deployment-time configuration choice, made per connection, not a
+runtime decision.  Nothing may probe one mode and switch to another: a link
+failure re-establishes the *same* configured mode or reports a typed failure.
+An operator picks ``brokered_tcp`` (TCP joined by an internet-accessible
+server), ``udp_rendezvous`` (the same rendezvous with NAT traversal), or
+``ssh_forward`` for infrastructure that permits nothing else.
+"""
+
+TRANSPORT_MODES: tuple[TransportMode, ...] = (
+    "brokered_tcp",
+    "udp_rendezvous",
+    "ssh_forward",
+)
+DEFAULT_REMOTE_TRANSPORT_MODE: TransportMode = "ssh_forward"
 
 
 class RelaySettings(BaseModel):
@@ -114,6 +134,8 @@ class RelaySettings(BaseModel):
     owner_session_generation_id: DurableRecordId | None = None
     owner_session_cluster: str | None = None
     owner_session_api_port: int | None = Field(default=None, gt=0, le=65_535)
+    remote_transport_mode: TransportMode = DEFAULT_REMOTE_TRANSPORT_MODE
+    remote_transport_interactive: bool = True
     remote_cluster: str | None = None
     session_owner_token: str | None = None
     allow_unauthenticated_owned_session: bool = False
@@ -294,6 +316,11 @@ class RelaySettings(BaseModel):
             owner_session_api_port=_optional_positive_int_env(
                 "CLIO_RELAY_OWNER_SESSION_API_PORT",
             ),
+            remote_transport_mode=_transport_mode_env(),
+            remote_transport_interactive=_boolean_env(
+                REMOTE_TRANSPORT_INTERACTIVE_ENV,
+                True,
+            ),
             remote_cluster=os.getenv("CLIO_RELAY_REMOTE_CLUSTER"),
             session_owner_token=os.getenv("CLIO_RELAY_SESSION_OWNER_TOKEN"),
             allow_unauthenticated_owned_session=_boolean_env(
@@ -413,6 +440,18 @@ def _positive_int_env(name: str, default: int) -> int:
     if value <= 0:
         raise ValueError(f"{name} must be a positive integer")
     return value
+
+
+def _transport_mode_env() -> TransportMode:
+    """Read the configured transport mode; never infer or probe one."""
+    raw = os.getenv(REMOTE_TRANSPORT_MODE_ENV)
+    if raw is None or raw == "":
+        return DEFAULT_REMOTE_TRANSPORT_MODE
+    normalized = raw.strip().lower()
+    if normalized not in TRANSPORT_MODES:
+        supported = ", ".join(TRANSPORT_MODES)
+        raise ValueError(f"{REMOTE_TRANSPORT_MODE_ENV} must be one of: {supported}")
+    return normalized
 
 
 def _optional_positive_int_env(name: str) -> int | None:

--- a/src/clio_relay/config.py
+++ b/src/clio_relay/config.py
@@ -113,6 +113,7 @@ class RelaySettings(BaseModel):
     owner_session_id: str | None = None
     owner_session_generation_id: DurableRecordId | None = None
     owner_session_cluster: str | None = None
+    owner_session_api_port: int | None = Field(default=None, gt=0, le=65_535)
     remote_cluster: str | None = None
     session_owner_token: str | None = None
     allow_unauthenticated_owned_session: bool = False
@@ -290,6 +291,9 @@ class RelaySettings(BaseModel):
             owner_session_id=os.getenv("CLIO_RELAY_OWNER_SESSION_ID"),
             owner_session_generation_id=os.getenv("CLIO_RELAY_SESSION_GENERATION_ID"),
             owner_session_cluster=os.getenv("CLIO_RELAY_OWNER_SESSION_CLUSTER"),
+            owner_session_api_port=_optional_positive_int_env(
+                "CLIO_RELAY_OWNER_SESSION_API_PORT",
+            ),
             remote_cluster=os.getenv("CLIO_RELAY_REMOTE_CLUSTER"),
             session_owner_token=os.getenv("CLIO_RELAY_SESSION_OWNER_TOKEN"),
             allow_unauthenticated_owned_session=_boolean_env(
@@ -402,6 +406,20 @@ def _positive_int_env(name: str, default: int) -> int:
     raw = os.getenv(name)
     if raw is None:
         return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be a positive integer") from exc
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def _optional_positive_int_env(name: str) -> int | None:
+    """Read one optional positive integer without inventing a default."""
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return None
     try:
         value = int(raw)
     except ValueError as exc:

--- a/src/clio_relay/control_channel.py
+++ b/src/clio_relay/control_channel.py
@@ -1,0 +1,602 @@
+"""One held relay-to-relay channel per remote connection.
+
+The relay transport design is a single persistent link between the local relay
+process and one remote relay process.  The link is established once, at
+connection bring-up, and every owned-session operation -- status, identity
+challenge, job submission, ingest, artifact content, watch -- rides it as plain
+HTTP against the mapped port.  Nothing in this module may reopen the underlying
+transport for an individual operation.
+
+Three transport modes are declared by the design:
+
+``brokered_tcp``
+    TCP through an internet-accessible relay point.  Both relays dial out and a
+    server-brokered handshake joins the two outbound connections.
+``udp_rendezvous``
+    The same rendezvous with a UDP hole-punching handshake, falling back to the
+    server-carried TCP path when traversal fails.
+``ssh_forward``
+    The fallback for infrastructure that permits nothing else: one SSH process
+    holding one port forward for the lifetime of the connection.
+
+Only ``ssh_forward`` is implemented here.  The other two modes are declared and
+refused with a typed error so that a missing mode is visible rather than
+silently degraded into per-operation SSH.
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import shlex
+import socket
+import subprocess
+import threading
+import time
+from collections.abc import Callable
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import IO, Any, Final, Literal, Protocol, cast
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field
+
+from clio_relay.cluster_config import ClusterDefinition
+from clio_relay.errors import RelayError
+from clio_relay.remote_cli import remote_env
+from clio_relay.remote_values import render_remote_shell_value
+from clio_relay.session_lifecycle import OwnedSessionIdentityChallengeRequest
+
+TransportMode = Literal["brokered_tcp", "udp_rendezvous", "ssh_forward"]
+
+CHANNEL_BOOTSTRAP_SCHEMA: Final = "clio-relay.channel-bootstrap.v1"
+CHANNEL_EVENT_SCHEMA: Final = "clio-relay.control-channel-event.v1"
+
+MAX_CHANNEL_BOOTSTRAP_BYTES: Final = 256 * 1024
+MAX_CHANNEL_EVENT_DETAIL_CHARS: Final = 2_000
+DEFAULT_CHANNEL_READY_TIMEOUT_SECONDS: Final = 30.0
+
+# A user completing interactive two-factor authorization is the expected cost of
+# bring-up in ``ssh_forward`` mode.  It is paid once per connection, so the
+# bring-up deadline is generous while every later operation is not.
+DEFAULT_CHANNEL_AUTHORIZATION_TIMEOUT_SECONDS: Final = 300.0
+
+ChannelEventName = Literal[
+    "authorization_required",
+    "establishing",
+    "established",
+    "establish_failed",
+    "dropped",
+    "reestablishing",
+    "reestablished",
+    "stream_reproven",
+    "closed",
+]
+
+
+class TransportModeUnavailable(RelayError):
+    """A declared transport mode has no implementation in this build."""
+
+
+class ChannelBootstrapError(RelayError):
+    """Bring-up could not obtain the exact out-of-band bootstrap document."""
+
+
+class ChannelDropped(RelayError):
+    """The held channel is gone and only an explicit reconnect may replace it."""
+
+
+class ChannelNotEstablished(RelayError):
+    """An operation was attempted before the connection held a channel."""
+
+
+@dataclass(frozen=True)
+class ChannelEndpoint:
+    """The local address at which the held channel reaches the remote relay."""
+
+    host: str
+    port: int
+
+    def __post_init__(self) -> None:
+        if not self.host:
+            raise ValueError("channel endpoint host must not be empty")
+        if not 1 <= self.port <= 65_535:
+            raise ValueError("channel endpoint port must be a valid TCP port")
+
+    @property
+    def base_url(self) -> str:
+        """Return the loopback base URL for HTTP requests over this channel."""
+        return f"http://{self.host}:{self.port}"
+
+
+class OwnedSessionChannelBootstrap(BaseModel):
+    """Facts the transport proves once, out of band, while establishing itself.
+
+    The owner token that signs ``identity`` is minted cluster-side and never
+    leaves the cluster, so the local relay cannot compute the expected identity
+    document on its own.  The transport therefore carries the document over the
+    same authenticated act that establishes the channel: in ``ssh_forward`` mode
+    the single SSH process that holds the forward also runs the cluster-local
+    status and challenge executors and reports their exact output.  That keeps
+    the identity proof anchored out of band without spending a second dial.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["clio-relay.channel-bootstrap.v1"] = CHANNEL_BOOTSTRAP_SCHEMA
+    status: dict[str, object] = Field(default_factory=dict[str, object])
+    identity: dict[str, object] = Field(default_factory=dict[str, object])
+
+
+class ChannelEvent(BaseModel):
+    """One typed, visible transport lifecycle transition.
+
+    Every establish, drop, and re-establish is recorded here.  A transport may
+    never degrade, retry, or redial without producing one of these.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal["clio-relay.control-channel-event.v1"] = CHANNEL_EVENT_SCHEMA
+    cluster: str = Field(min_length=1)
+    mode: TransportMode
+    event: ChannelEventName
+    attempt: int = Field(ge=0)
+    occurred_at: str
+    reason: str | None = None
+    detail: str | None = None
+    user_authorization_required: bool = False
+
+
+ChannelEventSink = Callable[[ChannelEvent], None]
+
+
+def channel_event(
+    *,
+    cluster: str,
+    mode: TransportMode,
+    event: ChannelEventName,
+    attempt: int,
+    reason: str | None = None,
+    detail: str | None = None,
+    user_authorization_required: bool = False,
+) -> ChannelEvent:
+    """Build one bounded transport event with a machine-readable reason."""
+    return ChannelEvent(
+        cluster=cluster,
+        mode=mode,
+        event=event,
+        attempt=attempt,
+        occurred_at=datetime.now(UTC).isoformat(),
+        reason=reason,
+        detail=None if detail is None else detail[:MAX_CHANNEL_EVENT_DETAIL_CHARS],
+        user_authorization_required=user_authorization_required,
+    )
+
+
+class ChannelProcess(Protocol):
+    """The subset of :class:`subprocess.Popen` a held channel process needs."""
+
+    stdin: IO[bytes] | None
+    stdout: IO[bytes] | None
+    stderr: IO[bytes] | None
+
+    def poll(self) -> int | None:
+        """Return the exit status, or None while the process still runs."""
+        ...
+
+    def terminate(self) -> None:
+        """Ask the process to stop."""
+        ...
+
+    def kill(self) -> None:
+        """Stop the process without asking."""
+        ...
+
+    def wait(self, timeout: float | None = None) -> int:
+        """Wait for process termination."""
+        ...
+
+
+ChannelProcessFactory = Callable[..., ChannelProcess]
+"""The injectable dial seam.
+
+Exactly one call to a factory of this type is exactly one new SSH connection.
+Tests assert the dial-count invariant by counting calls, so no code path may
+reach :mod:`subprocess` for the control plane except through a factory.
+"""
+
+
+def spawn_channel_process(*args: Any, **kwargs: Any) -> ChannelProcess:
+    """Spawn one real channel process (the production dial)."""
+    return cast(ChannelProcess, subprocess.Popen(*args, **kwargs))
+
+
+class RelayTransport(Protocol):
+    """One establishable relay-to-relay link.
+
+    Implementations own exactly one underlying connection for their lifetime.
+    ``establish`` may be called once per transport object; a dropped channel is
+    replaced by building a new transport, never by redialing inside one.
+    """
+
+    @property
+    def mode(self) -> TransportMode:
+        """Return the declared transport mode."""
+        ...
+
+    @property
+    def requires_user_authorization(self) -> bool:
+        """Return whether establishing may block on an interactive approval."""
+        ...
+
+    def establish(self, *, nonce: str) -> tuple[ChannelEndpoint, OwnedSessionChannelBootstrap]:
+        """Bring the link up once and return its endpoint and bootstrap facts."""
+        ...
+
+    def is_alive(self) -> bool:
+        """Return whether the link is still held."""
+        ...
+
+    def failure_detail(self) -> str | None:
+        """Return bounded diagnostic output captured from a failed link."""
+        ...
+
+    def close(self) -> None:
+        """Release the link."""
+        ...
+
+
+class SshForwardTransport:
+    """Mode (c): one SSH process holding one port forward for the connection.
+
+    The same process that holds the forward runs the cluster-local bring-up
+    command, so bring-up costs exactly one SSH connection and every subsequent
+    owned-session operation costs none.  The process is kept alive by an open
+    stdin pipe on the remote side; closing that pipe is how the channel is torn
+    down.
+    """
+
+    def __init__(
+        self,
+        *,
+        definition: ClusterDefinition,
+        session_id: str,
+        session_generation_id: str,
+        remote_api_port: int,
+        bootstrap_script: str,
+        process_factory: ChannelProcessFactory | None = None,
+        local_bind_port: int | None = None,
+        ready_timeout_seconds: float = DEFAULT_CHANNEL_READY_TIMEOUT_SECONDS,
+        authorization_timeout_seconds: float = (DEFAULT_CHANNEL_AUTHORIZATION_TIMEOUT_SECONDS),
+        allow_interactive_authorization: bool = True,
+    ) -> None:
+        if remote_api_port <= 0 or remote_api_port > 65_535:
+            raise ValueError("remote_api_port must be a valid TCP port")
+        if ready_timeout_seconds <= 0:
+            raise ValueError("ready_timeout_seconds must be positive")
+        if authorization_timeout_seconds <= 0:
+            raise ValueError("authorization_timeout_seconds must be positive")
+        self._definition = definition
+        self._session_id = session_id
+        self._session_generation_id = session_generation_id
+        self._remote_api_port = remote_api_port
+        self._bootstrap_script = bootstrap_script
+        self._process_factory = process_factory or spawn_channel_process
+        self._local_bind_port = local_bind_port
+        self._ready_timeout_seconds = ready_timeout_seconds
+        self._authorization_timeout_seconds = authorization_timeout_seconds
+        self._allow_interactive_authorization = allow_interactive_authorization
+        self._process: ChannelProcess | None = None
+        self._established = False
+        self._failure_detail: str | None = None
+
+    @property
+    def mode(self) -> TransportMode:
+        """Return the declared transport mode."""
+        return "ssh_forward"
+
+    @property
+    def requires_user_authorization(self) -> bool:
+        """Interactive two-factor approval is expected once, at bring-up."""
+        return self._allow_interactive_authorization
+
+    def argv(self, *, local_port: int) -> list[str]:
+        """Render the exact SSH argument vector for the held forward."""
+        options = [
+            "-o",
+            "ExitOnForwardFailure=yes",
+            "-o",
+            "ServerAliveInterval=15",
+            "-o",
+            "ServerAliveCountMax=4",
+        ]
+        if not self._allow_interactive_authorization:
+            # Only a non-interactive deployment (an automated gate) may refuse
+            # the authorization prompt.  The default keeps the user's single
+            # bring-up approval possible.
+            options = ["-o", "BatchMode=yes", *options]
+        return [
+            "ssh",
+            "-T",
+            *options,
+            "-L",
+            f"127.0.0.1:{local_port}:127.0.0.1:{self._remote_api_port}",
+            self._definition.ssh_host,
+            "bash",
+            "-lc",
+            self._bootstrap_script,
+        ]
+
+    def establish(self, *, nonce: str) -> tuple[ChannelEndpoint, OwnedSessionChannelBootstrap]:
+        """Dial once, hold the forward, and return the bring-up bootstrap."""
+        if self._established:
+            raise RelayError("ssh forward transport was already established")
+        if len(nonce) != 64 or any(character not in "0123456789abcdef" for character in nonce):
+            raise ValueError("channel bootstrap nonce must be a lowercase 256-bit hex value")
+        local_port = self._local_bind_port or _available_loopback_port()
+        process = self._process_factory(
+            self.argv(local_port=local_port),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self._process = process
+        self._established = True
+        try:
+            bootstrap = self._read_bootstrap(process)
+            endpoint = ChannelEndpoint(host="127.0.0.1", port=local_port)
+            _wait_for_channel_health(
+                process,
+                base_url=endpoint.base_url,
+                timeout_seconds=self._ready_timeout_seconds,
+            )
+        except BaseException:
+            self._failure_detail = self._drain_stderr()
+            self.close()
+            raise
+        return endpoint, bootstrap
+
+    def is_alive(self) -> bool:
+        """Return whether the held SSH process is still running."""
+        process = self._process
+        return process is not None and process.poll() is None
+
+    def failure_detail(self) -> str | None:
+        """Return bounded stderr captured when the channel failed."""
+        return self._failure_detail
+
+    def close(self) -> None:
+        """Close stdin so the remote holder exits, then stop the SSH process."""
+        process = self._process
+        self._process = None
+        if process is None:
+            return
+        stdin = process.stdin
+        if stdin is not None:
+            with suppress(OSError):
+                stdin.close()
+        if process.poll() is None:
+            with suppress(subprocess.TimeoutExpired, OSError):
+                process.wait(timeout=5)
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except (subprocess.TimeoutExpired, OSError):
+                process.kill()
+
+    def _read_bootstrap(self, process: ChannelProcess) -> OwnedSessionChannelBootstrap:
+        """Read the single bring-up document the held process prints first."""
+        stdout = process.stdout
+        if stdout is None:
+            raise ChannelBootstrapError("channel bring-up process has no readable output")
+        deadline_seconds = (
+            self._authorization_timeout_seconds
+            if self.requires_user_authorization
+            else self._ready_timeout_seconds
+        )
+        line = _read_line_with_deadline(
+            stdout,
+            timeout_seconds=deadline_seconds,
+            is_running=lambda: process.poll() is None,
+        )
+        if line is None:
+            detail = self._drain_stderr() or "no bring-up document was produced"
+            raise ChannelBootstrapError(
+                f"owned session channel bring-up did not report its bootstrap: {detail}"
+            )
+        if len(line) > MAX_CHANNEL_BOOTSTRAP_BYTES:
+            raise ChannelBootstrapError("owned session channel bootstrap exceeded its byte limit")
+        try:
+            document = json.loads(line.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            detail = self._drain_stderr() or line[:512].decode("utf-8", errors="replace")
+            raise ChannelBootstrapError(
+                f"owned session channel bootstrap was not UTF-8 JSON: {detail}"
+            ) from exc
+        try:
+            return OwnedSessionChannelBootstrap.model_validate(document)
+        except ValueError as exc:
+            raise ChannelBootstrapError(
+                f"owned session channel bootstrap is not the exact contract: {exc}"
+            ) from exc
+
+    def _drain_stderr(self) -> str | None:
+        """Return bounded stderr from the channel process without blocking forever."""
+        process = self._process
+        if process is None or process.stderr is None:
+            return None
+        try:
+            payload = process.stderr.read(MAX_CHANNEL_EVENT_DETAIL_CHARS)
+        except (OSError, ValueError):
+            return None
+        if not payload:
+            return None
+        return payload.decode("utf-8", errors="replace").strip() or None
+
+
+def owned_session_channel_bootstrap_script(
+    *,
+    definition: ClusterDefinition,
+    cluster: str,
+    session_id: str,
+    session_generation_id: str,
+    nonce: str,
+) -> str:
+    """Render the one cluster-local command that reports bring-up and holds the link.
+
+    The command reuses the exact cluster-local executors the per-operation SSH
+    scripts used to call one at a time -- ``session recovery-status`` and
+    ``session challenge-owned`` -- composes their already-valid JSON into one
+    line, and then blocks on stdin so the SSH session (and therefore the port
+    forward) stays up until the local relay closes the pipe.
+    """
+    relay_executable = render_remote_shell_value(
+        definition.relay_executable,
+        field="relay_executable",
+    )
+    challenge_request = OwnedSessionIdentityChallengeRequest(
+        cluster=cluster,
+        session_id=session_id,
+        session_generation_id=session_generation_id,
+        nonce=nonce,
+    ).model_dump_json()
+    return (
+        "set -euo pipefail\n"
+        "umask 077\n"
+        f"{remote_env(definition)}\n"
+        f"__clio_status=$({relay_executable} session recovery-status "
+        f"--cluster {shlex.quote(cluster)} --session-id {shlex.quote(session_id)})\n"
+        f"__clio_identity=$(printf '%s' {shlex.quote(challenge_request)} | "
+        f"{relay_executable} session challenge-owned)\n"
+        'printf \'{"schema_version":"%s","status":%s,"identity":%s}\\n\' '
+        f"{shlex.quote(CHANNEL_BOOTSTRAP_SCHEMA)} "
+        '"$__clio_status" "$__clio_identity"\n'
+        "exec cat >/dev/null\n"
+    )
+
+
+def build_transport(
+    *,
+    mode: TransportMode,
+    definition: ClusterDefinition,
+    session_id: str,
+    session_generation_id: str,
+    remote_api_port: int,
+    nonce: str,
+    process_factory: ChannelProcessFactory | None = None,
+    local_bind_port: int | None = None,
+    ready_timeout_seconds: float = DEFAULT_CHANNEL_READY_TIMEOUT_SECONDS,
+    allow_interactive_authorization: bool = True,
+) -> RelayTransport:
+    """Build the transport for one declared mode.
+
+    ``brokered_tcp`` and ``udp_rendezvous`` are part of the design and slot in
+    here as sibling implementations.  Until they exist this refuses with a typed
+    error rather than falling back, so an unimplemented mode can never quietly
+    become per-operation SSH.
+    """
+    if mode == "ssh_forward":
+        return SshForwardTransport(
+            definition=definition,
+            session_id=session_id,
+            session_generation_id=session_generation_id,
+            remote_api_port=remote_api_port,
+            bootstrap_script=owned_session_channel_bootstrap_script(
+                definition=definition,
+                cluster=definition.name,
+                session_id=session_id,
+                session_generation_id=session_generation_id,
+                nonce=nonce,
+            ),
+            process_factory=process_factory,
+            local_bind_port=local_bind_port,
+            ready_timeout_seconds=ready_timeout_seconds,
+            allow_interactive_authorization=allow_interactive_authorization,
+        )
+    if mode in ("brokered_tcp", "udp_rendezvous"):
+        raise TransportModeUnavailable(
+            f"relay transport mode {mode!r} is declared by the design but not implemented in "
+            "this build; configure the ssh_forward fallback explicitly instead of falling back"
+        )
+    raise ValueError(f"unknown relay transport mode: {mode!r}")
+
+
+def _available_loopback_port() -> int:
+    """Select an unused loopback port for the local end of the forward."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+    if not isinstance(port, int) or port <= 0:
+        raise RelayError("could not select a loopback port for the owned session channel")
+    return port
+
+
+def _read_line_with_deadline(
+    stream: IO[bytes],
+    *,
+    timeout_seconds: float,
+    is_running: Callable[[], bool],
+) -> bytes | None:
+    """Read one line within a bounded deadline without blocking the caller forever.
+
+    A pipe cannot be polled portably, so the blocking read runs on a helper
+    thread while this function owns the deadline.  The thread is a daemon: if
+    the deadline expires the caller tears the process down and the read fails.
+    """
+    results: queue.Queue[bytes | None] = queue.Queue(maxsize=1)
+
+    def _read() -> None:
+        try:
+            results.put(stream.readline())
+        except (OSError, ValueError):
+            results.put(None)
+
+    reader = threading.Thread(target=_read, name="clio-relay-channel-bootstrap", daemon=True)
+    reader.start()
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+        try:
+            line = results.get(timeout=min(0.25, remaining))
+        except queue.Empty:
+            if not is_running():
+                # The process exited; give the reader one bounded chance to
+                # surface whatever it had already buffered.
+                try:
+                    return results.get(timeout=0.5)
+                except queue.Empty:
+                    return None
+
+            continue
+        if line is None or not line.strip():
+            return None
+        return line.strip()
+
+
+def _wait_for_channel_health(
+    process: ChannelProcess,
+    *,
+    base_url: str,
+    timeout_seconds: float,
+) -> None:
+    """Wait for the mapped port to answer without opening any new transport."""
+    deadline = time.monotonic() + timeout_seconds
+    last_error = "channel forward did not become ready"
+    with httpx.Client(trust_env=False) as client:
+        while time.monotonic() < deadline:
+            if process.poll() is not None:
+                raise RelayError(f"owned session channel exited during bring-up: {last_error}")
+            try:
+                response = client.get(base_url + "/healthz", timeout=min(0.5, timeout_seconds))
+                if response.status_code == 200 and response.json().get("ok") is True:
+                    return
+                last_error = f"unexpected health response: HTTP {response.status_code}"
+            except (httpx.HTTPError, TypeError, ValueError) as exc:
+                last_error = str(exc)
+            time.sleep(0.05)
+    raise RelayError(f"owned session channel did not become ready: {last_error}")

--- a/src/clio_relay/control_channel.py
+++ b/src/clio_relay/control_channel.py
@@ -7,21 +7,26 @@ challenge, job submission, ingest, artifact content, watch -- rides it as plain
 HTTP against the mapped port.  Nothing in this module may reopen the underlying
 transport for an individual operation.
 
-Three transport modes are declared by the design:
+The mode is a deployment-time configuration choice, made per connection, and
+this layer never selects or switches one.  There is no probing, no "try TCP and
+degrade to SSH": an operator configures the pathway a connection uses, a link
+failure is reported as a typed failure, and a reconnect re-establishes the same
+configured mode.
 
 ``brokered_tcp``
     TCP through an internet-accessible relay point.  Both relays dial out and a
     server-brokered handshake joins the two outbound connections.
 ``udp_rendezvous``
-    The same rendezvous with a UDP hole-punching handshake, falling back to the
-    server-carried TCP path when traversal fails.
+    The same rendezvous with a UDP hole-punching handshake.  When traversal
+    fails its own handshake carries the link through the server instead; that
+    is internal to this mode, not a switch to another one.
 ``ssh_forward``
-    The fallback for infrastructure that permits nothing else: one SSH process
-    holding one port forward for the lifetime of the connection.
+    For infrastructure that permits nothing else: one SSH process holding one
+    port forward for the lifetime of the connection.
 
-Only ``ssh_forward`` is implemented here.  The other two modes are declared and
-refused with a typed error so that a missing mode is visible rather than
-silently degraded into per-operation SSH.
+Only ``ssh_forward`` is implemented here.  Configuring either other mode raises
+a typed error, so a missing implementation is visible rather than silently
+served by SSH.
 """
 
 from __future__ import annotations
@@ -33,6 +38,7 @@ import socket
 import subprocess
 import threading
 import time
+from collections import deque
 from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
@@ -43,12 +49,11 @@ import httpx
 from pydantic import BaseModel, ConfigDict, Field
 
 from clio_relay.cluster_config import ClusterDefinition
+from clio_relay.config import REMOTE_TRANSPORT_MODE_ENV, TransportMode
 from clio_relay.errors import RelayError
 from clio_relay.remote_cli import remote_env
 from clio_relay.remote_values import render_remote_shell_value
 from clio_relay.session_lifecycle import OwnedSessionIdentityChallengeRequest
-
-TransportMode = Literal["brokered_tcp", "udp_rendezvous", "ssh_forward"]
 
 CHANNEL_BOOTSTRAP_SCHEMA: Final = "clio-relay.channel-bootstrap.v1"
 CHANNEL_EVENT_SCHEMA: Final = "clio-relay.control-channel-event.v1"
@@ -135,6 +140,34 @@ class OwnedSessionChannelBootstrap(BaseModel):
     identity: dict[str, object] = Field(default_factory=dict[str, object])
 
 
+class StreamChannelsUnavailable(RelayError):
+    """This transport cannot yet carry multiplexed stream channels."""
+
+
+@dataclass(frozen=True)
+class ChannelLink:
+    """One established relay-to-relay link.
+
+    The link, not the owned-session API, is the unit the design holds open.
+    Owned-session request/response rides ``control_endpoint`` today, but the
+    same link is also what live application service streams must ride: a
+    compute node reaches the cluster relay over cluster-internal connectivity,
+    the cluster relay carries that traffic across this link, and the local relay
+    serves it -- identically in every mode, because a compute node on a real
+    HPC cluster has no route to the internet and cannot dial a relay host
+    itself.
+
+    ``stream_channels`` is therefore part of the link's shape from the start.
+    No mode implements it yet; :meth:`RelayTransport.open_stream_channel`
+    refuses with a typed error until one does, so adding it later extends this
+    interface instead of breaking it.
+    """
+
+    control_endpoint: ChannelEndpoint
+    bootstrap: OwnedSessionChannelBootstrap
+    stream_channels: bool = False
+
+
 class ChannelEvent(BaseModel):
     """One typed, visible transport lifecycle transition.
 
@@ -219,6 +252,56 @@ def spawn_channel_process(*args: Any, **kwargs: Any) -> ChannelProcess:
     return cast(ChannelProcess, subprocess.Popen(*args, **kwargs))
 
 
+class BoundedStderrBuffer:
+    """A drained, bounded record of what a held channel process wrote to stderr.
+
+    The channel process lives for the whole connection, so its stderr pipe must
+    be read continuously or it fills and the process blocks writing to it --
+    which in ``ssh_forward`` mode stops the port forward being serviced, with no
+    error and no event.  ``ssh -L`` writes one line per refused forwarded
+    connection, so this is reached in ordinary operation, and the pipe buffer is
+    only about 4 KiB on Windows.
+    """
+
+    def __init__(self, *, maximum_bytes: int = MAX_CHANNEL_EVENT_DETAIL_CHARS) -> None:
+        if maximum_bytes <= 0:
+            raise ValueError("stderr buffer maximum_bytes must be positive")
+        self._maximum_bytes = maximum_bytes
+        self._lock = threading.Lock()
+        self._chunks: deque[bytes] = deque()
+        self._size = 0
+
+    def append(self, payload: bytes) -> None:
+        """Record one chunk, discarding the oldest to stay inside the bound."""
+        with self._lock:
+            self._chunks.append(payload)
+            self._size += len(payload)
+            while self._size > self._maximum_bytes and len(self._chunks) > 1:
+                self._size -= len(self._chunks.popleft())
+
+    def text(self) -> str | None:
+        """Return the retained diagnostics, or None when nothing was written."""
+        with self._lock:
+            joined = b"".join(self._chunks)
+        detail = joined.decode("utf-8", errors="replace").strip()
+        return detail[-self._maximum_bytes :] or None
+
+
+def pump_stderr(stream: IO[bytes], buffer: BoundedStderrBuffer) -> threading.Thread:
+    """Continuously drain one process's stderr into a bounded buffer."""
+
+    def _pump() -> None:
+        try:
+            for line in stream:
+                buffer.append(line)
+        except (OSError, ValueError):
+            pass
+
+    thread = threading.Thread(target=_pump, name="clio-relay-channel-stderr", daemon=True)
+    thread.start()
+    return thread
+
+
 class RelayTransport(Protocol):
     """One establishable relay-to-relay link.
 
@@ -237,8 +320,18 @@ class RelayTransport(Protocol):
         """Return whether establishing may block on an interactive approval."""
         ...
 
-    def establish(self, *, nonce: str) -> tuple[ChannelEndpoint, OwnedSessionChannelBootstrap]:
-        """Bring the link up once and return its endpoint and bootstrap facts."""
+    def establish(self, *, nonce: str) -> ChannelLink:
+        """Bring the link up once and return it."""
+        ...
+
+    def open_stream_channel(self, *, name: str, remote_port: int) -> ChannelEndpoint:
+        """Map one additional stream channel onto the SAME held link.
+
+        This is how live application service traffic will ride the one link in
+        a later slice. It must never open new transport: a mode that cannot
+        multiplex additional channels onto its established link refuses with
+        :class:`StreamChannelsUnavailable` rather than dialing.
+        """
         ...
 
     def is_alive(self) -> bool:
@@ -295,6 +388,7 @@ class SshForwardTransport:
         self._authorization_timeout_seconds = authorization_timeout_seconds
         self._allow_interactive_authorization = allow_interactive_authorization
         self._process: ChannelProcess | None = None
+        self._stderr_buffer: BoundedStderrBuffer | None = None
         self._established = False
         self._failure_detail: str | None = None
 
@@ -323,6 +417,13 @@ class SshForwardTransport:
             # the authorization prompt.  The default keeps the user's single
             # bring-up approval possible.
             options = ["-o", "BatchMode=yes", *options]
+        # ssh joins its trailing operands with single spaces into ONE command
+        # string for the remote login shell; local argv boundaries are not
+        # preserved. The remote command must therefore arrive pre-quoted, the
+        # way remote_cli.py and session_lifecycle.py already do it. Passing the
+        # script as a separate argv element would strip `set -euo pipefail` of
+        # its effect and hand the body to whatever login shell the account has.
+        remote_command = f"bash -lc {shlex.quote(self._bootstrap_script)}"
         return [
             "ssh",
             "-T",
@@ -330,13 +431,11 @@ class SshForwardTransport:
             "-L",
             f"127.0.0.1:{local_port}:127.0.0.1:{self._remote_api_port}",
             self._definition.ssh_host,
-            "bash",
-            "-lc",
-            self._bootstrap_script,
+            remote_command,
         ]
 
-    def establish(self, *, nonce: str) -> tuple[ChannelEndpoint, OwnedSessionChannelBootstrap]:
-        """Dial once, hold the forward, and return the bring-up bootstrap."""
+    def establish(self, *, nonce: str) -> ChannelLink:
+        """Dial once, hold the forward, and return the established link."""
         if self._established:
             raise RelayError("ssh forward transport was already established")
         if len(nonce) != 64 or any(character not in "0123456789abcdef" for character in nonce):
@@ -350,6 +449,9 @@ class SshForwardTransport:
         )
         self._process = process
         self._established = True
+        if process.stderr is not None:
+            self._stderr_buffer = BoundedStderrBuffer()
+            pump_stderr(process.stderr, self._stderr_buffer)
         try:
             bootstrap = self._read_bootstrap(process)
             endpoint = ChannelEndpoint(host="127.0.0.1", port=local_port)
@@ -362,7 +464,20 @@ class SshForwardTransport:
             self._failure_detail = self._drain_stderr()
             self.close()
             raise
-        return endpoint, bootstrap
+        return ChannelLink(control_endpoint=endpoint, bootstrap=bootstrap)
+
+    def open_stream_channel(self, *, name: str, remote_port: int) -> ChannelEndpoint:
+        """Refuse until this mode can multiplex channels onto the held forward.
+
+        Adding a forward to an established SSH connection needs a control
+        socket on that same connection. That is multiplexing the one held link,
+        not per-operation dialing -- but it is not built here, and this must
+        never fall back to a second SSH connection.
+        """
+        raise StreamChannelsUnavailable(
+            f"ssh_forward cannot yet carry the {name!r} stream channel to remote port "
+            f"{remote_port}; live service streams must ride the one held link, not a new one"
+        )
 
     def is_alive(self) -> bool:
         """Return whether the held SSH process is still running."""
@@ -392,6 +507,12 @@ class SshForwardTransport:
                 process.wait(timeout=5)
             except (subprocess.TimeoutExpired, OSError):
                 process.kill()
+                with suppress(subprocess.TimeoutExpired, OSError):
+                    process.wait(timeout=5)
+        for stream in (process.stdout, process.stderr):
+            if stream is not None:
+                with suppress(OSError):
+                    stream.close()
 
     def _read_bootstrap(self, process: ChannelProcess) -> OwnedSessionChannelBootstrap:
         """Read the bring-up document the held process emits between its markers."""
@@ -428,17 +549,17 @@ class SshForwardTransport:
             ) from exc
 
     def _drain_stderr(self) -> str | None:
-        """Return bounded stderr from the channel process without blocking forever."""
-        process = self._process
-        if process is None or process.stderr is None:
+        """Return the most recent bounded diagnostics the channel process wrote.
+
+        This reads the ring buffer the stderr pump fills, never the pipe.  A
+        blocking read here would hang every bring-up failure path: the held
+        process is still alive, so its stderr pipe has no EOF and a fixed-size
+        read would wait for bytes that never come.
+        """
+        recorded = self._stderr_buffer
+        if recorded is None:
             return None
-        try:
-            payload = process.stderr.read(MAX_CHANNEL_EVENT_DETAIL_CHARS)
-        except (OSError, ValueError):
-            return None
-        if not payload:
-            return None
-        return payload.decode("utf-8", errors="replace").strip() or None
+        return recorded.text()
 
 
 def owned_session_channel_bootstrap_script(
@@ -503,12 +624,13 @@ def build_transport(
     ready_timeout_seconds: float = DEFAULT_CHANNEL_READY_TIMEOUT_SECONDS,
     allow_interactive_authorization: bool = True,
 ) -> RelayTransport:
-    """Build the transport for one declared mode.
+    """Build the transport for the mode this connection is configured to use.
 
     ``brokered_tcp`` and ``udp_rendezvous`` are part of the design and slot in
-    here as sibling implementations.  Until they exist this refuses with a typed
-    error rather than falling back, so an unimplemented mode can never quietly
-    become per-operation SSH.
+    here as sibling implementations.  Until they exist, asking for one is a
+    typed refusal: this function never substitutes a different mode, so a
+    connection configured for a server-brokered pathway can never quietly be
+    served by SSH instead.
     """
     if mode == "ssh_forward":
         return SshForwardTransport(
@@ -531,7 +653,8 @@ def build_transport(
     if mode in ("brokered_tcp", "udp_rendezvous"):
         raise TransportModeUnavailable(
             f"relay transport mode {mode!r} is declared by the design but not implemented in "
-            "this build; configure the ssh_forward fallback explicitly instead of falling back"
+            f"this build; set {REMOTE_TRANSPORT_MODE_ENV} to a mode this build implements "
+            "rather than expecting another mode to serve the connection"
         )
     raise ValueError(f"unknown relay transport mode: {mode!r}")
 

--- a/src/clio_relay/control_channel.py
+++ b/src/clio_relay/control_channel.py
@@ -53,6 +53,12 @@ TransportMode = Literal["brokered_tcp", "udp_rendezvous", "ssh_forward"]
 CHANNEL_BOOTSTRAP_SCHEMA: Final = "clio-relay.channel-bootstrap.v1"
 CHANNEL_EVENT_SCHEMA: Final = "clio-relay.control-channel-event.v1"
 
+# The bring-up document is framed, not positional: a login shell's profile may
+# print a banner first, and the cluster-local executors may pretty-print.
+# They begin with a letter so no shell parses them as an option operand.
+CHANNEL_BOOTSTRAP_BEGIN: Final = b"CLIO_RELAY_CHANNEL_BOOTSTRAP_BEGIN"
+CHANNEL_BOOTSTRAP_END: Final = b"CLIO_RELAY_CHANNEL_BOOTSTRAP_END"
+
 MAX_CHANNEL_BOOTSTRAP_BYTES: Final = 256 * 1024
 MAX_CHANNEL_EVENT_DETAIL_CHARS: Final = 2_000
 DEFAULT_CHANNEL_READY_TIMEOUT_SECONDS: Final = 30.0
@@ -388,7 +394,7 @@ class SshForwardTransport:
                 process.kill()
 
     def _read_bootstrap(self, process: ChannelProcess) -> OwnedSessionChannelBootstrap:
-        """Read the single bring-up document the held process prints first."""
+        """Read the bring-up document the held process emits between its markers."""
         stdout = process.stdout
         if stdout is None:
             raise ChannelBootstrapError("channel bring-up process has no readable output")
@@ -397,22 +403,20 @@ class SshForwardTransport:
             if self.requires_user_authorization
             else self._ready_timeout_seconds
         )
-        line = _read_line_with_deadline(
+        payload = _read_delimited_document(
             stdout,
             timeout_seconds=deadline_seconds,
-            is_running=lambda: process.poll() is None,
+            maximum_bytes=MAX_CHANNEL_BOOTSTRAP_BYTES,
         )
-        if line is None:
+        if payload is None:
             detail = self._drain_stderr() or "no bring-up document was produced"
             raise ChannelBootstrapError(
                 f"owned session channel bring-up did not report its bootstrap: {detail}"
             )
-        if len(line) > MAX_CHANNEL_BOOTSTRAP_BYTES:
-            raise ChannelBootstrapError("owned session channel bootstrap exceeded its byte limit")
         try:
-            document = json.loads(line.decode("utf-8"))
+            document = json.loads(payload.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            detail = self._drain_stderr() or line[:512].decode("utf-8", errors="replace")
+            detail = self._drain_stderr() or payload[:512].decode("utf-8", errors="replace")
             raise ChannelBootstrapError(
                 f"owned session channel bootstrap was not UTF-8 JSON: {detail}"
             ) from exc
@@ -463,6 +467,8 @@ def owned_session_channel_bootstrap_script(
         session_generation_id=session_generation_id,
         nonce=nonce,
     ).model_dump_json()
+    begin = CHANNEL_BOOTSTRAP_BEGIN.decode("ascii")
+    end = CHANNEL_BOOTSTRAP_END.decode("ascii")
     return (
         "set -euo pipefail\n"
         "umask 077\n"
@@ -471,9 +477,15 @@ def owned_session_channel_bootstrap_script(
         f"--cluster {shlex.quote(cluster)} --session-id {shlex.quote(session_id)})\n"
         f"__clio_identity=$(printf '%s' {shlex.quote(challenge_request)} | "
         f"{relay_executable} session challenge-owned)\n"
+        # Frame the document so a login-shell banner, or an executor that
+        # pretty-prints its JSON, cannot be mistaken for the bootstrap.
+        f"printf '%s\\n' {shlex.quote(begin)}\n"
         'printf \'{"schema_version":"%s","status":%s,"identity":%s}\\n\' '
         f"{shlex.quote(CHANNEL_BOOTSTRAP_SCHEMA)} "
         '"$__clio_status" "$__clio_identity"\n'
+        f"printf '%s\\n' {shlex.quote(end)}\n"
+        # Hold the SSH session, and therefore the port forward, until the local
+        # relay closes this pipe.
         "exec cat >/dev/null\n"
     )
 
@@ -534,48 +546,61 @@ def _available_loopback_port() -> int:
     return port
 
 
-def _read_line_with_deadline(
+def _read_delimited_document(
     stream: IO[bytes],
     *,
     timeout_seconds: float,
-    is_running: Callable[[], bool],
+    maximum_bytes: int,
 ) -> bytes | None:
-    """Read one line within a bounded deadline without blocking the caller forever.
+    """Read the marker-delimited bring-up document within a bounded deadline.
 
-    A pipe cannot be polled portably, so the blocking read runs on a helper
-    thread while this function owns the deadline.  The thread is a daemon: if
-    the deadline expires the caller tears the process down and the read fails.
+    The document is framed by explicit markers rather than assumed to be the
+    first line: the cluster-local executors are free to pretty-print their JSON,
+    and ``bash -lc`` runs a login shell whose profile may write a banner to
+    stdout before anything of ours appears.  Everything outside the markers is
+    ignored.
+
+    A pipe cannot be polled portably, so the blocking reads run on a helper
+    thread while this function owns the deadline.  The thread is a daemon and
+    ends at EOF, which the caller guarantees by tearing the process down.
     """
-    results: queue.Queue[bytes | None] = queue.Queue(maxsize=1)
+    lines: queue.Queue[bytes | None] = queue.Queue()
 
-    def _read() -> None:
+    def _pump() -> None:
         try:
-            results.put(stream.readline())
+            for line in stream:
+                lines.put(line)
         except (OSError, ValueError):
-            results.put(None)
+            pass
+        finally:
+            lines.put(None)
 
-    reader = threading.Thread(target=_read, name="clio-relay-channel-bootstrap", daemon=True)
+    reader = threading.Thread(target=_pump, name="clio-relay-channel-bootstrap", daemon=True)
     reader.start()
     deadline = time.monotonic() + timeout_seconds
+    collecting = False
+    collected: list[bytes] = []
+    collected_bytes = 0
     while True:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             return None
         try:
-            line = results.get(timeout=min(0.25, remaining))
+            line = lines.get(timeout=min(0.25, remaining))
         except queue.Empty:
-            if not is_running():
-                # The process exited; give the reader one bounded chance to
-                # surface whatever it had already buffered.
-                try:
-                    return results.get(timeout=0.5)
-                except queue.Empty:
-                    return None
-
             continue
-        if line is None or not line.strip():
+        if line is None:
             return None
-        return line.strip()
+        marker = line.strip()
+        if not collecting:
+            collecting = marker == CHANNEL_BOOTSTRAP_BEGIN
+            continue
+        if marker == CHANNEL_BOOTSTRAP_END:
+            return b"".join(collected)
+        collected_bytes += len(line)
+        if collected_bytes > maximum_bytes:
+            raise ChannelBootstrapError("owned session channel bootstrap exceeded its byte limit")
+        collected.append(line)
 
 
 def _wait_for_channel_health(

--- a/src/clio_relay/endpoint.py
+++ b/src/clio_relay/endpoint.py
@@ -2513,11 +2513,7 @@ class EndpointWorker:
             return McpRuntimeIngestOutcome(ingested=False)
         trusted, reason = _trusted_jarvis_mcp_result(job, result_document)
         if not trusted:
-            identity_matched, _identity_reason = _jarvis_mcp_result_identity_matches(
-                job,
-                result_document,
-            )
-            refusal = jarvis_dispatch_refusal(result_document) if identity_matched else None
+            refusal = _attributed_jarvis_dispatch_refusal(job, result_document)
             self.queue.append_event(
                 job.job_id,
                 "runtime.metadata_refused",
@@ -3210,6 +3206,32 @@ class EndpointWorker:
                 },
             )
         return values
+
+    def _recorded_jarvis_dispatch_refusal(
+        self,
+        job: RelayJob,
+        *,
+        spool: JobSpool,
+    ) -> JarvisDispatchRefusal | None:
+        """Return the typed refusal an earlier dispatch already persisted.
+
+        A worker that restarts, or one reconciling an attempt another worker
+        abandoned, reads the same durable answer the original dispatch recorded
+        rather than querying JARVIS for an execution the refusal proves absent.
+        """
+        storage_result_path = internal_filesystem_path(spool.path / "mcp-result.json")
+        if not storage_result_path.is_file():
+            return None
+        try:
+            document = json.loads(storage_result_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            self.queue.append_event(
+                job.job_id,
+                "runtime.metadata_read_failed",
+                f"MCP runtime result could not be read: {exc}",
+            )
+            return None
+        return _attributed_jarvis_dispatch_refusal(job, document)
 
     def _refuse_jarvis_execution_recovery(
         self,
@@ -4485,15 +4507,28 @@ class EndpointWorker:
                         relay_job_id=job.job_id,
                         task_id=task.task_id,
                     )
+                    recorded_refusal = self._recorded_jarvis_dispatch_refusal(
+                        job,
+                        spool=recovery_spool,
+                    )
                     with self._jarvis_execution_recovery_claim(job, task=task):
-                        recovered_dispatch = self._recover_jarvis_execution(
-                            job,
-                            task_id=task.task_id,
-                            spool=recovery_spool,
-                            state=recovered_state,
-                            digests=previous_digests,
-                            scheduler_job_ids=recovered_scheduler_job_ids,
-                        )
+                        if recorded_refusal is not None:
+                            self._refuse_jarvis_execution_recovery(
+                                job,
+                                task_id=task.task_id,
+                                spool=recovery_spool,
+                                refusal=recorded_refusal,
+                            )
+                            dispatch_refused = True
+                        else:
+                            recovered_dispatch = self._recover_jarvis_execution(
+                                job,
+                                task_id=task.task_id,
+                                spool=recovery_spool,
+                                state=recovered_state,
+                                digests=previous_digests,
+                                scheduler_job_ids=recovered_scheduler_job_ids,
+                            )
                     recovered_runtime = recovered_state[0]
                     task = self.queue.get_task(task.task_id)
                     recovery_intent = _durable_jarvis_execution_recovery(job, task)
@@ -6155,6 +6190,17 @@ def _jarvis_execution_recovery_is_pending(job: RelayJob, task: RelayTask) -> boo
     """Return whether scheduler identity is awaiting an exact JARVIS query."""
     intent = _durable_jarvis_execution_recovery(job, task)
     return intent is not None and intent["state"] == "pending"
+
+
+def _attributed_jarvis_dispatch_refusal(
+    job: RelayJob,
+    document: object,
+) -> JarvisDispatchRefusal | None:
+    """Return the typed refusal only when the result came from this job's route."""
+    identity_matched, _identity_reason = _jarvis_mcp_result_identity_matches(job, document)
+    if not identity_matched:
+        return None
+    return jarvis_dispatch_refusal(document)
 
 
 def _durable_jarvis_dispatch_refusal_detail(task: RelayTask) -> str:

--- a/src/clio_relay/endpoint.py
+++ b/src/clio_relay/endpoint.py
@@ -43,6 +43,12 @@ from clio_relay.filesystem_paths import (
 )
 from clio_relay.identifiers import filesystem_key
 from clio_relay.installation import installation_info
+from clio_relay.jarvis_dispatch_failure import (
+    JARVIS_DISPATCH_REFUSAL_RESOLUTION,
+    JarvisDispatchRefusal,
+    McpRuntimeIngestOutcome,
+    jarvis_dispatch_refusal,
+)
 from clio_relay.jarvis_execution import RUNTIME_SCHEDULER_PROVIDER_ENV
 from clio_relay.jarvis_mcp import (
     jarvis_cd_lock_binding_expectation,
@@ -1167,7 +1173,7 @@ class EndpointWorker:
                 package_progress_provider=package_log_progress_adapter,
                 source_authority=PackageProgressSourceAuthority.PACKAGE_LOG,
             )
-        mcp_runtime_ingested = self._ingest_mcp_runtime_metadata(
+        mcp_runtime_outcome = self._ingest_mcp_runtime_metadata(
             job,
             task_id=task.task_id,
             spool=spool,
@@ -1176,15 +1182,24 @@ class EndpointWorker:
             scheduler_job_ids=scheduler_job_ids,
         )
         dispatch_recovered = False
-        if jarvis_execution_recovery is not None and not mcp_runtime_ingested:
-            dispatch_recovered = self._recover_jarvis_execution(
-                job,
-                task_id=task.task_id,
-                spool=spool,
-                state=runtime_metadata_state,
-                digests=runtime_metadata_digests,
-                scheduler_job_ids=scheduler_job_ids,
-            )
+        dispatch_refusal = mcp_runtime_outcome.refusal
+        if jarvis_execution_recovery is not None and not mcp_runtime_outcome.ingested:
+            if dispatch_refusal is not None:
+                self._refuse_jarvis_execution_recovery(
+                    job,
+                    task_id=task.task_id,
+                    spool=spool,
+                    refusal=dispatch_refusal,
+                )
+            else:
+                dispatch_recovered = self._recover_jarvis_execution(
+                    job,
+                    task_id=task.task_id,
+                    spool=spool,
+                    state=runtime_metadata_state,
+                    digests=runtime_metadata_digests,
+                    scheduler_job_ids=scheduler_job_ids,
+                )
         scheduler_identity_reconciled = False
         if not endpoint_mcp_call or jarvis_execution_recovery is not None:
             scheduler_identity_reconciled = self._resolve_execution_ownership(
@@ -1229,7 +1244,14 @@ class EndpointWorker:
         self.queue.append_artifact(spool.artifact_for(spool.path / "stderr.log", kind="stderr"))
         self.queue.append_artifact(spool.artifact_for(spool.log_capture_path, kind="log_capture"))
         self._append_optional_result_artifacts(job, spool)
-        effective_returncode = 0 if dispatch_recovered else result.returncode
+        if dispatch_recovered:
+            effective_returncode = 0
+        elif dispatch_refusal is not None and result.returncode == 0:
+            # A recorded refusal is the run's answer. It stays the terminal
+            # outcome even if the transport that carried it exited cleanly.
+            effective_returncode = 1
+        else:
+            effective_returncode = result.returncode
         terminal_state = (
             JobState.CANCELED
             if self._job_cancellation_requested(job.job_id)
@@ -1288,19 +1310,30 @@ class EndpointWorker:
                 ),
             )
             return
+        failure_metadata: dict[str, object] = {"returncode": effective_returncode}
+        if dispatch_refusal is not None:
+            failure_metadata["jarvis_dispatch_refusal"] = dispatch_refusal.as_payload()
         self.queue.update_task_state(
             task.task_id,
             JobState.FAILED,
             message=f"Task failed: {task.name}",
-            metadata={"returncode": effective_returncode},
+            metadata=failure_metadata,
         )
         self.queue.update_job_state(
             job.job_id,
             JobState.FAILED,
             message=(
-                "Endpoint MCP operation failed" if endpoint_mcp_call else "JARVIS-CD run failed"
+                "JARVIS run failed"
+                if dispatch_refusal is not None
+                else "Endpoint MCP operation failed"
+                if endpoint_mcp_call
+                else "JARVIS-CD run failed"
             ),
-            error=f"exit code {effective_returncode}",
+            error=(
+                bounded_error_detail(dispatch_refusal.as_error_detail())
+                if dispatch_refusal is not None
+                else f"exit code {effective_returncode}"
+            ),
         )
 
     def _append_provenance_artifact(
@@ -2448,15 +2481,20 @@ class EndpointWorker:
         state: list[JarvisRuntimeMetadata | None],
         digests: set[str],
         scheduler_job_ids: list[str],
-    ) -> bool:
-        """Ingest structured runtime metadata returned by a remote MCP call."""
+    ) -> McpRuntimeIngestOutcome:
+        """Ingest structured runtime metadata returned by a remote MCP call.
+
+        Returns:
+            Whether native runtime metadata was adopted, together with the typed
+            refusal when the pinned route answered with an explicit tool error.
+        """
         route_valid, _route_reason = _trusted_jarvis_mcp_route(job)
         if not route_valid:
-            return False
+            return McpRuntimeIngestOutcome(ingested=False)
         result_path = spool.path / "mcp-result.json"
         storage_result_path = internal_filesystem_path(result_path)
         if not storage_result_path.exists():
-            return False
+            return McpRuntimeIngestOutcome(ingested=False)
         try:
             result_document = json.loads(storage_result_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
@@ -2465,9 +2503,14 @@ class EndpointWorker:
                 "runtime.metadata_read_failed",
                 f"MCP runtime result could not be read: {exc}",
             )
-            return False
+            return McpRuntimeIngestOutcome(ingested=False)
         trusted, reason = _trusted_jarvis_mcp_result(job, result_document)
         if not trusted:
+            identity_matched, _identity_reason = _jarvis_mcp_result_identity_matches(
+                job,
+                result_document,
+            )
+            refusal = jarvis_dispatch_refusal(result_document) if identity_matched else None
             self.queue.append_event(
                 job.job_id,
                 "runtime.metadata_refused",
@@ -2476,9 +2519,10 @@ class EndpointWorker:
                     "source": RuntimeMetadataSource.JARVIS_MCP.value,
                     "ownership_verified": False,
                     "reason": reason,
+                    "dispatch_refused": refusal is not None,
                 },
             )
-            return False
+            return McpRuntimeIngestOutcome(ingested=False, refusal=refusal)
         try:
             metadata = runtime_metadata_from_mcp_result_document(result_document)
         except ValueError as exc:
@@ -2496,7 +2540,7 @@ class EndpointWorker:
                 f"native JARVIS execution documents were invalid: {exc}"
             ) from exc
         if metadata is None:
-            return False
+            return McpRuntimeIngestOutcome(ingested=False)
         if not _runtime_metadata_is_native(metadata):
             self.queue.append_event(
                 job.job_id,
@@ -2508,7 +2552,7 @@ class EndpointWorker:
                     "reason": "native handle, record, and progress documents are required",
                 },
             )
-            return False
+            return McpRuntimeIngestOutcome(ingested=False)
         expected_pipeline_id = (
             job.spec.arguments.get("pipeline_id") if isinstance(job.spec, McpCallSpec) else None
         )
@@ -2565,7 +2609,7 @@ class EndpointWorker:
             resolution="dispatch_result",
             result_path=result_path,
         )
-        return True
+        return McpRuntimeIngestOutcome(ingested=True)
 
     def _recover_jarvis_execution(
         self,
@@ -3126,6 +3170,61 @@ class EndpointWorker:
                 "scheduler_job_id": metadata.scheduler_job_id,
                 "resolution": resolution,
                 "result_sha256": result_sha256,
+            },
+        )
+
+    def _refuse_jarvis_execution_recovery(
+        self,
+        job: RelayJob,
+        *,
+        task_id: str,
+        spool: JobSpool,
+        refusal: JarvisDispatchRefusal,
+    ) -> None:
+        """Settle ownership from one explicit JARVIS tool error on the dispatch.
+
+        The JARVIS user contract issues a durable execution handle only when a
+        run starts, so an ``isError`` answer proves no execution exists to query
+        or adopt. Recording it resolves the recovery intent instead of leaving
+        the durable job nonterminal behind an ownership question that cannot be
+        answered.
+        """
+        task = self.queue.get_task(task_id)
+        intent = _durable_jarvis_execution_recovery(job, task)
+        if intent is None:
+            return
+        if intent["state"] != "pending" or intent["dispatch_state"] != "started":
+            raise RelayError("JARVIS dispatch refusal did not match a released dispatch")
+        storage_result_path = internal_filesystem_path(spool.path / "mcp-result.json")
+        if not storage_result_path.is_file():
+            raise RelayError("JARVIS dispatch refusal has no durable result artifact")
+        result_sha256 = hashlib.sha256(storage_result_path.read_bytes()).hexdigest()
+        self.queue.update_task_metadata(
+            task_id,
+            {
+                "jarvis_execution_recovery": {
+                    **intent,
+                    "state": "resolved",
+                    "last_error": None,
+                    "next_retry_at": None,
+                    "result_sha256": result_sha256,
+                    "resolved_at": utc_now().isoformat(),
+                    "resolution": JARVIS_DISPATCH_REFUSAL_RESOLUTION,
+                    "scheduler_provider": None,
+                    "scheduler_job_id": None,
+                    "query_process": None,
+                },
+                "jarvis_dispatch_refusal": refusal.as_payload(),
+            },
+        )
+        self.queue.append_event(
+            job.job_id,
+            "jarvis.dispatch_refused",
+            f"JARVIS refused the run: {refusal.as_error_detail()}",
+            payload={
+                "task_id": task_id,
+                "result_sha256": result_sha256,
+                **refusal.as_payload(),
             },
         )
 
@@ -4307,6 +4406,7 @@ class EndpointWorker:
             try:
                 recovered_dispatch = False
                 dispatch_not_released = False
+                dispatch_refused = False
                 recovered_runtime: JarvisRuntimeMetadata | None = None
                 recovery_spool: JobSpool | None = None
                 process_id = self._terminate_recorded_execution(
@@ -4359,6 +4459,11 @@ class EndpointWorker:
                     recovered_runtime = recovered_state[0]
                     task = self.queue.get_task(task.task_id)
                     recovery_intent = _durable_jarvis_execution_recovery(job, task)
+                elif (
+                    recovery_intent is not None
+                    and recovery_intent.get("resolution") == JARVIS_DISPATCH_REFUSAL_RESOLUTION
+                ):
+                    dispatch_refused = True
                 elif recovery_intent is not None:
                     recovery_spool = JobSpool(
                         self.settings.spool_dir,
@@ -4374,7 +4479,7 @@ class EndpointWorker:
                     recovered_dispatch = True
                 if recovery_intent is None:
                     self._reconcile_recorded_scheduler_submission(job, task)
-                elif dispatch_not_released:
+                elif dispatch_not_released or dispatch_refused:
                     pass
                 elif recovery_intent["state"] != "resolved" or not recovered_dispatch:
                     raise SchedulerSubmissionUnresolvedError(
@@ -4389,6 +4494,7 @@ class EndpointWorker:
                     and self._scheduler_cancel_was_requested(job.job_id)
                     and recovery_intent is not None
                     and not dispatch_not_released
+                    and not dispatch_refused
                 ):
                     owned_ids = self._durable_scheduler_job_ids(
                         job,
@@ -4446,6 +4552,18 @@ class EndpointWorker:
                             job.job_id,
                             JobState.SUCCEEDED,
                             message="JARVIS MCP response recovered from durable execution",
+                        )
+                elif dispatch_refused and not cancellation_requested:
+                    current_job = self.queue.get_job(job.job_id)
+                    if current_job.state not in {
+                        JobState.FAILED,
+                        JobState.CANCELED,
+                    }:
+                        self.queue.update_job_state(
+                            job.job_id,
+                            JobState.FAILED,
+                            message="JARVIS run failed",
+                            error=_durable_jarvis_dispatch_refusal_detail(task),
                         )
                 elif dispatch_not_released and not cancellation_requested:
                     current_job = self.queue.get_job(job.job_id)
@@ -5917,7 +6035,13 @@ def _durable_jarvis_execution_recovery(
                 or re.fullmatch(r"[0-9a-f]{64}", result_sha256) is None
             )
         )
-        or resolution not in {None, "dispatch_result", "execution_query"}
+        or resolution
+        not in {
+            None,
+            "dispatch_result",
+            "execution_query",
+            JARVIS_DISPATCH_REFUSAL_RESOLUTION,
+        }
         or (
             scheduler_provider is not None
             and (not isinstance(scheduler_provider, str) or not scheduler_provider)
@@ -5995,6 +6119,20 @@ def _jarvis_execution_recovery_is_pending(job: RelayJob, task: RelayTask) -> boo
     return intent is not None and intent["state"] == "pending"
 
 
+def _durable_jarvis_dispatch_refusal_detail(task: RelayTask) -> str:
+    """Return the typed reason recorded when JARVIS refused one durable run."""
+    payload = task.metadata.get("jarvis_dispatch_refusal")
+    if isinstance(payload, dict):
+        typed = cast(dict[str, object], payload)
+        code = typed.get("code")
+        message = typed.get("message")
+        if isinstance(code, str) and code and isinstance(message, str) and message:
+            bounded = bounded_error_detail(f"{code}: {message}")
+            if bounded is not None:
+                return bounded
+    return "JARVIS refused the run without a recorded typed reason"
+
+
 def _durable_runtime_recovery_state(
     task: RelayTask,
 ) -> tuple[JarvisRuntimeMetadata | None, set[str]]:
@@ -6013,13 +6151,18 @@ def _durable_runtime_recovery_state(
     return runtime, {digest}
 
 
-def _trusted_jarvis_mcp_result(
+def _jarvis_mcp_result_identity_matches(
     job: RelayJob,
     document: object,
     *,
     expected_tool: str = "jarvis_run",
 ) -> tuple[bool, str]:
-    """Verify runtime identity came from the configured owned JARVIS MCP call."""
+    """Verify one MCP result document came from this durable job's pinned route.
+
+    Identity is independent of the call's outcome: a dispatch that answered with
+    a tool error still proves which route produced it, which is what lets the
+    worker record that answer as this job's typed failure.
+    """
     route_valid, route_reason = _trusted_jarvis_mcp_route(
         job,
         expected_tool=expected_tool,
@@ -6063,6 +6206,24 @@ def _trusted_jarvis_mcp_result(
         artifact_failure = "MCP result server artifact identity is not the exact relay release pin"
     if not artifact_verified:
         return False, artifact_failure
+    return True, "configured JARVIS MCP command and durable route matched"
+
+
+def _trusted_jarvis_mcp_result(
+    job: RelayJob,
+    document: object,
+    *,
+    expected_tool: str = "jarvis_run",
+) -> tuple[bool, str]:
+    """Verify runtime identity came from the configured owned JARVIS MCP call."""
+    identity_matched, identity_reason = _jarvis_mcp_result_identity_matches(
+        job,
+        document,
+        expected_tool=expected_tool,
+    )
+    if not identity_matched:
+        return False, identity_reason
+    typed = cast(dict[str, object], document)
     if (
         typed.get("returncode") != 0
         or typed.get("timed_out") is True

--- a/src/clio_relay/endpoint.py
+++ b/src/clio_relay/endpoint.py
@@ -56,6 +56,10 @@ from clio_relay.jarvis_mcp import (
     jarvis_mcp_server_artifact_binding_verified,
 )
 from clio_relay.jarvis_provider import JarvisCdProvider
+from clio_relay.jarvis_run_environment import (
+    jarvis_run_environment_values,
+    registered_site_spack_command,
+)
 from clio_relay.models import (
     CLIO_PROVENANCE_METADATA_KEY,
     REGISTERED_JARVIS_USER_CONTRACT,
@@ -1014,6 +1018,9 @@ class EndpointWorker:
         if endpoint_mcp_call:
             assert isinstance(job.spec, McpCallSpec)
             execution_environment_values = _minimal_mcp_runner_environment(job.spec.env_from)
+            execution_environment_values.update(
+                self._jarvis_run_environment_values(job, task_id=task.task_id)
+            )
             if progress_sidecar_enabled:
                 execution_environment_values.update(
                     {
@@ -3172,6 +3179,37 @@ class EndpointWorker:
                 "result_sha256": result_sha256,
             },
         )
+
+    def _jarvis_run_environment_values(
+        self,
+        job: RelayJob,
+        *,
+        task_id: str,
+    ) -> dict[str, str]:
+        """Compose the site runtime identity this cluster registered for JARVIS.
+
+        A ``jarvis_run`` resolves its ``spack_specs`` inside the JARVIS MCP child
+        this worker spawns, so the child needs the same Spack executable the
+        cluster registered and the Spack route already receives. A cluster that
+        declares none keeps the previous environment exactly.
+        """
+        route_valid, _route_reason = _trusted_jarvis_mcp_route(job)
+        if not route_valid:
+            return {}
+        spack_command = registered_site_spack_command(job.cluster)
+        values = jarvis_run_environment_values(spack_command)
+        if values:
+            self.queue.append_event(
+                job.job_id,
+                "jarvis.run_environment_composed",
+                "Registered cluster Spack executable composed into the JARVIS run environment",
+                payload={
+                    "task_id": task_id,
+                    "cluster": job.cluster,
+                    "spack_command": spack_command,
+                },
+            )
+        return values
 
     def _refuse_jarvis_execution_recovery(
         self,

--- a/src/clio_relay/http_api.py
+++ b/src/clio_relay/http_api.py
@@ -148,6 +148,7 @@ from clio_relay.storage_runtime import StorageAdmissionError, storage_managed_qu
 from clio_relay.validation_report import redact_sensitive_values
 
 ModelRecord = TypeVar("ModelRecord", bound=BaseModel)
+OWNED_SESSION_STATUS_SCHEMA = "clio-relay.owned-session-status.v1"
 INPUT_ARTIFACT_REQUEST_JSON_OVERHEAD_BYTES = 16 * 1024
 MAX_INPUT_ARTIFACT_BASE64_CHARS = 4 * ((MAX_INPUT_FILE_MAX_BYTES + 2) // 3)
 
@@ -1252,6 +1253,35 @@ def create_app(settings: RelaySettings | None = None) -> FastAPI:
             generation_id=resolved.owner_session_generation_id,
             nonce=nonce,
         )
+
+    @app.get("/session-status", dependencies=[auth_dependency])
+    def session_status() -> dict[str, object]:
+        """Report this live owned session over the connection's held channel.
+
+        This is the HTTP replacement for the per-operation ``ssh ... bash -s``
+        status probe.  It is the running API process describing itself, so its
+        ``evidence`` is named exactly that: it proves liveness and exact
+        identity, not the cluster-local filesystem and process ownership audit.
+        That stronger audit stays where it can actually be produced -- the
+        cluster-local recovery-status executor, carried out of band once by the
+        transport that establishes the channel.
+        """
+        if (
+            resolved.owner_session_id is None
+            or resolved.owner_session_generation_id is None
+            or owner_session_cluster is None
+        ):
+            raise HTTPException(status_code=404, detail="owned session status is unavailable")
+        return {
+            "schema_version": OWNED_SESSION_STATUS_SCHEMA,
+            "owner": "clio-relay",
+            "cluster": owner_session_cluster,
+            "session_id": resolved.owner_session_id,
+            "session_generation_id": resolved.owner_session_generation_id,
+            "remote_api_port": resolved.owner_session_api_port,
+            "running": True,
+            "evidence": "live_api_self_report",
+        }
 
     @app.get("/storage/status", dependencies=[auth_dependency])
     def storage_status() -> dict[str, object]:

--- a/src/clio_relay/input_staging.py
+++ b/src/clio_relay/input_staging.py
@@ -498,6 +498,30 @@ def reconcile_jarvis_run_inputs(
     return tuple(sorted(resolutions, key=lambda item: item.binding.identity()))
 
 
+def jarvis_run_input_drift(
+    current: JarvisPipelineInputBindings,
+    *,
+    settings: RelaySettings,
+) -> tuple[str, ...]:
+    """Return tracked step settings whose workspace content changed after staging.
+
+    A JARVIS route that cannot carry a resolved run manifest to the cluster must
+    detect drift before it ingests anything, so a changed local file becomes a
+    typed refusal rather than a run that claims bytes the configuration never
+    received.
+    """
+    snapshots = _snapshot_inputs_by_binding(current=current, settings=settings)
+    existing_by_identity = {item.identity(): item for item in current.bindings}
+    return tuple(
+        sorted(
+            f"{snapshot.step_id}.{snapshot.canonical_setting}"
+            for snapshot in snapshots
+            if existing_by_identity[(snapshot.step_id, snapshot.canonical_setting)].sha256
+            != snapshot.sha256
+        )
+    )
+
+
 def _snapshot_inputs(
     *,
     step_id: str,

--- a/src/clio_relay/jarvis_dispatch_failure.py
+++ b/src/clio_relay/jarvis_dispatch_failure.py
@@ -1,0 +1,121 @@
+"""Typed JARVIS dispatch refusals carried by a durable ``jarvis_run`` result.
+
+The registered JARVIS user contract returns a durable execution handle from
+``jarvis_run`` and resolves every requested Spack runtime *before* direct or
+scheduler execution. An explicit ``isError`` answer therefore settles ownership:
+no execution handle was issued, so there is no durable execution for the relay
+to query or adopt. The worker records that answer as a typed refusal and
+terminalizes the durable job with it instead of entering the lost-response
+recovery loop, which can only ever fail for an execution that was never created.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import cast
+
+JARVIS_DISPATCH_REFUSAL_SCHEMA = "clio-relay.jarvis-dispatch-refusal.v1"
+"""Schema of the durable event payload recording one refusal."""
+
+JARVIS_ERROR_PAYLOAD_SCHEMA = "jarvis.error.v1"
+"""Schema of the typed error document the JARVIS MCP server returns."""
+
+JARVIS_DISPATCH_REFUSAL_RESOLUTION = "dispatch_refusal"
+"""Recovery-intent resolution recorded when the dispatch itself answered."""
+
+UNTYPED_REFUSAL_CODE = "jarvis_tool_error"
+"""Code used when an ``isError`` answer carries no typed JARVIS payload."""
+
+MAX_REFUSAL_MESSAGE_CHARS = 2_000
+
+
+@dataclass(frozen=True)
+class JarvisDispatchRefusal:
+    """One explicit JARVIS tool error returned by a durable run dispatch."""
+
+    code: str
+    message: str
+    pipeline_id: str | None
+    execution_id: str | None
+    payload_schema_version: str | None
+
+    def as_payload(self) -> dict[str, object]:
+        """Return the durable event payload describing this refusal."""
+        return {
+            "schema_version": JARVIS_DISPATCH_REFUSAL_SCHEMA,
+            "code": self.code,
+            "message": self.message,
+            "pipeline_id": self.pipeline_id,
+            "execution_id": self.execution_id,
+            "payload_schema_version": self.payload_schema_version,
+        }
+
+    def as_error_detail(self) -> str:
+        """Return the typed reason recorded on the terminal durable job."""
+        return f"{self.code}: {self.message}"
+
+
+@dataclass(frozen=True)
+class McpRuntimeIngestOutcome:
+    """Result of reading one durable MCP dispatch result for runtime metadata."""
+
+    ingested: bool
+    refusal: JarvisDispatchRefusal | None = None
+
+
+def jarvis_dispatch_refusal(document: object) -> JarvisDispatchRefusal | None:
+    """Return the typed refusal when a JARVIS dispatch answered with a tool error.
+
+    Args:
+        document: The persisted ``mcp-result.json`` document. Its route identity
+            must already have been matched against the durable job spec.
+
+    Returns:
+        The typed refusal, or ``None`` when the dispatch did not return an
+        explicit tool error. A dispatch that timed out is never a refusal: the
+        response was lost rather than answered, so ownership stays unresolved.
+    """
+    if not isinstance(document, dict):
+        return None
+    typed = cast(dict[str, object], document)
+    if typed.get("timed_out") is True:
+        return None
+    protocol_result = typed.get("protocol_result")
+    if not isinstance(protocol_result, dict):
+        return None
+    if cast(dict[str, object], protocol_result).get("isError") is not True:
+        return None
+    structured = typed.get("structured_result")
+    if isinstance(structured, dict):
+        payload = cast(dict[str, object], structured)
+        error = payload.get("error")
+        if payload.get("schema_version") == JARVIS_ERROR_PAYLOAD_SCHEMA and isinstance(error, dict):
+            fields = cast(dict[str, object], error)
+            code = fields.get("code")
+            message = fields.get("message")
+            if isinstance(code, str) and code and isinstance(message, str) and message:
+                return JarvisDispatchRefusal(
+                    code=code,
+                    message=message[:MAX_REFUSAL_MESSAGE_CHARS],
+                    pipeline_id=_optional_text(fields.get("pipeline_id")),
+                    execution_id=_optional_text(fields.get("execution_id")),
+                    payload_schema_version=JARVIS_ERROR_PAYLOAD_SCHEMA,
+                )
+    protocol_error = typed.get("protocol_error")
+    message = (
+        protocol_error
+        if isinstance(protocol_error, str) and protocol_error
+        else "the JARVIS MCP tool returned isError without a typed payload"
+    )
+    return JarvisDispatchRefusal(
+        code=UNTYPED_REFUSAL_CODE,
+        message=message[:MAX_REFUSAL_MESSAGE_CHARS],
+        pipeline_id=None,
+        execution_id=None,
+        payload_schema_version=None,
+    )
+
+
+def _optional_text(value: object) -> str | None:
+    """Return one non-empty string field, or ``None`` when it is absent."""
+    return value if isinstance(value, str) and value else None

--- a/src/clio_relay/jarvis_input_plane.py
+++ b/src/clio_relay/jarvis_input_plane.py
@@ -1,0 +1,652 @@
+"""Route-agnostic staging plane for declared JARVIS package inputs.
+
+Both JARVIS doors reach the cluster through the same package contract: a package
+description declares which settings name caller-local files, and clio-relay
+snapshots, ingests, and rewrites exactly those settings before the configuration
+reaches JARVIS. This module owns that orchestration so the registered remote-MCP
+route (``clio-kit-jarvis-user-v3.6``) and the built-in virtual JARVIS door share
+one implementation instead of two drifting copies.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Protocol, cast
+from uuid import uuid4
+
+from clio_relay.cluster_config import ClusterDefinition
+from clio_relay.config import RelaySettings
+from clio_relay.core_queue import ClioCoreQueue
+from clio_relay.input_staging import (
+    JarvisPackageInputContract,
+    jarvis_package_input_contract_from_record,
+    jarvis_package_input_contract_record,
+    jarvis_package_input_route,
+    jarvis_pipeline_input_route,
+    jarvis_run_input_drift,
+    merge_artifact_uses,
+    parse_jarvis_package_input_contract,
+    reconcile_jarvis_run_inputs,
+    stage_jarvis_add_step_inputs,
+    stage_jarvis_edit_step_inputs,
+)
+from clio_relay.jarvis_mcp import (
+    CLIO_KIT_JARVIS_MCP_VERSION,
+    CLIO_KIT_JARVIS_USER_CONTRACT_ID,
+    CLIO_KIT_JARVIS_USER_CONTRACT_SHA256,
+    CLIO_KIT_JARVIS_USER_WIRE_SHA256,
+    JARVIS_MCP_CACHE_SERVER_NAME,
+)
+from clio_relay.models import (
+    ArtifactUse,
+    JarvisPackageInputRoute,
+    JarvisPipelineInputBinding,
+    JarvisPipelineInputBindings,
+    JarvisPipelineInputRoute,
+    JarvisRunInputManifest,
+    artifact_use_payload,
+)
+
+JSON = dict[str, Any]
+BUILTIN_JARVIS_SERVER_NAME = JARVIS_MCP_CACHE_SERVER_NAME
+BUILTIN_JARVIS_ROUTE_SCHEMA = "clio-relay.builtin-jarvis-route.v1"
+
+
+class JarvisInputSessionCache(Protocol):
+    """The per-client cache of package semantics observed by one MCP session."""
+
+    def remember_jarvis_package_inputs(self, contract: JarvisPackageInputContract) -> None:
+        """Remember one structured package description for this initialized client."""
+
+    def jarvis_package_inputs(self, cache_key: str) -> JarvisPackageInputContract | None:
+        """Return one exact structured package input contract, if it was observed."""
+        ...
+
+    def remember_jarvis_pipeline_inputs(
+        self,
+        cache_key: str,
+        uses: tuple[ArtifactUse, ...],
+    ) -> None:
+        """Remember immutable inputs accepted by one exact JARVIS pipeline route."""
+
+    def jarvis_pipeline_inputs(self, cache_key: str) -> tuple[ArtifactUse, ...]:
+        """Return immutable inputs previously accepted for one exact pipeline route."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class JarvisStagingRoute:
+    """One exact JARVIS door identity that staged inputs are bound to."""
+
+    cluster: str
+    server_name: str
+    cluster_route_revision: str
+    registration_revision: str
+    expected_server_artifact_digest: str | None
+    remote_tool_name: str
+    carries_run_input_manifest: bool
+    reconciles_every_description: bool
+
+
+@dataclass(frozen=True, slots=True)
+class JarvisInputPlan:
+    """Staged arguments and the durable records one JARVIS call must reconcile."""
+
+    route: JarvisStagingRoute
+    arguments: JSON
+    automatic_artifact_uses: tuple[ArtifactUse, ...] = ()
+    require_terminal_wait: bool = False
+    reconciliation_required: bool = False
+    run_input_manifest: JarvisRunInputManifest | None = None
+    run_idempotency_key: str | None = None
+    described_package_name: str | None = None
+    package_route: JarvisPackageInputRoute | None = None
+    package_cache_key: str | None = None
+    pipeline_route: JarvisPipelineInputRoute | None = None
+    pipeline_cache_key: str | None = None
+    staged_bindings: tuple[JarvisPipelineInputBinding, ...] = ()
+    removed_binding_identities: tuple[tuple[str, str], ...] = ()
+    staged_manifest_sha256: str | None = None
+    binding_mutation_required: bool = False
+
+
+def builtin_jarvis_registration_revision() -> str:
+    """Return the pinned identity of the relay's own built-in JARVIS door.
+
+    The registered route is identified by its remote-MCP registration. The
+    built-in door has no registration: its equivalent binding is the exact
+    clio-kit release and user contract this relay ships, so staged inputs never
+    cross a JARVIS contract or launcher change.
+    """
+    return _stable_digest(
+        {
+            "schema_version": BUILTIN_JARVIS_ROUTE_SCHEMA,
+            "server_name": BUILTIN_JARVIS_SERVER_NAME,
+            "contract": CLIO_KIT_JARVIS_USER_CONTRACT_ID,
+            "contract_sha256": CLIO_KIT_JARVIS_USER_CONTRACT_SHA256,
+            "wire_sha256": CLIO_KIT_JARVIS_USER_WIRE_SHA256,
+            "clio_kit_version": CLIO_KIT_JARVIS_MCP_VERSION,
+        }
+    )
+
+
+def builtin_jarvis_staging_route(
+    *,
+    cluster: str,
+    cluster_route_revision: str,
+    expected_server_artifact_digest: str | None,
+    remote_tool_name: str,
+) -> JarvisStagingRoute:
+    """Return the exact staging identity of one built-in JARVIS door call."""
+    return JarvisStagingRoute(
+        cluster=cluster,
+        server_name=BUILTIN_JARVIS_SERVER_NAME,
+        cluster_route_revision=cluster_route_revision,
+        registration_revision=builtin_jarvis_registration_revision(),
+        expected_server_artifact_digest=expected_server_artifact_digest,
+        remote_tool_name=remote_tool_name,
+        # The durable MCP call spec and the cluster-side mcp_call runner accept a
+        # resolved run manifest only for the registered contract, so the built-in
+        # door refuses drifted content instead of silently running stale bytes.
+        carries_run_input_manifest=False,
+        # A registered route reconciles every description because the structured
+        # result is also its registration acceptance evidence. The built-in door
+        # has no registration to accept, so only a package description - the one
+        # that carries input bindings - is reconciled, and every other JARVIS
+        # description keeps its asynchronous relay receipt.
+        reconciles_every_description=False,
+    )
+
+
+def prepare_jarvis_inputs(
+    forwarded_arguments: JSON,
+    *,
+    route: JarvisStagingRoute,
+    queue: ClioCoreQueue,
+    settings: RelaySettings,
+    session: JarvisInputSessionCache | None,
+    resolve_definition: Callable[[str], ClusterDefinition],
+    requested_idempotency_key: str | None,
+) -> JarvisInputPlan:
+    """Stage every declared local input this JARVIS call carries, or refuse loudly."""
+    if route.remote_tool_name == "jarvis_describe":
+        return _prepare_describe(forwarded_arguments, route=route)
+    if route.remote_tool_name == "jarvis_add_step":
+        return _prepare_add_step(
+            forwarded_arguments,
+            route=route,
+            queue=queue,
+            settings=settings,
+            session=session,
+            resolve_definition=resolve_definition,
+        )
+    if route.remote_tool_name == "jarvis_edit_step":
+        return _prepare_edit_step(
+            forwarded_arguments,
+            route=route,
+            queue=queue,
+            settings=settings,
+            resolve_definition=resolve_definition,
+        )
+    if route.remote_tool_name == "jarvis_run":
+        return _prepare_run(
+            forwarded_arguments,
+            route=route,
+            queue=queue,
+            settings=settings,
+            session=session,
+            resolve_definition=resolve_definition,
+            requested_idempotency_key=requested_idempotency_key,
+        )
+    return JarvisInputPlan(route=route, arguments=forwarded_arguments)
+
+
+def jarvis_submission_idempotency_key(
+    plan: JarvisInputPlan,
+    *,
+    merged_artifact_uses: list[ArtifactUse],
+    requested_idempotency_key: str | None,
+) -> str | None:
+    """Return the exact key a staged submission must reuse, or None when free."""
+    if plan.run_idempotency_key is not None:
+        return plan.run_idempotency_key
+    if requested_idempotency_key:
+        return requested_idempotency_key
+    if not plan.reconciliation_required:
+        return None
+    return "mcp:virtual:reconcile:" + _stable_digest(
+        {
+            "cluster": plan.route.cluster,
+            "server_name": plan.route.server_name,
+            "cluster_route_revision": plan.route.cluster_route_revision,
+            "registration_revision": plan.route.registration_revision,
+            "expected_server_artifact_digest": plan.route.expected_server_artifact_digest,
+            "tool": plan.route.remote_tool_name,
+            "arguments": plan.arguments,
+            "used_artifact_refs": [artifact_use_payload(item) for item in merged_artifact_uses],
+        }
+    )
+
+
+def record_jarvis_inputs(
+    result: JSON,
+    *,
+    plan: JarvisInputPlan,
+    queue: ClioCoreQueue,
+    session: JarvisInputSessionCache | None,
+) -> None:
+    """Accept package semantics and staged lineage only from a terminal result."""
+    tool = plan.route.remote_tool_name
+    if tool == "jarvis_describe":
+        if plan.reconciliation_required:
+            require_terminal_staging_reconciliation(result, operation="jarvis_describe")
+        _record_described_package(result, plan=plan, queue=queue, session=session)
+        return
+    if tool == "jarvis_add_step" and plan.automatic_artifact_uses:
+        require_terminal_staging_reconciliation(result, operation="jarvis_add_step")
+    if tool == "jarvis_edit_step" and plan.binding_mutation_required:
+        require_terminal_staging_reconciliation(result, operation="jarvis_edit_step")
+    if not _accepted_terminal_result(result):
+        return
+    if tool == "jarvis_add_step" and plan.pipeline_route is not None and plan.staged_bindings:
+        observed_step_id = jarvis_add_step_result_step_id(result)
+        expected_step_ids = {item.step_id for item in plan.staged_bindings}
+        if expected_step_ids != {observed_step_id}:
+            raise ValueError(
+                "jarvis_add_step returned a different step identity than its staged inputs"
+            )
+        queue.update_jarvis_pipeline_input_bindings(
+            plan.pipeline_route,
+            upserts=plan.staged_bindings,
+        )
+    if (
+        tool == "jarvis_edit_step"
+        and plan.pipeline_route is not None
+        and plan.binding_mutation_required
+    ):
+        queue.update_jarvis_pipeline_input_bindings(
+            plan.pipeline_route,
+            upserts=plan.staged_bindings,
+            remove=plan.removed_binding_identities,
+        )
+    if (
+        tool == "jarvis_add_step"
+        and plan.pipeline_route is not None
+        and plan.pipeline_cache_key is not None
+        and plan.automatic_artifact_uses
+        and plan.staged_manifest_sha256 is not None
+    ):
+        durable_lineage = queue.merge_jarvis_pipeline_input_lineage(
+            plan.pipeline_route,
+            plan.automatic_artifact_uses,
+            manifest_sha256=plan.staged_manifest_sha256,
+        )
+        if session is not None:
+            session.remember_jarvis_pipeline_inputs(
+                plan.pipeline_cache_key,
+                durable_lineage.artifact_uses,
+            )
+
+
+def require_terminal_staging_reconciliation(result: JSON, *, operation: str) -> None:
+    """Refuse to lose package semantics or staged-input lineage after a bounded wait."""
+    if result.get("terminal") is True:
+        return
+    cluster = result.get("cluster")
+    job_id = result.get("job_id")
+    route_revision = result.get("route_revision")
+    handle = f"cluster={cluster!r}, job_id={job_id!r}, route_revision={route_revision!r}"
+    raise ValueError(
+        f"{operation} did not become terminal during bounded contract reconciliation; "
+        f"the durable relay job remains observable ({handle}). Use relay_wait on that exact "
+        "handle, then retry this call with identical arguments. Relay reuses the deterministic "
+        "reconciliation identity when idempotency_key was omitted. No package contract or "
+        "staged-input lineage was accepted locally."
+    )
+
+
+def jarvis_add_step_result_step_id(result: JSON) -> str:
+    """Extract the exact accepted step identity from a terminal add-step result."""
+    raw_mcp_result = result.get("mcp_result")
+    if not isinstance(raw_mcp_result, dict):
+        raise ValueError("jarvis_add_step terminal result omitted its MCP result")
+    raw_structured = cast(JSON, raw_mcp_result).get("structured_result")
+    if not isinstance(raw_structured, dict):
+        raise ValueError("jarvis_add_step terminal result omitted structured output")
+    structured = cast(JSON, raw_structured)
+    raw_nested = structured.get("result")
+    has_flat_identity = "step_id" in structured
+    if has_flat_identity and raw_nested is not None:
+        raise ValueError("jarvis_add_step structured output has ambiguous result envelopes")
+    if has_flat_identity:
+        raw_payload = structured
+    elif isinstance(raw_nested, dict):
+        # Compatibility for relay evidence produced by the historical test adapter.
+        # FastMCP's declared JARVIS contract returns the object itself.
+        raw_payload = cast(JSON, raw_nested)
+    else:
+        raise ValueError("jarvis_add_step structured output omitted its step identity")
+    step_id = raw_payload.get("step_id")
+    if not isinstance(step_id, str) or not step_id:
+        raise ValueError("jarvis_add_step structured output omitted its step identity")
+    return step_id
+
+
+def _prepare_describe(forwarded_arguments: JSON, *, route: JarvisStagingRoute) -> JarvisInputPlan:
+    # v3.6 descriptions are control queries whose structured result is part of
+    # the agent-facing contract. Reconcile them transparently even when the
+    # generated default is omitted or a legacy client sends false.
+    described_package_name: str | None = None
+    package_route: JarvisPackageInputRoute | None = None
+    package_cache_key: str | None = None
+    if forwarded_arguments.get("target") == "package":
+        described_package_name = _required_argument(forwarded_arguments, "package_name")
+        package_route = _package_route(route, package_name=described_package_name)
+        package_cache_key = package_route.identity_sha256()
+    reconciled = route.reconciles_every_description or described_package_name is not None
+    return JarvisInputPlan(
+        route=route,
+        arguments=forwarded_arguments,
+        require_terminal_wait=reconciled,
+        reconciliation_required=reconciled,
+        described_package_name=described_package_name,
+        package_route=package_route,
+        package_cache_key=package_cache_key,
+    )
+
+
+def _prepare_add_step(
+    forwarded_arguments: JSON,
+    *,
+    route: JarvisStagingRoute,
+    queue: ClioCoreQueue,
+    settings: RelaySettings,
+    session: JarvisInputSessionCache | None,
+    resolve_definition: Callable[[str], ClusterDefinition],
+) -> JarvisInputPlan:
+    package_name = _required_argument(forwarded_arguments, "package_name")
+    package_route = _package_route(route, package_name=package_name)
+    package_cache_key = package_route.identity_sha256()
+    contract = None if session is None else session.jarvis_package_inputs(package_cache_key)
+    if contract is None:
+        durable_contract = queue.get_jarvis_package_input_contract(package_route)
+        if durable_contract is not None:
+            contract = jarvis_package_input_contract_from_record(durable_contract)
+            if session is not None:
+                session.remember_jarvis_package_inputs(contract)
+    if contract is None:
+        raise ValueError(
+            "jarvis_add_step requires a successful jarvis_describe package call on "
+            "this exact cluster route before package configuration"
+        )
+    staged = stage_jarvis_add_step_inputs(
+        forwarded_arguments,
+        contract=contract,
+        definition=resolve_definition(route.cluster),
+        settings=settings,
+    )
+    # Pipeline lineage is bound to the owner session generation that staged it.
+    # A package configuration that stages nothing needs no lineage route, so a
+    # package without declared file inputs stays usable without an owned session.
+    pipeline_route = (
+        _pipeline_route(
+            route,
+            settings=settings,
+            pipeline_id=_required_argument(staged.arguments, "pipeline_id"),
+        )
+        if staged.bindings
+        else None
+    )
+    return JarvisInputPlan(
+        route=route,
+        arguments=staged.arguments,
+        automatic_artifact_uses=staged.artifact_uses,
+        # Staged inputs become durable pipeline lineage only after JARVIS accepts
+        # this exact add-step. Never return an asynchronous receipt that can lose
+        # that acceptance edge across an MCP restart.
+        require_terminal_wait=bool(staged.artifact_uses),
+        reconciliation_required=bool(staged.artifact_uses),
+        package_route=package_route,
+        package_cache_key=package_cache_key,
+        pipeline_route=pipeline_route,
+        pipeline_cache_key=None if pipeline_route is None else pipeline_route.identity_sha256(),
+        staged_bindings=staged.bindings,
+        staged_manifest_sha256=staged.manifest_sha256,
+    )
+
+
+def _prepare_edit_step(
+    forwarded_arguments: JSON,
+    *,
+    route: JarvisStagingRoute,
+    queue: ClioCoreQueue,
+    settings: RelaySettings,
+    resolve_definition: Callable[[str], ClusterDefinition],
+) -> JarvisInputPlan:
+    if not _tracked_bindings_are_reachable(settings):
+        return JarvisInputPlan(route=route, arguments=forwarded_arguments)
+    pipeline_route = _pipeline_route(
+        route,
+        settings=settings,
+        pipeline_id=_required_argument(forwarded_arguments, "pipeline_id"),
+    )
+    current_bindings = queue.get_jarvis_pipeline_input_bindings(pipeline_route)
+    if current_bindings is None:
+        return JarvisInputPlan(
+            route=route,
+            arguments=forwarded_arguments,
+            pipeline_route=pipeline_route,
+            pipeline_cache_key=pipeline_route.identity_sha256(),
+        )
+    staged = stage_jarvis_edit_step_inputs(
+        forwarded_arguments,
+        current=current_bindings,
+        definition=resolve_definition(route.cluster),
+        settings=settings,
+    )
+    binding_mutation_required = bool(staged.bindings or staged.removed_binding_identities)
+    return JarvisInputPlan(
+        route=route,
+        arguments=staged.arguments,
+        automatic_artifact_uses=staged.artifact_uses,
+        require_terminal_wait=binding_mutation_required,
+        reconciliation_required=bool(staged.artifact_uses),
+        pipeline_route=pipeline_route,
+        pipeline_cache_key=pipeline_route.identity_sha256(),
+        staged_bindings=staged.bindings,
+        removed_binding_identities=staged.removed_binding_identities,
+        staged_manifest_sha256=staged.manifest_sha256,
+        binding_mutation_required=binding_mutation_required,
+    )
+
+
+def _prepare_run(
+    forwarded_arguments: JSON,
+    *,
+    route: JarvisStagingRoute,
+    queue: ClioCoreQueue,
+    settings: RelaySettings,
+    session: JarvisInputSessionCache | None,
+    resolve_definition: Callable[[str], ClusterDefinition],
+    requested_idempotency_key: str | None,
+) -> JarvisInputPlan:
+    if not _tracked_bindings_are_reachable(settings):
+        return JarvisInputPlan(route=route, arguments=forwarded_arguments)
+    pipeline_route = _pipeline_route(
+        route,
+        settings=settings,
+        pipeline_id=_required_argument(forwarded_arguments, "pipeline_id"),
+    )
+    pipeline_cache_key = pipeline_route.identity_sha256()
+    run_idempotency_key = requested_idempotency_key or _fresh_idempotency_key(route)
+    current_bindings = queue.get_jarvis_pipeline_input_bindings(pipeline_route)
+    if current_bindings is None or not current_bindings.bindings:
+        durable_lineage = queue.get_jarvis_pipeline_input_lineage(pipeline_route)
+        durable_uses = () if durable_lineage is None else durable_lineage.artifact_uses
+        session_uses = (
+            [] if session is None else list(session.jarvis_pipeline_inputs(pipeline_cache_key))
+        )
+        inherited_uses = tuple(merge_artifact_uses(session_uses, durable_uses))
+        return JarvisInputPlan(
+            route=route,
+            arguments=forwarded_arguments,
+            automatic_artifact_uses=inherited_uses,
+            reconciliation_required=bool(inherited_uses),
+            run_idempotency_key=run_idempotency_key,
+            pipeline_route=pipeline_route,
+            pipeline_cache_key=pipeline_cache_key,
+        )
+    run_input_manifest = queue.get_jarvis_run_input_manifest(
+        pipeline_route,
+        idempotency_key=run_idempotency_key,
+    )
+    if run_input_manifest is None:
+        if not route.carries_run_input_manifest:
+            _require_staged_content_is_current(current_bindings, settings=settings, route=route)
+        resolutions = reconcile_jarvis_run_inputs(
+            current_bindings,
+            definition=resolve_definition(route.cluster),
+            settings=settings,
+        )
+        run_input_manifest = queue.put_jarvis_run_input_manifest(
+            JarvisRunInputManifest.create(
+                route=pipeline_route,
+                idempotency_key=run_idempotency_key,
+                resolutions=resolutions,
+            )
+        )
+        queue.update_jarvis_pipeline_input_bindings(
+            pipeline_route,
+            upserts=tuple(item.binding for item in run_input_manifest.resolutions),
+        )
+    return JarvisInputPlan(
+        route=route,
+        arguments=forwarded_arguments,
+        automatic_artifact_uses=run_input_manifest.artifact_uses,
+        reconciliation_required=bool(run_input_manifest.artifact_uses),
+        run_input_manifest=run_input_manifest,
+        run_idempotency_key=run_idempotency_key,
+        pipeline_route=pipeline_route,
+        pipeline_cache_key=pipeline_cache_key,
+    )
+
+
+def _require_staged_content_is_current(
+    current_bindings: JarvisPipelineInputBindings,
+    *,
+    settings: RelaySettings,
+    route: JarvisStagingRoute,
+) -> None:
+    """Refuse a run whose staged bytes no longer match the caller's workspace."""
+    drifted = jarvis_run_input_drift(current_bindings, settings=settings)
+    if not drifted:
+        return
+    raise ValueError(
+        "local input content changed after it was staged for this pipeline: "
+        f"{', '.join(drifted)}. The "
+        f"{route.server_name} JARVIS route cannot restage inside jarvis_run; call "
+        "jarvis_edit_step with the same setting to stage the new content, then run again."
+    )
+
+
+def _record_described_package(
+    result: JSON,
+    *,
+    plan: JarvisInputPlan,
+    queue: ClioCoreQueue,
+    session: JarvisInputSessionCache | None,
+) -> None:
+    if plan.described_package_name is None or plan.package_cache_key is None:
+        return
+    package_contract = parse_jarvis_package_input_contract(
+        result,
+        cache_key=plan.package_cache_key,
+    )
+    if result.get("state") == "succeeded" and package_contract is None:
+        raise ValueError(
+            "successful jarvis_describe package call omitted its package input contract"
+        )
+    if package_contract is None:
+        return
+    if plan.described_package_name not in package_contract.package_names:
+        raise ValueError("jarvis_describe returned a different package than the requested package")
+    for package_name in package_contract.package_names:
+        alias_route = _package_route(plan.route, package_name=package_name)
+        alias_contract = JarvisPackageInputContract(
+            cache_key=alias_route.identity_sha256(),
+            package_names=package_contract.package_names,
+            local_file_settings=package_contract.local_file_settings,
+            settings_sha256=package_contract.settings_sha256,
+        )
+        saved_contract = queue.put_jarvis_package_input_contract(
+            jarvis_package_input_contract_record(route=alias_route, contract=alias_contract)
+        )
+        if session is not None:
+            session.remember_jarvis_package_inputs(
+                jarvis_package_input_contract_from_record(saved_contract)
+            )
+
+
+def _package_route(route: JarvisStagingRoute, *, package_name: str) -> JarvisPackageInputRoute:
+    return jarvis_package_input_route(
+        cluster=route.cluster,
+        server_name=route.server_name,
+        cluster_route_revision=route.cluster_route_revision,
+        registration_revision=route.registration_revision,
+        expected_server_artifact_digest=route.expected_server_artifact_digest,
+        package_name=package_name,
+    )
+
+
+def _tracked_bindings_are_reachable(settings: RelaySettings) -> bool:
+    """Return whether staged pipeline bindings can exist for this relay identity.
+
+    Every durable binding names the owner session generation that staged it, so
+    without an active owned session no binding of any pipeline is addressable and
+    there is nothing for an edit or a run to reconcile.
+    """
+    return (
+        settings.owner_session_id is not None and settings.owner_session_generation_id is not None
+    )
+
+
+def _pipeline_route(
+    route: JarvisStagingRoute,
+    *,
+    settings: RelaySettings,
+    pipeline_id: str,
+) -> JarvisPipelineInputRoute:
+    return jarvis_pipeline_input_route(
+        cluster=route.cluster,
+        server_name=route.server_name,
+        cluster_route_revision=route.cluster_route_revision,
+        registration_revision=route.registration_revision,
+        expected_server_artifact_digest=route.expected_server_artifact_digest,
+        pipeline_id=pipeline_id,
+        owner_session_id=settings.owner_session_id,
+        owner_session_generation_id=settings.owner_session_generation_id,
+    )
+
+
+def _accepted_terminal_result(result: JSON) -> bool:
+    return result.get("state") == "succeeded" and result.get("terminal") is True
+
+
+def _fresh_idempotency_key(route: JarvisStagingRoute) -> str:
+    return f"mcp:virtual:{route.cluster}:{route.server_name}:{route.remote_tool_name}:{uuid4().hex}"
+
+
+def _required_argument(arguments: JSON, key: str) -> str:
+    value = arguments.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{key} is required")
+    return value
+
+
+def _stable_digest(value: dict[str, object]) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()

--- a/src/clio_relay/jarvis_mcp.py
+++ b/src/clio_relay/jarvis_mcp.py
@@ -599,12 +599,6 @@ def virtual_jarvis_tool_definitions(*, clusters: list[str] | None = None) -> lis
                 "include_service_runtimes=true; bind one with relay_bind_jarvis_runtime before "
                 "opening a viewer. Never use execution_id as gateway_session_id."
             )
-        elif remote_tool == "jarvis_add_step":
-            tool_guidance = (
-                " package_search is discovery only. Before add_step, call jarvis_describe with "
-                "target='package' and package_name set to the selected canonical name, then use "
-                "that package-owned settings contract rather than guessing settings."
-            )
         elif remote_tool == "jarvis_run":
             tool_guidance = (
                 " wait_for_terminal is a clio-relay transport control: it waits only for the "

--- a/src/clio_relay/jarvis_run_environment.py
+++ b/src/clio_relay/jarvis_run_environment.py
@@ -1,0 +1,90 @@
+"""Site runtime identity composed by the relay for one JARVIS MCP child.
+
+The relay spawns the JARVIS MCP server itself, so it — not the operator's per
+server registration — composes that child's environment. A cluster registers one
+``spack_executable``; that path is the single Spack identity for every route on
+the cluster that needs Spack. The Spack route already receives it through its
+registered ``--spack-command`` argument. This module carries the same registered
+path to the JARVIS run environment, where ``spack load`` runs inside the JARVIS
+MCP child.
+
+The JARVIS MCP server resolves Spack from ``JARVIS_MCP_SPACK_COMMAND`` first and
+only then searches ``PATH``, ``SPACK_ROOT/bin``, ``~/.local/spack`` and
+``/opt/spack``, so an explicitly composed variable is the typed mechanism rather
+than an ambient search hit. The worker publishes the registered path under a
+relay-owned name; the bundled MCP runner maps that name onto the child variable
+the JARVIS server reads.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from clio_relay.cluster_config import ClusterRegistry, default_registry_path
+from clio_relay.errors import ConfigurationError, RelayError
+from clio_relay.remote_values import expand_remote_value_on_host
+
+RELAY_JARVIS_SPACK_COMMAND_ENV = "CLIO_RELAY_JARVIS_SPACK_COMMAND"
+"""Relay-owned worker variable carrying one cluster's registered Spack path."""
+
+JARVIS_MCP_SPACK_COMMAND_CHILD_ENV = "JARVIS_MCP_SPACK_COMMAND"
+"""Variable the JARVIS MCP server reads before any filesystem search."""
+
+
+def registered_site_spack_command(
+    cluster: str,
+    *,
+    registry_path: Path | None = None,
+) -> str | None:
+    """Return the Spack executable one cluster registered, expanded for this host.
+
+    Args:
+        cluster: Name of the cluster whose registration is being executed.
+        registry_path: Explicit registry location; defaults to the configured
+            cluster registry of the running endpoint.
+
+    Returns:
+        The registered absolute path, or ``None`` when no registry is configured
+        on this host, it does not describe this cluster, or the cluster declares
+        no Spack executable. An absent declaration never invents a default.
+
+    Raises:
+        ConfigurationError: If a configured registry cannot be read, or the
+            declared value cannot be expanded on this host. A registry that
+            exists but cannot be understood is a refusal, never a quiet
+            downgrade to an unresolved Spack runtime.
+    """
+    resolved_path = registry_path or default_registry_path()
+    if not resolved_path.exists():
+        return None
+    try:
+        registry = ClusterRegistry.load(resolved_path)
+    except (OSError, ValueError, RelayError) as error:
+        raise ConfigurationError(
+            f"configured cluster registry could not be read for {cluster}: {error}"
+        ) from error
+    definition = registry.clusters.get(cluster)
+    if definition is None or definition.spack_executable is None:
+        return None
+    return expand_remote_value_on_host(
+        definition.spack_executable,
+        field="spack_executable",
+        home=os.path.expanduser("~"),
+    )
+
+
+def jarvis_run_environment_values(spack_command: str | None) -> dict[str, str]:
+    """Return the relay-composed run-environment values for a JARVIS MCP call.
+
+    Args:
+        spack_command: The cluster's registered Spack executable, or ``None``
+            when the cluster declares none.
+
+    Returns:
+        A mapping to merge into the MCP runner environment. It is empty when the
+        cluster declares no Spack executable, leaving behavior unchanged.
+    """
+    if spack_command is None:
+        return {}
+    return {RELAY_JARVIS_SPACK_COMMAND_ENV: spack_command}

--- a/src/clio_relay/live_acceptance.py
+++ b/src/clio_relay/live_acceptance.py
@@ -47,6 +47,10 @@ from clio_relay.jarvis_service_runtime import (
     JarvisServiceRuntimeBinding,
     JarvisServiceRuntimeHandoff,
 )
+from clio_relay.job_identity import (
+    OWNER_SESSION_ID_HEADER,
+    SESSION_GENERATION_ID_HEADER,
+)
 from clio_relay.mcp_stdio_validation import (
     PackagedMcpStdioSession,
     decode_strict_json,
@@ -72,10 +76,6 @@ from clio_relay.runtime_metadata import (
     native_execution_documents,
 )
 from clio_relay.service_runtime import ServiceRuntimeStopResult, ServiceRuntimeSupervisor
-from clio_relay.session_api import (
-    OWNER_SESSION_ID_HEADER,
-    SESSION_GENERATION_ID_HEADER,
-)
 from clio_relay.storage_runtime import StorageManagedQueue, storage_managed_queue
 from clio_relay.transport_probe import (
     run_frp_direct_http_probe,

--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -43,15 +43,15 @@ from clio_relay.identifiers import (
 from clio_relay.input_staging import (
     REGISTERED_JARVIS_CONTRACT_ID,
     JarvisPackageInputContract,
-    jarvis_package_input_contract_from_record,
-    jarvis_package_input_contract_record,
-    jarvis_package_input_route,
-    jarvis_pipeline_input_route,
     merge_artifact_uses,
-    parse_jarvis_package_input_contract,
-    reconcile_jarvis_run_inputs,
-    stage_jarvis_add_step_inputs,
-    stage_jarvis_edit_step_inputs,
+)
+from clio_relay.jarvis_input_plane import (
+    JarvisInputPlan,
+    JarvisStagingRoute,
+    builtin_jarvis_staging_route,
+    jarvis_submission_idempotency_key,
+    prepare_jarvis_inputs,
+    record_jarvis_inputs,
 )
 from clio_relay.jarvis_mcp import (
     JARVIS_MCP_CACHE_SERVER_NAME,
@@ -65,6 +65,7 @@ from clio_relay.jarvis_mcp import (
     jarvis_service_runtime_handoff_json_schema,
     render_virtual_jarvis_agent_context,
     virtual_jarvis_call_arguments,
+    virtual_jarvis_remote_tool,
     virtual_jarvis_tool_definitions,
 )
 from clio_relay.jarvis_service_runtime import (
@@ -82,8 +83,6 @@ from clio_relay.models import (
     Cursor,
     GatewaySession,
     GatewaySessionState,
-    JarvisPackageInputRoute,
-    JarvisPipelineInputBinding,
     JarvisRunInputManifest,
     JarvisRunSpec,
     JobKind,
@@ -1850,10 +1849,10 @@ def _call_tool(
         result = _submit_jarvis_mcp_call(arguments, queue=queue, settings=settings)
     elif is_virtual_jarvis_tool(name):
         call_arguments = virtual_jarvis_call_arguments(name, arguments)
+        cluster = _required_str(call_arguments, "cluster")
         if require_advertised_remote_mcp_catalog:
             if catalog is None:
                 raise ValueError("JARVIS virtual tool catalog was not resolved")
-            cluster = _required_str(call_arguments, "cluster")
             expected_route_revision = catalog.cluster_route_revisions.get(cluster)
             if expected_route_revision is None:
                 raise ValueError(
@@ -1867,7 +1866,18 @@ def _call_tool(
                 )
             call_arguments["expected_cluster_route_revision"] = expected_route_revision
             call_arguments["catalog_expected_server_artifact_digest"] = expected_artifact_digest
+        builtin_plan = _stage_builtin_jarvis_inputs(
+            call_arguments,
+            tool_name=name,
+            cluster=cluster,
+            queue=queue,
+            settings=settings,
+            session=session,
+            requested_idempotency_key=arguments.get("idempotency_key"),
+        )
         result = _submit_jarvis_mcp_call(call_arguments, queue=queue, settings=settings)
+        if builtin_plan is not None:
+            record_jarvis_inputs(result, plan=builtin_plan, queue=queue, session=session)
         if catalog is None:
             raise ValueError("JARVIS virtual tool catalog was not resolved")
         result["catalog_revision"] = catalog.revision
@@ -1877,169 +1887,35 @@ def _call_tool(
         route = catalog.resolve(name, cluster)
         forwarded_arguments = catalog.forwarded_arguments(name, arguments)
         relay_arguments = catalog.relay_arguments(name, arguments)
-        described_package_name: str | None = None
-        package_input_route: JarvisPackageInputRoute | None = None
-        package_cache_key: str | None = None
-        pipeline_cache_key: str | None = None
-        pipeline_input_route = None
-        automatic_input_uses: tuple[ArtifactUse, ...] = ()
-        staged_input_manifest_sha256: str | None = None
-        staged_input_bindings: tuple[JarvisPipelineInputBinding, ...] = ()
-        removed_input_binding_identities: tuple[tuple[str, str], ...] = ()
-        binding_mutation_required = False
-        run_input_manifest: JarvisRunInputManifest | None = None
-        base_idempotency_key: str | None = None
+        raw_requested_key = relay_arguments.get("idempotency_key")
+        requested_idempotency_key = str(raw_requested_key) if raw_requested_key else None
+        input_plan: JarvisInputPlan | None = None
         if route.contract == REGISTERED_JARVIS_CONTRACT_ID:
             if session is None:
                 raise ValueError("registered JARVIS package semantics require an MCP session")
-            if route.remote_tool_name == "jarvis_describe":
-                # v3.6 descriptions are control queries whose structured result is part of
-                # the agent-facing contract. Reconcile them transparently even when the
-                # generated default is omitted or a legacy client sends false.
+            input_plan = prepare_jarvis_inputs(
+                forwarded_arguments,
+                route=JarvisStagingRoute(
+                    cluster=cluster,
+                    server_name=route.server_name,
+                    cluster_route_revision=route.cluster_route_revision,
+                    registration_revision=route.registration_revision,
+                    expected_server_artifact_digest=route.expected_server_artifact_digest,
+                    remote_tool_name=route.remote_tool_name,
+                    carries_run_input_manifest=True,
+                    reconciles_every_description=True,
+                ),
+                queue=queue,
+                settings=settings,
+                session=session,
+                resolve_definition=_remote_cluster_definition,
+                requested_idempotency_key=requested_idempotency_key,
+            )
+            forwarded_arguments = input_plan.arguments
+            if input_plan.require_terminal_wait:
                 relay_arguments["wait_for_terminal"] = True
-                if forwarded_arguments.get("target") == "package":
-                    described_package_name = _required_str(forwarded_arguments, "package_name")
-                    package_input_route = jarvis_package_input_route(
-                        cluster=cluster,
-                        server_name=route.server_name,
-                        cluster_route_revision=route.cluster_route_revision,
-                        registration_revision=route.registration_revision,
-                        expected_server_artifact_digest=route.expected_server_artifact_digest,
-                        package_name=described_package_name,
-                    )
-                    package_cache_key = package_input_route.identity_sha256()
-            elif route.remote_tool_name == "jarvis_add_step":
-                package_name = _required_str(forwarded_arguments, "package_name")
-                package_input_route = jarvis_package_input_route(
-                    cluster=cluster,
-                    server_name=route.server_name,
-                    cluster_route_revision=route.cluster_route_revision,
-                    registration_revision=route.registration_revision,
-                    expected_server_artifact_digest=route.expected_server_artifact_digest,
-                    package_name=package_name,
-                )
-                package_cache_key = package_input_route.identity_sha256()
-                package_contract = session.jarvis_package_inputs(package_cache_key)
-                if package_contract is None:
-                    durable_contract = queue.get_jarvis_package_input_contract(package_input_route)
-                    if durable_contract is not None:
-                        package_contract = jarvis_package_input_contract_from_record(
-                            durable_contract
-                        )
-                        session.remember_jarvis_package_inputs(package_contract)
-                if package_contract is None:
-                    raise ValueError(
-                        "jarvis_add_step requires a successful jarvis_describe package call on "
-                        "this exact registered cluster route before package configuration"
-                    )
-                staged = stage_jarvis_add_step_inputs(
-                    forwarded_arguments,
-                    contract=package_contract,
-                    definition=_remote_cluster_definition(cluster),
-                    settings=settings,
-                )
-                forwarded_arguments = staged.arguments
-                automatic_input_uses = staged.artifact_uses
-                staged_input_manifest_sha256 = staged.manifest_sha256
-                staged_input_bindings = staged.bindings
-                if automatic_input_uses:
-                    # Staged inputs become durable pipeline lineage only after JARVIS accepts
-                    # this exact add-step. Never return an asynchronous receipt that can lose
-                    # that acceptance edge across an MCP restart.
-                    relay_arguments["wait_for_terminal"] = True
-                pipeline_input_route = jarvis_pipeline_input_route(
-                    cluster=cluster,
-                    server_name=route.server_name,
-                    cluster_route_revision=route.cluster_route_revision,
-                    registration_revision=route.registration_revision,
-                    expected_server_artifact_digest=route.expected_server_artifact_digest,
-                    pipeline_id=_required_str(forwarded_arguments, "pipeline_id"),
-                    owner_session_id=settings.owner_session_id,
-                    owner_session_generation_id=settings.owner_session_generation_id,
-                )
-                pipeline_cache_key = pipeline_input_route.identity_sha256()
-            elif route.remote_tool_name == "jarvis_edit_step":
-                pipeline_input_route = jarvis_pipeline_input_route(
-                    cluster=cluster,
-                    server_name=route.server_name,
-                    cluster_route_revision=route.cluster_route_revision,
-                    registration_revision=route.registration_revision,
-                    expected_server_artifact_digest=route.expected_server_artifact_digest,
-                    pipeline_id=_required_str(forwarded_arguments, "pipeline_id"),
-                    owner_session_id=settings.owner_session_id,
-                    owner_session_generation_id=settings.owner_session_generation_id,
-                )
-                pipeline_cache_key = pipeline_input_route.identity_sha256()
-                current_bindings = queue.get_jarvis_pipeline_input_bindings(pipeline_input_route)
-                if current_bindings is not None:
-                    staged = stage_jarvis_edit_step_inputs(
-                        forwarded_arguments,
-                        current=current_bindings,
-                        definition=_remote_cluster_definition(cluster),
-                        settings=settings,
-                    )
-                    forwarded_arguments = staged.arguments
-                    automatic_input_uses = staged.artifact_uses
-                    staged_input_manifest_sha256 = staged.manifest_sha256
-                    staged_input_bindings = staged.bindings
-                    removed_input_binding_identities = staged.removed_binding_identities
-                    binding_mutation_required = bool(
-                        staged_input_bindings or removed_input_binding_identities
-                    )
-                    if binding_mutation_required:
-                        relay_arguments["wait_for_terminal"] = True
-            elif route.remote_tool_name == "jarvis_run":
-                pipeline_input_route = jarvis_pipeline_input_route(
-                    cluster=cluster,
-                    server_name=route.server_name,
-                    cluster_route_revision=route.cluster_route_revision,
-                    registration_revision=route.registration_revision,
-                    expected_server_artifact_digest=route.expected_server_artifact_digest,
-                    pipeline_id=_required_str(forwarded_arguments, "pipeline_id"),
-                    owner_session_id=settings.owner_session_id,
-                    owner_session_generation_id=settings.owner_session_generation_id,
-                )
-                pipeline_cache_key = pipeline_input_route.identity_sha256()
-                base_idempotency_key = str(
-                    relay_arguments.get("idempotency_key")
-                    or (
-                        f"mcp:virtual:{cluster}:{route.server_name}:"
-                        f"{route.remote_tool_name}:{uuid4().hex}"
-                    )
-                )
-                current_bindings = queue.get_jarvis_pipeline_input_bindings(pipeline_input_route)
-                if current_bindings is not None and current_bindings.bindings:
-                    run_input_manifest = queue.get_jarvis_run_input_manifest(
-                        pipeline_input_route,
-                        idempotency_key=base_idempotency_key,
-                    )
-                    if run_input_manifest is None:
-                        resolutions = reconcile_jarvis_run_inputs(
-                            current_bindings,
-                            definition=_remote_cluster_definition(cluster),
-                            settings=settings,
-                        )
-                        run_input_manifest = queue.put_jarvis_run_input_manifest(
-                            JarvisRunInputManifest.create(
-                                route=pipeline_input_route,
-                                idempotency_key=base_idempotency_key,
-                                resolutions=resolutions,
-                            )
-                        )
-                        queue.update_jarvis_pipeline_input_bindings(
-                            pipeline_input_route,
-                            upserts=tuple(item.binding for item in run_input_manifest.resolutions),
-                        )
-                    automatic_input_uses = run_input_manifest.artifact_uses
-                else:
-                    durable_lineage = queue.get_jarvis_pipeline_input_lineage(pipeline_input_route)
-                    durable_uses = () if durable_lineage is None else durable_lineage.artifact_uses
-                    automatic_input_uses = tuple(
-                        merge_artifact_uses(
-                            list(session.jarvis_pipeline_inputs(pipeline_cache_key)),
-                            durable_uses,
-                        )
-                    )
+        automatic_input_uses = () if input_plan is None else input_plan.automatic_artifact_uses
+        run_input_manifest = None if input_plan is None else input_plan.run_input_manifest
         merged_input_uses = merge_artifact_uses(
             _artifact_use_refs(relay_arguments),
             automatic_input_uses,
@@ -2048,34 +1924,19 @@ def _call_tool(
             relay_arguments["used_artifact_refs"] = [
                 artifact_use_payload(item) for item in merged_input_uses
             ]
-        reconciliation_required = (
-            route.contract == REGISTERED_JARVIS_CONTRACT_ID
-            and route.remote_tool_name == "jarvis_describe"
-        ) or bool(automatic_input_uses)
-        reconciliation_idempotency_key = "mcp:virtual:reconcile:" + _stable_digest(
-            {
-                "cluster": cluster,
-                "server_name": route.server_name,
-                "cluster_route_revision": route.cluster_route_revision,
-                "registration_revision": route.registration_revision,
-                "expected_server_artifact_digest": route.expected_server_artifact_digest,
-                "tool": route.remote_tool_name,
-                "arguments": forwarded_arguments,
-                "used_artifact_refs": [artifact_use_payload(item) for item in merged_input_uses],
-            }
-        )
-        if base_idempotency_key is None:
-            base_idempotency_key = str(
-                relay_arguments.get("idempotency_key")
-                or (
-                    reconciliation_idempotency_key
-                    if reconciliation_required
-                    else (
-                        f"mcp:virtual:{cluster}:{route.server_name}:"
-                        f"{route.remote_tool_name}:{uuid4().hex}"
-                    )
-                )
+        staged_idempotency_key = (
+            None
+            if input_plan is None
+            else jarvis_submission_idempotency_key(
+                input_plan,
+                merged_artifact_uses=merged_input_uses,
+                requested_idempotency_key=requested_idempotency_key,
             )
+        )
+        base_idempotency_key = staged_idempotency_key or str(
+            requested_idempotency_key
+            or (f"mcp:virtual:{cluster}:{route.server_name}:{route.remote_tool_name}:{uuid4().hex}")
+        )
         result = _submit_mcp_call(
             {
                 "cluster": cluster,
@@ -2112,102 +1973,8 @@ def _call_tool(
             queue=queue,
             settings=settings,
         )
-        if (
-            route.contract == REGISTERED_JARVIS_CONTRACT_ID
-            and route.remote_tool_name == "jarvis_describe"
-        ):
-            _require_terminal_staging_reconciliation(result, operation="jarvis_describe")
-        if described_package_name is not None and package_cache_key is not None:
-            assert session is not None
-            package_contract = parse_jarvis_package_input_contract(
-                result,
-                cache_key=package_cache_key,
-            )
-            if result.get("state") == "succeeded" and package_contract is None:
-                raise ValueError(
-                    "successful jarvis_describe package call omitted its package input contract"
-                )
-            if package_contract is not None:
-                if described_package_name not in package_contract.package_names:
-                    raise ValueError(
-                        "jarvis_describe returned a different package than the requested package"
-                    )
-                for package_name in package_contract.package_names:
-                    alias_route = jarvis_package_input_route(
-                        cluster=cluster,
-                        server_name=route.server_name,
-                        cluster_route_revision=route.cluster_route_revision,
-                        registration_revision=route.registration_revision,
-                        expected_server_artifact_digest=route.expected_server_artifact_digest,
-                        package_name=package_name,
-                    )
-                    alias_contract = JarvisPackageInputContract(
-                        cache_key=alias_route.identity_sha256(),
-                        package_names=package_contract.package_names,
-                        local_file_settings=package_contract.local_file_settings,
-                        settings_sha256=package_contract.settings_sha256,
-                    )
-                    saved_contract = queue.put_jarvis_package_input_contract(
-                        jarvis_package_input_contract_record(
-                            route=alias_route,
-                            contract=alias_contract,
-                        )
-                    )
-                    session.remember_jarvis_package_inputs(
-                        jarvis_package_input_contract_from_record(saved_contract)
-                    )
-        if route.remote_tool_name == "jarvis_add_step" and automatic_input_uses:
-            _require_terminal_staging_reconciliation(result, operation="jarvis_add_step")
-        if route.remote_tool_name == "jarvis_edit_step" and binding_mutation_required:
-            _require_terminal_staging_reconciliation(result, operation="jarvis_edit_step")
-        if (
-            route.remote_tool_name == "jarvis_add_step"
-            and pipeline_input_route is not None
-            and staged_input_bindings
-            and result.get("state") == "succeeded"
-            and result.get("terminal") is True
-        ):
-            observed_step_id = _jarvis_add_step_result_step_id(result)
-            expected_step_ids = {item.step_id for item in staged_input_bindings}
-            if expected_step_ids != {observed_step_id}:
-                raise ValueError(
-                    "jarvis_add_step returned a different step identity than its staged inputs"
-                )
-            queue.update_jarvis_pipeline_input_bindings(
-                pipeline_input_route,
-                upserts=staged_input_bindings,
-            )
-        if (
-            route.remote_tool_name == "jarvis_edit_step"
-            and pipeline_input_route is not None
-            and binding_mutation_required
-            and result.get("state") == "succeeded"
-            and result.get("terminal") is True
-        ):
-            queue.update_jarvis_pipeline_input_bindings(
-                pipeline_input_route,
-                upserts=staged_input_bindings,
-                remove=removed_input_binding_identities,
-            )
-        if (
-            route.remote_tool_name == "jarvis_add_step"
-            and pipeline_cache_key is not None
-            and pipeline_input_route is not None
-            and automatic_input_uses
-            and staged_input_manifest_sha256 is not None
-            and result.get("state") == "succeeded"
-            and result.get("terminal") is True
-        ):
-            assert session is not None
-            durable_lineage = queue.merge_jarvis_pipeline_input_lineage(
-                pipeline_input_route,
-                automatic_input_uses,
-                manifest_sha256=staged_input_manifest_sha256,
-            )
-            session.remember_jarvis_pipeline_inputs(
-                pipeline_cache_key,
-                durable_lineage.artifact_uses,
-            )
+        if input_plan is not None:
+            record_jarvis_inputs(result, plan=input_plan, queue=queue, session=session)
         result["catalog_revision"] = catalog.revision
     elif name == "relay_get_job":
         job_id = _required_durable_record_id(arguments, "job_id")
@@ -5106,50 +4873,6 @@ def _owned_session_submission_result(
     return result
 
 
-def _require_terminal_staging_reconciliation(result: JSON, *, operation: str) -> None:
-    """Refuse to lose package semantics or staged-input lineage after a bounded wait."""
-    if result.get("terminal") is True:
-        return
-    cluster = result.get("cluster")
-    job_id = result.get("job_id")
-    route_revision = result.get("route_revision")
-    handle = f"cluster={cluster!r}, job_id={job_id!r}, route_revision={route_revision!r}"
-    raise ValueError(
-        f"{operation} did not become terminal during bounded contract reconciliation; "
-        f"the durable relay job remains observable ({handle}). Use relay_wait on that exact "
-        "handle, then retry this call with identical arguments. Relay reuses the deterministic "
-        "reconciliation identity when idempotency_key was omitted. No package contract or "
-        "staged-input lineage was accepted locally."
-    )
-
-
-def _jarvis_add_step_result_step_id(result: JSON) -> str:
-    """Extract the exact accepted step identity from a terminal add-step result."""
-    raw_mcp_result = result.get("mcp_result")
-    if not isinstance(raw_mcp_result, dict):
-        raise ValueError("jarvis_add_step terminal result omitted its MCP result")
-    raw_structured = cast(JSON, raw_mcp_result).get("structured_result")
-    if not isinstance(raw_structured, dict):
-        raise ValueError("jarvis_add_step terminal result omitted structured output")
-    structured = cast(JSON, raw_structured)
-    raw_nested = structured.get("result")
-    has_flat_identity = "step_id" in structured
-    if has_flat_identity and raw_nested is not None:
-        raise ValueError("jarvis_add_step structured output has ambiguous result envelopes")
-    if has_flat_identity:
-        raw_payload = structured
-    elif isinstance(raw_nested, dict):
-        # Compatibility for relay evidence produced by the historical test adapter.
-        # FastMCP's declared JARVIS contract returns the object itself.
-        raw_payload = cast(JSON, raw_nested)
-    else:
-        raise ValueError("jarvis_add_step structured output omitted its step identity")
-    step_id = raw_payload.get("step_id")
-    if not isinstance(step_id, str) or not step_id:
-        raise ValueError("jarvis_add_step structured output omitted its step identity")
-    return step_id
-
-
 def _submit_local_job(
     queue: ClioCoreQueue,
     job: RelayJob,
@@ -5183,6 +4906,60 @@ def _submit_local_job(
         }
     )
     return queue.submit_job(job.model_copy(update={"metadata": metadata}))
+
+
+def _stage_builtin_jarvis_inputs(
+    call_arguments: JSON,
+    *,
+    tool_name: str,
+    cluster: str,
+    queue: ClioCoreQueue,
+    settings: RelaySettings,
+    session: McpSessionState | None,
+    requested_idempotency_key: object,
+) -> JarvisInputPlan | None:
+    """Engage the shared input-staging plane for one built-in JARVIS door call.
+
+    The built-in door reaches the same clio-kit JARVIS contract as a registered
+    route, so a package setting declared as a local file is staged, ingested, and
+    rewritten identically. When the built-in JARVIS MCP runs on this host there is
+    no machine boundary to cross: the configured path is already the path the
+    package reads, so the plane stays out of the call.
+    """
+    definition = _remote_cluster_definition(cluster)
+    if not should_execute_on_cluster(definition):
+        return None
+    requested_key = str(requested_idempotency_key) if requested_idempotency_key else None
+    plan = prepare_jarvis_inputs(
+        _object(call_arguments.get("arguments", {})),
+        route=builtin_jarvis_staging_route(
+            cluster=cluster,
+            cluster_route_revision=_route_revision(definition),
+            expected_server_artifact_digest=jarvis_mcp_artifact_binding(cluster),
+            remote_tool_name=virtual_jarvis_remote_tool(tool_name),
+        ),
+        queue=queue,
+        settings=settings,
+        session=session,
+        resolve_definition=_remote_cluster_definition,
+        requested_idempotency_key=requested_key,
+    )
+    call_arguments["arguments"] = plan.arguments
+    if plan.require_terminal_wait:
+        call_arguments["wait_for_terminal"] = True
+    merged_input_uses = merge_artifact_uses([], plan.automatic_artifact_uses)
+    if merged_input_uses:
+        call_arguments["used_artifact_refs"] = [
+            artifact_use_payload(item) for item in merged_input_uses
+        ]
+    staged_idempotency_key = jarvis_submission_idempotency_key(
+        plan,
+        merged_artifact_uses=merged_input_uses,
+        requested_idempotency_key=requested_key,
+    )
+    if staged_idempotency_key is not None:
+        call_arguments["idempotency_key"] = staged_idempotency_key
+    return plan
 
 
 def _submit_jarvis_mcp_call(

--- a/src/clio_relay/remote_connection.py
+++ b/src/clio_relay/remote_connection.py
@@ -46,6 +46,9 @@ from clio_relay.job_identity import (
 
 MAX_SESSION_API_RESPONSE_BYTES: Final = 8 * 1024 * 1024
 MAX_RECORDED_CHANNEL_EVENTS: Final = 256
+# Idle streams held over the one channel; more concurrent operations simply open
+# more streams through the same forward, which costs no new transport.
+MAX_POOLED_CHANNEL_STREAMS: Final = 8
 DEFAULT_OWNED_SESSION_API_PORT: Final = 8765
 CHANNEL_EVENT_REPORT_SCHEMA: Final = "clio-relay.control-channel-report.v1"
 
@@ -131,7 +134,9 @@ class RemoteConnection:
         self._endpoint: ChannelEndpoint | None = None
         self._bootstrap: OwnedSessionChannelBootstrap | None = None
         self._nonce: str | None = None
-        self._stream: http.client.HTTPConnection | None = None
+        self._idle_streams: list[http.client.HTTPConnection] = []
+        self._open_streams = 0
+        self._transport_generation = 0
         self._attempt = 0
         self._events: list[ChannelEvent] = []
 
@@ -227,9 +232,9 @@ class RemoteConnection:
             not math.isfinite(response_timeout_seconds) or response_timeout_seconds <= 0
         ):
             raise ValueError("response_timeout_seconds must be positive and finite")
-        with self._lock:
-            stream = self._live_stream()
-            return _request_json_on_stream(
+        stream = self._acquire_stream()
+        try:
+            document = _request_json_on_stream(
                 stream=stream,
                 method=normalized_method,
                 path=path,
@@ -240,6 +245,11 @@ class RemoteConnection:
                 generation_id=self._generation_id,
                 response_timeout_seconds=response_timeout_seconds,
             )
+        except BaseException:
+            self._discard_stream(stream)
+            raise
+        self._release_stream(stream)
+        return document
 
     def session_status(self) -> dict[str, object]:
         """Read the remote relay session's status over the held channel.
@@ -366,7 +376,8 @@ class RemoteConnection:
         self._endpoint = endpoint
         self._bootstrap = bootstrap
         self._nonce = nonce
-        self._stream = stream
+        self._idle_streams = [stream]
+        self._open_streams = 1
         self._record(
             channel_event(
                 cluster=self.cluster,
@@ -402,76 +413,115 @@ class RemoteConnection:
                 "configure CLIO_RELAY_OWNER_SESSION_API_PORT for this connection"
             )
 
-    def _live_stream(self) -> http.client.HTTPConnection:
-        """Return the proven stream, re-proving it over the same held channel.
+    def _acquire_stream(self) -> http.client.HTTPConnection:
+        """Take one proven HTTP stream over the held channel.
 
-        A broken TCP stream is not a broken channel.  Re-opening it costs no new
-        transport: it is another connection through the forward that is already
-        held.  The re-opened stream is re-proven against the same out-of-band
-        bring-up identity document before any credential is sent, so the
-        connection never talks to an unproven listener.
+        Streams are pooled, not shared: a long poll on one operation must not
+        block every other operation on the same cluster.  Opening another stream
+        is another TCP connection *through the forward that is already held*, so
+        it costs no new transport -- the dial count is unchanged.  Every stream
+        is proven against the same out-of-band bring-up identity document before
+        any credential is sent, so none of them talks to an unproven listener.
         """
-        transport = self._transport
-        if transport is None:
-            raise ChannelNotEstablished(
-                f"owned session connection for {self.cluster} has no channel; call connect()"
-            )
-        if not transport.is_alive():
-            self._record(
-                channel_event(
-                    cluster=self.cluster,
-                    mode=self._transport_mode,
-                    event="dropped",
-                    attempt=self._attempt,
-                    reason="transport_exited",
-                    detail=transport.failure_detail(),
+        with self._lock:
+            transport = self._transport
+            if transport is None:
+                raise ChannelNotEstablished(
+                    f"owned session connection for {self.cluster} has no channel; call connect()"
                 )
-            )
-            raise ChannelDropped(
-                f"owned session channel for {self.cluster} dropped; "
-                "call reconnect() to re-establish it"
-            )
-        stream = self._stream
-        if stream is not None and stream.sock is not None:
-            return stream
-        endpoint = self._endpoint
-        bootstrap = self._bootstrap
-        nonce = self._nonce
-        if endpoint is None or bootstrap is None or nonce is None:
-            raise ChannelNotEstablished(
-                f"owned session connection for {self.cluster} lost its proven bring-up identity"
-            )
-        reproven = _open_identity_bound_stream(
+            if not transport.is_alive():
+                self._record(
+                    channel_event(
+                        cluster=self.cluster,
+                        mode=self._transport_mode,
+                        event="dropped",
+                        attempt=self._attempt,
+                        reason="transport_exited",
+                        detail=transport.failure_detail(),
+                    )
+                )
+                raise ChannelDropped(
+                    f"owned session channel for {self.cluster} dropped; "
+                    "call reconnect() to re-establish it"
+                )
+            while self._idle_streams:
+                candidate = self._idle_streams.pop()
+                if candidate.sock is not None:
+                    return candidate
+                with suppress(OSError):
+                    candidate.close()
+            endpoint = self._endpoint
+            bootstrap = self._bootstrap
+            nonce = self._nonce
+            generation = self._transport_generation
+            if endpoint is None or bootstrap is None or nonce is None:
+                raise ChannelNotEstablished(
+                    f"owned session connection for {self.cluster} lost its proven bring-up identity"
+                )
+        proven = _open_identity_bound_stream(
             endpoint=endpoint,
             nonce=nonce,
             expected_identity=bootstrap.identity,
             timeout_seconds=self._timeout_seconds,
         )
-        self._stream = reproven
-        self._record(
-            channel_event(
-                cluster=self.cluster,
-                mode=self._transport_mode,
-                event="stream_reproven",
-                attempt=self._attempt,
-                reason="http_stream_closed",
-            )
-        )
-        return reproven
+        with self._lock:
+            if generation != self._transport_generation:
+                # The channel was replaced while this stream was being proven;
+                # it belongs to a link that no longer exists.
+                with suppress(OSError):
+                    proven.close()
+                raise ChannelDropped(
+                    f"owned session channel for {self.cluster} was replaced while "
+                    "a stream was being proven"
+                )
+            self._open_streams += 1
+            if self._open_streams > 1:
+                self._record(
+                    channel_event(
+                        cluster=self.cluster,
+                        mode=self._transport_mode,
+                        event="stream_reproven",
+                        attempt=self._attempt,
+                        reason="http_stream_opened",
+                    )
+                )
+        return proven
+
+    def _release_stream(self, stream: http.client.HTTPConnection) -> None:
+        """Return one still-usable stream to the pool."""
+        with self._lock:
+            if stream.sock is None or self._transport is None:
+                self._close_stream_locked(stream)
+                return
+            if len(self._idle_streams) >= MAX_POOLED_CHANNEL_STREAMS:
+                self._close_stream_locked(stream)
+                return
+            self._idle_streams.append(stream)
+
+    def _discard_stream(self, stream: http.client.HTTPConnection) -> None:
+        """Drop one stream that failed; the channel itself is unaffected."""
+        with self._lock:
+            self._close_stream_locked(stream)
+
+    def _close_stream_locked(self, stream: http.client.HTTPConnection) -> None:
+        with suppress(OSError):
+            stream.close()
+        self._open_streams = max(0, self._open_streams - 1)
 
     def _release_locked(self, *, reason: str) -> None:
-        """Drop the held stream and transport without recording an event."""
+        """Drop every stream and the transport without recording an event."""
         del reason
-        stream = self._stream
-        self._stream = None
-        if stream is not None:
+        streams = self._idle_streams
+        self._idle_streams = []
+        for stream in streams:
             with suppress(OSError):
                 stream.close()
+        self._open_streams = 0
+        self._transport_generation += 1
         transport = self._transport
         self._transport = None
         self._endpoint = None
         self._bootstrap = None
-        self._nonce = None
         if transport is not None:
             transport.close()
 
@@ -539,6 +589,22 @@ class RemoteConnectionRegistry:
         """Return the existing connection for one cluster without creating it."""
         with self._lock:
             return self._connections.get(cluster)
+
+    def reconnect(self, cluster: str) -> RemoteConnection:
+        """Re-establish one cluster's dropped channel on explicit instruction.
+
+        This is the only way a replacement transport is ever opened.  In
+        ``ssh_forward`` mode calling it is what the present user authorizes, so
+        it must be reached from an operator action and never from a retry.
+        """
+        with self._lock:
+            connection = self._connections.get(cluster)
+        if connection is None:
+            raise ConfigurationError(
+                f"no owned session connection is held for cluster {cluster}"
+            )
+        connection.reconnect()
+        return connection
 
     def disconnect(self, cluster: str) -> None:
         """Close and forget one cluster's connection."""

--- a/src/clio_relay/remote_connection.py
+++ b/src/clio_relay/remote_connection.py
@@ -24,17 +24,17 @@ from contextlib import suppress
 from typing import Final, Literal, cast
 
 from clio_relay.cluster_config import ClusterDefinition
-from clio_relay.config import RelaySettings
+from clio_relay.config import RelaySettings, TransportMode
 from clio_relay.control_channel import (
     ChannelDropped,
     ChannelEndpoint,
     ChannelEvent,
     ChannelEventSink,
+    ChannelLink,
     ChannelNotEstablished,
     ChannelProcessFactory,
     OwnedSessionChannelBootstrap,
     RelayTransport,
-    TransportMode,
     build_transport,
     channel_event,
 )
@@ -103,11 +103,11 @@ class RemoteConnection:
         definition: ClusterDefinition,
         settings: RelaySettings,
         remote_api_port: int | None = None,
-        transport_mode: TransportMode = "ssh_forward",
+        transport_mode: TransportMode | None = None,
         process_factory: ChannelProcessFactory | None = None,
         timeout_seconds: float = 30.0,
         event_sink: ChannelEventSink | None = None,
-        allow_interactive_authorization: bool = True,
+        allow_interactive_authorization: bool | None = None,
     ) -> None:
         if timeout_seconds <= 0:
             raise ValueError("timeout_seconds must be positive")
@@ -124,18 +124,32 @@ class RemoteConnection:
             settings=settings,
             remote_api_port=remote_api_port,
         )
-        self._transport_mode: TransportMode = transport_mode
+        # The mode is configuration, never a runtime choice: it is fixed for the
+        # connection's whole life and every reconnect re-establishes this same
+        # mode. Nothing here probes a mode or substitutes another one.
+        self._transport_mode: TransportMode = transport_mode or settings.remote_transport_mode
         self._process_factory = process_factory
         self._timeout_seconds = timeout_seconds
         self._event_sink = event_sink
-        self._allow_interactive_authorization = allow_interactive_authorization
+        # A headless deployment must be able to refuse the prompt rather than
+        # burn its whole bring-up deadline waiting for a tty that is not there.
+        self._allow_interactive_authorization = (
+            settings.remote_transport_interactive
+            if allow_interactive_authorization is None
+            else allow_interactive_authorization
+        )
         self._lock = threading.RLock()
         self._transport: RelayTransport | None = None
         self._endpoint: ChannelEndpoint | None = None
         self._bootstrap: OwnedSessionChannelBootstrap | None = None
+        self._link: ChannelLink | None = None
         self._nonce: str | None = None
         self._idle_streams: list[http.client.HTTPConnection] = []
         self._open_streams = 0
+        # Counts proofs, not live streams: the event means "another stream was
+        # proven after bring-up", which is true both when one replaces a dead
+        # stream and when concurrency needs an extra one.
+        self._streams_proven = 0
         self._transport_generation = 0
         self._attempt = 0
         self._events: list[ChannelEvent] = []
@@ -180,6 +194,15 @@ class RemoteConnection:
     def bootstrap(self) -> OwnedSessionChannelBootstrap | None:
         """Return the out-of-band bring-up document proven for this channel."""
         return self._bootstrap
+
+    @property
+    def link(self) -> ChannelLink | None:
+        """Return the established link, or None when no channel is held.
+
+        The link is what every kind of traffic rides, not just owned-session
+        request/response; a later slice adds multiplexed stream channels to it.
+        """
+        return self._link
 
     def connect(self) -> None:
         """Establish the channel once.
@@ -351,7 +374,9 @@ class RemoteConnection:
             allow_interactive_authorization=self._allow_interactive_authorization,
         )
         try:
-            endpoint, bootstrap = transport.establish(nonce=nonce)
+            link = transport.establish(nonce=nonce)
+            endpoint = link.control_endpoint
+            bootstrap = link.bootstrap
             self._verify_bootstrap(bootstrap)
             stream = _open_identity_bound_stream(
                 endpoint=endpoint,
@@ -375,9 +400,11 @@ class RemoteConnection:
         self._transport = transport
         self._endpoint = endpoint
         self._bootstrap = bootstrap
+        self._link = link
         self._nonce = nonce
         self._idle_streams = [stream]
         self._open_streams = 1
+        self._streams_proven = 1
         self._record(
             channel_event(
                 cluster=self.cluster,
@@ -448,8 +475,7 @@ class RemoteConnection:
                 candidate = self._idle_streams.pop()
                 if candidate.sock is not None:
                     return candidate
-                with suppress(OSError):
-                    candidate.close()
+                self._close_stream_locked(candidate)
             endpoint = self._endpoint
             bootstrap = self._bootstrap
             nonce = self._nonce
@@ -475,7 +501,8 @@ class RemoteConnection:
                     "a stream was being proven"
                 )
             self._open_streams += 1
-            if self._open_streams > 1:
+            self._streams_proven += 1
+            if self._streams_proven > 1:
                 self._record(
                     channel_event(
                         cluster=self.cluster,
@@ -517,6 +544,7 @@ class RemoteConnection:
             with suppress(OSError):
                 stream.close()
         self._open_streams = 0
+        self._streams_proven = 0
         self._transport_generation += 1
         transport = self._transport
         self._transport = None
@@ -546,6 +574,7 @@ class RemoteConnectionRegistry:
     def __init__(self) -> None:
         self._lock = threading.RLock()
         self._connections: dict[str, RemoteConnection] = {}
+        self._retired: list[dict[str, object]] = []
 
     def connection(
         self,
@@ -553,37 +582,57 @@ class RemoteConnectionRegistry:
         definition: ClusterDefinition,
         settings: RelaySettings,
         remote_api_port: int | None = None,
-        transport_mode: TransportMode = "ssh_forward",
+        transport_mode: TransportMode | None = None,
         process_factory: ChannelProcessFactory | None = None,
         timeout_seconds: float = 30.0,
         event_sink: ChannelEventSink | None = None,
-        allow_interactive_authorization: bool = True,
+        allow_interactive_authorization: bool | None = None,
     ) -> RemoteConnection:
-        """Return the held connection for one cluster, establishing it once."""
+        """Return the held connection for one cluster, establishing it once.
+
+        Bring-up can block for as long as a user takes to authorize it, so the
+        registry lock is never held across it: one cluster connecting must not
+        stall every other cluster's operations, nor the acceptance report.
+        """
         with self._lock:
             existing = self._connections.get(definition.name)
             if existing is not None and existing.matches(
                 settings=settings,
                 remote_api_port=remote_api_port,
             ):
-                existing.connect()
-                return existing
-            if existing is not None:
-                existing.close()
-                del self._connections[definition.name]
-            created = RemoteConnection(
-                definition=definition,
-                settings=settings,
-                remote_api_port=remote_api_port,
-                transport_mode=transport_mode,
-                process_factory=process_factory,
-                timeout_seconds=timeout_seconds,
-                event_sink=event_sink,
-                allow_interactive_authorization=allow_interactive_authorization,
-            )
-            created.connect()
+                held = existing
+            else:
+                held = None
+                if existing is not None:
+                    # The pinned identity changed, so this is a different
+                    # connection, not a retry. Retire the old one but keep its
+                    # transport count, or the acceptance measurement loses it.
+                    self._connections.pop(definition.name, None)
+                    self._retired.append(_retired_report(existing))
+        if held is not None:
+            held.connect()
+            return held
+        if existing is not None:
+            existing.close()
+        created = RemoteConnection(
+            definition=definition,
+            settings=settings,
+            remote_api_port=remote_api_port,
+            transport_mode=transport_mode,
+            process_factory=process_factory,
+            timeout_seconds=timeout_seconds,
+            event_sink=event_sink,
+            allow_interactive_authorization=allow_interactive_authorization,
+        )
+        created.connect()
+        with self._lock:
+            raced = self._connections.get(definition.name)
+            if raced is not None:
+                self._retired.append(_retired_report(created))
+                created.close()
+                return raced
             self._connections[definition.name] = created
-            return created
+        return created
 
     def get(self, cluster: str) -> RemoteConnection | None:
         """Return the existing connection for one cluster without creating it."""
@@ -610,6 +659,8 @@ class RemoteConnectionRegistry:
         """Close and forget one cluster's connection."""
         with self._lock:
             connection = self._connections.pop(cluster, None)
+            if connection is not None:
+                self._retired.append(_retired_report(connection))
         if connection is not None:
             connection.close()
 
@@ -618,6 +669,7 @@ class RemoteConnectionRegistry:
         with self._lock:
             connections = list(self._connections.values())
             self._connections.clear()
+            self._retired.extend(_retired_report(item) for item in connections)
         for connection in connections:
             connection.close()
 
@@ -637,6 +689,7 @@ class RemoteConnectionRegistry:
         """
         with self._lock:
             connections = dict(self._connections)
+            retired = list(self._retired)
         clusters: dict[str, object] = {}
         for cluster, connection in connections.items():
             events = connection.events
@@ -651,14 +704,33 @@ class RemoteConnectionRegistry:
                 ),
                 "events": [event.model_dump(mode="json") for event in events],
             }
+        live = sum(
+            cast(int, cast(dict[str, object], value)["transport_connections_opened"])
+            for value in clusters.values()
+        )
+        retired_total = sum(
+            cast(int, item["transport_connections_opened"]) for item in retired
+        )
         return {
             "schema_version": CHANNEL_EVENT_REPORT_SCHEMA,
             "clusters": clusters,
-            "transport_connections_opened": sum(
-                cast(int, cast(dict[str, object], value)["transport_connections_opened"])
-                for value in clusters.values()
-            ),
+            "retired": retired,
+            "transport_connections_opened": live + retired_total,
         }
+
+
+def _retired_report(connection: RemoteConnection) -> dict[str, object]:
+    """Keep a retired connection's transport count for the acceptance report."""
+    events = connection.events
+    return {
+        "cluster": connection.cluster,
+        "session_id": connection.session_id,
+        "session_generation_id": connection.session_generation_id,
+        "transport_mode": connection.transport_mode,
+        "transport_connections_opened": sum(
+            1 for event in events if event.event in {"established", "reestablished"}
+        ),
+    }
 
 
 _REGISTRY = RemoteConnectionRegistry()

--- a/src/clio_relay/remote_connection.py
+++ b/src/clio_relay/remote_connection.py
@@ -1,0 +1,772 @@
+"""Connection-scoped owned-session control plane over one held channel.
+
+One local relay process manages a connection to each remote relay it is
+connected to.  A connection establishes its transport once, at bring-up, and
+holds it for the connection's lifetime.  Every owned-session operation is plain
+HTTP over the mapped port of that held channel.
+
+Nothing here may re-establish transport implicitly.  A dropped channel raises
+:class:`~clio_relay.control_channel.ChannelDropped`; replacing it is an explicit
+:meth:`RemoteConnection.reconnect` call that emits typed, visible events -- in
+``ssh_forward`` mode that call is what a present user authorizes.
+"""
+
+from __future__ import annotations
+
+import hmac
+import http.client
+import json
+import math
+import secrets
+import threading
+import urllib.parse
+from contextlib import suppress
+from typing import Final, Literal, cast
+
+from clio_relay.cluster_config import ClusterDefinition
+from clio_relay.config import RelaySettings
+from clio_relay.control_channel import (
+    ChannelDropped,
+    ChannelEndpoint,
+    ChannelEvent,
+    ChannelEventSink,
+    ChannelNotEstablished,
+    ChannelProcessFactory,
+    OwnedSessionChannelBootstrap,
+    RelayTransport,
+    TransportMode,
+    build_transport,
+    channel_event,
+)
+from clio_relay.errors import ConfigurationError, ObservationTimeoutError, RelayError
+from clio_relay.job_identity import (
+    OWNER_SESSION_ID_HEADER,
+    SESSION_GENERATION_ID_HEADER,
+)
+
+MAX_SESSION_API_RESPONSE_BYTES: Final = 8 * 1024 * 1024
+MAX_RECORDED_CHANNEL_EVENTS: Final = 256
+DEFAULT_OWNED_SESSION_API_PORT: Final = 8765
+CHANNEL_EVENT_REPORT_SCHEMA: Final = "clio-relay.control-channel-report.v1"
+
+_IDENTITY_FIELDS: Final = (
+    "schema_version",
+    "cluster",
+    "session_id",
+    "session_generation_id",
+    "nonce",
+)
+
+
+def validate_channel_request(*, method: str, path: str) -> str:
+    """Validate one owned-session request line before it reaches the channel."""
+    normalized_method = method.upper()
+    if normalized_method not in {"GET", "POST"}:
+        raise ValueError("owned session API method must be GET or POST")
+    if (
+        not path.startswith("/")
+        or path.startswith("//")
+        or any(character in path for character in ("\r", "\n", "?"))
+    ):
+        raise ValueError("owned session API path must be an absolute path without a query")
+    return normalized_method
+
+
+def resolve_remote_api_port(
+    *,
+    settings: RelaySettings,
+    remote_api_port: int | None = None,
+) -> int:
+    """Resolve the remote relay's owned-session API port for this connection.
+
+    The port is connection configuration, not a per-operation discovery: the
+    held forward has to be pointed at it before the channel exists.  Whatever
+    is resolved here is verified against the remote relay's own report during
+    bring-up, so a wrong port fails visibly instead of binding to a stranger.
+    """
+    resolved = remote_api_port or settings.owner_session_api_port
+    port = resolved or DEFAULT_OWNED_SESSION_API_PORT
+    if not 1 <= port <= 65_535:
+        raise ConfigurationError("owned session remote API port must be a valid TCP port")
+    return port
+
+
+class RemoteConnection:
+    """One local relay's held link to one remote relay, for its whole lifetime."""
+
+    def __init__(
+        self,
+        *,
+        definition: ClusterDefinition,
+        settings: RelaySettings,
+        remote_api_port: int | None = None,
+        transport_mode: TransportMode = "ssh_forward",
+        process_factory: ChannelProcessFactory | None = None,
+        timeout_seconds: float = 30.0,
+        event_sink: ChannelEventSink | None = None,
+        allow_interactive_authorization: bool = True,
+    ) -> None:
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        session_id, generation_id, api_token = owned_session_credentials(
+            definition=definition,
+            settings=settings,
+        )
+        self._definition = definition
+        self._settings = settings
+        self._session_id = session_id
+        self._generation_id = generation_id
+        self._api_token = api_token
+        self._remote_api_port = resolve_remote_api_port(
+            settings=settings,
+            remote_api_port=remote_api_port,
+        )
+        self._transport_mode: TransportMode = transport_mode
+        self._process_factory = process_factory
+        self._timeout_seconds = timeout_seconds
+        self._event_sink = event_sink
+        self._allow_interactive_authorization = allow_interactive_authorization
+        self._lock = threading.RLock()
+        self._transport: RelayTransport | None = None
+        self._endpoint: ChannelEndpoint | None = None
+        self._bootstrap: OwnedSessionChannelBootstrap | None = None
+        self._nonce: str | None = None
+        self._stream: http.client.HTTPConnection | None = None
+        self._attempt = 0
+        self._events: list[ChannelEvent] = []
+
+    @property
+    def cluster(self) -> str:
+        """Return the remote relay's cluster name."""
+        return self._definition.name
+
+    @property
+    def session_id(self) -> str:
+        """Return the exact owned session this connection is pinned to."""
+        return self._session_id
+
+    @property
+    def session_generation_id(self) -> str:
+        """Return the exact owned session generation this connection is pinned to."""
+        return self._generation_id
+
+    @property
+    def remote_api_port(self) -> int:
+        """Return the remote relay port the held channel maps."""
+        return self._remote_api_port
+
+    @property
+    def transport_mode(self) -> TransportMode:
+        """Return the declared transport mode of the held channel."""
+        return self._transport_mode
+
+    @property
+    def connected(self) -> bool:
+        """Return whether the channel is currently held."""
+        transport = self._transport
+        return transport is not None and transport.is_alive()
+
+    @property
+    def events(self) -> tuple[ChannelEvent, ...]:
+        """Return the bounded, typed transport lifecycle record."""
+        return tuple(self._events)
+
+    @property
+    def bootstrap(self) -> OwnedSessionChannelBootstrap | None:
+        """Return the out-of-band bring-up document proven for this channel."""
+        return self._bootstrap
+
+    def connect(self) -> None:
+        """Establish the channel once.
+
+        Calling this on an already-connected connection is a no-op and costs no
+        new transport.  It never silently replaces a dropped channel; use
+        :meth:`reconnect` for that.
+        """
+        with self._lock:
+            if self.connected:
+                return
+            if self._transport is not None:
+                raise ChannelDropped(
+                    f"owned session channel for {self.cluster} dropped; "
+                    "call reconnect() to re-establish it"
+                )
+            self._establish(event="established")
+
+    def reconnect(self) -> None:
+        """Explicitly replace a dropped channel with exactly one new transport."""
+        with self._lock:
+            previous = self._transport
+            detail = None if previous is None else previous.failure_detail()
+            self._release_locked(reason="reconnect_requested")
+            self._record(
+                channel_event(
+                    cluster=self.cluster,
+                    mode=self._transport_mode,
+                    event="reestablishing",
+                    attempt=self._attempt,
+                    reason="channel_dropped",
+                    detail=detail,
+                    user_authorization_required=self._allow_interactive_authorization,
+                )
+            )
+            self._establish(event="reestablished")
+
+    def request_json(
+        self,
+        *,
+        method: str,
+        path: str,
+        query: dict[str, object] | None = None,
+        body: dict[str, object] | None = None,
+        response_timeout_seconds: float | None = None,
+    ) -> object:
+        """Issue one authenticated JSON request over the held channel."""
+        normalized_method = validate_channel_request(method=method, path=path)
+        if response_timeout_seconds is not None and (
+            not math.isfinite(response_timeout_seconds) or response_timeout_seconds <= 0
+        ):
+            raise ValueError("response_timeout_seconds must be positive and finite")
+        with self._lock:
+            stream = self._live_stream()
+            return _request_json_on_stream(
+                stream=stream,
+                method=normalized_method,
+                path=path,
+                query=query,
+                body=body,
+                api_token=self._api_token,
+                session_id=self._session_id,
+                generation_id=self._generation_id,
+                response_timeout_seconds=response_timeout_seconds,
+            )
+
+    def session_status(self) -> dict[str, object]:
+        """Read the remote relay session's status over the held channel.
+
+        This replaces the per-operation ``ssh ... bash -s`` status probe.  The
+        remote report is cross-checked against the identity this connection is
+        pinned to, so a channel that started answering for a different session
+        or generation fails loudly instead of being used.
+        """
+        document = self.request_json(method="GET", path="/session-status")
+        if not isinstance(document, dict):
+            raise RelayError("owned session status response is not a JSON object")
+        status = cast(dict[str, object], document)
+        if (
+            status.get("owner") != "clio-relay"
+            or status.get("cluster") != self.cluster
+            or status.get("session_id") != self._session_id
+            or status.get("session_generation_id") != self._generation_id
+            or status.get("running") is not True
+        ):
+            raise RelayError(
+                "owned session status does not describe the exact connected generation for "
+                f"{self.cluster}/{self._session_id}"
+            )
+        return status
+
+    def close(self) -> None:
+        """Release the held channel and record the closure."""
+        with self._lock:
+            if self._transport is None:
+                return
+            self._release_locked(reason="closed")
+            self._record(
+                channel_event(
+                    cluster=self.cluster,
+                    mode=self._transport_mode,
+                    event="closed",
+                    attempt=self._attempt,
+                )
+            )
+
+    def matches(
+        self,
+        *,
+        settings: RelaySettings,
+        remote_api_port: int | None = None,
+    ) -> bool:
+        """Return whether a held connection still serves this exact identity."""
+        try:
+            session_id, generation_id, api_token = owned_session_credentials(
+                definition=self._definition,
+                settings=settings,
+            )
+        except ConfigurationError:
+            return False
+        resolved_port = resolve_remote_api_port(
+            settings=settings,
+            remote_api_port=remote_api_port,
+        )
+        return (
+            session_id == self._session_id
+            and generation_id == self._generation_id
+            and api_token == self._api_token
+            and resolved_port == self._remote_api_port
+        )
+
+    def _establish(self, *, event: Literal["established", "reestablished"]) -> None:
+        """Bring one transport up and prove the remote relay behind it."""
+        self._attempt += 1
+        nonce = secrets.token_hex(32)
+        if self._allow_interactive_authorization:
+            self._record(
+                channel_event(
+                    cluster=self.cluster,
+                    mode=self._transport_mode,
+                    event="authorization_required",
+                    attempt=self._attempt,
+                    reason="transport_requires_user_authorization",
+                    user_authorization_required=True,
+                )
+            )
+        self._record(
+            channel_event(
+                cluster=self.cluster,
+                mode=self._transport_mode,
+                event="establishing",
+                attempt=self._attempt,
+            )
+        )
+        transport = build_transport(
+            mode=self._transport_mode,
+            definition=self._definition,
+            session_id=self._session_id,
+            session_generation_id=self._generation_id,
+            remote_api_port=self._remote_api_port,
+            nonce=nonce,
+            process_factory=self._process_factory,
+            ready_timeout_seconds=self._timeout_seconds,
+            allow_interactive_authorization=self._allow_interactive_authorization,
+        )
+        try:
+            endpoint, bootstrap = transport.establish(nonce=nonce)
+            self._verify_bootstrap(bootstrap)
+            stream = _open_identity_bound_stream(
+                endpoint=endpoint,
+                nonce=nonce,
+                expected_identity=bootstrap.identity,
+                timeout_seconds=self._timeout_seconds,
+            )
+        except BaseException as exc:
+            transport.close()
+            self._record(
+                channel_event(
+                    cluster=self.cluster,
+                    mode=self._transport_mode,
+                    event="establish_failed",
+                    attempt=self._attempt,
+                    reason=type(exc).__name__,
+                    detail=str(exc),
+                )
+            )
+            raise
+        self._transport = transport
+        self._endpoint = endpoint
+        self._bootstrap = bootstrap
+        self._nonce = nonce
+        self._stream = stream
+        self._record(
+            channel_event(
+                cluster=self.cluster,
+                mode=self._transport_mode,
+                event=event,
+                attempt=self._attempt,
+            )
+        )
+
+    def _verify_bootstrap(self, bootstrap: OwnedSessionChannelBootstrap) -> None:
+        """Require the remote relay to be the exact, live, owned generation."""
+        status = bootstrap.status
+        remote_api_port = status.get("remote_api_port")
+        if (
+            status.get("owner") != "clio-relay"
+            or status.get("cluster") != self._definition.name
+            or status.get("session_id") != self._session_id
+            or status.get("session_generation_id") != self._generation_id
+            or status.get("running") is not True
+            or status.get("ownership_verified") is not True
+            or isinstance(remote_api_port, bool)
+            or not isinstance(remote_api_port, int)
+            or not 1 <= remote_api_port <= 65_535
+        ):
+            raise RelayError(
+                "remote relay session is not the active, ownership-verified generation requested "
+                f"for {self._definition.name}/{self._session_id}"
+            )
+        if remote_api_port != self._remote_api_port:
+            raise RelayError(
+                "remote relay session reported owned API port "
+                f"{remote_api_port}, but the held channel maps {self._remote_api_port}; "
+                "configure CLIO_RELAY_OWNER_SESSION_API_PORT for this connection"
+            )
+
+    def _live_stream(self) -> http.client.HTTPConnection:
+        """Return the proven stream, re-proving it over the same held channel.
+
+        A broken TCP stream is not a broken channel.  Re-opening it costs no new
+        transport: it is another connection through the forward that is already
+        held.  The re-opened stream is re-proven against the same out-of-band
+        bring-up identity document before any credential is sent, so the
+        connection never talks to an unproven listener.
+        """
+        transport = self._transport
+        if transport is None:
+            raise ChannelNotEstablished(
+                f"owned session connection for {self.cluster} has no channel; call connect()"
+            )
+        if not transport.is_alive():
+            self._record(
+                channel_event(
+                    cluster=self.cluster,
+                    mode=self._transport_mode,
+                    event="dropped",
+                    attempt=self._attempt,
+                    reason="transport_exited",
+                    detail=transport.failure_detail(),
+                )
+            )
+            raise ChannelDropped(
+                f"owned session channel for {self.cluster} dropped; "
+                "call reconnect() to re-establish it"
+            )
+        stream = self._stream
+        if stream is not None and stream.sock is not None:
+            return stream
+        endpoint = self._endpoint
+        bootstrap = self._bootstrap
+        nonce = self._nonce
+        if endpoint is None or bootstrap is None or nonce is None:
+            raise ChannelNotEstablished(
+                f"owned session connection for {self.cluster} lost its proven bring-up identity"
+            )
+        reproven = _open_identity_bound_stream(
+            endpoint=endpoint,
+            nonce=nonce,
+            expected_identity=bootstrap.identity,
+            timeout_seconds=self._timeout_seconds,
+        )
+        self._stream = reproven
+        self._record(
+            channel_event(
+                cluster=self.cluster,
+                mode=self._transport_mode,
+                event="stream_reproven",
+                attempt=self._attempt,
+                reason="http_stream_closed",
+            )
+        )
+        return reproven
+
+    def _release_locked(self, *, reason: str) -> None:
+        """Drop the held stream and transport without recording an event."""
+        del reason
+        stream = self._stream
+        self._stream = None
+        if stream is not None:
+            with suppress(OSError):
+                stream.close()
+        transport = self._transport
+        self._transport = None
+        self._endpoint = None
+        self._bootstrap = None
+        self._nonce = None
+        if transport is not None:
+            transport.close()
+
+    def _record(self, event: ChannelEvent) -> None:
+        """Append one bounded typed event and forward it to the sink."""
+        self._events.append(event)
+        if len(self._events) > MAX_RECORDED_CHANNEL_EVENTS:
+            del self._events[: len(self._events) - MAX_RECORDED_CHANNEL_EVENTS]
+        sink = self._event_sink
+        if sink is not None:
+            sink(event)
+
+
+class RemoteConnectionRegistry:
+    """The one local relay's connections to many remote relays.
+
+    The client-facing MCP endpoint stays single and stable while connections in
+    here come and go; a cluster's connection is created on first use and reused
+    by every later operation for that cluster.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._connections: dict[str, RemoteConnection] = {}
+
+    def connection(
+        self,
+        *,
+        definition: ClusterDefinition,
+        settings: RelaySettings,
+        remote_api_port: int | None = None,
+        transport_mode: TransportMode = "ssh_forward",
+        process_factory: ChannelProcessFactory | None = None,
+        timeout_seconds: float = 30.0,
+        event_sink: ChannelEventSink | None = None,
+        allow_interactive_authorization: bool = True,
+    ) -> RemoteConnection:
+        """Return the held connection for one cluster, establishing it once."""
+        with self._lock:
+            existing = self._connections.get(definition.name)
+            if existing is not None and existing.matches(
+                settings=settings,
+                remote_api_port=remote_api_port,
+            ):
+                existing.connect()
+                return existing
+            if existing is not None:
+                existing.close()
+                del self._connections[definition.name]
+            created = RemoteConnection(
+                definition=definition,
+                settings=settings,
+                remote_api_port=remote_api_port,
+                transport_mode=transport_mode,
+                process_factory=process_factory,
+                timeout_seconds=timeout_seconds,
+                event_sink=event_sink,
+                allow_interactive_authorization=allow_interactive_authorization,
+            )
+            created.connect()
+            self._connections[definition.name] = created
+            return created
+
+    def get(self, cluster: str) -> RemoteConnection | None:
+        """Return the existing connection for one cluster without creating it."""
+        with self._lock:
+            return self._connections.get(cluster)
+
+    def disconnect(self, cluster: str) -> None:
+        """Close and forget one cluster's connection."""
+        with self._lock:
+            connection = self._connections.pop(cluster, None)
+        if connection is not None:
+            connection.close()
+
+    def close_all(self) -> None:
+        """Close every held connection this local relay owns."""
+        with self._lock:
+            connections = list(self._connections.values())
+            self._connections.clear()
+        for connection in connections:
+            connection.close()
+
+    @property
+    def clusters(self) -> tuple[str, ...]:
+        """Return the clusters this local relay currently holds a channel to."""
+        with self._lock:
+            return tuple(sorted(self._connections))
+
+    def event_report(self) -> dict[str, object]:
+        """Return the client half of the one-held-channel acceptance measurement.
+
+        ``established`` plus ``reestablished`` is exactly the number of new
+        transport connections this local relay opened, which is what a desktop
+        process sampler and the cluster's ``sshd`` session log independently
+        count in the deployment gate.  Reading it costs no transport.
+        """
+        with self._lock:
+            connections = dict(self._connections)
+        clusters: dict[str, object] = {}
+        for cluster, connection in connections.items():
+            events = connection.events
+            clusters[cluster] = {
+                "transport_mode": connection.transport_mode,
+                "session_id": connection.session_id,
+                "session_generation_id": connection.session_generation_id,
+                "remote_api_port": connection.remote_api_port,
+                "connected": connection.connected,
+                "transport_connections_opened": sum(
+                    1 for event in events if event.event in {"established", "reestablished"}
+                ),
+                "events": [event.model_dump(mode="json") for event in events],
+            }
+        return {
+            "schema_version": CHANNEL_EVENT_REPORT_SCHEMA,
+            "clusters": clusters,
+            "transport_connections_opened": sum(
+                cast(int, cast(dict[str, object], value)["transport_connections_opened"])
+                for value in clusters.values()
+            ),
+        }
+
+
+_REGISTRY = RemoteConnectionRegistry()
+
+
+def connection_registry() -> RemoteConnectionRegistry:
+    """Return the process-wide registry of remote relay connections."""
+    return _REGISTRY
+
+
+def owned_session_credentials(
+    *,
+    definition: ClusterDefinition,
+    settings: RelaySettings,
+) -> tuple[str, str, str]:
+    """Return the exact owned session identity and token for one connection."""
+    session_id = settings.owner_session_id
+    generation_id = settings.owner_session_generation_id
+    api_token = settings.api_token
+    if session_id is None or generation_id is None:
+        raise ConfigurationError(
+            "owned remote request requires CLIO_RELAY_OWNER_SESSION_ID and "
+            "CLIO_RELAY_SESSION_GENERATION_ID"
+        )
+    if settings.resolved_owner_session_cluster() != definition.name:
+        raise ConfigurationError(
+            "owned remote request requires CLIO_RELAY_OWNER_SESSION_CLUSTER to match the "
+            "selected route"
+        )
+    if not api_token:
+        raise ConfigurationError(
+            "owned remote request requires CLIO_RELAY_API_TOKEN for authentication"
+        )
+    return session_id, generation_id, api_token
+
+
+def _open_identity_bound_stream(
+    *,
+    endpoint: ChannelEndpoint,
+    nonce: str,
+    expected_identity: dict[str, object],
+    timeout_seconds: float,
+) -> http.client.HTTPConnection:
+    """Prove one non-reconnecting TCP stream before any credential is sent."""
+    stream = http.client.HTTPConnection(endpoint.host, endpoint.port, timeout=timeout_seconds)
+    try:
+        stream.connect()
+        stream.auto_open = 0
+        stream.request(
+            "GET",
+            "/session-identity?" + urllib.parse.urlencode({"nonce": nonce}),
+            headers={"Accept": "application/json", "Connection": "keep-alive"},
+        )
+        proof_response = stream.getresponse()
+        proof_document = read_json_response(proof_response, label="session identity challenge")
+        if proof_response.status != 200 or not isinstance(proof_document, dict):
+            raise RelayError("owned session API did not return a valid server identity challenge")
+        verify_session_identity(
+            cast(dict[str, object], proof_document),
+            expected=expected_identity,
+        )
+        if proof_response.will_close or stream.sock is None:
+            raise RelayError(
+                "owned session API closed the identity-proven connection before authentication"
+            )
+        return stream
+    except (OSError, http.client.HTTPException) as exc:
+        stream.close()
+        raise RelayError("owned session API identity challenge failed") from exc
+    except BaseException:
+        stream.close()
+        raise
+
+
+def _request_json_on_stream(
+    *,
+    stream: http.client.HTTPConnection,
+    method: str,
+    path: str,
+    query: dict[str, object] | None,
+    body: dict[str, object] | None,
+    api_token: str,
+    session_id: str,
+    generation_id: str,
+    response_timeout_seconds: float | None,
+) -> object:
+    """Issue one request without permitting HTTPConnection to reconnect."""
+    encoded_query = "" if query is None else "?" + urllib.parse.urlencode(query)
+    encoded_body = None if body is None else json.dumps(body).encode("utf-8")
+    proven_socket = stream.sock
+    prior_connection_timeout = stream.timeout
+    prior_socket_timeout: float | None = None
+    response_timeout_applied = False
+    try:
+        if response_timeout_seconds is not None:
+            if proven_socket is None:
+                raise RelayError("owned session API identity-proven connection is not open")
+            prior_socket_timeout = proven_socket.gettimeout()
+            stream.timeout = response_timeout_seconds
+            proven_socket.settimeout(response_timeout_seconds)
+            response_timeout_applied = True
+        headers = {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {api_token}",
+            OWNER_SESSION_ID_HEADER: session_id,
+            SESSION_GENERATION_ID_HEADER: generation_id,
+        }
+        if encoded_body is not None:
+            headers["Content-Type"] = "application/json"
+        stream.request(
+            method,
+            path + encoded_query,
+            body=encoded_body,
+            headers=headers,
+        )
+        response = stream.getresponse()
+        document = read_json_response(response, label=f"{method} {path}")
+        if not 200 <= response.status < 300:
+            detail = json.dumps(document, ensure_ascii=False)[:2_000]
+            raise RelayError(
+                f"owned session API request failed: {method} {path}: "
+                f"HTTP {response.status}: {detail}"
+            )
+        return document
+    except (OSError, http.client.HTTPException) as exc:
+        if response_timeout_applied and isinstance(exc, TimeoutError):
+            raise ObservationTimeoutError(
+                f"owned session API response observation timed out for {method} {path}"
+            ) from exc
+        raise RelayError(
+            f"owned session API identity-bound request failed for {method} {path}: {exc}"
+        ) from exc
+    finally:
+        if response_timeout_seconds is not None:
+            stream.timeout = prior_connection_timeout
+            if (
+                response_timeout_applied
+                and stream.sock is proven_socket
+                and proven_socket is not None
+            ):
+                try:
+                    proven_socket.settimeout(prior_socket_timeout)
+                except OSError:
+                    # The response may have closed the proven socket.  Never let
+                    # HTTPConnection reconnect it under the authenticated client.
+                    stream.close()
+
+
+def read_json_response(response: http.client.HTTPResponse, *, label: str) -> object:
+    """Read one bounded JSON document from a channel response."""
+    payload = response.read(MAX_SESSION_API_RESPONSE_BYTES + 1)
+    if len(payload) > MAX_SESSION_API_RESPONSE_BYTES:
+        raise RelayError(f"owned session API {label} response exceeded its byte limit")
+    try:
+        return json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RelayError(f"owned session API {label} response was not UTF-8 JSON") from exc
+
+
+def verify_session_identity(
+    observed: dict[str, object],
+    *,
+    expected: dict[str, object],
+) -> None:
+    """Require the reached listener to be the out-of-band proven session."""
+    if any(observed.get(field) != expected.get(field) for field in _IDENTITY_FIELDS):
+        raise RelayError("owned session API server identity did not match the SSH-proven session")
+    observed_signature = observed.get("hmac_sha256")
+    expected_signature = expected.get("hmac_sha256")
+    if (
+        not isinstance(observed_signature, str)
+        or not isinstance(expected_signature, str)
+        or len(observed_signature) != 64
+        or len(expected_signature) != 64
+        or not hmac.compare_digest(observed_signature, expected_signature)
+    ):
+        raise RelayError("owned session API server identity HMAC did not verify")

--- a/src/clio_relay/remote_connection.py
+++ b/src/clio_relay/remote_connection.py
@@ -649,9 +649,7 @@ class RemoteConnectionRegistry:
         with self._lock:
             connection = self._connections.get(cluster)
         if connection is None:
-            raise ConfigurationError(
-                f"no owned session connection is held for cluster {cluster}"
-            )
+            raise ConfigurationError(f"no owned session connection is held for cluster {cluster}")
         connection.reconnect()
         return connection
 
@@ -708,9 +706,7 @@ class RemoteConnectionRegistry:
             cast(int, cast(dict[str, object], value)["transport_connections_opened"])
             for value in clusters.values()
         )
-        retired_total = sum(
-            cast(int, item["transport_connections_opened"]) for item in retired
-        )
+        retired_total = sum(cast(int, item["transport_connections_opened"]) for item in retired)
         return {
             "schema_version": CHANNEL_EVENT_REPORT_SCHEMA,
             "clusters": clusters,

--- a/src/clio_relay/remote_mcp.py
+++ b/src/clio_relay/remote_mcp.py
@@ -1498,13 +1498,6 @@ class VirtualRemoteMcpTool:
                 "The terminal reconciliation is automatic; if its bound expires, relay "
                 "returns an error containing the still-observable durable job handle."
             )
-        elif exact_v36_routes and self.remote_tool.name == "jarvis_add_step":
-            description += (
-                " When configuration contains a package-declared local-file input, relay "
-                "performs bounded terminal reconciliation before recording durable input "
-                "lineage; calls without staged local inputs retain ordinary asynchronous "
-                "semantics."
-            )
         elif exact_v36_routes and self.remote_tool.name == "jarvis_run":
             description += (
                 " On each genuinely new run identity, relay securely reconciles every tracked "

--- a/src/clio_relay/remote_values.py
+++ b/src/clio_relay/remote_values.py
@@ -45,6 +45,30 @@ def remote_value_expands_home(value: str) -> bool:
     return _leading_home_suffix(value) is not None
 
 
+def expand_remote_value_on_host(value: str, *, field: str, home: str) -> str:
+    """Expand a leading remote ``$HOME`` token against the host that runs the value.
+
+    Args:
+        value: The operator-configured remote value.
+        field: Configuration field name used in refusal messages.
+        home: Absolute home directory of the account executing on that host.
+
+    Returns:
+        The value with only an exact leading ``$HOME`` token replaced.
+
+    Raises:
+        ConfigurationError: If the value carries control characters, or requests
+            HOME expansion while the executing account has no home directory.
+    """
+    _validate_remote_value(value, field=field)
+    home_suffix = _leading_home_suffix(value)
+    if home_suffix is None:
+        return value
+    if not home:
+        raise ConfigurationError(f"remote {field} requires a home directory to expand $HOME")
+    return f"{home.rstrip('/')}{home_suffix}"
+
+
 def validate_remote_path(value: str, *, field: str) -> None:
     """Require an absolute POSIX path or one anchored by an exact leading HOME token."""
     _validate_remote_value(value, field=field)

--- a/src/clio_relay/session_api.py
+++ b/src/clio_relay/session_api.py
@@ -1,32 +1,24 @@
-"""Authenticated client transport for one exact owned relay session API."""
+"""Authenticated client for one exact owned relay session API.
+
+Every operation here rides the connection-scoped channel the local relay
+established once, at bring-up, for this cluster.  This module owns owned-session
+*semantics* -- submission receipts, transforms, identity documents -- and never
+owns transport: see :mod:`clio_relay.control_channel` for the held link and
+:mod:`clio_relay.remote_connection` for the connection that holds it.
+"""
 
 from __future__ import annotations
 
 import hashlib
 import hmac
-import http.client
-import json
-import math
-import secrets
-import socket
-import subprocess
-import time
-import urllib.parse
-from collections.abc import Generator
-from contextlib import ExitStack, contextmanager
 from typing import Final, cast
 
-import httpx
 from pydantic import ValidationError
 
 from clio_relay.cluster_config import ClusterDefinition
 from clio_relay.config import RelaySettings
-from clio_relay.errors import ConfigurationError, ObservationTimeoutError, RelayError
+from clio_relay.errors import RelayError
 from clio_relay.jarvis_mcp import is_virtual_jarvis_control_query
-from clio_relay.job_identity import (
-    OWNER_SESSION_ID_HEADER,
-    SESSION_GENERATION_ID_HEADER,
-)
 from clio_relay.models import (
     MCP_ADMISSION_AUTHORITY_METADATA_KEY,
     REGISTERED_JARVIS_USER_CONTRACT,
@@ -44,14 +36,27 @@ from clio_relay.models import (
     deterministic_jarvis_execution_id,
     is_owned_jarvis_run_spec,
 )
-from clio_relay.remote_mcp import resolve_pinned_mcp_admission
-from clio_relay.session_lifecycle import (
-    challenge_remote_session_identity,
-    status_remote_session,
+from clio_relay.remote_connection import (
+    MAX_SESSION_API_RESPONSE_BYTES,
+    RemoteConnection,
+    RemoteConnectionRegistry,
+    connection_registry,
+    validate_channel_request,
 )
+from clio_relay.remote_mcp import resolve_pinned_mcp_admission
 
 SESSION_IDENTITY_SCHEMA: Final = "clio-relay.session-identity.v1"
-MAX_SESSION_API_RESPONSE_BYTES: Final = 8 * 1024 * 1024
+__all__ = [
+    "MAX_SESSION_API_RESPONSE_BYTES",
+    "OWNED_SESSION_WAIT_RESPONSE_GRACE_SECONDS",
+    "SESSION_IDENTITY_SCHEMA",
+    "OwnedSessionApiClient",
+    "get_owned_session_transform",
+    "record_owned_session_transform",
+    "request_owned_session_json",
+    "session_identity_document",
+    "submit_owned_session_job",
+]
 # Leave part of clio-agent's ordinary 30-second transport budget available for
 # propagating the completed MCP result after this inner long-poll returns.
 OWNED_SESSION_WAIT_RESPONSE_GRACE_SECONDS: Final = 10.0
@@ -68,7 +73,15 @@ _JOB_SUBMISSION_PATHS = frozenset(
 
 
 class OwnedSessionApiClient:
-    """Identity-proven client for one exact owned session generation."""
+    """Identity-proven client for one exact owned session generation.
+
+    This is a handle onto the channel the local relay already holds for the
+    cluster, not a transport of its own.  Entering it costs no new connection:
+    the channel was established once, at connection bring-up, and every
+    owned-session operation -- status, identity, submission, ingest, artifact
+    content, watch -- rides that one link.  Leaving the context releases the
+    handle and leaves the channel held for the next operation.
+    """
 
     def __init__(
         self,
@@ -76,74 +89,37 @@ class OwnedSessionApiClient:
         definition: ClusterDefinition,
         settings: RelaySettings,
         timeout_seconds: float = 30.0,
+        registry: RemoteConnectionRegistry | None = None,
     ) -> None:
         if timeout_seconds <= 0:
             raise ValueError("timeout_seconds must be positive")
         self._definition = definition
         self._settings = settings
         self._timeout_seconds = timeout_seconds
-        self._stack: ExitStack | None = None
-        self._connection: http.client.HTTPConnection | None = None
-        self._session_id: str | None = None
-        self._generation_id: str | None = None
-        self._api_token: str | None = None
+        self._registry = registry
+        self._connection: RemoteConnection | None = None
 
     def __enter__(self) -> OwnedSessionApiClient:
-        """Prove the SSH-authenticated server and bind one persistent TCP stream."""
-        session_id, generation_id, api_token = _owned_session_credentials(
+        """Bind to the held channel for this cluster, establishing it once."""
+        registry = self._registry or connection_registry()
+        self._connection = registry.connection(
             definition=self._definition,
             settings=self._settings,
+            timeout_seconds=self._timeout_seconds,
         )
-        remote_api_port = _verified_remote_api_port(
-            definition=self._definition,
-            session_id=session_id,
-            generation_id=generation_id,
-        )
-        nonce = secrets.token_hex(32)
-        expected_identity = challenge_remote_session_identity(
-            definition=self._definition,
-            session_id=session_id,
-            session_generation_id=generation_id,
-            nonce=nonce,
-        )
-        stack = ExitStack()
-        try:
-            readiness_client = stack.enter_context(httpx.Client(trust_env=False))
-            local_port = stack.enter_context(
-                _ssh_forward(
-                    definition=self._definition,
-                    remote_api_port=remote_api_port,
-                    client=readiness_client,
-                    timeout_seconds=self._timeout_seconds,
-                )
-            )
-            connection = _open_identity_bound_connection(
-                local_port=local_port,
-                nonce=nonce,
-                expected_identity=expected_identity,
-                timeout_seconds=self._timeout_seconds,
-            )
-            stack.callback(connection.close)
-        except BaseException:
-            stack.close()
-            raise
-        self._stack = stack
-        self._connection = connection
-        self._session_id = session_id
-        self._generation_id = generation_id
-        self._api_token = api_token
         return self
 
     def __exit__(self, *_args: object) -> None:
-        """Close the proven stream and its SSH forward without reconnecting."""
-        stack = self._stack
-        self._stack = None
+        """Release the handle; the connection keeps its channel held."""
         self._connection = None
-        self._session_id = None
-        self._generation_id = None
-        self._api_token = None
-        if stack is not None:
-            stack.close()
+
+    @property
+    def connection(self) -> RemoteConnection:
+        """Return the held connection backing this handle."""
+        connection = self._connection
+        if connection is None:
+            raise RuntimeError("owned session API client is not open")
+        return connection
 
     def request_json(
         self,
@@ -154,33 +130,17 @@ class OwnedSessionApiClient:
         body: dict[str, object] | None = None,
         response_timeout_seconds: float | None = None,
     ) -> object:
-        """Issue one authenticated JSON request on the already proven TCP stream.
+        """Issue one authenticated JSON request over the held channel.
 
         ``response_timeout_seconds`` changes only the response deadline for this
-        request. It does not relax the bounded SSH-forward or identity-proof
-        deadlines, and the connection's ordinary timeout is restored before a
-        later request reuses the same proven stream.
+        request. It never relaxes the channel's bring-up deadlines, and the
+        stream's ordinary timeout is restored before a later request reuses it.
         """
-        normalized_method = _validate_request(method=method, path=path)
-        if response_timeout_seconds is not None and (
-            not math.isfinite(response_timeout_seconds) or response_timeout_seconds <= 0
-        ):
-            raise ValueError("response_timeout_seconds must be positive and finite")
-        connection = self._connection
-        session_id = self._session_id
-        generation_id = self._generation_id
-        api_token = self._api_token
-        if connection is None or session_id is None or generation_id is None or api_token is None:
-            raise RuntimeError("owned session API client is not open")
-        return _request_json_on_connection(
-            connection=connection,
-            method=normalized_method,
+        return self.connection.request_json(
+            method=method,
             path=path,
             query=query,
             body=body,
-            api_token=api_token,
-            session_id=session_id,
-            generation_id=generation_id,
             response_timeout_seconds=response_timeout_seconds,
         )
 
@@ -299,8 +259,8 @@ def request_owned_session_json(
     body: dict[str, object] | None = None,
     timeout_seconds: float = 30.0,
 ) -> object:
-    """Call one exact-generation session API after proving its server identity."""
-    _validate_request(method=method, path=path)
+    """Call one exact-generation session API over the connection's held channel."""
+    validate_channel_request(method=method, path=path)
     with OwnedSessionApiClient(
         definition=definition,
         settings=settings,
@@ -575,303 +535,3 @@ def _expected_jarvis_mcp_arguments(
     if supplied_execution_id is not None and supplied_execution_id != expected_execution_id:
         raise RelayError("owned session JARVIS run used a different execution identity")
     return {**expected_arguments, "execution_id": expected_execution_id}
-
-
-def _owned_session_credentials(
-    *,
-    definition: ClusterDefinition,
-    settings: RelaySettings,
-) -> tuple[str, str, str]:
-    session_id = settings.owner_session_id
-    generation_id = settings.owner_session_generation_id
-    api_token = settings.api_token
-    if session_id is None or generation_id is None:
-        raise ConfigurationError(
-            "owned remote request requires CLIO_RELAY_OWNER_SESSION_ID and "
-            "CLIO_RELAY_SESSION_GENERATION_ID"
-        )
-    if settings.resolved_owner_session_cluster() != definition.name:
-        raise ConfigurationError(
-            "owned remote request requires CLIO_RELAY_OWNER_SESSION_CLUSTER to match the "
-            "selected route"
-        )
-    if not api_token:
-        raise ConfigurationError(
-            "owned remote request requires CLIO_RELAY_API_TOKEN for authentication"
-        )
-    return session_id, generation_id, api_token
-
-
-def _verified_remote_api_port(
-    *,
-    definition: ClusterDefinition,
-    session_id: str,
-    generation_id: str,
-) -> int:
-    remote_status = status_remote_session(definition=definition, session_id=session_id)
-    remote_api_port = remote_status.get("remote_api_port")
-    if (
-        remote_status.get("owner") != "clio-relay"
-        or remote_status.get("cluster") != definition.name
-        or remote_status.get("session_id") != session_id
-        or remote_status.get("session_generation_id") != generation_id
-        or remote_status.get("running") is not True
-        or remote_status.get("ownership_verified") is not True
-        or isinstance(remote_api_port, bool)
-        or not isinstance(remote_api_port, int)
-        or not 1 <= remote_api_port <= 65_535
-    ):
-        raise RelayError(
-            "remote relay session is not the active, ownership-verified generation requested "
-            f"for {definition.name}/{session_id}"
-        )
-    return remote_api_port
-
-
-def _validate_request(*, method: str, path: str) -> str:
-    normalized_method = method.upper()
-    if normalized_method not in {"GET", "POST"}:
-        raise ValueError("owned session API method must be GET or POST")
-    if (
-        not path.startswith("/")
-        or path.startswith("//")
-        or any(character in path for character in ("\r", "\n", "?"))
-    ):
-        raise ValueError("owned session API path must be an absolute path without a query")
-    return normalized_method
-
-
-def _open_identity_bound_connection(
-    *,
-    local_port: int,
-    nonce: str,
-    expected_identity: dict[str, object],
-    timeout_seconds: float,
-) -> http.client.HTTPConnection:
-    """Prove one non-reconnecting TCP stream before any credential is sent."""
-    connection = http.client.HTTPConnection("127.0.0.1", local_port, timeout=timeout_seconds)
-    try:
-        connection.connect()
-        connection.auto_open = 0
-        connection.request(
-            "GET",
-            "/session-identity?" + urllib.parse.urlencode({"nonce": nonce}),
-            headers={"Accept": "application/json", "Connection": "keep-alive"},
-        )
-        proof_response = connection.getresponse()
-        proof_document = _read_json_response(proof_response, label="session identity challenge")
-        if proof_response.status != 200 or not isinstance(proof_document, dict):
-            raise RelayError("owned session API did not return a valid server identity challenge")
-        _verify_session_identity(
-            cast(dict[str, object], proof_document),
-            expected=expected_identity,
-        )
-        if proof_response.will_close or connection.sock is None:
-            raise RelayError(
-                "owned session API closed the identity-proven connection before authentication"
-            )
-        return connection
-    except (OSError, http.client.HTTPException) as exc:
-        connection.close()
-        raise RelayError("owned session API identity challenge failed") from exc
-    except BaseException:
-        connection.close()
-        raise
-
-
-def _request_json_on_connection(
-    *,
-    connection: http.client.HTTPConnection,
-    method: str,
-    path: str,
-    query: dict[str, object] | None,
-    body: dict[str, object] | None,
-    api_token: str,
-    session_id: str,
-    generation_id: str,
-    response_timeout_seconds: float | None,
-) -> object:
-    """Issue one request without permitting HTTPConnection to reconnect."""
-    encoded_query = "" if query is None else "?" + urllib.parse.urlencode(query)
-    encoded_body = None if body is None else json.dumps(body).encode("utf-8")
-    proven_socket = connection.sock
-    prior_connection_timeout = connection.timeout
-    prior_socket_timeout: float | None = None
-    response_timeout_applied = False
-    try:
-        if response_timeout_seconds is not None:
-            if proven_socket is None:
-                raise RelayError("owned session API identity-proven connection is not open")
-            prior_socket_timeout = proven_socket.gettimeout()
-            connection.timeout = response_timeout_seconds
-            proven_socket.settimeout(response_timeout_seconds)
-            response_timeout_applied = True
-        headers = {
-            "Accept": "application/json",
-            "Authorization": f"Bearer {api_token}",
-            OWNER_SESSION_ID_HEADER: session_id,
-            SESSION_GENERATION_ID_HEADER: generation_id,
-        }
-        if encoded_body is not None:
-            headers["Content-Type"] = "application/json"
-        connection.request(
-            method,
-            path + encoded_query,
-            body=encoded_body,
-            headers=headers,
-        )
-        response = connection.getresponse()
-        document = _read_json_response(response, label=f"{method} {path}")
-        if not 200 <= response.status < 300:
-            detail = json.dumps(document, ensure_ascii=False)[:2_000]
-            raise RelayError(
-                f"owned session API request failed: {method} {path}: "
-                f"HTTP {response.status}: {detail}"
-            )
-        return document
-    except (OSError, http.client.HTTPException) as exc:
-        if response_timeout_applied and isinstance(exc, TimeoutError):
-            raise ObservationTimeoutError(
-                f"owned session API response observation timed out for {method} {path}"
-            ) from exc
-        raise RelayError(
-            f"owned session API identity-bound request failed for {method} {path}: {exc}"
-        ) from exc
-    finally:
-        if response_timeout_seconds is not None:
-            connection.timeout = prior_connection_timeout
-            if (
-                response_timeout_applied
-                and connection.sock is proven_socket
-                and proven_socket is not None
-            ):
-                try:
-                    proven_socket.settimeout(prior_socket_timeout)
-                except OSError:
-                    # The response may have closed the proven socket. Never let
-                    # HTTPConnection reconnect it under the authenticated client.
-                    connection.close()
-
-
-def _read_json_response(response: http.client.HTTPResponse, *, label: str) -> object:
-    payload = response.read(MAX_SESSION_API_RESPONSE_BYTES + 1)
-    if len(payload) > MAX_SESSION_API_RESPONSE_BYTES:
-        raise RelayError(f"owned session API {label} response exceeded its byte limit")
-    try:
-        return json.loads(payload.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise RelayError(f"owned session API {label} response was not UTF-8 JSON") from exc
-
-
-def _verify_session_identity(
-    observed: dict[str, object],
-    *,
-    expected: dict[str, object],
-) -> None:
-    fields = (
-        "schema_version",
-        "cluster",
-        "session_id",
-        "session_generation_id",
-        "nonce",
-    )
-    if any(observed.get(field) != expected.get(field) for field in fields):
-        raise RelayError("owned session API server identity did not match the SSH-proven session")
-    observed_signature = observed.get("hmac_sha256")
-    expected_signature = expected.get("hmac_sha256")
-    if (
-        not isinstance(observed_signature, str)
-        or not isinstance(expected_signature, str)
-        or len(observed_signature) != 64
-        or len(expected_signature) != 64
-        or not hmac.compare_digest(observed_signature, expected_signature)
-    ):
-        raise RelayError("owned session API server identity HMAC did not verify")
-
-
-@contextmanager
-def _ssh_forward(
-    *,
-    definition: ClusterDefinition,
-    remote_api_port: int,
-    client: httpx.Client,
-    timeout_seconds: float,
-) -> Generator[int, None, None]:
-    """Open a bounded loopback-only SSH forward and always stop it after the request."""
-    local_port = _available_loopback_port()
-    process = subprocess.Popen(
-        [
-            "ssh",
-            "-N",
-            "-T",
-            "-o",
-            "BatchMode=yes",
-            "-o",
-            "ExitOnForwardFailure=yes",
-            "-L",
-            f"127.0.0.1:{local_port}:127.0.0.1:{remote_api_port}",
-            definition.ssh_host,
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    base_url = f"http://127.0.0.1:{local_port}"
-    try:
-        _wait_for_forward(
-            process,
-            client=client,
-            base_url=base_url,
-            timeout_seconds=timeout_seconds,
-        )
-        yield local_port
-    finally:
-        _terminate_forward(process)
-
-
-def _available_loopback_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
-        probe.bind(("127.0.0.1", 0))
-        port = probe.getsockname()[1]
-    if not isinstance(port, int) or port <= 0:
-        raise RelayError("could not select a loopback port for the owned session API")
-    return port
-
-
-def _wait_for_forward(
-    process: subprocess.Popen[bytes],
-    *,
-    client: httpx.Client,
-    base_url: str,
-    timeout_seconds: float,
-) -> None:
-    deadline = time.monotonic() + timeout_seconds
-    last_error = "SSH forward did not become ready"
-    while time.monotonic() < deadline:
-        if process.poll() is not None:
-            raise RelayError(_forward_error(process, "owned session SSH forward exited"))
-        try:
-            response = client.get(base_url + "/healthz", timeout=min(0.5, timeout_seconds))
-            if response.status_code == 200 and response.json().get("ok") is True:
-                return
-            last_error = f"unexpected health response: HTTP {response.status_code}"
-        except (httpx.HTTPError, TypeError, ValueError) as exc:
-            last_error = str(exc)
-        time.sleep(0.05)
-    raise RelayError(f"owned session SSH forward did not become ready: {last_error}")
-
-
-def _terminate_forward(process: subprocess.Popen[bytes]) -> None:
-    if process.poll() is not None:
-        return
-    process.terminate()
-    try:
-        process.wait(timeout=5)
-    except subprocess.TimeoutExpired:
-        process.kill()
-        process.wait(timeout=5)
-
-
-def _forward_error(process: subprocess.Popen[bytes], fallback: str) -> str:
-    stderr = process.stderr.read() if process.stderr is not None else b""
-    detail = stderr.decode("utf-8", errors="replace").strip()
-    return detail or fallback

--- a/src/clio_relay/session_lifecycle.py
+++ b/src/clio_relay/session_lifecycle.py
@@ -68,8 +68,11 @@ SESSION_RELAY_CANCELED_CHECK_ID = "cleanup.relay-jobs-canceled"
 SESSION_SCHEDULER_CANCELED_CHECK_ID = "cleanup.explicit-job-cancel"
 _REMOTE_SESSION_COMMAND_TIMEOUT_SECONDS = 120.0
 _REMOTE_SESSION_START_RECOVERY_TIMEOUT_SECONDS = 15.0
-# One start watch is one bounded server-side wait, never a client redial loop.
-MAX_REMOTE_SESSION_START_WAIT_SECONDS = 60.0
+# One start watch is a bounded server-side wait, never a client redial loop.
+# The cap matches the ordinary remote-command budget above, so the CLI's default
+# 120-second watch costs exactly one connection; a longer watch costs one more
+# per cap rather than one per polling interval.
+MAX_REMOTE_SESSION_START_WAIT_SECONDS = _REMOTE_SESSION_COMMAND_TIMEOUT_SECONDS
 _REMOTE_SESSION_START_WAIT_TRANSPORT_MARGIN_SECONDS = 15.0
 _REMOTE_API_READINESS_TIMEOUT_SECONDS = 60.0
 _MAX_OWNED_SESSION_DOCUMENT_BYTES = 1024 * 1024

--- a/src/clio_relay/session_lifecycle.py
+++ b/src/clio_relay/session_lifecycle.py
@@ -68,6 +68,9 @@ SESSION_RELAY_CANCELED_CHECK_ID = "cleanup.relay-jobs-canceled"
 SESSION_SCHEDULER_CANCELED_CHECK_ID = "cleanup.explicit-job-cancel"
 _REMOTE_SESSION_COMMAND_TIMEOUT_SECONDS = 120.0
 _REMOTE_SESSION_START_RECOVERY_TIMEOUT_SECONDS = 15.0
+# One start watch is one bounded server-side wait, never a client redial loop.
+MAX_REMOTE_SESSION_START_WAIT_SECONDS = 60.0
+_REMOTE_SESSION_START_WAIT_TRANSPORT_MARGIN_SECONDS = 15.0
 _REMOTE_API_READINESS_TIMEOUT_SECONDS = 60.0
 _MAX_OWNED_SESSION_DOCUMENT_BYTES = 1024 * 1024
 MAX_OWNED_SESSION_CLEANUP_REPORT_BYTES = 32 * 1024 * 1024
@@ -3092,6 +3095,60 @@ def inspect_owned_session_start_status(
         )
 
 
+def owned_session_start_status_is_terminal(status: OwnedSessionRecoveryStatus) -> bool:
+    """Return whether one start observation needs no further waiting."""
+    if status.start_state in {"failed", "failed_cleaned", "not_current"}:
+        return True
+    return (
+        status.start_state == "ready"
+        and status.recovery_verified
+        and status.ownership_verified
+        and status.session_generation_id is not None
+    )
+
+
+def wait_owned_session_start_status(
+    *,
+    cluster: str,
+    session_id: str,
+    start_operation_id: str,
+    cluster_route_revision: str,
+    core_dir: Path,
+    wait_seconds: float = 0.0,
+    poll_seconds: float = 0.25,
+    inspect: Callable[..., OwnedSessionRecoveryStatus] | None = None,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> OwnedSessionRecoveryStatus:
+    """Observe one exact start, blocking cluster-side until it is terminal.
+
+    This is the cluster-local half of a start watch.  The desktop issues one
+    command carrying its remaining deadline instead of redialing per interval,
+    so a watch costs one transport connection regardless of how long the start
+    takes.  The wait is bounded and always returns the latest exact observation.
+    """
+    if not math.isfinite(wait_seconds) or wait_seconds < 0:
+        raise ValueError("start status wait_seconds must be finite and nonnegative")
+    if not math.isfinite(poll_seconds) or poll_seconds <= 0:
+        raise ValueError("start status poll_seconds must be finite and positive")
+    observe = inspect or inspect_owned_session_start_status
+    deadline = monotonic() + wait_seconds
+    while True:
+        status = observe(
+            cluster=cluster,
+            session_id=session_id,
+            start_operation_id=start_operation_id,
+            cluster_route_revision=cluster_route_revision,
+            core_dir=core_dir,
+        )
+        if owned_session_start_status_is_terminal(status):
+            return status
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            return status
+        sleep(min(poll_seconds, remaining))
+
+
 def _inspect_owned_session_cleanup_receipt(
     *,
     cluster: str,
@@ -5845,6 +5902,7 @@ def execute_owned_session_start(
                 "CLIO_RELAY_SESSION_ROUTE_REVISION": request.cluster_route_revision,
                 "CLIO_RELAY_OWNER_SESSION_ID": request.session_id,
                 "CLIO_RELAY_OWNER_SESSION_CLUSTER": request.cluster,
+                "CLIO_RELAY_OWNER_SESSION_API_PORT": str(request.remote_api_port),
                 "CLIO_RELAY_REMOTE_CLUSTER": request.cluster,
                 **request.input_policy.environment(),
             }
@@ -7330,15 +7388,30 @@ def status_remote_session_start(
     *,
     definition: ClusterDefinition,
     selector: OwnedSessionStartStatusSelector,
+    wait_seconds: float = 0.0,
 ) -> OwnedSessionRecoveryStatus:
-    """Return a nonblocking remote observation for one exact start operation."""
+    """Return one remote observation for one exact start operation.
+
+    With ``wait_seconds`` the cluster-local command blocks against its durable
+    state until the start is terminal, so a watch does not redial per interval.
+    """
     if definition.name != selector.cluster:
         raise RelayError("owned-session start status selector changed cluster")
+    bounded_wait = max(0.0, min(wait_seconds, MAX_REMOTE_SESSION_START_WAIT_SECONDS))
+    transport_timeout = (
+        _REMOTE_SESSION_START_RECOVERY_TIMEOUT_SECONDS
+        if bounded_wait <= 0
+        else bounded_wait + _REMOTE_SESSION_START_WAIT_TRANSPORT_MARGIN_SECONDS
+    )
     try:
         output = _ssh_script(
             definition,
-            _owned_start_status_script(definition=definition, selector=selector),
-            timeout_seconds=_REMOTE_SESSION_START_RECOVERY_TIMEOUT_SECONDS,
+            _owned_start_status_script(
+                definition=definition,
+                selector=selector,
+                wait_seconds=bounded_wait,
+            ),
+            timeout_seconds=transport_timeout,
         )
     except _RemoteSessionCommandDeadline as exc:
         return OwnedSessionRecoveryStatus(
@@ -7500,12 +7573,14 @@ def query_remote_session_start(
     definition: ClusterDefinition,
     plan: OwnedSessionStartPlan,
     transport_deadline_exceeded: bool = False,
+    wait_seconds: float = 0.0,
 ) -> OwnedSessionStartResult:
     """Query one exact start once; callers choose any aggregate polling policy."""
     try:
         status = status_remote_session_start(
             definition=definition,
             selector=plan.status_selector,
+            wait_seconds=wait_seconds,
         )
     except RelayError as exc:
         status = OwnedSessionRecoveryStatus(
@@ -7534,7 +7609,11 @@ def watch_remote_session_start(
     monotonic: Callable[[], float] = time.monotonic,
     sleep: Callable[[float], None] = time.sleep,
 ) -> OwnedSessionStartResult:
-    """Poll one exact start until ready, terminal failure, or bounded detach.
+    """Watch one exact start until ready, terminal failure, or bounded detach.
+
+    The watch is a bounded server-side wait against the remote relay's durable
+    start state, not a client redial loop: each observation blocks remotely for
+    what remains of the deadline and returns as soon as the start is terminal.
 
     A watch timeout does not erase or reinterpret the durable operation.  The
     returned nonterminal result remains a handle carrying the exact status and
@@ -7544,8 +7623,17 @@ def watch_remote_session_start(
         raise ValueError("start watch timeout_seconds must be finite and positive")
     if not math.isfinite(poll_seconds) or poll_seconds <= 0:
         raise ValueError("start watch poll_seconds must be finite and positive")
-    query_once = query or (lambda: query_remote_session_start(definition=definition, plan=plan))
     deadline = monotonic() + timeout_seconds
+
+    def _durable_wait() -> OwnedSessionStartResult:
+        remaining_wait = max(deadline - monotonic(), 0.0)
+        return query_remote_session_start(
+            definition=definition,
+            plan=plan,
+            wait_seconds=min(remaining_wait, MAX_REMOTE_SESSION_START_WAIT_SECONDS),
+        )
+
+    query_once = query or _durable_wait
     while True:
         result = query_once()
         if result.terminal:
@@ -7975,9 +8063,16 @@ def _owned_start_status_script(
     *,
     definition: ClusterDefinition,
     selector: OwnedSessionStartStatusSelector,
+    wait_seconds: float = 0.0,
 ) -> str:
-    """Render the nonblocking exact-operation start-status command."""
+    """Render the exact-operation start-status command.
+
+    ``wait_seconds`` makes the cluster-local command block against its own
+    durable state until the start reaches a terminal observation, so one watch
+    costs one command instead of one command per polling interval.
+    """
     relay_executable = _owned_session_relay_executable(definition)
+    wait_argument = "" if wait_seconds <= 0 else f" --wait-seconds {wait_seconds:g}"
     return (
         "set -euo pipefail\n"
         f"{remote_env(definition)}\n"
@@ -7986,7 +8081,7 @@ def _owned_start_status_script(
         f"--session-id {shlex.quote(selector.session_id)} "
         f"--start-operation-id {shlex.quote(selector.start_operation_id)} "
         "--cluster-route-revision "
-        f"{shlex.quote(selector.cluster_route_revision)}\n"
+        f"{shlex.quote(selector.cluster_route_revision)}{wait_argument}\n"
     )
 
 

--- a/tests/test_bounded_command_package.py
+++ b/tests/test_bounded_command_package.py
@@ -82,12 +82,13 @@ def test_configure_menu_declares_every_configured_setting(monkeypatch: MonkeyPat
     package = _load_bounded_package(monkeypatch)
     menu = _configure_menu(package)
 
-    assert set(menu) == {"command", "workdir", "env", "timeout_seconds", "progress"}
+    assert set(menu) == {"command", "workdir", "env", "timeout_seconds", "progress", "script"}
     assert menu["command"]["type"] is list
     assert menu["workdir"]["type"] is str
     assert menu["env"]["type"] is dict
     assert menu["timeout_seconds"]["type"] is int
     assert menu["progress"]["type"] is dict
+    assert menu["script"]["type"] is str
     for name, option in menu.items():
         message = option.get("msg")
         assert isinstance(message, str) and message, f"{name} declares no description"
@@ -100,8 +101,74 @@ def test_configure_menu_marks_only_the_command_as_required(monkeypatch: MonkeyPa
     menu = _configure_menu(package)
 
     assert "default" not in menu["command"]
-    for name in ("workdir", "env", "timeout_seconds", "progress"):
+    for name in ("workdir", "env", "timeout_seconds", "progress", "script"):
         assert menu[name].get("default") is not None, f"{name} would become required"
+
+
+def test_script_setting_declares_the_relay_local_file_input_binding(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    # clio_relay.input_staging.parse_jarvis_package_input_contract stages a setting
+    # only when its describe output carries exactly this binding object, and rejects
+    # any other key set as "unsupported or malformed". Without it the relay forwards
+    # the caller's bare path to JARVIS unchanged and the file never reaches the job.
+    package = _load_bounded_package(monkeypatch)
+    menu = _configure_menu(package)
+
+    assert menu["script"]["input_binding"] == {
+        "schema_version": "jarvis.configuration-input-binding.v1",
+        "kind": "local_file",
+        "structure": "regular_file",
+    }
+    for name in ("command", "workdir", "env", "timeout_seconds", "progress"):
+        assert "input_binding" not in menu[name], f"{name} must not be staged as a file"
+
+
+def test_staged_script_is_appended_to_the_command(monkeypatch: MonkeyPatch) -> None:
+    # The relay rewrites 'script' to the staged cluster path before JARVIS records
+    # the step, so start() must execute that path rather than the caller's own.
+    package = _load_bounded_package(monkeypatch)
+    captured: dict[str, Any] = {}
+
+    def capture(command: list[str], **kwargs: object) -> Any:
+        captured["command"] = command
+        del kwargs
+        return cast(Any, package).subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(package, "_run_streaming", capture)
+    command = cast(Any, package).BoundedCommand()
+    command.config = {"command": ["bash"], "script": "/staged/inputs/smoke.sh"}
+
+    command.start()
+
+    assert captured["command"] == ["bash", "/staged/inputs/smoke.sh"]
+
+
+def test_unset_script_leaves_the_command_untouched(monkeypatch: MonkeyPatch) -> None:
+    package = _load_bounded_package(monkeypatch)
+    captured: dict[str, Any] = {}
+
+    def capture(command: list[str], **kwargs: object) -> Any:
+        captured["command"] = command
+        del kwargs
+        return cast(Any, package).subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(package, "_run_streaming", capture)
+    command = cast(Any, package).BoundedCommand()
+    command.config = {"command": ["hostname"], "script": ""}
+
+    command.start()
+
+    assert captured["command"] == ["hostname"]
+
+
+def test_non_string_script_is_rejected(monkeypatch: MonkeyPatch) -> None:
+    package = _load_bounded_package(monkeypatch)
+    command = cast(Any, package).BoundedCommand()
+    command.config = {"command": ["bash"], "script": ["smoke.sh"]}
+
+    with raises(ValueError):
+        command.start()
 
 
 def test_menu_defaults_execute_a_command_without_limit_or_workdir(
@@ -121,7 +188,7 @@ def test_menu_defaults_execute_a_command_without_limit_or_workdir(
         for name, option in _configure_menu(package).items()
         if "default" in option
     }
-    assert set(command.config) == {"workdir", "env", "timeout_seconds", "progress"}
+    assert set(command.config) == {"workdir", "env", "timeout_seconds", "progress", "script"}
     command.config["command"] = [sys.executable, "-c", "print('menu-default-run')"]
 
     command.start()
@@ -190,8 +257,23 @@ def _load_bounded_package(monkeypatch: MonkeyPatch) -> ModuleType:
     class Application:
         config: dict[str, Any]
 
+    class ConfigurationInputBinding:
+        """Mirror of the JARVIS-CD binding whose exact dict the relay parses."""
+
+        def __init__(self, *, kind: str, structure: str) -> None:
+            self.kind = kind
+            self.structure = structure
+
+        def to_dict(self) -> dict[str, Any]:
+            return {
+                "schema_version": "jarvis.configuration-input-binding.v1",
+                "kind": self.kind,
+                "structure": self.structure,
+            }
+
     jarvis_api = ModuleType("clio_relay._jarvis_api")
     cast(Any, jarvis_api).Application = Application
+    cast(Any, jarvis_api).ConfigurationInputBinding = ConfigurationInputBinding
     progress = ModuleType("clio_relay.bounded_command.progress")
 
     def no_progress_adapter(config: object) -> None:

--- a/tests/test_bounded_command_package.py
+++ b/tests/test_bounded_command_package.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any, cast
 
-from pytest import MonkeyPatch
+from pytest import MonkeyPatch, raises
 
 
 def test_bounded_tail_discards_oldest_output(monkeypatch: MonkeyPatch) -> None:
@@ -76,6 +76,112 @@ def test_bounded_command_scrubs_relay_capabilities_but_keeps_provider_credential
     scrubbed = cast(Any, package)._scrub_relay_environment(environment)
 
     assert scrubbed == {"SITE_PROVIDER_TOKEN": "provider-owned", "PATH": "kept"}
+
+
+def test_configure_menu_declares_every_configured_setting(monkeypatch: MonkeyPatch) -> None:
+    package = _load_bounded_package(monkeypatch)
+    menu = _configure_menu(package)
+
+    assert set(menu) == {"command", "workdir", "env", "timeout_seconds", "progress"}
+    assert menu["command"]["type"] is list
+    assert menu["workdir"]["type"] is str
+    assert menu["env"]["type"] is dict
+    assert menu["timeout_seconds"]["type"] is int
+    assert menu["progress"]["type"] is dict
+    for name, option in menu.items():
+        message = option.get("msg")
+        assert isinstance(message, str) and message, f"{name} declares no description"
+
+
+def test_configure_menu_marks_only_the_command_as_required(monkeypatch: MonkeyPatch) -> None:
+    # JARVIS derives "required" from a missing or None menu default, so an optional
+    # setting without a concrete default is rejected before the package ever runs.
+    package = _load_bounded_package(monkeypatch)
+    menu = _configure_menu(package)
+
+    assert "default" not in menu["command"]
+    for name in ("workdir", "env", "timeout_seconds", "progress"):
+        assert menu[name].get("default") is not None, f"{name} would become required"
+
+
+def test_menu_defaults_execute_a_command_without_limit_or_workdir(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    # JARVIS applies every menu default into the package config before start(),
+    # so the declared defaults must mean "no working directory" and "no timeout".
+    package = _load_bounded_package(monkeypatch)
+
+    def discard_output(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+
+    monkeypatch.setattr(package, "print", discard_output, raising=False)
+    command = cast(Any, package).BoundedCommand()
+    command.config = {
+        name: option["default"]
+        for name, option in _configure_menu(package).items()
+        if "default" in option
+    }
+    assert set(command.config) == {"workdir", "env", "timeout_seconds", "progress"}
+    command.config["command"] = [sys.executable, "-c", "print('menu-default-run')"]
+
+    command.start()
+
+
+def test_configure_rejects_a_command_that_is_not_a_string_vector(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    package = _load_bounded_package(monkeypatch)
+    command = cast(Any, package).BoundedCommand()
+    config: dict[str, Any] = {}
+    command.config = config
+
+    with raises(ValueError):
+        command._configure(command="hostname")
+    with raises(ValueError):
+        command._configure(command=[])
+    with raises(ValueError):
+        command._configure(command=["hostname", 3])
+
+    command._configure(workdir="/tmp")
+    assert config == {"workdir": "/tmp"}
+
+
+def test_default_progress_setting_configures_no_adapter(monkeypatch: MonkeyPatch) -> None:
+    package = _load_bounded_package(monkeypatch)
+    progress = _load_progress_module(monkeypatch)
+    default = _configure_menu(package)["progress"]["default"]
+    assert cast(Any, progress).adapter_from_config(default) is None
+
+
+def _configure_menu(package: ModuleType) -> dict[str, dict[str, Any]]:
+    command = cast(Any, package).BoundedCommand()
+    options = cast(list[dict[str, Any]], command._configure_menu())
+    menu: dict[str, dict[str, Any]] = {}
+    for option in options:
+        assert isinstance(option, dict)
+        name = option.get("name")
+        assert isinstance(name, str) and name
+        assert name not in menu
+        menu[name] = option
+    return menu
+
+
+def _load_progress_module(monkeypatch: MonkeyPatch) -> ModuleType:
+    path = (
+        Path(__file__).parents[1]
+        / "jarvis-packages"
+        / "clio_relay"
+        / "clio_relay"
+        / "bounded_command"
+        / "progress.py"
+    )
+    spec = importlib.util.spec_from_file_location("clio_relay_bounded_progress_test", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load bounded command progress module")
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _load_bounded_package(monkeypatch: MonkeyPatch) -> ModuleType:

--- a/tests/test_builtin_jarvis_input_staging.py
+++ b/tests/test_builtin_jarvis_input_staging.py
@@ -1,0 +1,809 @@
+"""MCP-flow tests for JARVIS local-input staging through the built-in JARVIS door."""
+
+from __future__ import annotations
+
+import base64
+import copy
+import hashlib
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from clio_relay import mcp_server as mcp_server_module
+from clio_relay.cluster_config import ClusterDefinition, cluster_route_revision
+from clio_relay.config import RelaySettings
+from clio_relay.core_queue import ClioCoreQueue
+from clio_relay.input_staging import (
+    JarvisPackageInputContract,
+    jarvis_package_input_contract_record,
+    jarvis_package_input_route,
+)
+from clio_relay.jarvis_input_plane import builtin_jarvis_staging_route, prepare_jarvis_inputs
+from clio_relay.mcp_server import McpSessionState, handle_request
+from clio_relay.models import (
+    ArtifactRef,
+    ArtifactUse,
+    InputArtifactSpec,
+    JobKind,
+    JobState,
+    McpCallSpec,
+    RelayJob,
+    deterministic_input_artifact_id,
+)
+from clio_relay.remote_mcp import VirtualRemoteMcpCatalog
+
+JSON = dict[str, Any]
+BUILTIN_ARTIFACT_DIGEST = "a" * 64
+
+
+class _BuiltinJarvisHarness:
+    """Deterministic owned-session boundary for built-in JARVIS door dispatch."""
+
+    def __init__(self, *, settings: RelaySettings) -> None:
+        self.settings = settings
+        self.submitted_payloads: list[JSON] = []
+        self.ingest_bodies: list[JSON] = []
+        self.nonterminal_tools: set[str] = set()
+        self.declare_input_binding = True
+        self._submission_by_key: dict[str, RelayJob] = {}
+
+    def submit_owned(self, **kwargs: object) -> RelayJob:
+        """Record the exact submitted payload and return one durable owned job."""
+        payload = copy.deepcopy(cast(JSON, kwargs["payload"]))
+        assert kwargs["path"] == "/jobs/jarvis-mcp-call"
+        self.submitted_payloads.append(payload)
+        idempotency_key = cast(str, payload["idempotency_key"])
+        existing = self._submission_by_key.get(idempotency_key)
+        if existing is not None:
+            return existing
+        raw_uses = cast(list[object], payload.get("used_artifact_refs", []))
+        job = RelayJob(
+            job_id=_durable_id("job", idempotency_key),
+            cluster=cast(str, payload["cluster"]),
+            kind=JobKind.MCP_CALL,
+            spec=McpCallSpec(
+                server="clio-kit",
+                server_args=["mcp-server", "jarvis"],
+                expected_server_artifact_digest=cast(
+                    str | None,
+                    payload.get("expected_server_artifact_digest"),
+                ),
+                tool=cast(str, payload["tool"]),
+                arguments=copy.deepcopy(cast(JSON, payload["arguments"])),
+                timeout_seconds=cast(int | None, payload.get("timeout_seconds")),
+            ),
+            idempotency_key=idempotency_key,
+            used_artifact_refs=[ArtifactUse.model_validate(item) for item in raw_uses],
+            metadata={
+                "owner": "clio-relay",
+                "owner_session_id": self.settings.owner_session_id,
+                "owner_session_generation_id": self.settings.owner_session_generation_id,
+            },
+        )
+        self._submission_by_key[idempotency_key] = job
+        return job
+
+    def submission_result(
+        self,
+        job: RelayJob,
+        *,
+        definition: ClusterDefinition,
+        wait_for_terminal_result: bool,
+        **_kwargs: object,
+    ) -> JSON:
+        """Return a terminal, artifact-verified result for the requested JARVIS call."""
+        assert isinstance(job.spec, McpCallSpec)
+        if job.spec.tool == "jarvis_describe":
+            assert wait_for_terminal_result is True
+        if job.spec.tool in {"jarvis_add_step", "jarvis_edit_step"} and job.used_artifact_refs:
+            assert wait_for_terminal_result is True
+        if job.spec.tool in self.nonterminal_tools:
+            return {
+                "cluster": definition.name,
+                "job_id": job.job_id,
+                "state": "queued",
+                "kind": "mcp_call",
+                "terminal": False,
+                "remote": True,
+                "route_revision": cluster_route_revision(definition),
+            }
+        result: JSON = {
+            "cluster": definition.name,
+            "job_id": job.job_id,
+            "state": "succeeded",
+            "kind": "mcp_call",
+            "terminal": True,
+            "remote": True,
+            "route_revision": cluster_route_revision(definition),
+            "last_error": None,
+        }
+        if job.spec.tool == "jarvis_describe":
+            result["mcp_result"] = _describe_mcp_result(
+                declare_input_binding=self.declare_input_binding
+            )
+        elif job.spec.tool == "jarvis_add_step":
+            package_name = cast(str, job.spec.arguments["package_name"])
+            result["mcp_result"] = {
+                "tool": "jarvis_add_step",
+                "structured_result": {
+                    "pipeline_id": job.spec.arguments["pipeline_id"],
+                    "appended": package_name,
+                    "step_id": job.spec.arguments.get("step_id") or package_name.rsplit(".", 1)[-1],
+                    "configured": True,
+                    "config": job.spec.arguments.get("config", {}),
+                },
+            }
+        return result
+
+    def ingest(self, body: JSON) -> JSON:
+        """Return the exact hidden-ingest response for one bounded content snapshot."""
+        self.ingest_bodies.append(copy.deepcopy(body))
+        data = base64.b64decode(cast(str, body["data_base64"]), validate=True)
+        logical_name = cast(str, body["logical_name"])
+        sha256 = cast(str, body["sha256"])
+        assert len(data) == body["size_bytes"]
+        assert hashlib.sha256(data).hexdigest() == sha256
+        idempotency_key = cast(str, body["idempotency_key"])
+        producer = RelayJob(
+            job_id=_durable_id("job", idempotency_key),
+            cluster="ares",
+            kind=JobKind.INPUT_INGEST,
+            state=JobState.SUCCEEDED,
+            spec=InputArtifactSpec(
+                logical_name=logical_name,
+                size_bytes=len(data),
+                sha256=sha256,
+            ),
+            idempotency_key=idempotency_key,
+            metadata={
+                "owner": "clio-relay",
+                "owner_session_id": self.settings.owner_session_id,
+                "owner_session_generation_id": self.settings.owner_session_generation_id,
+            },
+        )
+        artifact = ArtifactRef(
+            artifact_id=deterministic_input_artifact_id(producer.job_id),
+            job_id=producer.job_id,
+            uri=f"file:///srv/clio-relay/{producer.job_id}/inputs/{logical_name}",
+            kind="input",
+            size_bytes=len(data),
+            sha256=sha256,
+        )
+        return {
+            "job": producer.model_dump(mode="json"),
+            "artifact": artifact.model_dump(mode="json"),
+        }
+
+
+def test_builtin_jarvis_input_flows_from_describe_through_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The built-in door stages its declared file, rewrites config, and pins the run."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    source = workspace / "in.lj"
+    source.write_text("units lj\nrun 5000\n", encoding="utf-8")
+    settings, definition, harness = _configured_flow(tmp_path, workspace=workspace)
+    _patch_flow(monkeypatch, definition=definition, harness=harness)
+    queue = ClioCoreQueue(settings.core_dir)
+    session = McpSessionState()
+    _advertise(queue, settings=settings, session=session)
+
+    described = _describe_package(queue, settings=settings, session=session)
+    assert "error" not in described
+    assert len(session.jarvis_package_input_contracts) == 2
+    contracts = list(session.jarvis_package_input_contracts.values())
+    assert {contract.package_names for contract in contracts} == {("builtin.lammps", "lammps")}
+    assert all(contract.local_file_settings[0].canonical_name == "script" for contract in contracts)
+
+    add_arguments: JSON = {
+        "cluster": "ares",
+        "pipeline_id": "science-run",
+        "package_name": "lammps",
+        "config": {
+            "script": "in.lj",
+            "out": ".",
+            "restart_path": "researcher-owned/restart.bin",
+        },
+        "idempotency_key": "builtin-add-lammps",
+    }
+    added = _call(
+        queue,
+        settings=settings,
+        session=session,
+        name="jarvis_add_step",
+        arguments=add_arguments,
+    )
+    assert "error" not in added
+    assert add_arguments["config"]["script"] == "in.lj"
+    add_payload = harness.submitted_payloads[-1]
+    forwarded_config = cast(JSON, cast(JSON, add_payload["arguments"])["config"])
+    assert forwarded_config["script"].startswith("/srv/clio-relay/job_")
+    assert forwarded_config["script"].endswith("/inputs/in.lj")
+    assert forwarded_config["out"] == "."
+    assert forwarded_config["restart_path"] == "researcher-owned/restart.bin"
+    add_uses = cast(list[JSON], add_payload["used_artifact_refs"])
+    source_sha256 = hashlib.sha256(source.read_bytes()).hexdigest()
+    assert len(add_uses) == 1
+    assert add_uses[0]["sha256"] == source_sha256
+    assert add_uses[0]["provenance"]["evidence"] == "schema-arg"
+    assert add_uses[0]["provenance"]["arg"] == "script"
+    assert len(harness.ingest_bodies) == 1
+
+    # A restarted MCP process must recover the exact lineage from durable storage.
+    queue = ClioCoreQueue(settings.core_dir)
+    session = McpSessionState()
+    _advertise(queue, settings=settings, session=session)
+
+    ran = _call(
+        queue,
+        settings=settings,
+        session=session,
+        name="jarvis_run",
+        arguments={
+            "cluster": "ares",
+            "pipeline_id": "science-run",
+            "idempotency_key": "builtin-run-lammps",
+        },
+    )
+    assert "error" not in ran
+    run_payload = harness.submitted_payloads[-1]
+    assert run_payload["tool"] == "jarvis_run"
+    assert run_payload["used_artifact_refs"] == add_uses
+    assert len(harness.ingest_bodies) == 1
+
+
+def test_builtin_edit_step_restages_tracked_binding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tracked built-in edit stages the newly named file and rewrites its config."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    first = workspace / "first.lj"
+    second = workspace / "second.lj"
+    first.write_text("run 1\n", encoding="utf-8")
+    second.write_text("run 2\n", encoding="utf-8")
+    settings, definition, harness = _configured_flow(tmp_path, workspace=workspace)
+    _patch_flow(monkeypatch, definition=definition, harness=harness)
+    queue = ClioCoreQueue(settings.core_dir)
+    session = McpSessionState()
+    _advertise(queue, settings=settings, session=session)
+    _describe_package(queue, settings=settings, session=session)
+    added = _call(
+        queue,
+        settings=settings,
+        session=session,
+        name="jarvis_add_step",
+        arguments={
+            "cluster": "ares",
+            "pipeline_id": "edited-pipeline",
+            "package_name": "lammps",
+            "config": {"script": "first.lj"},
+            "idempotency_key": "builtin-edited-add",
+        },
+    )
+    assert "error" not in added
+
+    edited = _call(
+        queue,
+        settings=settings,
+        session=session,
+        name="jarvis_edit_step",
+        arguments={
+            "cluster": "ares",
+            "pipeline_id": "edited-pipeline",
+            "step_id": "lammps",
+            "config": {"script": "second.lj"},
+            "operation": "edit",
+            "idempotency_key": "builtin-edited-v2",
+        },
+    )
+    assert "error" not in edited
+    edit_payload = harness.submitted_payloads[-1]
+    edit_config = cast(JSON, cast(JSON, edit_payload["arguments"])["config"])
+    assert edit_config["script"].endswith("/inputs/second.lj")
+    assert cast(list[JSON], edit_payload["used_artifact_refs"])[0]["sha256"] == (
+        hashlib.sha256(second.read_bytes()).hexdigest()
+    )
+    assert len(harness.ingest_bodies) == 2
+
+
+def test_builtin_run_refuses_content_that_drifted_after_staging(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A run cannot claim freshly changed bytes the cluster configuration never received."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    source = workspace / "in.lj"
+    source.write_text("run 1\n", encoding="utf-8")
+    settings, definition, harness = _configured_flow(tmp_path, workspace=workspace)
+    _patch_flow(monkeypatch, definition=definition, harness=harness)
+    queue = ClioCoreQueue(settings.core_dir)
+    session = McpSessionState()
+    _advertise(queue, settings=settings, session=session)
+    _describe_package(queue, settings=settings, session=session)
+    added = _call(
+        queue,
+        settings=settings,
+        session=session,
+        name="jarvis_add_step",
+        arguments={
+            "cluster": "ares",
+            "pipeline_id": "drift-pipeline",
+            "package_name": "lammps",
+            "config": {"script": "in.lj"},
+            "idempotency_key": "builtin-drift-add",
+        },
+    )
+    assert "error" not in added
+    source.write_text("run 2\n", encoding="utf-8")
+
+    ran = _call(
+        queue,
+        settings=settings,
+        session=session,
+        name="jarvis_run",
+        arguments={
+            "cluster": "ares",
+            "pipeline_id": "drift-pipeline",
+            "idempotency_key": "builtin-drift-run",
+        },
+    )
+
+    assert ran["error"]["code"] == -32000
+    assert "jarvis_edit_step" in ran["error"]["message"]
+    assert "lammps.script" in ran["error"]["message"]
+    assert harness.submitted_payloads[-1]["tool"] == "jarvis_add_step"
+    assert len(harness.ingest_bodies) == 1
+
+
+def test_builtin_add_step_without_describe_refuses_before_reading_local_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The built-in door requires route-bound package semantics before configuration."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "in.lj").write_text("run 1\n", encoding="utf-8")
+    settings, definition, harness = _configured_flow(tmp_path, workspace=workspace)
+    _patch_flow(monkeypatch, definition=definition, harness=harness)
+
+    def forbidden_snapshot(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("local file was read without package schema evidence")
+
+    monkeypatch.setattr(
+        "clio_relay.input_staging.snapshot_owned_regular_file",
+        forbidden_snapshot,
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+    session = McpSessionState()
+    _advertise(queue, settings=settings, session=session)
+
+    response = _call(
+        queue,
+        settings=settings,
+        session=session,
+        name="jarvis_add_step",
+        arguments={
+            "cluster": "ares",
+            "pipeline_id": "no-description",
+            "package_name": "lammps",
+            "config": {"script": "in.lj"},
+        },
+    )
+
+    assert response["error"]["code"] == -32000
+    assert "requires a successful jarvis_describe" in response["error"]["message"]
+    assert harness.submitted_payloads == []
+    assert harness.ingest_bodies == []
+
+
+def test_builtin_add_step_refuses_unreadable_declared_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A declared local file that cannot be read never reaches the cluster verbatim."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    settings, definition, harness = _configured_flow(tmp_path, workspace=workspace)
+    _patch_flow(monkeypatch, definition=definition, harness=harness)
+    queue = ClioCoreQueue(settings.core_dir)
+    session = McpSessionState()
+    _advertise(queue, settings=settings, session=session)
+    _describe_package(queue, settings=settings, session=session)
+
+    response = _call(
+        queue,
+        settings=settings,
+        session=session,
+        name="jarvis_add_step",
+        arguments={
+            "cluster": "ares",
+            "pipeline_id": "missing-input",
+            "package_name": "lammps",
+            "config": {"script": "absent.lj"},
+            "idempotency_key": "builtin-missing-add",
+        },
+    )
+
+    assert response["error"]["code"] == -32000
+    assert harness.ingest_bodies == []
+    assert [payload["tool"] for payload in harness.submitted_payloads] == ["jarvis_describe"]
+
+
+def test_builtin_add_step_refuses_without_configured_input_workspace_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Staging a declared file requires the operator-configured private workspace root."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "in.lj").write_text("run 1\n", encoding="utf-8")
+    settings, definition, harness = _configured_flow(
+        tmp_path,
+        workspace=workspace,
+        workspace_root_configured=False,
+    )
+    _patch_flow(monkeypatch, definition=definition, harness=harness)
+    queue = ClioCoreQueue(settings.core_dir)
+    session = McpSessionState()
+    _advertise(queue, settings=settings, session=session)
+    _describe_package(queue, settings=settings, session=session)
+
+    response = _call(
+        queue,
+        settings=settings,
+        session=session,
+        name="jarvis_add_step",
+        arguments={
+            "cluster": "ares",
+            "pipeline_id": "unrooted",
+            "package_name": "lammps",
+            "config": {"script": "in.lj"},
+            "idempotency_key": "builtin-unrooted-add",
+        },
+    )
+
+    assert response["error"]["code"] == -32000
+    assert "CLIO_RELAY_INPUT_WORKSPACE_ROOT" in response["error"]["message"]
+    assert harness.ingest_bodies == []
+    assert [payload["tool"] for payload in harness.submitted_payloads] == ["jarvis_describe"]
+
+
+def test_builtin_add_step_refuses_without_owned_remote_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Byte ingest requires the relay-owned remote session that carries it."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "in.lj").write_text("run 1\n", encoding="utf-8")
+    settings, definition, harness = _configured_flow(tmp_path, workspace=workspace)
+    _patch_flow(monkeypatch, definition=definition, harness=harness)
+    queue = ClioCoreQueue(settings.core_dir)
+    session = McpSessionState()
+    _advertise(queue, settings=settings, session=session)
+    _describe_package(queue, settings=settings, session=session)
+    unowned = _settings(
+        tmp_path,
+        workspace=workspace,
+        owner_session_id=None,
+    )
+
+    response = _call(
+        queue,
+        settings=unowned,
+        session=session,
+        name="jarvis_add_step",
+        arguments={
+            "cluster": "ares",
+            "pipeline_id": "unowned",
+            "package_name": "lammps",
+            "config": {"script": "in.lj"},
+            "idempotency_key": "builtin-unowned-add",
+        },
+    )
+
+    assert response["error"]["code"] == -32000
+    assert "relay-owned remote session" in response["error"]["message"]
+    assert harness.ingest_bodies == []
+    assert [payload["tool"] for payload in harness.submitted_payloads] == ["jarvis_describe"]
+
+
+def test_builtin_add_step_forwards_settings_without_input_bindings_verbatim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A package whose settings declare no binding keeps cluster-side paths untouched."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    settings, definition, harness = _configured_flow(tmp_path, workspace=workspace)
+    _patch_flow(monkeypatch, definition=definition, harness=harness, declare_input_binding=False)
+    queue = ClioCoreQueue(settings.core_dir)
+    session = McpSessionState()
+    _advertise(queue, settings=settings, session=session)
+    _describe_package(queue, settings=settings, session=session)
+
+    added = _call(
+        queue,
+        settings=settings,
+        session=session,
+        name="jarvis_add_step",
+        arguments={
+            "cluster": "ares",
+            "pipeline_id": "unbound-pipeline",
+            "package_name": "lammps",
+            "config": {"script": "/cluster/absolute/in.lj", "out": "."},
+            "idempotency_key": "builtin-unbound-add",
+        },
+    )
+
+    assert "error" not in added
+    payload = harness.submitted_payloads[-1]
+    assert cast(JSON, payload["arguments"])["config"] == {
+        "script": "/cluster/absolute/in.lj",
+        "out": ".",
+    }
+    assert payload.get("used_artifact_refs", []) == []
+    assert harness.ingest_bodies == []
+
+
+def test_builtin_package_without_declared_inputs_configures_without_owned_session(
+    tmp_path: Path,
+) -> None:
+    """A package that stages nothing needs no owned session and no lineage route."""
+    settings = _settings(tmp_path, workspace=None, owner_session_id=None)
+    queue = ClioCoreQueue(settings.core_dir)
+    definition = ClusterDefinition(name="ares", ssh_host="ares-login")
+    route = builtin_jarvis_staging_route(
+        cluster="ares",
+        cluster_route_revision=cluster_route_revision(definition),
+        expected_server_artifact_digest=BUILTIN_ARTIFACT_DIGEST,
+        remote_tool_name="jarvis_add_step",
+    )
+    package_route = jarvis_package_input_route(
+        cluster=route.cluster,
+        server_name=route.server_name,
+        cluster_route_revision=route.cluster_route_revision,
+        registration_revision=route.registration_revision,
+        expected_server_artifact_digest=route.expected_server_artifact_digest,
+        package_name="lammps",
+    )
+    queue.put_jarvis_package_input_contract(
+        jarvis_package_input_contract_record(
+            route=package_route,
+            contract=JarvisPackageInputContract(
+                cache_key=package_route.identity_sha256(),
+                package_names=("lammps",),
+                local_file_settings=(),
+                settings_sha256="0" * 64,
+            ),
+        )
+    )
+
+    plan = prepare_jarvis_inputs(
+        {
+            "pipeline_id": "unbound",
+            "package_name": "lammps",
+            "config": {"script": "/cluster/absolute/in.lj"},
+        },
+        route=route,
+        queue=queue,
+        settings=settings,
+        session=None,
+        resolve_definition=lambda _cluster: definition,
+        requested_idempotency_key=None,
+    )
+
+    assert plan.arguments["config"] == {"script": "/cluster/absolute/in.lj"}
+    assert plan.automatic_artifact_uses == ()
+    assert plan.pipeline_route is None
+    assert plan.require_terminal_wait is False
+
+
+def _settings(
+    tmp_path: Path,
+    *,
+    workspace: Path | None,
+    owner_session_id: str | None = "desktop-session",
+) -> RelaySettings:
+    return RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        owner_session_id=owner_session_id,
+        owner_session_generation_id=(
+            "generation_0123456789abcdef0123456789abcdef" if owner_session_id else None
+        ),
+        owner_session_cluster="ares" if owner_session_id else None,
+        api_token="session-token",
+        input_workspace_root=workspace,
+        input_file_max_bytes=1024,
+        input_total_max_bytes=4096,
+    )
+
+
+def _configured_flow(
+    tmp_path: Path,
+    *,
+    workspace: Path,
+    workspace_root_configured: bool = True,
+) -> tuple[RelaySettings, ClusterDefinition, _BuiltinJarvisHarness]:
+    definition = ClusterDefinition(name="ares", ssh_host="ares-login")
+    settings = _settings(tmp_path, workspace=workspace if workspace_root_configured else None)
+    return settings, definition, _BuiltinJarvisHarness(settings=settings)
+
+
+def _patch_flow(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    definition: ClusterDefinition,
+    harness: _BuiltinJarvisHarness,
+    declare_input_binding: bool = True,
+) -> None:
+    harness.declare_input_binding = declare_input_binding
+    route_revision = cluster_route_revision(definition)
+
+    def catalog(**_kwargs: object) -> VirtualRemoteMcpCatalog:
+        return VirtualRemoteMcpCatalog(
+            revision="d" * 64,
+            tools={},
+            issues=(),
+            cluster_route_revisions={"ares": route_revision},
+            jarvis_artifact_bindings={"ares": BUILTIN_ARTIFACT_DIGEST},
+        )
+
+    class FakeOwnedSessionApiClient:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        def __enter__(self) -> FakeOwnedSessionApiClient:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def request_json(
+            self,
+            *,
+            method: str,
+            path: str,
+            body: JSON,
+            **_kwargs: object,
+        ) -> object:
+            assert method == "POST"
+            assert path == "/input-artifacts/ingest"
+            return harness.ingest(body)
+
+    def remote_definition(_cluster: str) -> ClusterDefinition:
+        return definition
+
+    def artifact_binding(_cluster: str) -> str:
+        return BUILTIN_ARTIFACT_DIGEST
+
+    def execute_remotely(_definition: ClusterDefinition) -> bool:
+        return True
+
+    monkeypatch.setattr(mcp_server_module, "_remote_mcp_catalog", catalog)
+    monkeypatch.setattr(mcp_server_module, "_remote_cluster_definition", remote_definition)
+    monkeypatch.setattr(mcp_server_module, "jarvis_mcp_artifact_binding", artifact_binding)
+    monkeypatch.setattr(mcp_server_module, "should_execute_on_cluster", execute_remotely)
+    monkeypatch.setattr(mcp_server_module, "submit_owned_session_job", harness.submit_owned)
+    monkeypatch.setattr(
+        mcp_server_module,
+        "_owned_session_submission_result",
+        harness.submission_result,
+    )
+    monkeypatch.setattr(
+        "clio_relay.input_staging.OwnedSessionApiClient",
+        FakeOwnedSessionApiClient,
+    )
+
+
+def _advertise(
+    queue: ClioCoreQueue,
+    *,
+    settings: RelaySettings,
+    session: McpSessionState,
+) -> None:
+    response = handle_request(
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        queue=queue,
+        settings=settings,
+        profile="user",
+        session=session,
+    )
+    assert response is not None and "error" not in response
+
+
+def _call(
+    queue: ClioCoreQueue,
+    *,
+    settings: RelaySettings,
+    session: McpSessionState,
+    name: str,
+    arguments: JSON,
+) -> JSON:
+    response = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments},
+        },
+        queue=queue,
+        settings=settings,
+        profile="user",
+        session=session,
+    )
+    assert response is not None
+    return response
+
+
+def _describe_package(
+    queue: ClioCoreQueue,
+    *,
+    settings: RelaySettings,
+    session: McpSessionState,
+    idempotency_key: str = "builtin-describe-package",
+) -> JSON:
+    response = _call(
+        queue,
+        settings=settings,
+        session=session,
+        name="jarvis_describe",
+        arguments={
+            "cluster": "ares",
+            "target": "package",
+            "package_name": "lammps",
+            "idempotency_key": idempotency_key,
+        },
+    )
+    assert "error" not in response
+    return response
+
+
+def _describe_mcp_result(*, declare_input_binding: bool = True) -> JSON:
+    script_setting: JSON = {
+        "name": "script",
+        "aliases": [],
+        "type": "str",
+        "required": False,
+        "nullable": False,
+        "default": "",
+    }
+    if declare_input_binding:
+        script_setting["input_binding"] = {
+            "schema_version": "jarvis.configuration-input-binding.v1",
+            "kind": "local_file",
+            "structure": "regular_file",
+        }
+    return {
+        "tool": "jarvis_describe",
+        "structured_result": {
+            "result": {
+                "target": "package",
+                "package": {
+                    "name": "builtin.lammps",
+                    "short_name": "lammps",
+                    "settings": [
+                        script_setting,
+                        {
+                            "name": "out",
+                            "type": "str",
+                            "required": False,
+                            "nullable": False,
+                            "default": ".",
+                        },
+                    ],
+                },
+            }
+        },
+    }
+
+
+def _durable_id(prefix: str, value: str) -> str:
+    return f"{prefix}_{hashlib.sha256(value.encode('utf-8')).hexdigest()[:32]}"

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -24,6 +24,10 @@ from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.errors import ConfigurationError
 from clio_relay.http_api import create_app
 from clio_relay.jarvis_mcp import jarvis_cd_lock_binding_expectation
+from clio_relay.job_identity import (
+    OWNER_SESSION_ID_HEADER,
+    SESSION_GENERATION_ID_HEADER,
+)
 from clio_relay.models import (
     MCP_ADMISSION_AUTHORITY_METADATA_KEY,
     ArtifactRef,
@@ -55,11 +59,7 @@ from clio_relay.remote_mcp import (
     remote_mcp_registration_revision,
     remote_mcp_server_artifact_digest,
 )
-from clio_relay.session_api import (
-    OWNER_SESSION_ID_HEADER,
-    SESSION_GENERATION_ID_HEADER,
-    session_identity_document,
-)
+from clio_relay.session_api import session_identity_document
 from clio_relay.spool import JobSpool
 from clio_relay.storage_runtime import StorageManagedQueue
 

--- a/tests/test_input_artifact_ingest.py
+++ b/tests/test_input_artifact_ingest.py
@@ -21,6 +21,7 @@ from clio_relay.config import RelaySettings
 from clio_relay.core_queue import INPUT_INGEST_ORIGINAL_POLICY_METADATA_KEY, ClioCoreQueue
 from clio_relay.errors import QueueConflictError
 from clio_relay.http_api import InputArtifactBodyLimitMiddleware, create_app
+from clio_relay.job_identity import OWNER_SESSION_ID_HEADER, SESSION_GENERATION_ID_HEADER
 from clio_relay.models import (
     INPUT_INGEST_POLICY_METADATA_KEY,
     EndpointRegistration,
@@ -36,7 +37,6 @@ from clio_relay.models import (
     utc_now,
 )
 from clio_relay.queue_management import diagnose_job
-from clio_relay.session_api import OWNER_SESSION_ID_HEADER, SESSION_GENERATION_ID_HEADER
 from clio_relay.spool import JobSpool
 from clio_relay.storage_runtime import storage_managed_queue
 

--- a/tests/test_jarvis_run_failure_reporting.py
+++ b/tests/test_jarvis_run_failure_reporting.py
@@ -437,6 +437,86 @@ def test_refusal_outranks_a_clean_transport_exit(
     assert result.last_error == f"{SPECIMEN_ERROR_CODE}: {SPECIMEN_ERROR_MESSAGE}"
 
 
+def test_restart_cleanup_settles_a_run_left_stuck_by_an_earlier_build(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A job already stuck behind a failed recovery query settles on the next pass.
+
+    This reproduces the live specimen's durable state: the errored dispatch is in
+    the spool, the recovery intent is still pending, and the job never left
+    ``running``. Restart cleanup must read the recorded answer instead of
+    querying JARVIS again for an execution that was never created.
+    """
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    command = ["clio-kit", "mcp-server", "jarvis"]
+    server_artifact = {
+        **verified_jarvis_server_artifact(),
+        "install_spec": "/releases/clio-kit.whl",
+    }
+    digest = remote_mcp_server_artifact_digest(server_artifact)
+    monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
+    job = _submit_registered_run(
+        queue,
+        command=command,
+        digest=digest,
+        idempotency_key="copper-elastic-v1-run-007",
+    )
+    spec = cast(McpCallSpec, job.spec)
+    provider = _DispatchProvider(
+        document=_specimen_error_result_document(
+            command=command,
+            digest=digest,
+            server_artifact=server_artifact,
+            arguments=spec.arguments,
+            expected_registered_contract=spec.expected_registered_contract,
+            execution_id=cast(str, spec.arguments["execution_id"]),
+        ),
+        returncode=1,
+    )
+    worker = _worker(settings, queue, provider)
+
+    def _blind_to_refusals(_document: object) -> None:
+        return None
+
+    def _failed_recovery_query(*_args: object, **_kwargs: object) -> bool:
+        raise endpoint_module.SchedulerSubmissionUnresolvedError(
+            "artifact-pinned JARVIS execution recovery result was not trusted"
+        )
+
+    monkeypatch.setattr(endpoint_module, "jarvis_dispatch_refusal", _blind_to_refusals)
+    monkeypatch.setattr(
+        endpoint_module.EndpointWorker,
+        "_recover_jarvis_execution",
+        _failed_recovery_query,
+    )
+
+    stuck = worker.run_once()
+
+    assert stuck is not None
+    assert stuck.state is JobState.RUNNING
+    stuck_task = queue.list_tasks(job.job_id)[0]
+    stuck_intent = cast(dict[str, object], stuck_task.metadata["jarvis_execution_recovery"])
+    assert stuck_intent["state"] == "pending"
+
+    monkeypatch.undo()
+    monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
+
+    assert worker.run_once() is None
+
+    settled = queue.get_job(job.job_id)
+    assert settled.state is JobState.FAILED
+    assert settled.last_error == f"{SPECIMEN_ERROR_CODE}: {SPECIMEN_ERROR_MESSAGE}"
+    settled_task = queue.get_task(stuck_task.task_id)
+    assert settled_task.state is JobState.FAILED
+    settled_intent = cast(dict[str, object], settled_task.metadata["jarvis_execution_recovery"])
+    assert settled_intent["state"] == "resolved"
+    assert settled_intent["resolution"] == "dispatch_refusal"
+    events, _cursor = queue.drain_events(Cursor(job_id=job.job_id), limit=300)
+    assert "jarvis.dispatch_refused" in {event.event_type for event in events}
+
+
 def test_successful_jarvis_run_still_terminalizes_as_succeeded(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/test_jarvis_run_failure_reporting.py
+++ b/tests/test_jarvis_run_failure_reporting.py
@@ -1,4 +1,4 @@
-"""A refused JARVIS run reaches a terminal state carrying its typed reason.
+"""A refused JARVIS run terminalizes, and a registered Spack path reaches it.
 
 The MCP result documents below reproduce the shapes captured on the isolated
 ``p5run2`` deployment for durable job ``job_63d173b2bf8a47d2b811860ac26af569``:
@@ -19,14 +19,23 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, cast
 
+import pytest
 from pytest import MonkeyPatch
 
 from clio_relay import endpoint as endpoint_module
+from clio_relay import jarvis_run_environment as jarvis_run_environment_module
+from clio_relay.cluster_config import ClusterDefinition, ClusterRegistry
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.endpoint import EndpointWorker
+from clio_relay.errors import ConfigurationError
 from clio_relay.jarvis_dispatch_failure import jarvis_dispatch_refusal
 from clio_relay.jarvis_provider import JarvisCdProvider
+from clio_relay.jarvis_run_environment import (
+    RELAY_JARVIS_SPACK_COMMAND_ENV,
+    jarvis_run_environment_values,
+    registered_site_spack_command,
+)
 from clio_relay.models import (
     Cursor,
     EndpointRole,
@@ -47,6 +56,7 @@ SPECIMEN_ERROR_MESSAGE = (
     "Run failed: Spack executable was not found in PATH, SPACK_ROOT/bin, "
     "~/.local/spack, or /opt/spack"
 )
+SITE_SPACK_COMMAND = "/home/operator/.local/share/clio-relay/site-profiles/ares-spack-v1/bin/spack"
 
 
 def _specimen_error_result_document(
@@ -547,3 +557,169 @@ def test_successful_protocol_result_is_not_a_refusal() -> None:
     }
 
     assert jarvis_dispatch_refusal(document) is None
+
+
+def _registry_with(tmp_path: Path, *, spack_executable: str | None) -> Path:
+    registry_path = tmp_path / "clusters.json"
+    ClusterRegistry(
+        clusters={
+            CLUSTER: ClusterDefinition(
+                name=CLUSTER,
+                ssh_host="localhost",
+                spack_executable=spack_executable,
+            )
+        }
+    ).save(registry_path)
+    return registry_path
+
+
+def test_registered_spack_executable_reaches_the_run_environment(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A declared cluster Spack executable is composed for the JARVIS child."""
+    registry_path = _registry_with(tmp_path, spack_executable=SITE_SPACK_COMMAND)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+
+    resolved = registered_site_spack_command(CLUSTER)
+
+    assert resolved == SITE_SPACK_COMMAND
+    assert jarvis_run_environment_values(resolved) == {
+        RELAY_JARVIS_SPACK_COMMAND_ENV: SITE_SPACK_COMMAND
+    }
+
+
+def test_home_anchored_spack_executable_expands_on_the_executing_host(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A ``$HOME``-anchored registration resolves against the worker's account."""
+    registry_path = _registry_with(
+        tmp_path,
+        spack_executable="$HOME/.local/share/clio-relay/site-profiles/ares-spack-v1/bin/spack",
+    )
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+
+    def _fake_expanduser(_value: str) -> str:
+        return "/home/operator"
+
+    monkeypatch.setattr(jarvis_run_environment_module.os.path, "expanduser", _fake_expanduser)
+
+    assert registered_site_spack_command(CLUSTER) == SITE_SPACK_COMMAND
+
+
+def test_cluster_without_a_declaration_composes_nothing(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """An undeclared Spack executable never invents a default."""
+    registry_path = _registry_with(tmp_path, spack_executable=None)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+
+    assert registered_site_spack_command(CLUSTER) is None
+    assert jarvis_run_environment_values(None) == {}
+    assert registered_site_spack_command("another-cluster") is None
+
+
+def test_unreadable_registry_refuses_instead_of_downgrading(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A configured registry that cannot be read is a refusal, not a quiet skip."""
+    registry_path = tmp_path / "clusters.json"
+    registry_path.write_text("{not json", encoding="utf-8")
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+
+    with pytest.raises(ConfigurationError, match="cluster registry could not be read"):
+        registered_site_spack_command(CLUSTER)
+
+
+def test_worker_publishes_the_registered_spack_command_to_the_mcp_runner(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The dispatched runner environment carries the cluster's Spack identity."""
+    registry_path = _registry_with(tmp_path, spack_executable=SITE_SPACK_COMMAND)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    command = ["clio-kit", "mcp-server", "jarvis"]
+    server_artifact = {
+        **verified_jarvis_server_artifact(),
+        "install_spec": "/releases/clio-kit.whl",
+    }
+    digest = remote_mcp_server_artifact_digest(server_artifact)
+    monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
+    job = _submit_registered_run(
+        queue,
+        command=command,
+        digest=digest,
+        idempotency_key="copper-elastic-v1-run-004",
+    )
+    spec = cast(McpCallSpec, job.spec)
+    provider = _DispatchProvider(
+        document=_successful_result_document(
+            command=command,
+            digest=digest,
+            server_artifact=server_artifact,
+            arguments=spec.arguments,
+            expected_registered_contract=spec.expected_registered_contract,
+            execution_id=cast(str, spec.arguments["execution_id"]),
+        ),
+        returncode=0,
+    )
+
+    result = _worker(settings, queue, provider).run_once()
+
+    assert result is not None
+    assert result.state is JobState.SUCCEEDED
+    assert provider.environments
+    assert provider.environments[0][RELAY_JARVIS_SPACK_COMMAND_ENV] == SITE_SPACK_COMMAND
+    events, _cursor = queue.drain_events(Cursor(job_id=job.job_id), limit=200)
+    composed = [event for event in events if event.event_type == "jarvis.run_environment_composed"]
+    assert len(composed) == 1
+    assert composed[0].payload["spack_command"] == SITE_SPACK_COMMAND
+
+
+def test_worker_without_a_declaration_leaves_the_run_environment_unchanged(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """No declaration keeps the previously composed runner environment exactly."""
+    registry_path = _registry_with(tmp_path, spack_executable=None)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    command = ["clio-kit", "mcp-server", "jarvis"]
+    server_artifact = {
+        **verified_jarvis_server_artifact(),
+        "install_spec": "/releases/clio-kit.whl",
+    }
+    digest = remote_mcp_server_artifact_digest(server_artifact)
+    monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
+    job = _submit_registered_run(
+        queue,
+        command=command,
+        digest=digest,
+        idempotency_key="copper-elastic-v1-run-005",
+    )
+    spec = cast(McpCallSpec, job.spec)
+    provider = _DispatchProvider(
+        document=_successful_result_document(
+            command=command,
+            digest=digest,
+            server_artifact=server_artifact,
+            arguments=spec.arguments,
+            expected_registered_contract=spec.expected_registered_contract,
+            execution_id=cast(str, spec.arguments["execution_id"]),
+        ),
+        returncode=0,
+    )
+
+    result = _worker(settings, queue, provider).run_once()
+
+    assert result is not None
+    assert provider.environments
+    assert RELAY_JARVIS_SPACK_COMMAND_ENV not in provider.environments[0]
+    events, _cursor = queue.drain_events(Cursor(job_id=job.job_id), limit=200)
+    assert not [event for event in events if event.event_type == "jarvis.run_environment_composed"]

--- a/tests/test_jarvis_run_failure_reporting.py
+++ b/tests/test_jarvis_run_failure_reporting.py
@@ -1,0 +1,549 @@
+"""A refused JARVIS run reaches a terminal state carrying its typed reason.
+
+The MCP result documents below reproduce the shapes captured on the isolated
+``p5run2`` deployment for durable job ``job_63d173b2bf8a47d2b811860ac26af569``:
+``relay-spool/job_63d1.../mcp-result.json`` recorded ``returncode`` 1,
+``protocol_error`` ``"tools/call returned isError=true"``, ``timed_out`` false,
+``protocol_result.isError`` true and a ``jarvis.error.v1`` structured payload
+carrying ``jarvis_run_failed`` with the message
+``"Run failed: Spack executable was not found in PATH, SPACK_ROOT/bin,
+~/.local/spack, or /opt/spack"``. The durable job stayed ``running`` with
+``updated_at`` frozen two seconds after creation.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+from pytest import MonkeyPatch
+
+from clio_relay import endpoint as endpoint_module
+from clio_relay.config import RelaySettings
+from clio_relay.core_queue import ClioCoreQueue
+from clio_relay.endpoint import EndpointWorker
+from clio_relay.jarvis_dispatch_failure import jarvis_dispatch_refusal
+from clio_relay.jarvis_provider import JarvisCdProvider
+from clio_relay.models import (
+    Cursor,
+    EndpointRole,
+    JobKind,
+    JobState,
+    McpCallSpec,
+    RelayJob,
+    deterministic_jarvis_execution_id,
+)
+from clio_relay.remote_mcp import remote_mcp_server_artifact_digest
+from tests.jarvis_mcp_fakes import verified_jarvis_server_artifact
+
+CLUSTER = "ares-p5run2"
+PIPELINE_ID = "copper-elastic-v1"
+SPACK_LOAD_SPEC = "/p5gjmq4rseitqanua7mdd2zdnag4v3u2"
+SPECIMEN_ERROR_CODE = "jarvis_run_failed"
+SPECIMEN_ERROR_MESSAGE = (
+    "Run failed: Spack executable was not found in PATH, SPACK_ROOT/bin, "
+    "~/.local/spack, or /opt/spack"
+)
+
+
+def _specimen_error_result_document(
+    *,
+    command: list[str],
+    digest: str,
+    server_artifact: dict[str, Any],
+    arguments: dict[str, object],
+    expected_registered_contract: str | None,
+    execution_id: str,
+) -> dict[str, object]:
+    """Return the errored dispatch document captured from the live specimen."""
+    structured: dict[str, object] = {
+        "schema_version": "jarvis.error.v1",
+        "error": {
+            "code": SPECIMEN_ERROR_CODE,
+            "execution_id": execution_id,
+            "message": SPECIMEN_ERROR_MESSAGE,
+            "pipeline_id": PIPELINE_ID,
+        },
+    }
+    return {
+        "server": command[0],
+        "server_args": command[1:],
+        "expected_server_artifact_digest": digest,
+        "expected_registered_contract": expected_registered_contract,
+        "expected_jarvis_cd_lock_binding": (
+            None
+            if expected_registered_contract is not None
+            else endpoint_module.jarvis_cd_lock_binding_expectation()
+        ),
+        "observed_server_artifact_digest": digest,
+        "server_artifact": server_artifact,
+        "operation": "tools/call",
+        "tool": "jarvis_run",
+        "arguments": arguments,
+        "env_from": {},
+        "protocol_result": {
+            "content": [{"type": "text", "text": json.dumps(structured, sort_keys=True)}],
+            "isError": True,
+        },
+        "structured_result": structured,
+        "protocol_error": "tools/call returned isError=true",
+        "protocol_version": "2024-11-05",
+        "result_validation": None,
+        "returncode": 1,
+        "timed_out": False,
+        "duration_seconds": 5.603851318359375,
+    }
+
+
+def _successful_result_document(
+    *,
+    command: list[str],
+    digest: str,
+    server_artifact: dict[str, Any],
+    arguments: dict[str, object],
+    expected_registered_contract: str | None,
+    execution_id: str,
+) -> dict[str, object]:
+    """Return the handle-first success document a completed run persists."""
+    handle: dict[str, object] = {
+        "schema_version": "jarvis.execution.handle.v1",
+        "execution_id": execution_id,
+        "pipeline_id": PIPELINE_ID,
+        "mode": "direct",
+        "scheduler_provider": None,
+        "scheduler_native_id": None,
+        "cluster": None,
+    }
+    record: dict[str, object] = {
+        "schema_version": "jarvis.execution.record.v1",
+        "execution_id": execution_id,
+        "pipeline_id": PIPELINE_ID,
+        "pipeline_name": PIPELINE_ID,
+        "mode": "direct",
+        "scheduler_provider": None,
+        "scheduler_native_id": None,
+        "cluster": None,
+        "state": "completed",
+        "submitted": False,
+        "terminal": True,
+        "created_at": "2026-08-07T06:11:44Z",
+        "updated_at": "2026-08-07T06:11:49Z",
+        "return_code": 0,
+        "error": None,
+        "metadata": {},
+    }
+    progress: dict[str, object] = {
+        "schema_version": "jarvis.execution.progress.v1",
+        "execution_id": execution_id,
+        "pipeline_id": PIPELINE_ID,
+        "execution_state": "completed",
+        "terminal": True,
+        "packages": [],
+    }
+    structured: dict[str, object] = {
+        "execution_handle": handle,
+        "execution_record": record,
+        "progress": progress,
+        "runtime_metadata": {
+            "schema_version": "jarvis.runtime.v1",
+            "source": "jarvis_mcp",
+            "execution_id": execution_id,
+            "pipeline_id": PIPELINE_ID,
+            "mode": "direct",
+            "scheduler_provider": None,
+            "scheduler_native_id": None,
+            "cluster": None,
+            "scheduler_type": None,
+            "scheduler_job_id": None,
+            "scheduler_phase": None,
+            "script_path": None,
+            "hostfile_path": None,
+            "output_path": f"/runs/{PIPELINE_ID}/stdout.log",
+            "error_path": f"/runs/{PIPELINE_ID}/stderr.log",
+            "package_provenance": [
+                {
+                    "pkg_id": "copper-elastic-step1",
+                    "pkg_type": "builtin.lammps",
+                    "global_id": "builtin.lammps.copper-elastic-step1",
+                    "config_path": f"/runs/{PIPELINE_ID}/copper-elastic-step1.yaml",
+                }
+            ],
+            "terminal": {
+                "state": "completed",
+                "terminal": True,
+                "returncode": 0,
+                "reason": None,
+                "started_at": "2026-08-07T06:11:44Z",
+                "finished_at": "2026-08-07T06:11:49Z",
+            },
+            "details": {
+                "execution_owner": "jarvis_cd.execution_record",
+                "submit": None,
+                "wait": True,
+                "environment": {
+                    "schema_version": "jarvis.environment.v1",
+                    "spack_specs": [SPACK_LOAD_SPEC],
+                },
+                "execution_handle": handle,
+                "execution_record": record,
+                "scheduler_submission": None,
+            },
+        },
+    }
+    return {
+        "server": command[0],
+        "server_args": command[1:],
+        "expected_server_artifact_digest": digest,
+        "expected_registered_contract": expected_registered_contract,
+        "expected_jarvis_cd_lock_binding": (
+            None
+            if expected_registered_contract is not None
+            else endpoint_module.jarvis_cd_lock_binding_expectation()
+        ),
+        "observed_server_artifact_digest": digest,
+        "server_artifact": server_artifact,
+        "operation": "tools/call",
+        "tool": "jarvis_run",
+        "arguments": arguments,
+        "env_from": {},
+        "protocol_result": {"structuredContent": structured},
+        "structured_result": structured,
+        "protocol_error": None,
+        "protocol_version": "2024-11-05",
+        "result_validation": None,
+        "returncode": 0,
+        "timed_out": False,
+    }
+
+
+class _DispatchProvider(JarvisCdProvider):
+    """Run the endpoint MCP transport and persist one prepared result document."""
+
+    def __init__(
+        self,
+        *,
+        document: dict[str, object] | None,
+        returncode: int,
+    ) -> None:
+        super().__init__(jarvis_bin="jarvis")
+        self._document = document
+        self._returncode = returncode
+        self.environments: list[dict[str, str]] = []
+
+    def run_command_streaming(
+        self,
+        command: list[str],
+        *,
+        process_label: str = "JARVIS-CD",
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        credential_payload: str | None = None,
+        on_stdout: Callable[[str], None] | None = None,
+        on_stderr: Callable[[str], None] | None = None,
+        on_start: Callable[[int], None] | None = None,
+        should_cancel: Callable[[], bool] | None = None,
+        on_poll: Callable[[], None] | None = None,
+        timeout_seconds: int | None = None,
+        on_timeout: Callable[[], None] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        del command, credential_payload, on_stderr, should_cancel, on_poll
+        del timeout_seconds, on_timeout
+        assert process_label == "endpoint MCP operation"
+        assert cwd is not None
+        if env is not None:
+            self.environments.append(dict(env))
+        if on_start is not None:
+            on_start(4242)
+        if on_stdout is not None:
+            on_stdout("relay mcp transport\n")
+        if self._document is not None:
+            (cwd / "mcp-result.json").write_text(
+                json.dumps(self._document, sort_keys=True),
+                encoding="utf-8",
+            )
+        return subprocess.CompletedProcess(["endpoint-mcp-runner"], self._returncode, "", "")
+
+
+def _submit_registered_run(
+    queue: ClioCoreQueue,
+    *,
+    command: list[str],
+    digest: str,
+    idempotency_key: str,
+) -> RelayJob:
+    """Submit the registered handle-first ``jarvis_run`` the specimen recorded."""
+    job_id = "job_63d173b2bf8a47d2b811860ac26af569"
+    execution_id = deterministic_jarvis_execution_id(
+        cluster=CLUSTER,
+        idempotency_key=idempotency_key,
+        job_id=job_id,
+    )
+    return queue.submit_job(
+        RelayJob(
+            job_id=job_id,
+            cluster=CLUSTER,
+            kind=JobKind.MCP_CALL,
+            spec=McpCallSpec(
+                server=command[0],
+                server_args=command[1:],
+                expected_server_artifact_digest=digest,
+                expected_registered_contract="clio-kit-jarvis-user-v3.6",
+                tool="jarvis_run",
+                arguments={
+                    "pipeline_id": PIPELINE_ID,
+                    "spack_specs": [SPACK_LOAD_SPEC],
+                    "execution_id": execution_id,
+                },
+                timeout_seconds=14_400,
+            ),
+            idempotency_key=idempotency_key,
+        )
+    )
+
+
+def _worker(
+    settings: RelaySettings,
+    queue: ClioCoreQueue,
+    provider: _DispatchProvider,
+) -> EndpointWorker:
+    worker = EndpointWorker(
+        role=EndpointRole.WORKER,
+        settings=settings,
+        cluster=CLUSTER,
+        queue=queue,
+        provider=provider,
+    )
+    worker.register()
+    return worker
+
+
+def test_errored_jarvis_run_terminalizes_with_its_typed_reason(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The specimen's errored dispatch fails the durable job with its reason."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    command = ["clio-kit", "mcp-server", "jarvis"]
+    server_artifact = {
+        **verified_jarvis_server_artifact(),
+        "install_spec": "/releases/clio-kit.whl",
+    }
+    digest = remote_mcp_server_artifact_digest(server_artifact)
+    monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
+    job = _submit_registered_run(
+        queue,
+        command=command,
+        digest=digest,
+        idempotency_key="copper-elastic-v1-run-001",
+    )
+    spec = cast(McpCallSpec, job.spec)
+    provider = _DispatchProvider(
+        document=_specimen_error_result_document(
+            command=command,
+            digest=digest,
+            server_artifact=server_artifact,
+            arguments=spec.arguments,
+            expected_registered_contract=spec.expected_registered_contract,
+            execution_id=cast(str, spec.arguments["execution_id"]),
+        ),
+        returncode=1,
+    )
+
+    result = _worker(settings, queue, provider).run_once()
+
+    assert result is not None
+    assert result.state is JobState.FAILED
+    durable_job = queue.get_job(job.job_id)
+    assert durable_job.state is JobState.FAILED
+    assert durable_job.last_error == f"{SPECIMEN_ERROR_CODE}: {SPECIMEN_ERROR_MESSAGE}"
+    assert durable_job.updated_at > durable_job.created_at
+    task = queue.list_tasks(job.job_id)[0]
+    assert task.state is JobState.FAILED
+    refusal = task.metadata["jarvis_dispatch_refusal"]
+    assert isinstance(refusal, dict)
+    typed = cast(dict[str, object], refusal)
+    assert typed["schema_version"] == "clio-relay.jarvis-dispatch-refusal.v1"
+    assert typed["code"] == SPECIMEN_ERROR_CODE
+    assert typed["message"] == SPECIMEN_ERROR_MESSAGE
+    assert typed["pipeline_id"] == PIPELINE_ID
+    assert typed["execution_id"] == spec.arguments["execution_id"]
+    recovery = task.metadata["jarvis_execution_recovery"]
+    assert isinstance(recovery, dict)
+    intent = cast(dict[str, object], recovery)
+    assert intent["state"] == "resolved"
+    assert intent["resolution"] == "dispatch_refusal"
+    assert intent["attempts"] == 0
+    events, _cursor = queue.drain_events(Cursor(job_id=job.job_id), limit=200)
+    event_types = [event.event_type for event in events]
+    assert "jarvis.dispatch_refused" in event_types
+    assert "jarvis.execution_recovery_started" not in event_types
+    assert "jarvis.execution_reconciliation_deferred" not in event_types
+    refused = next(event for event in events if event.event_type == "jarvis.dispatch_refused")
+    assert refused.payload["code"] == SPECIMEN_ERROR_CODE
+    assert refused.payload["message"] == SPECIMEN_ERROR_MESSAGE
+
+
+def test_refusal_outranks_a_clean_transport_exit(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The run's own answer decides the outcome, not the transport's exit code."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    command = ["clio-kit", "mcp-server", "jarvis"]
+    server_artifact = {
+        **verified_jarvis_server_artifact(),
+        "install_spec": "/releases/clio-kit.whl",
+    }
+    digest = remote_mcp_server_artifact_digest(server_artifact)
+    monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
+    job = _submit_registered_run(
+        queue,
+        command=command,
+        digest=digest,
+        idempotency_key="copper-elastic-v1-run-006",
+    )
+    spec = cast(McpCallSpec, job.spec)
+    provider = _DispatchProvider(
+        document=_specimen_error_result_document(
+            command=command,
+            digest=digest,
+            server_artifact=server_artifact,
+            arguments=spec.arguments,
+            expected_registered_contract=spec.expected_registered_contract,
+            execution_id=cast(str, spec.arguments["execution_id"]),
+        ),
+        returncode=0,
+    )
+
+    result = _worker(settings, queue, provider).run_once()
+
+    assert result is not None
+    assert result.state is JobState.FAILED
+    assert result.last_error == f"{SPECIMEN_ERROR_CODE}: {SPECIMEN_ERROR_MESSAGE}"
+
+
+def test_successful_jarvis_run_still_terminalizes_as_succeeded(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A dispatch that returned its execution handle keeps succeeding."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    command = ["clio-kit", "mcp-server", "jarvis"]
+    server_artifact = {
+        **verified_jarvis_server_artifact(),
+        "install_spec": "/releases/clio-kit.whl",
+    }
+    digest = remote_mcp_server_artifact_digest(server_artifact)
+    monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
+    job = _submit_registered_run(
+        queue,
+        command=command,
+        digest=digest,
+        idempotency_key="copper-elastic-v1-run-002",
+    )
+    spec = cast(McpCallSpec, job.spec)
+    provider = _DispatchProvider(
+        document=_successful_result_document(
+            command=command,
+            digest=digest,
+            server_artifact=server_artifact,
+            arguments=spec.arguments,
+            expected_registered_contract=spec.expected_registered_contract,
+            execution_id=cast(str, spec.arguments["execution_id"]),
+        ),
+        returncode=0,
+    )
+
+    result = _worker(settings, queue, provider).run_once()
+
+    assert result is not None
+    assert result.state is JobState.SUCCEEDED
+    task = queue.list_tasks(job.job_id)[0]
+    assert "jarvis_dispatch_refusal" not in task.metadata
+    recovery = cast(dict[str, object], task.metadata["jarvis_execution_recovery"])
+    assert recovery["resolution"] == "dispatch_result"
+
+
+def test_run_without_any_result_stays_nonterminal_for_recovery(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A lost run response still defers rather than inventing a terminal answer."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    command = ["clio-kit", "mcp-server", "jarvis"]
+    server_artifact = {
+        **verified_jarvis_server_artifact(),
+        "install_spec": "/releases/clio-kit.whl",
+    }
+    digest = remote_mcp_server_artifact_digest(server_artifact)
+    monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
+    job = _submit_registered_run(
+        queue,
+        command=command,
+        digest=digest,
+        idempotency_key="copper-elastic-v1-run-003",
+    )
+    provider = _DispatchProvider(document=None, returncode=1)
+
+    result = _worker(settings, queue, provider).run_once()
+
+    assert result is not None
+    assert result.state is JobState.RUNNING
+    task = queue.list_tasks(job.job_id)[0]
+    recovery = cast(dict[str, object], task.metadata["jarvis_execution_recovery"])
+    assert recovery["state"] == "pending"
+    assert "jarvis_dispatch_refusal" not in task.metadata
+    events, _cursor = queue.drain_events(Cursor(job_id=job.job_id), limit=200)
+    event_types = {event.event_type for event in events}
+    assert "jarvis.dispatch_refused" not in event_types
+    assert "jarvis.execution_reconciliation_deferred" in event_types
+
+
+def test_timed_out_dispatch_is_never_read_as_an_answered_refusal() -> None:
+    """A lost response carries no answer even when the transport recorded an error."""
+    document: dict[str, object] = {
+        "returncode": 1,
+        "timed_out": True,
+        "protocol_error": "tools/call timed out",
+        "protocol_result": {"isError": True},
+        "structured_result": None,
+    }
+
+    assert jarvis_dispatch_refusal(document) is None
+
+
+def test_untyped_tool_error_still_reports_a_typed_refusal() -> None:
+    """An isError answer without a JARVIS payload still reaches the caller typed."""
+    document: dict[str, object] = {
+        "returncode": 1,
+        "timed_out": False,
+        "protocol_error": "tools/call returned isError=true",
+        "protocol_result": {"isError": True},
+        "structured_result": {"schema_version": "jarvis.unexpected.v9"},
+    }
+
+    refusal = jarvis_dispatch_refusal(document)
+
+    assert refusal is not None
+    assert refusal.code == "jarvis_tool_error"
+    assert refusal.message == "tools/call returned isError=true"
+    assert refusal.payload_schema_version is None
+
+
+def test_successful_protocol_result_is_not_a_refusal() -> None:
+    """A dispatch that answered without an error is never recorded as refused."""
+    document: dict[str, object] = {
+        "returncode": 0,
+        "timed_out": False,
+        "protocol_error": None,
+        "protocol_result": {"isError": False},
+    }
+
+    assert jarvis_dispatch_refusal(document) is None

--- a/tests/test_jarvis_service_runtime.py
+++ b/tests/test_jarvis_service_runtime.py
@@ -25,7 +25,6 @@ import clio_relay.mcp_server as mcp_server_module
 import clio_relay.owner_session_admission as owner_session_admission_module
 import clio_relay.remote_cli as remote_cli_module
 import clio_relay.service_runtime as service_runtime_module
-import clio_relay.session_api as session_api_module
 from clio_relay.browser_gateway import BrowserAttachmentGrant, BrowserDetachmentResult
 from clio_relay.cli import app
 from clio_relay.cluster_config import (
@@ -62,6 +61,7 @@ from clio_relay.models import (
     SchedulerStatus,
     ServiceRuntimeSpec,
 )
+from clio_relay.remote_connection import validate_channel_request
 from clio_relay.remote_mcp import remote_mcp_server_artifact_digest
 from clio_relay.service_runtime import (
     ServiceRuntimePendingResult,
@@ -364,7 +364,7 @@ def test_owned_session_authority_uses_identity_bound_api_when_browser_attach_is_
     )
 
     assert (
-        session_api_module._validate_request(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        validate_channel_request(
             method="POST",
             path=runtime_binding.OWNED_SESSION_JARVIS_RUNTIME_AUTHORITY_PATH,
         )

--- a/tests/test_mcp_call_runner.py
+++ b/tests/test_mcp_call_runner.py
@@ -1634,6 +1634,44 @@ def test_mcp_call_runner_refuses_unverified_builtin_jarvis_launcher_before_launc
     assert "launcher digest did not verify" in result["protocol_error"]
 
 
+def test_relay_composed_spack_identity_reaches_the_jarvis_child(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The composed cluster Spack path is applied as the child's JARVIS variable."""
+    runner = _load_runner()
+    monkeypatch.setenv("CLIO_RELAY_JARVIS_SPACK_COMMAND", "/site/spack/bin/spack")
+    overrides = cast(Any, runner)._child_environment_overrides(wait_for_locked_launcher=False)
+    captured: dict[str, dict[str, str]] = {}
+
+    class _RecordedPopen:
+        def __init__(self, *_args: object, **kwargs: object) -> None:
+            captured["env"] = cast(dict[str, str], kwargs["env"])
+
+    monkeypatch.setattr(cast(Any, runner).subprocess, "Popen", _RecordedPopen)
+    cast(Any, runner)._open_process(
+        ["server"],
+        env_from={},
+        environment_overrides=overrides,
+    )
+
+    assert overrides == {"JARVIS_MCP_SPACK_COMMAND": "/site/spack/bin/spack"}
+    assert captured["env"]["JARVIS_MCP_SPACK_COMMAND"] == "/site/spack/bin/spack"
+    assert "CLIO_RELAY_JARVIS_SPACK_COMMAND" not in captured["env"]
+
+
+def test_child_overrides_are_empty_without_a_composed_spack_identity(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """An unregistered cluster leaves the child environment exactly as before."""
+    runner = _load_runner()
+    monkeypatch.delenv("CLIO_RELAY_JARVIS_SPACK_COMMAND", raising=False)
+
+    assert cast(Any, runner)._child_environment_overrides(wait_for_locked_launcher=False) == {}
+    assert cast(Any, runner)._child_environment_overrides(wait_for_locked_launcher=True) == {
+        "CLIO_KIT_UV_CACHE_PRUNE": "0"
+    }
+
+
 def test_registered_jarvis_server_uses_artifact_binding_without_relay_dependency_pin(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/test_mcp_input_staging.py
+++ b/tests/test_mcp_input_staging.py
@@ -22,6 +22,7 @@ from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.errors import QueueConflictError
 from clio_relay.input_staging import REGISTERED_JARVIS_CONTRACT_ID
+from clio_relay.jarvis_input_plane import jarvis_add_step_result_step_id
 from clio_relay.mcp_server import McpSessionState, handle_request
 from clio_relay.models import (
     ArtifactRef,
@@ -892,12 +893,7 @@ def test_add_step_identity_accepts_historical_nested_result() -> None:
         }
     }
 
-    assert (
-        mcp_server_module._jarvis_add_step_result_step_id(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
-            result
-        )
-        == "lammps"
-    )
+    assert jarvis_add_step_result_step_id(result) == "lammps"
 
 
 def test_add_step_identity_rejects_ambiguous_result_envelopes() -> None:
@@ -912,9 +908,7 @@ def test_add_step_identity_rejects_ambiguous_result_envelopes() -> None:
     }
 
     with pytest.raises(ValueError, match="ambiguous result envelopes"):
-        mcp_server_module._jarvis_add_step_result_step_id(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
-            result
-        )
+        jarvis_add_step_result_step_id(result)
 
 
 def _configured_flow(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -492,9 +492,12 @@ def test_mcp_lists_relay_tools(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     add_step_tool = next(
         tool for tool in response["result"]["tools"] if tool["name"] == "jarvis_add_step"
     )
-    assert "package_search is discovery only" in add_step_tool["description"]
-    assert "target='package'" in add_step_tool["description"]
-    assert "package-owned settings contract rather than guessing" in add_step_tool["description"]
+    # The tool description carries relay transport semantics only. Behavioral
+    # steering prose was reverted: the failure it suppressed was a package
+    # returning a null deployment, which is a data defect, not a prompt gap.
+    assert "package_search is discovery only" not in add_step_tool["description"]
+    assert "rather than guessing" not in add_step_tool["description"]
+    assert "durable relay job" in add_step_tool["description"]
 
 
 @pytest.mark.parametrize("profile", ["user", "admin"])

--- a/tests/test_owned_session_channel.py
+++ b/tests/test_owned_session_channel.py
@@ -1,0 +1,726 @@
+"""The one-held-channel invariant for the owned-session control plane.
+
+These tests assert the design property directly, in the unit the deployment
+gate measures: how many new SSH connections the desktop opens.  One connection
+is one call to the injected channel-process factory, so the counts here are the
+same counts the two-sided acceptance harness reads from a process sampler and
+the cluster's ``sshd`` session log.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from fastapi.testclient import TestClient
+
+from clio_relay.cluster_config import (
+    CLUSTER_REGISTRY_ENV,
+    ClusterDefinition,
+    ClusterRegistry,
+    cluster_route_revision,
+)
+from clio_relay.config import RelaySettings
+from clio_relay.control_channel import (
+    ChannelDropped,
+    SshForwardTransport,
+    TransportModeUnavailable,
+    build_transport,
+    owned_session_channel_bootstrap_script,
+)
+from clio_relay.errors import RelayError
+from clio_relay.http_api import create_app
+from clio_relay.job_identity import OWNER_SESSION_ID_HEADER, SESSION_GENERATION_ID_HEADER
+from clio_relay.remote_connection import (
+    DEFAULT_OWNED_SESSION_API_PORT,
+    RemoteConnectionRegistry,
+    resolve_remote_api_port,
+)
+from clio_relay.session_api import OwnedSessionApiClient, session_identity_document
+
+NONCE = "1" * 64
+OWNER_TOKEN = "owner-token"
+
+
+class _Response:
+    def __init__(self, document: object, *, status: int = 200) -> None:
+        self._payload = json.dumps(document).encode("utf-8")
+        self.status = status
+        self.will_close = False
+
+    def read(self, _amount: int) -> bytes:
+        return self._payload
+
+
+class _Socket:
+    def __init__(self, timeout: float | None) -> None:
+        self.timeout = timeout
+
+    def gettimeout(self) -> float | None:
+        return self.timeout
+
+    def settimeout(self, timeout: float | None) -> None:
+        self.timeout = timeout
+
+
+class _Stream:
+    """One fake proven HTTP stream over the held channel."""
+
+    def __init__(self, harness: _Harness, timeout: float) -> None:
+        self.harness = harness
+        self.cluster = harness.dialing_cluster
+        self.auto_open = 1
+        self.timeout = timeout
+        self.socket = _Socket(timeout)
+        self.sock: object | None = None
+        self.closed = False
+
+    def connect(self) -> None:
+        self.sock = self.socket
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: bytes | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.harness.requests.append(
+            {"method": method, "path": path, "body": body, "headers": dict(headers or {})}
+        )
+
+    def getresponse(self) -> _Response:
+        path = cast(str, self.harness.requests[-1]["path"])
+        if path.startswith("/session-identity"):
+            return _Response(self.harness.identity_for(self.cluster))
+        return _Response(self.harness.responses.get(path, {"ok": True}))
+
+    def close(self) -> None:
+        self.closed = True
+        self.sock = None
+
+
+class _ChannelProcess:
+    """One fake held-channel process: exactly one of these is one SSH dial."""
+
+    def __init__(self, bootstrap: dict[str, object], argv: list[str]) -> None:
+        self.argv = argv
+        self.stdin = io.BytesIO()
+        self.stdout = io.BytesIO(json.dumps(bootstrap).encode("utf-8") + b"\n")
+        self.stderr = io.BytesIO(b"")
+        self.returncode: int | None = None
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.returncode = -15
+
+    def kill(self) -> None:
+        self.returncode = -9
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        if self.returncode is None:
+            self.returncode = 0
+        return self.returncode
+
+    def drop(self) -> None:
+        """Simulate the remote end dying while the local relay still holds it."""
+        self.returncode = 255
+
+
+class _Harness:
+    """Records every dial and every request made over the held channel."""
+
+    def __init__(self, *, generation_id: str = "generation-1") -> None:
+        self.generation_id = generation_id
+        self.processes: list[_ChannelProcess] = []
+        self.streams: list[_Stream] = []
+        self.requests: list[dict[str, object]] = []
+        self.responses: dict[str, object] = {}
+        self.registry = RemoteConnectionRegistry()
+        self.dialing_cluster = "ares"
+
+    @property
+    def dials(self) -> int:
+        """Return the number of new SSH connections opened so far."""
+        return len(self.processes)
+
+    @property
+    def identity(self) -> dict[str, str]:
+        """Return the identity document the default remote relay signs."""
+        return self.identity_for("ares")
+
+    def bootstrap(
+        self,
+        *,
+        cluster: str = "ares",
+        remote_api_port: int = DEFAULT_OWNED_SESSION_API_PORT,
+    ) -> dict[str, object]:
+        """Return the exact out-of-band document one bring-up dial reports."""
+        return {
+            "schema_version": "clio-relay.channel-bootstrap.v1",
+            "status": {
+                "owner": "clio-relay",
+                "cluster": cluster,
+                "session_id": "desktop-session-1",
+                "session_generation_id": self.generation_id,
+                "remote_api_port": remote_api_port,
+                "running": True,
+                "ownership_verified": True,
+            },
+            "identity": self.identity_for(cluster),
+        }
+
+    def identity_for(self, cluster: str) -> dict[str, str]:
+        """Return the identity document one named remote relay signs."""
+        return session_identity_document(
+            owner_token=OWNER_TOKEN,
+            cluster=cluster,
+            session_id="desktop-session-1",
+            generation_id=self.generation_id,
+            nonce=NONCE,
+        )
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, harness: _Harness) -> _Harness:
+    """Replace the real transport at the exact seams production code uses."""
+
+    def process_factory(argv: list[str], **_kwargs: object) -> _ChannelProcess:
+        cluster = next(
+            (item.removesuffix("-login") for item in argv if item.endswith("-login")),
+            "ares",
+        )
+        harness.dialing_cluster = cluster
+        process = _ChannelProcess(harness.bootstrap(cluster=cluster), argv)
+        harness.processes.append(process)
+        return process
+
+    def stream_factory(*_args: object, **kwargs: object) -> _Stream:
+        timeout = kwargs.get("timeout", 30.0)
+        stream = _Stream(harness, float(cast(float, timeout)))
+        harness.streams.append(stream)
+        return stream
+
+    def skip_health(*_args: object, **_kwargs: object) -> None:
+        """The forward is faked, so its loopback readiness probe is a no-op."""
+
+    def fixed_nonce(_size: int) -> str:
+        return NONCE
+
+    monkeypatch.setattr("clio_relay.control_channel.spawn_channel_process", process_factory)
+    monkeypatch.setattr("clio_relay.control_channel._wait_for_channel_health", skip_health)
+    monkeypatch.setattr("clio_relay.remote_connection.secrets.token_hex", fixed_nonce)
+    monkeypatch.setattr("clio_relay.remote_connection.http.client.HTTPConnection", stream_factory)
+    monkeypatch.setattr("clio_relay.session_api.connection_registry", lambda: harness.registry)
+    return harness
+
+
+def _settings(tmp_path: Path, *, cluster: str = "ares") -> RelaySettings:
+    return RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        api_token="session-api-token",
+        owner_session_id="desktop-session-1",
+        owner_session_generation_id="generation-1",
+        owner_session_cluster=cluster,
+    )
+
+
+def _definition(name: str = "ares") -> ClusterDefinition:
+    return ClusterDefinition(name=name, ssh_host=f"{name}-login")
+
+
+def _connect(tmp_path: Path, harness: _Harness) -> Any:
+    """Establish the connection for the default cluster and return it."""
+    return harness.registry.connection(
+        definition=_definition(),
+        settings=_settings(tmp_path),
+    )
+
+
+def test_channel_bring_up_performs_exactly_one_ssh_dial(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    harness = _install(monkeypatch, _Harness())
+
+    connection = _connect(tmp_path, harness)
+
+    assert harness.dials == 1
+    assert connection.connected is True
+    assert [event.event for event in connection.events] == [
+        "authorization_required",
+        "establishing",
+        "established",
+    ]
+    assert connection.events[0].user_authorization_required is True
+    assert connection.events[-1].mode == "ssh_forward"
+
+
+def test_arbitrary_owned_session_operations_perform_zero_new_ssh_dials(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The acceptance criterion: any number of operations, still one connection."""
+    harness = _install(monkeypatch, _Harness())
+    definition = _definition()
+    settings = _settings(tmp_path)
+
+    for index in range(12):
+        with OwnedSessionApiClient(definition=definition, settings=settings) as client:
+            client.request_json(method="GET", path=f"/jobs/job_{index}/status")
+            client.request_json(method="POST", path=f"/jobs/job_{index}/wait", body={})
+            client.request_json(method="GET", path=f"/artifacts/artifact_{index}/content")
+            client.request_json(method="POST", path="/input-artifacts/ingest", body={})
+
+    assert harness.dials == 1
+    assert len(harness.streams) == 1
+    operation_paths = [
+        request["path"]
+        for request in harness.requests
+        if not cast(str, request["path"]).startswith("/session-identity")
+    ]
+    assert len(operation_paths) == 48
+    assert "/artifacts/artifact_0/content" in operation_paths
+    assert "/input-artifacts/ingest" in operation_paths
+
+
+def test_dropped_channel_never_redials_without_an_explicit_reconnect(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unattended redial is the violation; the drop must surface instead."""
+    harness = _install(monkeypatch, _Harness())
+    connection = _connect(tmp_path, harness)
+
+    harness.processes[0].drop()
+
+    with pytest.raises(ChannelDropped, match="call reconnect"):
+        connection.request_json(method="GET", path="/jobs/job_1/status")
+
+    assert harness.dials == 1
+    dropped = [event for event in connection.events if event.event == "dropped"]
+    assert len(dropped) == 1
+    assert dropped[0].reason == "transport_exited"
+
+    with pytest.raises(ChannelDropped, match="call reconnect"):
+        connection.connect()
+
+    assert harness.dials == 1
+
+
+def test_reconnect_performs_exactly_one_new_dial_and_emits_typed_events(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    harness = _install(monkeypatch, _Harness())
+    connection = _connect(tmp_path, harness)
+    harness.processes[0].drop()
+    with pytest.raises(ChannelDropped):
+        connection.request_json(method="GET", path="/jobs/job_1/status")
+
+    connection.reconnect()
+
+    assert harness.dials == 2
+    assert connection.connected is True
+    names = [event.event for event in connection.events]
+    assert names == [
+        "authorization_required",
+        "establishing",
+        "established",
+        "dropped",
+        "reestablishing",
+        "authorization_required",
+        "establishing",
+        "reestablished",
+    ]
+    reestablishing = connection.events[names.index("reestablishing")]
+    assert reestablishing.reason == "channel_dropped"
+    assert reestablishing.user_authorization_required is True
+
+    connection.request_json(method="GET", path="/jobs/job_1/status")
+    assert harness.dials == 2
+
+
+def test_reestablished_channel_serves_operations_without_further_dials(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    harness = _install(monkeypatch, _Harness())
+    connection = _connect(tmp_path, harness)
+    harness.processes[0].drop()
+    with pytest.raises(ChannelDropped):
+        connection.request_json(method="GET", path="/jobs/job_1/status")
+    connection.reconnect()
+
+    for index in range(8):
+        connection.request_json(method="GET", path=f"/jobs/job_{index}/status")
+
+    assert harness.dials == 2
+
+
+def test_broken_http_stream_is_reproven_over_the_same_channel_without_a_new_dial(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dead TCP stream is not a dead channel; re-proving it costs no transport."""
+    harness = _install(monkeypatch, _Harness())
+    connection = _connect(tmp_path, harness)
+
+    harness.streams[0].close()
+    connection.request_json(method="GET", path="/jobs/job_1/status")
+
+    assert harness.dials == 1
+    assert len(harness.streams) == 2
+    assert [event.event for event in connection.events][-1] == "stream_reproven"
+    identity_requests = [
+        request
+        for request in harness.requests
+        if cast(str, request["path"]).startswith("/session-identity")
+    ]
+    assert len(identity_requests) == 2
+    assert all("Authorization" not in cast(dict[str, str], r["headers"]) for r in identity_requests)
+
+
+def test_one_local_relay_holds_one_channel_per_remote_relay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One local relay manages many remote relays; each holds exactly one channel."""
+    harness = _install(monkeypatch, _Harness())
+
+    ares = harness.registry.connection(
+        definition=_definition("ares"),
+        settings=_settings(tmp_path, cluster="ares"),
+    )
+    theta = harness.registry.connection(
+        definition=_definition("theta"),
+        settings=_settings(tmp_path, cluster="theta"),
+    )
+
+    assert harness.dials == 2
+    assert harness.registry.clusters == ("ares", "theta")
+
+    for _ in range(5):
+        ares.request_json(method="GET", path="/jobs/job_1/status")
+        theta.request_json(method="GET", path="/jobs/job_1/status")
+    assert harness.dials == 2
+
+    # Asking again for a cluster already connected reuses its held channel.
+    assert (
+        harness.registry.connection(
+            definition=_definition("ares"),
+            settings=_settings(tmp_path, cluster="ares"),
+        )
+        is ares
+    )
+    assert harness.dials == 2
+
+    # One remote relay disconnecting leaves the other's channel untouched.
+    harness.registry.disconnect("ares")
+    assert harness.registry.clusters == ("theta",)
+    assert harness.processes[0].poll() is not None
+    assert theta.connected is True
+    theta.request_json(method="GET", path="/jobs/job_1/status")
+    assert harness.dials == 2
+
+
+def test_channel_close_releases_the_held_process_and_records_it(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    harness = _install(monkeypatch, _Harness())
+    connection = _connect(tmp_path, harness)
+
+    connection.close()
+
+    assert connection.connected is False
+    assert harness.processes[0].poll() is not None
+    assert [event.event for event in connection.events][-1] == "closed"
+    with pytest.raises(RelayError):
+        connection.request_json(method="GET", path="/jobs/job_1/status")
+    assert harness.dials == 1
+
+
+def test_bring_up_command_reports_status_and_identity_then_holds_the_forward() -> None:
+    """One command carries the whole bring-up: no second dial for status or identity."""
+    script = owned_session_channel_bootstrap_script(
+        definition=_definition(),
+        cluster="ares",
+        session_id="desktop-session-1",
+        session_generation_id="generation-1",
+        nonce=NONCE,
+    )
+
+    assert "session recovery-status --cluster ares --session-id desktop-session-1" in script
+    assert "session challenge-owned" in script
+    assert f'"nonce":"{NONCE}"' in script
+    assert '"session_generation_id":"generation-1"' in script
+    assert "clio-relay.channel-bootstrap.v1" in script
+    # The trailing hold is what keeps the one SSH session (and its forward) up.
+    assert script.rstrip().endswith("exec cat >/dev/null")
+
+
+def test_ssh_forward_argv_maps_the_owned_api_port_and_allows_one_authorization() -> None:
+    transport = SshForwardTransport(
+        definition=_definition(),
+        session_id="desktop-session-1",
+        session_generation_id="generation-1",
+        remote_api_port=8765,
+        bootstrap_script="true",
+    )
+
+    argv = transport.argv(local_port=18_795)
+
+    assert argv[:2] == ["ssh", "-T"]
+    assert "-L" in argv
+    assert argv[argv.index("-L") + 1] == "127.0.0.1:18795:127.0.0.1:8765"
+    assert argv[-3:-1] == ["bash", "-lc"]
+    assert "ares-login" in argv
+    # The user is present for exactly this one connection, so it must be able
+    # to prompt: BatchMode would make interactive two-factor approval fail.
+    assert "BatchMode=yes" not in argv
+    assert "ExitOnForwardFailure=yes" in argv
+    assert transport.requires_user_authorization is True
+    assert transport.mode == "ssh_forward"
+
+
+def test_noninteractive_transport_opts_out_of_the_authorization_prompt() -> None:
+    transport = SshForwardTransport(
+        definition=_definition(),
+        session_id="desktop-session-1",
+        session_generation_id="generation-1",
+        remote_api_port=8765,
+        bootstrap_script="true",
+        allow_interactive_authorization=False,
+    )
+
+    assert "BatchMode=yes" in transport.argv(local_port=18_795)
+    assert transport.requires_user_authorization is False
+
+
+@pytest.mark.parametrize("mode", ["brokered_tcp", "udp_rendezvous"])
+def test_declared_transport_modes_refuse_instead_of_falling_back(mode: str) -> None:
+    """An unbuilt mode must never quietly become per-operation SSH."""
+    with pytest.raises(TransportModeUnavailable, match=mode):
+        build_transport(
+            mode=cast(Any, mode),
+            definition=_definition(),
+            session_id="desktop-session-1",
+            session_generation_id="generation-1",
+            remote_api_port=8765,
+            nonce=NONCE,
+        )
+
+
+def test_bring_up_refuses_a_channel_that_maps_a_different_owned_api_port(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    harness = _Harness()
+    _install(monkeypatch, harness)
+    def mismatched_port_factory(argv: list[str], **_kwargs: object) -> _ChannelProcess:
+        process = _ChannelProcess(harness.bootstrap(remote_api_port=9999), argv)
+        harness.processes.append(process)
+        return process
+
+    monkeypatch.setattr(
+        "clio_relay.control_channel.spawn_channel_process",
+        mismatched_port_factory,
+    )
+
+    with pytest.raises(RelayError, match="CLIO_RELAY_OWNER_SESSION_API_PORT"):
+        _connect(tmp_path, harness)
+
+    assert harness.dials == 1
+    assert harness.streams == []
+
+
+def test_remote_api_port_resolves_from_configuration_not_per_operation_discovery(
+    tmp_path: Path,
+) -> None:
+    settings = _settings(tmp_path)
+    assert resolve_remote_api_port(settings=settings) == DEFAULT_OWNED_SESSION_API_PORT
+    assert resolve_remote_api_port(settings=settings, remote_api_port=18_795) == 18_795
+
+    configured = settings.model_copy(update={"owner_session_api_port": 9001})
+    assert resolve_remote_api_port(settings=configured) == 9001
+
+
+def _owned_session_app_settings(tmp_path: Path) -> RelaySettings:
+    return RelaySettings(
+        core_dir=tmp_path / "core",
+        spool_dir=tmp_path / "spool",
+        api_token="session-api-token",
+        owner_session_id="desktop-session-1",
+        owner_session_generation_id="generation-1",
+        owner_session_cluster="test-cluster",
+        owner_session_api_port=8765,
+        session_owner_token="o" * 32,
+    )
+
+
+def _bind_authority(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    definition = ClusterDefinition(name="test-cluster", ssh_host="test-cluster")
+    registry_path = tmp_path / "session-authority" / "clusters.json"
+    ClusterRegistry(clusters={definition.name: definition}).save(registry_path)
+    payload = registry_path.read_bytes()
+    monkeypatch.setenv(CLUSTER_REGISTRY_ENV, str(registry_path))
+    monkeypatch.setenv("CLIO_RELAY_SESSION_REGISTRY_SHA256", hashlib.sha256(payload).hexdigest())
+    monkeypatch.setenv("CLIO_RELAY_SESSION_ROUTE_REVISION", cluster_route_revision(definition))
+
+
+def test_session_status_endpoint_reports_the_exact_live_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Status moved from an ``ssh bash -s`` script to the owned API."""
+    _bind_authority(monkeypatch, tmp_path)
+    client = cast(Any, TestClient(create_app(_owned_session_app_settings(tmp_path))))
+
+    response = client.get(
+        "/session-status",
+        headers={
+            "Authorization": "Bearer session-api-token",
+            OWNER_SESSION_ID_HEADER: "desktop-session-1",
+            SESSION_GENERATION_ID_HEADER: "generation-1",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "schema_version": "clio-relay.owned-session-status.v1",
+        "owner": "clio-relay",
+        "cluster": "test-cluster",
+        "session_id": "desktop-session-1",
+        "session_generation_id": "generation-1",
+        "remote_api_port": 8765,
+        "running": True,
+        "evidence": "live_api_self_report",
+    }
+
+
+def test_session_status_endpoint_requires_the_exact_owner_credentials(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _bind_authority(monkeypatch, tmp_path)
+    client = cast(Any, TestClient(create_app(_owned_session_app_settings(tmp_path))))
+
+    assert client.get("/session-status").status_code == 401
+    replaced = client.get(
+        "/session-status",
+        headers={
+            "Authorization": "Bearer session-api-token",
+            OWNER_SESSION_ID_HEADER: "desktop-session-1",
+            SESSION_GENERATION_ID_HEADER: "generation-2",
+        },
+    )
+    assert replaced.status_code == 409
+
+
+def test_session_status_over_the_held_channel_cross_checks_the_pinned_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    harness = _install(monkeypatch, _Harness())
+    connection = _connect(tmp_path, harness)
+    harness.responses["/session-status"] = {
+        "schema_version": "clio-relay.owned-session-status.v1",
+        "owner": "clio-relay",
+        "cluster": "ares",
+        "session_id": "desktop-session-1",
+        "session_generation_id": "generation-1",
+        "remote_api_port": DEFAULT_OWNED_SESSION_API_PORT,
+        "running": True,
+        "evidence": "live_api_self_report",
+    }
+
+    status = connection.session_status()
+
+    assert status["session_generation_id"] == "generation-1"
+    assert harness.dials == 1
+
+    harness.responses["/session-status"] = {
+        "schema_version": "clio-relay.owned-session-status.v1",
+        "owner": "clio-relay",
+        "cluster": "ares",
+        "session_id": "desktop-session-1",
+        "session_generation_id": "generation-9",
+        "running": True,
+        "evidence": "live_api_self_report",
+    }
+    with pytest.raises(RelayError, match="exact connected generation"):
+        connection.session_status()
+    assert harness.dials == 1
+
+
+def test_identity_mismatch_over_the_channel_refuses_before_any_credential(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The HTTP listener must be the session the out-of-band bring-up proved."""
+    harness = _install(monkeypatch, _Harness())
+
+    forged = dict(harness.identity)
+    forged["hmac_sha256"] = "f" * 64
+    monkeypatch.setattr(
+        "clio_relay.remote_connection._IDENTITY_FIELDS",
+        ("schema_version", "cluster", "session_id", "session_generation_id", "nonce"),
+    )
+    original = _Stream.getresponse
+
+    def forged_response(self: _Stream) -> _Response:
+        path = cast(str, self.harness.requests[-1]["path"])
+        if path.startswith("/session-identity"):
+            return _Response(forged)
+        return original(self)
+
+    monkeypatch.setattr(_Stream, "getresponse", forged_response)
+
+    with pytest.raises(RelayError, match="HMAC did not verify"):
+        _connect(tmp_path, harness)
+
+    assert harness.dials == 1
+    authenticated = [
+        request
+        for request in harness.requests
+        if "Authorization" in cast(dict[str, str], request["headers"])
+    ]
+    assert authenticated == []
+
+
+def test_event_report_counts_the_transport_connections_the_gate_measures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The client half of the two-sided acceptance measurement."""
+    harness = _install(monkeypatch, _Harness())
+    connection = _connect(tmp_path, harness)
+    for index in range(10):
+        connection.request_json(method="GET", path=f"/jobs/job_{index}/status")
+
+    report = harness.registry.event_report()
+
+    assert report["schema_version"] == "clio-relay.control-channel-report.v1"
+    assert report["transport_connections_opened"] == 1
+    ares = cast(dict[str, object], cast(dict[str, object], report["clusters"])["ares"])
+    assert ares["transport_connections_opened"] == 1
+    assert ares["transport_mode"] == "ssh_forward"
+    assert ares["connected"] is True
+    assert ares["remote_api_port"] == DEFAULT_OWNED_SESSION_API_PORT
+
+    harness.processes[0].drop()
+    with pytest.raises(ChannelDropped):
+        connection.request_json(method="GET", path="/jobs/job_1/status")
+    connection.reconnect()
+
+    reconnected = harness.registry.event_report()
+    assert reconnected["transport_connections_opened"] == 2
+    assert harness.dials == 2

--- a/tests/test_owned_session_channel.py
+++ b/tests/test_owned_session_channel.py
@@ -569,6 +569,7 @@ def test_bring_up_refuses_a_channel_that_maps_a_different_owned_api_port(
 ) -> None:
     harness = _Harness()
     _install(monkeypatch, harness)
+
     def mismatched_port_factory(argv: list[str], **_kwargs: object) -> _ChannelProcess:
         process = _ChannelProcess(harness.bootstrap(remote_api_port=9999), argv)
         harness.processes.append(process)

--- a/tests/test_owned_session_channel.py
+++ b/tests/test_owned_session_channel.py
@@ -12,13 +12,18 @@ from __future__ import annotations
 import hashlib
 import io
 import json
+import shlex
+import subprocess
+import sys
 import threading
+import time
 from pathlib import Path
 from typing import Any, cast
 
 import pytest
 from fastapi.testclient import TestClient
 
+from clio_relay import remote_connection
 from clio_relay.cluster_config import (
     CLUSTER_REGISTRY_ENV,
     ClusterDefinition,
@@ -32,6 +37,7 @@ from clio_relay.control_channel import (
     ChannelBootstrapError,
     ChannelDropped,
     SshForwardTransport,
+    StreamChannelsUnavailable,
     TransportModeUnavailable,
     build_transport,
     owned_session_channel_bootstrap_script,
@@ -132,18 +138,28 @@ class _ChannelProcess:
         )
         self.stderr = io.BytesIO(b"")
         self.returncode: int | None = None
+        self.ignores_stdin_close = False
+        self.terminated = False
+        self.killed = False
 
     def poll(self) -> int | None:
         return self.returncode
 
     def terminate(self) -> None:
-        self.returncode = -15
+        self.terminated = True
+        if not self.ignores_stdin_close:
+            self.returncode = -15
 
     def kill(self) -> None:
+        self.killed = True
         self.returncode = -9
 
     def wait(self, timeout: float | None = None) -> int:
         del timeout
+        if self.ignores_stdin_close:
+            # A real ssh that does not notice the closed pipe: close() must
+            # escalate to terminate() and, failing that, kill().
+            raise subprocess.TimeoutExpired(cmd="ssh", timeout=5)
         if self.returncode is None:
             self.returncode = 0
         return self.returncode
@@ -487,12 +503,13 @@ def test_bring_up_command_reports_status_and_identity_then_holds_the_forward() -
 
 
 def test_ssh_forward_argv_maps_the_owned_api_port_and_allows_one_authorization() -> None:
+    script = "set -euo pipefail\nfoo 'bar baz'\nexec cat >/dev/null\n"
     transport = SshForwardTransport(
         definition=_definition(),
         session_id="desktop-session-1",
         session_generation_id="generation-1",
         remote_api_port=8765,
-        bootstrap_script="true",
+        bootstrap_script=script,
     )
 
     argv = transport.argv(local_port=18_795)
@@ -500,8 +517,16 @@ def test_ssh_forward_argv_maps_the_owned_api_port_and_allows_one_authorization()
     assert argv[:2] == ["ssh", "-T"]
     assert "-L" in argv
     assert argv[argv.index("-L") + 1] == "127.0.0.1:18795:127.0.0.1:8765"
-    assert argv[-3:-1] == ["bash", "-lc"]
-    assert "ares-login" in argv
+    assert argv[-2] == "ares-login"
+
+    # ssh joins its trailing operands with spaces into ONE remote command
+    # string, so the script must arrive already quoted. Reconstruct what the
+    # remote login shell is actually handed and prove it re-parses to exactly
+    # `bash -lc <script>` -- an unquoted script would lose `set -euo pipefail`
+    # and be interpreted by whatever login shell the account happens to have.
+    remote_command = argv[-1]
+    assert shlex.split(remote_command) == ["bash", "-lc", script]
+    assert "\n" not in remote_command.split(" ", 2)[0]
     # The user is present for exactly this one connection, so it must be able
     # to prompt: BatchMode would make interactive two-factor approval fail.
     assert "BatchMode=yes" not in argv
@@ -689,10 +714,6 @@ def test_identity_mismatch_over_the_channel_refuses_before_any_credential(
 
     forged = dict(harness.identity)
     forged["hmac_sha256"] = "f" * 64
-    monkeypatch.setattr(
-        "clio_relay.remote_connection._IDENTITY_FIELDS",
-        ("schema_version", "cluster", "session_id", "session_generation_id", "nonce"),
-    )
     original = _Stream.getresponse
 
     def forged_response(self: _Stream) -> _Response:
@@ -864,3 +885,157 @@ def test_bring_up_without_the_framed_document_fails_with_a_typed_reason(
 
     assert harness.dials == 1
     assert harness.streams == []
+
+
+def test_close_escalates_to_terminate_and_kill_when_the_process_ignores_the_pipe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Closing stdin is the polite teardown; it must not be the only one."""
+    harness = _install(monkeypatch, _Harness())
+    connection = _connect(tmp_path, harness)
+    process = harness.processes[0]
+    process.ignores_stdin_close = True
+
+    connection.close()
+
+    assert process.terminated is True
+    assert process.killed is True
+    assert process.poll() is not None
+
+
+def test_a_stream_proven_against_a_replaced_channel_is_refused(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stream must never outlive the link it was proven against."""
+    harness = _install(monkeypatch, _Harness())
+    connection = _connect(tmp_path, harness)
+    # Empty the pool so the next acquire has to prove a new stream.
+    harness.streams[0].close()
+    connection._idle_streams.clear()  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+
+    original_open = remote_connection._open_identity_bound_stream  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    replaced_once = False
+
+    def replace_channel_midway(**kwargs: Any) -> Any:
+        nonlocal replaced_once
+        if not replaced_once:
+            # The channel is replaced while this stream is being proven. Only
+            # do it on the first prove, or the reconnect recurses into itself.
+            replaced_once = True
+            harness.processes[0].drop()
+            connection.reconnect()
+        return original_open(**kwargs)
+
+    monkeypatch.setattr(
+        remote_connection,
+        "_open_identity_bound_stream",
+        replace_channel_midway,
+    )
+
+    with pytest.raises(ChannelDropped, match="replaced while"):
+        connection.request_json(method="GET", path="/jobs/job_1/status")
+
+
+def test_bring_up_diagnostics_do_not_block_on_a_live_process_pipe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The failure path must not hang, and a chatty channel must not wedge.
+
+    Uses a real child process, because the hazards are properties of OS pipes:
+    a fixed-size read on a live process's stderr blocks until EOF, and an
+    undrained stderr pipe fills and stops the writer -- which for a real ``ssh``
+    means the port forward stops being serviced, silently.
+    """
+    harness = _Harness()
+    _install(monkeypatch, harness)
+    # Writes far more than any pipe buffer to stderr, emits no bootstrap, and
+    # never exits on its own.
+    child_source = (
+        "import sys, time\n"
+        "for index in range(20000):\n"
+        "    sys.stderr.write('channel %d: open failed: connect failed\n' % index)\n"
+        "sys.stderr.flush()\n"
+        "time.sleep(600)\n"
+    )
+    spawned: list[subprocess.Popen[bytes]] = []
+
+    def real_child_factory(_argv: list[str], **kwargs: object) -> subprocess.Popen[bytes]:
+        del kwargs
+        process = subprocess.Popen(
+            [sys.executable, "-c", child_source],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        spawned.append(process)
+        harness.processes.append(cast(Any, process))
+        return process
+
+    monkeypatch.setattr("clio_relay.control_channel.spawn_channel_process", real_child_factory)
+
+    transport = SshForwardTransport(
+        definition=_definition(),
+        session_id="desktop-session-1",
+        session_generation_id="generation-1",
+        remote_api_port=DEFAULT_OWNED_SESSION_API_PORT,
+        bootstrap_script="true",
+        process_factory=real_child_factory,
+        ready_timeout_seconds=2.0,
+        authorization_timeout_seconds=2.0,
+    )
+    started = time.monotonic()
+    try:
+        with pytest.raises(ChannelBootstrapError, match="did not report its bootstrap"):
+            transport.establish(nonce=NONCE)
+    finally:
+        transport.close()
+        for process in spawned:
+            if process.poll() is None:  # pragma: no cover - defensive cleanup
+                process.kill()
+                process.wait(timeout=10)
+    elapsed = time.monotonic() - started
+
+    # Without the stderr pump the child wedges on a full pipe; without a
+    # non-blocking drain the failure path never returns at all.
+    assert elapsed < 30
+    assert spawned[0].poll() is not None
+
+
+def test_the_link_is_shaped_for_stream_channels_and_refuses_to_dial_for_them() -> None:
+    """Live service streams must ride the one link, never a second one.
+
+    The compute node on a real HPC cluster has no route to the internet, so the
+    only viable path is compute node to cluster relay to this link. Nothing
+    implements it yet; what must hold now is that the link's shape admits it and
+    that asking refuses rather than opening new transport.
+    """
+    transport = SshForwardTransport(
+        definition=_definition(),
+        session_id="desktop-session-1",
+        session_generation_id="generation-1",
+        remote_api_port=8765,
+        bootstrap_script="true",
+    )
+
+    with pytest.raises(StreamChannelsUnavailable, match="one held link"):
+        transport.open_stream_channel(name="paraview", remote_port=11111)
+
+
+def test_established_link_reports_its_control_endpoint_and_stream_capability(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    harness = _install(monkeypatch, _Harness())
+    connection = _connect(tmp_path, harness)
+
+    link = connection.link
+    assert link is not None
+    assert link.control_endpoint.host == "127.0.0.1"
+    assert link.control_endpoint.base_url.startswith("http://127.0.0.1:")
+    assert link.bootstrap.status["session_id"] == "desktop-session-1"
+    # No mode carries multiplexed stream channels yet; the flag says so rather
+    # than the capability being absent from the interface.
+    assert link.stream_channels is False

--- a/tests/test_owned_session_channel.py
+++ b/tests/test_owned_session_channel.py
@@ -27,6 +27,9 @@ from clio_relay.cluster_config import (
 )
 from clio_relay.config import RelaySettings
 from clio_relay.control_channel import (
+    CHANNEL_BOOTSTRAP_BEGIN,
+    CHANNEL_BOOTSTRAP_END,
+    ChannelBootstrapError,
     ChannelDropped,
     SshForwardTransport,
     TransportModeUnavailable,
@@ -108,10 +111,25 @@ class _Stream:
 class _ChannelProcess:
     """One fake held-channel process: exactly one of these is one SSH dial."""
 
-    def __init__(self, bootstrap: dict[str, object], argv: list[str]) -> None:
+    def __init__(
+        self,
+        bootstrap: dict[str, object],
+        argv: list[str],
+        *,
+        banner: bytes = b"",
+        indent: int | None = None,
+    ) -> None:
         self.argv = argv
         self.stdin = io.BytesIO()
-        self.stdout = io.BytesIO(json.dumps(bootstrap).encode("utf-8") + b"\n")
+        self.stdout = io.BytesIO(
+            banner
+            + CHANNEL_BOOTSTRAP_BEGIN
+            + b"\n"
+            + json.dumps(bootstrap, indent=indent).encode("utf-8")
+            + b"\n"
+            + CHANNEL_BOOTSTRAP_END
+            + b"\n"
+        )
         self.stderr = io.BytesIO(b"")
         self.returncode: int | None = None
 
@@ -787,3 +805,62 @@ def test_registry_reconnect_is_the_single_explicit_reestablish_entry_point(
     with pytest.raises(ConfigurationError, match="no owned session connection is held"):
         harness.registry.reconnect("theta")
     assert harness.dials == 2
+
+
+def test_bring_up_survives_a_login_banner_and_pretty_printed_executor_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bootstrap is framed, not positional.
+
+    ``bash -lc`` runs a login shell whose profile commonly writes a banner to
+    stdout, and ``session recovery-status`` pretty-prints its JSON across many
+    lines. Neither may break bring-up.
+    """
+    harness = _Harness()
+    _install(monkeypatch, harness)
+
+    def noisy_factory(argv: list[str], **_kwargs: object) -> _ChannelProcess:
+        process = _ChannelProcess(
+            harness.bootstrap(),
+            argv,
+            banner=b"Welcome to ares\nLast login: Tue\n\n",
+            indent=2,
+        )
+        harness.processes.append(process)
+        return process
+
+    monkeypatch.setattr("clio_relay.control_channel.spawn_channel_process", noisy_factory)
+
+    connection = _connect(tmp_path, harness)
+
+    assert connection.connected is True
+    assert harness.dials == 1
+    bootstrap = connection.bootstrap
+    assert bootstrap is not None
+    assert bootstrap.status["session_generation_id"] == "generation-1"
+
+
+def test_bring_up_without_the_framed_document_fails_with_a_typed_reason(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bring-up whose executors failed must not be mistaken for a good one."""
+    harness = _Harness()
+    _install(monkeypatch, harness)
+
+    def failing_factory(argv: list[str], **_kwargs: object) -> _ChannelProcess:
+        process = _ChannelProcess(harness.bootstrap(), argv)
+        process.stdout = io.BytesIO(b"Welcome to ares\n")
+        process.stderr = io.BytesIO(b"clio-relay: owned session metadata is unavailable\n")
+        process.returncode = 1
+        harness.processes.append(process)
+        return process
+
+    monkeypatch.setattr("clio_relay.control_channel.spawn_channel_process", failing_factory)
+
+    with pytest.raises(ChannelBootstrapError, match="did not report its bootstrap"):
+        _connect(tmp_path, harness)
+
+    assert harness.dials == 1
+    assert harness.streams == []

--- a/tests/test_owned_session_channel.py
+++ b/tests/test_owned_session_channel.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import hashlib
 import io
 import json
+import threading
 from pathlib import Path
 from typing import Any, cast
 
@@ -32,7 +33,7 @@ from clio_relay.control_channel import (
     build_transport,
     owned_session_channel_bootstrap_script,
 )
-from clio_relay.errors import RelayError
+from clio_relay.errors import ConfigurationError, RelayError
 from clio_relay.http_api import create_app
 from clio_relay.job_identity import OWNER_SESSION_ID_HEADER, SESSION_GENERATION_ID_HEADER
 from clio_relay.remote_connection import (
@@ -723,4 +724,66 @@ def test_event_report_counts_the_transport_connections_the_gate_measures(
 
     reconnected = harness.registry.event_report()
     assert reconnected["transport_connections_opened"] == 2
+    assert harness.dials == 2
+
+
+def test_concurrent_operations_share_the_channel_without_serializing_or_redialing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A long poll on one operation must not block the rest of the cluster.
+
+    Extra streams run through the forward that is already held, so concurrency
+    costs more TCP connections but never another SSH connection.
+    """
+    harness = _install(monkeypatch, _Harness())
+    connection = _connect(tmp_path, harness)
+    blocked = threading.Event()
+    released = threading.Event()
+    original_getresponse = _Stream.getresponse
+
+    def slow_wait(self: _Stream) -> _Response:
+        path = cast(str, self.harness.requests[-1]["path"])
+        if path.endswith("/wait"):
+            blocked.set()
+            assert released.wait(timeout=10)
+        return original_getresponse(self)
+
+    monkeypatch.setattr(_Stream, "getresponse", slow_wait)
+
+    waiter = threading.Thread(
+        target=lambda: connection.request_json(method="POST", path="/jobs/job_1/wait", body={}),
+        daemon=True,
+    )
+    waiter.start()
+    assert blocked.wait(timeout=10)
+
+    # The long poll is still in flight; other operations must proceed anyway.
+    for index in range(4):
+        connection.request_json(method="GET", path=f"/jobs/job_{index}/status")
+
+    released.set()
+    waiter.join(timeout=10)
+    assert waiter.is_alive() is False
+
+    assert harness.dials == 1
+    assert len(harness.streams) == 2
+
+
+def test_registry_reconnect_is_the_single_explicit_reestablish_entry_point(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    harness = _install(monkeypatch, _Harness())
+    connection = _connect(tmp_path, harness)
+    harness.processes[0].drop()
+
+    reconnected = harness.registry.reconnect("ares")
+
+    assert reconnected is connection
+    assert harness.dials == 2
+    assert connection.connected is True
+
+    with pytest.raises(ConfigurationError, match="no owned session connection is held"):
+        harness.registry.reconnect("theta")
     assert harness.dials == 2

--- a/tests/test_session_api.py
+++ b/tests/test_session_api.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
 import http.client
+import io
 import json
-from collections.abc import Generator
-from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 import pytest
 
 from clio_relay.cluster_config import ClusterDefinition
 from clio_relay.config import RelaySettings
 from clio_relay.errors import ObservationTimeoutError, RelayError
+from clio_relay.job_identity import (
+    OWNER_SESSION_ID_HEADER,
+    SESSION_GENERATION_ID_HEADER,
+)
 from clio_relay.models import (
     MCP_ADMISSION_AUTHORITY_METADATA_KEY,
     REGISTERED_JARVIS_USER_CONTRACT,
@@ -23,9 +26,8 @@ from clio_relay.models import (
     RelayJob,
     prepare_owned_jarvis_run_submission,
 )
+from clio_relay.remote_connection import RemoteConnectionRegistry
 from clio_relay.session_api import (
-    OWNER_SESSION_ID_HEADER,
-    SESSION_GENERATION_ID_HEADER,
     OwnedSessionApiClient,
     session_identity_document,
     submit_owned_session_job,
@@ -116,12 +118,55 @@ class _Connection:
         self.sock = None
 
 
-class _ReadinessClient:
-    def __enter__(self) -> _ReadinessClient:
-        return self
+class _ChannelProcess:
+    """One fake held-channel process standing in for the bring-up SSH dial."""
 
-    def __exit__(self, *_args: object) -> None:
-        return None
+    def __init__(self, bootstrap: dict[str, object]) -> None:
+        self.stdin = io.BytesIO()
+        self.stdout = io.BytesIO(json.dumps(bootstrap).encode("utf-8") + b"\n")
+        self.stderr = io.BytesIO(b"")
+        self.returncode: int | None = None
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.returncode = -15
+
+    def kill(self) -> None:
+        self.returncode = -9
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        if self.returncode is None:
+            self.returncode = 0
+        return self.returncode
+
+    def drop(self) -> None:
+        """Simulate the held channel dying without a local close."""
+        self.returncode = 255
+
+
+def _bootstrap_document(
+    *,
+    identity: dict[str, str],
+    session_generation_id: str = "generation-1",
+    remote_api_port: int = 8765,
+) -> dict[str, object]:
+    """Return the exact out-of-band document one bring-up dial reports."""
+    return {
+        "schema_version": "clio-relay.channel-bootstrap.v1",
+        "status": {
+            "owner": "clio-relay",
+            "cluster": "ares",
+            "session_id": "desktop-session-1",
+            "session_generation_id": session_generation_id,
+            "remote_api_port": remote_api_port,
+            "running": True,
+            "ownership_verified": True,
+        },
+        "identity": dict(identity),
+    }
 
 
 def _settings(tmp_path: Path) -> RelaySettings:
@@ -205,22 +250,16 @@ def _install_transport(
     *,
     responses: list[_Response],
     fail_authenticated_request: bool = False,
-) -> tuple[list[dict[str, object]], list[_Connection]]:
+    bootstrap: dict[str, object] | None = None,
+) -> _Transport:
+    """Install one fake held channel and expose its dial and request record.
+
+    Every element of the real transport is replaced at the seam the production
+    code actually uses: the channel process factory (one call == one SSH dial),
+    the loopback health probe, and the proven HTTP stream.  Nothing here can
+    reach a real ``ssh`` process, so a dial count is exact.
+    """
     nonce = "1" * 64
-
-    def status(*, definition: ClusterDefinition, session_id: str) -> dict[str, object]:
-        assert definition.name == "ares"
-        assert session_id == "desktop-session-1"
-        return {
-            "owner": "clio-relay",
-            "cluster": "ares",
-            "session_id": "desktop-session-1",
-            "session_generation_id": "generation-1",
-            "remote_api_port": 8766,
-            "running": True,
-            "ownership_verified": True,
-        }
-
     expected_identity = session_identity_document(
         owner_token="owner-token",
         cluster="ares",
@@ -228,15 +267,14 @@ def _install_transport(
         generation_id="generation-1",
         nonce=nonce,
     )
-
-    def challenge(**_kwargs: object) -> dict[str, object]:
-        return dict(expected_identity)
+    document = bootstrap or _bootstrap_document(identity=expected_identity)
 
     captured: list[dict[str, object]] = []
     connections: list[_Connection] = []
+    processes: list[_ChannelProcess] = []
 
-    def connection_factory(*_args: object, **_kwargs: object) -> _Connection:
-        timeout_value = _kwargs.get("timeout", 30.0)
+    def connection_factory(*_args: object, **kwargs: object) -> _Connection:
+        timeout_value = kwargs.get("timeout", 30.0)
         if isinstance(timeout_value, bool) or not isinstance(timeout_value, (int, float)):
             raise AssertionError("HTTP connection timeout must be numeric")
         connection = _Connection(
@@ -248,23 +286,48 @@ def _install_transport(
         connections.append(connection)
         return connection
 
-    @contextmanager
-    def forward(**_kwargs: Any) -> Generator[int, None, None]:
-        yield 18_766
+    def process_factory(*_args: object, **_kwargs: object) -> _ChannelProcess:
+        process = _ChannelProcess(document)
+        processes.append(process)
+        return process
 
     def token_hex(_size: int) -> str:
         return nonce
 
-    def readiness_client(**_kwargs: object) -> _ReadinessClient:
-        return _ReadinessClient()
+    registry = RemoteConnectionRegistry()
 
-    monkeypatch.setattr("clio_relay.session_api.status_remote_session", status)
-    monkeypatch.setattr("clio_relay.session_api.challenge_remote_session_identity", challenge)
-    monkeypatch.setattr("clio_relay.session_api.secrets.token_hex", token_hex)
-    monkeypatch.setattr("clio_relay.session_api.httpx.Client", readiness_client)
-    monkeypatch.setattr("clio_relay.session_api.http.client.HTTPConnection", connection_factory)
-    monkeypatch.setattr("clio_relay.session_api._ssh_forward", forward)
-    return captured, connections
+    def skip_health(*_args: object, **_kwargs: object) -> None:
+        """The forward is faked, so its loopback readiness probe is a no-op."""
+
+    monkeypatch.setattr("clio_relay.control_channel.spawn_channel_process", process_factory)
+    monkeypatch.setattr("clio_relay.control_channel._wait_for_channel_health", skip_health)
+    monkeypatch.setattr("clio_relay.remote_connection.secrets.token_hex", token_hex)
+    monkeypatch.setattr(
+        "clio_relay.remote_connection.http.client.HTTPConnection",
+        connection_factory,
+    )
+    monkeypatch.setattr("clio_relay.session_api.connection_registry", lambda: registry)
+    return _Transport(
+        captured=captured,
+        connections=connections,
+        processes=processes,
+        registry=registry,
+    )
+
+
+@dataclass
+class _Transport:
+    """The observable record of one installed fake channel."""
+
+    captured: list[dict[str, object]]
+    connections: list[_Connection]
+    processes: list[_ChannelProcess]
+    registry: RemoteConnectionRegistry
+
+    @property
+    def dials(self) -> int:
+        """Return how many new channel processes (SSH dials) were spawned."""
+        return len(self.processes)
 
 
 def _submit_jarvis_run_receipt(
@@ -317,7 +380,7 @@ def test_owned_session_client_proves_identity_before_sending_credentials(
         generation_id="generation-1",
         nonce="1" * 64,
     )
-    captured, connections = _install_transport(
+    transport = _install_transport(
         monkeypatch,
         responses=[
             _Response(identity),
@@ -343,19 +406,19 @@ def test_owned_session_client_proves_identity_before_sending_credentials(
     assert job.owner_session_id == "desktop-session-1"
     assert job.owner_session_generation_id == "generation-1"
     assert job.metadata["owner_session_generation_id"] == "generation-1"
-    assert len(connections) == 1
-    proof_headers = captured[0]["headers"]
+    assert len(transport.connections) == 1
+    proof_headers = transport.captured[0]["headers"]
     assert isinstance(proof_headers, dict)
     assert "Authorization" not in proof_headers
     assert OWNER_SESSION_ID_HEADER not in proof_headers
     assert SESSION_GENERATION_ID_HEADER not in proof_headers
-    assert captured[0]["path"] == f"/session-identity?nonce={'1' * 64}"
-    auth_headers = captured[1]["headers"]
+    assert transport.captured[0]["path"] == f"/session-identity?nonce={'1' * 64}"
+    auth_headers = transport.captured[1]["headers"]
     assert isinstance(auth_headers, dict)
     assert auth_headers["Authorization"] == "Bearer session-api-token"
     assert auth_headers[OWNER_SESSION_ID_HEADER] == "desktop-session-1"
     assert auth_headers[SESSION_GENERATION_ID_HEADER] == "generation-1"
-    assert captured[1]["auto_open"] == 0
+    assert transport.captured[1]["auto_open"] == 0
 
 
 def test_owned_session_submission_rejects_dropped_artifact_dependencies(
@@ -544,7 +607,7 @@ def test_owned_session_client_reuses_one_proven_connection_for_composite_request
         generation_id="generation-1",
         nonce="1" * 64,
     )
-    captured, connections = _install_transport(
+    transport = _install_transport(
         monkeypatch,
         responses=[_Response(identity), _Response({"state": "running"}), _Response({"ok": True})],
     )
@@ -558,8 +621,8 @@ def test_owned_session_client_reuses_one_proven_connection_for_composite_request
             method="GET", path="/jobs/job_1/logs/stdout", query={"offset": 0, "limit": 64}
         ) == {"ok": True}
 
-    assert len(connections) == 1
-    assert [request["method"] for request in captured] == ["GET", "GET", "GET"]
+    assert len(transport.connections) == 1
+    assert [request["method"] for request in transport.captured] == ["GET", "GET", "GET"]
 
 
 def test_owned_session_client_scopes_long_response_timeout_to_one_request(
@@ -573,7 +636,7 @@ def test_owned_session_client_scopes_long_response_timeout_to_one_request(
         generation_id="generation-1",
         nonce="1" * 64,
     )
-    _captured, connections = _install_transport(
+    transport = _install_transport(
         monkeypatch,
         responses=[_Response(identity), _Response({"state": "succeeded"}), _Response({})],
     )
@@ -587,12 +650,12 @@ def test_owned_session_client_scopes_long_response_timeout_to_one_request(
             path="/jobs/job_1/wait",
             response_timeout_seconds=610,
         ) == {"state": "succeeded"}
-        assert connections[0].timeout == 30
-        assert connections[0].socket.timeout == 30
+        assert transport.connections[0].timeout == 30
+        assert transport.connections[0].socket.timeout == 30
         assert client.request_json(method="GET", path="/jobs/job_1/status") == {}
 
-    assert len(connections) == 1
-    assert connections[0].socket.timeout_changes == [610, 30]
+    assert len(transport.connections) == 1
+    assert transport.connections[0].socket.timeout_changes == [610, 30]
 
 
 def test_owned_session_client_types_only_a_bounded_response_deadline_as_observation_timeout(
@@ -606,7 +669,7 @@ def test_owned_session_client_types_only_a_bounded_response_deadline_as_observat
         generation_id="generation-1",
         nonce="1" * 64,
     )
-    _captured, connections = _install_transport(
+    transport = _install_transport(
         monkeypatch,
         responses=[_Response(identity), _TimeoutResponse({})],
     )
@@ -624,7 +687,7 @@ def test_owned_session_client_types_only_a_bounded_response_deadline_as_observat
             response_timeout_seconds=0.25,
         )
 
-    assert connections[0].socket.timeout_changes == [0.25, 30]
+    assert transport.connections[0].socket.timeout_changes == [0.25, 30]
 
 
 def test_owned_session_client_never_reconnects_after_identity_proof(
@@ -638,7 +701,7 @@ def test_owned_session_client_never_reconnects_after_identity_proof(
         generation_id="generation-1",
         nonce="1" * 64,
     )
-    captured, connections = _install_transport(
+    transport = _install_transport(
         monkeypatch,
         responses=[_Response(identity)],
         fail_authenticated_request=True,
@@ -653,31 +716,27 @@ def test_owned_session_client_never_reconnects_after_identity_proof(
     ):
         client.request_json(method="GET", path="/jobs/job_1/status")
 
-    assert len(connections) == 1
-    assert captured[1]["auto_open"] == 0
+    assert len(transport.connections) == 1
+    assert transport.captured[1]["auto_open"] == 0
 
 
-def test_owned_session_client_rejects_replaced_generation_before_transport(
+def test_owned_session_client_rejects_replaced_generation_before_credentials(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def status(*, definition: ClusterDefinition, session_id: str) -> dict[str, object]:
-        del definition, session_id
-        return {
-            "owner": "clio-relay",
-            "cluster": "ares",
-            "session_id": "desktop-session-1",
-            "session_generation_id": "generation-2",
-            "remote_api_port": 8766,
-            "running": True,
-            "ownership_verified": True,
-        }
-
-    def fail_client(**_kwargs: object) -> _ReadinessClient:
-        raise AssertionError("stale generation opened an HTTP transport")
-
-    monkeypatch.setattr("clio_relay.session_api.status_remote_session", status)
-    monkeypatch.setattr("clio_relay.session_api.httpx.Client", fail_client)
+    """A channel that reaches a replaced generation never carries a credential."""
+    identity = session_identity_document(
+        owner_token="owner-token",
+        cluster="ares",
+        session_id="desktop-session-1",
+        generation_id="generation-2",
+        nonce="1" * 64,
+    )
+    transport = _install_transport(
+        monkeypatch,
+        responses=[_Response(identity)],
+        bootstrap=_bootstrap_document(identity=identity, session_generation_id="generation-2"),
+    )
 
     with pytest.raises(RelayError, match="ownership-verified generation"):
         submit_owned_session_job(
@@ -692,3 +751,8 @@ def test_owned_session_client_rejects_replaced_generation_before_transport(
                 "idempotency_key": "stale-generation",
             },
         )
+
+    assert transport.dials == 1
+    assert transport.connections == []
+    assert transport.captured == []
+    assert transport.processes[0].poll() is not None

--- a/tests/test_session_api.py
+++ b/tests/test_session_api.py
@@ -10,6 +10,7 @@ import pytest
 
 from clio_relay.cluster_config import ClusterDefinition
 from clio_relay.config import RelaySettings
+from clio_relay.control_channel import CHANNEL_BOOTSTRAP_BEGIN, CHANNEL_BOOTSTRAP_END
 from clio_relay.errors import ObservationTimeoutError, RelayError
 from clio_relay.job_identity import (
     OWNER_SESSION_ID_HEADER,
@@ -123,7 +124,14 @@ class _ChannelProcess:
 
     def __init__(self, bootstrap: dict[str, object]) -> None:
         self.stdin = io.BytesIO()
-        self.stdout = io.BytesIO(json.dumps(bootstrap).encode("utf-8") + b"\n")
+        self.stdout = io.BytesIO(
+            CHANNEL_BOOTSTRAP_BEGIN
+            + b"\n"
+            + json.dumps(bootstrap).encode("utf-8")
+            + b"\n"
+            + CHANNEL_BOOTSTRAP_END
+            + b"\n"
+        )
         self.stderr = io.BytesIO(b"")
         self.returncode: int | None = None
 

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -5015,3 +5015,37 @@ def test_owned_session_start_status_wait_returns_on_the_first_terminal_observati
 
     assert status.start_state == "ready"
     assert calls == ["starting", "starting", "ready"]
+
+
+def test_default_cli_start_watch_costs_exactly_one_remote_command(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The CLI's default 120s watch must fit inside one bounded remote wait."""
+    definition, _release, plan = _durable_start_plan()
+    scripts: list[str] = []
+    pending = _durable_start_status(plan, state="starting")
+    moments = iter((0.0, 0.0, 120.0))
+
+    def fake_ssh(
+        _definition: ClusterDefinition,
+        script: str,
+        *,
+        timeout_seconds: float = 0.0,
+    ) -> str:
+        del timeout_seconds
+        scripts.append(script)
+        return pending.model_dump_json()
+
+    monkeypatch.setattr(session_lifecycle, "_ssh_script", fake_ssh)
+
+    result = session_lifecycle.watch_remote_session_start(
+        definition=definition,
+        plan=plan,
+        timeout_seconds=120.0,
+        monotonic=lambda: next(moments),
+        sleep=lambda _seconds: None,
+    )
+
+    assert result.watch_deadline_exceeded is True
+    assert len(scripts) == 1
+    assert "--wait-seconds 120" in scripts[0]

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -10,7 +10,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 import pytest
 from pytest import MonkeyPatch
@@ -4911,3 +4911,107 @@ def test_owned_teardown_delegates_to_pinned_cluster_local_executor() -> None:
     assert "exec 9>" not in script
     assert "metadata.json" not in script
     assert "last_cleanup" not in script
+
+
+def test_start_watch_is_one_bounded_server_side_wait_not_a_redial_loop(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A start watch must cost one remote command, whatever the start costs."""
+    definition, _release, plan = _durable_start_plan()
+    scripts: list[str] = []
+    timeouts: list[float] = []
+    ready = _durable_start_status(plan, state="ready")
+
+    def fake_ssh(
+        _definition: ClusterDefinition,
+        script: str,
+        *,
+        timeout_seconds: float = 0.0,
+    ) -> str:
+        scripts.append(script)
+        timeouts.append(timeout_seconds)
+        return ready.model_dump_json()
+
+    monkeypatch.setattr(session_lifecycle, "_ssh_script", fake_ssh)
+
+    result = session_lifecycle.watch_remote_session_start(
+        definition=definition,
+        plan=plan,
+        timeout_seconds=45.0,
+        sleep=lambda _seconds: None,
+    )
+
+    assert result.state == "ready"
+    assert len(scripts) == 1
+    assert "--wait-seconds 45" in scripts[0]
+    # The transport deadline must outlast the remote wait it is carrying.
+    assert timeouts[0] > 45.0
+
+
+def test_start_watch_bounds_the_remote_wait_it_asks_for(monkeypatch: MonkeyPatch) -> None:
+    definition, _release, plan = _durable_start_plan()
+    scripts: list[str] = []
+    pending = _durable_start_status(plan, state="starting")
+    moments = iter((0.0, 0.0, 600.0))
+
+    def fake_ssh(
+        _definition: ClusterDefinition,
+        script: str,
+        *,
+        timeout_seconds: float = 0.0,
+    ) -> str:
+        del timeout_seconds
+        scripts.append(script)
+        return pending.model_dump_json()
+
+    monkeypatch.setattr(session_lifecycle, "_ssh_script", fake_ssh)
+
+    result = session_lifecycle.watch_remote_session_start(
+        definition=definition,
+        plan=plan,
+        timeout_seconds=600.0,
+        monotonic=lambda: next(moments),
+        sleep=lambda _seconds: None,
+    )
+
+    assert result.watch_deadline_exceeded is True
+    assert len(scripts) == 1
+    assert (
+        f"--wait-seconds {session_lifecycle.MAX_REMOTE_SESSION_START_WAIT_SECONDS:g}" in scripts[0]
+    )
+
+
+def test_owned_session_start_status_wait_returns_on_the_first_terminal_observation() -> None:
+    observations = iter(("starting", "starting", "ready"))
+    calls: list[str] = []
+
+    def fake_inspect(**kwargs: object) -> OwnedSessionRecoveryStatus:
+        state = next(observations)
+        calls.append(state)
+        return OwnedSessionRecoveryStatus(
+            cluster=str(kwargs["cluster"]),
+            session_id=str(kwargs["session_id"]),
+            session_generation_id="generation-start",
+            start_operation_id=str(kwargs["start_operation_id"]),
+            cluster_route_revision=str(kwargs["cluster_route_revision"]),
+            start_state=cast(Any, state),
+            running=state == "ready",
+            ownership_verified=state == "ready",
+            recovery_verified=state == "ready",
+            start_attempt_verified=True,
+        )
+
+    status = session_lifecycle.wait_owned_session_start_status(
+        cluster="ares",
+        session_id="session-start",
+        start_operation_id="start_test",
+        cluster_route_revision="revision-1",
+        core_dir=Path("core"),
+        wait_seconds=30.0,
+        inspect=fake_inspect,
+        monotonic=iter([0.0, 1.0, 2.0, 3.0, 4.0]).__next__,
+        sleep=lambda _seconds: None,
+    )
+
+    assert status.start_state == "ready"
+    assert calls == ["starting", "starting", "ready"]

--- a/tests/test_transport_probe.py
+++ b/tests/test_transport_probe.py
@@ -726,7 +726,9 @@ def test_ssh_forward_probe_preserves_nonterminal_start_after_transport_deadline(
         *,
         definition: ClusterDefinition,
         selector: OwnedSessionStartStatusSelector,
+        wait_seconds: float = 0.0,
     ) -> OwnedSessionRecoveryStatus:
+        del wait_seconds
         assert definition == ClusterDefinition(name="test-cluster", ssh_host="test-host")
         status_selectors.append(selector)
         return OwnedSessionRecoveryStatus(


### PR DESCRIPTION
Restores clio-relay to the design of record on [#179](https://github.com/iowarp/clio-relay/issues/179) and its comments: one persistent relay-to-relay link per remote connection, relay-owned input staging on every JARVIS door, and documentation that states the design rather than the deviation.

This is the merge gate for the campaign tracked on [#182](https://github.com/iowarp/clio-relay/issues/182). Everything a correct-shape deployment needs comes through the front door here, so a cluster can be wiped and redeployed from released artifacts instead of from branches.

Four branches, merged in dependency order onto `origin/main`, each merge verified before the next. No conflicts: the only file two branches both touched is `docs/remote-mcp-federation.md`, and their edits land in different sections.

## What is in it

### 1. `fix/176-builtin-jarvis-staging` — the package side of #176

`clio_relay.bounded_command` now declares the five settings it actually reads, so JARVIS menu validation stops rejecting every setting the package consumes through `jarvis_add_step` ("Unknown argument 'command=[...]'"). Command validation moves into one helper used by both `_configure` and `start`, so an invalid argument vector is refused when the step is added rather than after the job is scheduled.

It also declares a `script` setting carrying the `ConfigurationInputBinding(kind="local_file", structure="regular_file")` that `input_staging.py` requires verbatim, appended to the command vector as its final argument, so any interpreter can run a file staged from the caller's machine. `builtin.my_shell` has exactly the wrong shape for this — a bare `str` setting — and ships from the upstream JARVIS builtin repository, which relay does not own.

Finally, the module docstring says what the package does. That docstring is the only text bounded package discovery ranks over, and "JARVIS-CD package for bounded relay commands" names nothing a caller would search for.

### 2. `fix/176-builtin-jarvis-staging-wiring` — the relay side of #176

Relay answered a package's declared file input — snapshot, ingest through the owned session, materialize on the cluster, rewrite the configuration, record the artifact use — only inside the registered remote-MCP dispatch branch. Calls arriving through the built-in virtual `jarvis_*` tools were dispatched earlier and never entered the staging plane: the path was forwarded verbatim, `used_artifact_refs` stayed empty, and the job failed inside the workload with "No such file or directory" while the pipeline reported success.

Both doors now share one implementation. The orchestration moves out of `mcp_server._call_tool` into `src/clio_relay/jarvis_input_plane.py`, keyed on a `JarvisStagingRoute` that names the exact door identity staged inputs bind to. The registered route keeps its behaviour exactly. The built-in route builds the same route identity from the cluster route revision, the discovered clio-kit server artifact digest, and a registration revision derived from relay's own pinned clio-kit release, so staged inputs never cross a JARVIS contract or launcher change. `mcp_server.py` loses about 300 lines net.

Two differences are deliberate and typed, not silent: the built-in door engages staging only when the JARVIS MCP runs on another machine, and a built-in run whose staged content drifted is refused by name (`jarvis_run_input_drift`) rather than run against bytes the configuration never received.

### 3. `design/179-one-link-control-plane` — the control plane

On 1.5.10 a single `jarvis_describe` cost nine fresh SSH connections and about 35 seconds of pure handshake: a status probe, an identity challenge, and a brand-new ephemeral `-L` forward per client context, torn down after each one.

A remote connection now establishes its transport once, at bring-up, and holds it for the connection's lifetime. `control_channel.py` declares `RelayTransport` with the three design modes; `ssh_forward` is implemented as one SSH process that holds the forward *and* runs the two cluster-local executors the separate dials used to run, reporting their output as one framed bootstrap document before blocking on stdin. `brokered_tcp` and `udp_rendezvous` slot in as siblings and raise `TransportModeUnavailable`, so an unbuilt mode can never quietly degrade into per-operation SSH.

`remote_connection.py` holds the channel, pools proven HTTP streams over it so one long poll cannot serialize a cluster, keeps a typed bounded event record, and exposes an explicit `reconnect()` that a user authorizes and a retry cannot reach. `RemoteConnectionRegistry` maps each cluster to its own connection, so one local relay manages many remote relays behind one stable client-facing endpoint.

`OwnedSessionApiClient` keeps its shape and becomes a handle onto the held channel, so all 18 call sites across `mcp_server`, `input_staging`, and `jarvis_service_runtime` ride the one link unchanged. `GET /session-status` replaces the SSH status script and names its own evidence (`live_api_self_report`) rather than claiming a cluster-local ownership audit it cannot produce. `session start-status-owned --wait-seconds` blocks cluster-side against durable state, so the CLI's default 120-second start watch is exactly one connection instead of one per 0.5s poll.

The branch also reverts the two `jarvis_add_step` description addenda added during the benchmark campaign. The failure they suppressed was a package returning a null deployment, which is a data defect, not a prompt gap.

### 4. `docs/relay-design-semantics` — the documentation

Adds `docs/connection-model.md` as normative: what a connection is, the one-link rule, the three transport modes, the SSH budget as a hard number, the 2FA operating assumption, reconnect as first-class, one local relay for many remotes, the virtual MCP layer, relay-owned input staging, `used_artifact_refs` as the proof of engagement, the bounded bootstrap-time exception, and a "never do this" list written against the concrete ways the model has been misread. README, `architecture.md`, `operations.md`, the connect walkthrough, the agent context files, and the release-acceptance runbook are corrected to agree with it, and the runbook's two out-of-band run-input steps are marked non-conforming in place.

### 5. Merge-truth follow-up (added in this PR)

The docs branch marked #176 and #179 as *known deviations* because neither had merged. Both are in this PR, so those sections would now teach the opposite of what the code does.

- `connection-model.md` splits its deviations into "closed by this release" and "still deviating", with the residual list taken from #182.
- `one-link-control-plane.md` gains the matching "what still dials and should not" section, so the implementation doc cannot be read as claiming more than it delivers.
- `docs/ai/interface-context.md` and `docs/ai/system-context.md` carry the same split.
- `docs/remote-mcp-federation.md` stops telling readers that an empty `used_artifact_refs` is expected on the built-in door, and states the two typed differences that remain.
- `docs/release-acceptance-1.0.md`'s two non-conforming steps name #182 as the rewrite tracker instead of waiting on #176.

Also runs `ruff format` on the two files the control-plane branch left unformatted. Format only, no semantic change.

## Issue map

- **Fixes #176** — both halves, package and wiring.
- **Addresses #179 partially.** The owned-session control plane rides one held channel. #179 stays open for its residuals, all of which are now documented in-tree and listed on #182: `relay_bind_jarvis_runtime` admission dialing through `remote_cli.run_remote_clio` (measured at four per bind), the `jarvis_service_runtime` scheduler bridge (~20 sites), cluster-targeted CLI dispatch under `CLIO_RELAY_CLI_MODE=auto`, no production surface calling `reconnect()`, the two unbuilt transport modes, the compute-node-side live-stream `frpc`, the connection-lifetime nonce, and the `--wait-seconds` wire-compat break.
- **#177 stays open.** The capability now exists on both doors; the end-to-end proof is the release gate and has not been run.
- **#182** tracks the campaign and holds the residual checklist and the both-ends deploy gate this PR unblocks.

Explicitly **not** in this PR:

- Any change to `allow_unauthenticated_owned_session`. Owner decision, untouched — it appears in the diff only as context lines.
- `backport/1510-addstep-envelope`. Superseded: `main` already carries the envelope fix (7c929f7). That branch is deployment history for the current desktop door and must not be merged.

## Verification

Windows 11, Python 3.12, `uv run --no-sync`.

| gate | result | same on `origin/main`? |
|---|---|---|
| `ruff check .` | all checks passed | yes |
| `ruff format --check .` | 210 files already formatted | yes (after the format-only commit here) |
| `pyright` (strict) | 0 errors, 0 warnings, 0 informations | yes |

Both branches' new and touched suites, run serially after each merge step and again after the last one — all green:

| suite | tests |
|---|---|
| `test_owned_session_channel.py` (new, #179) | 29 |
| `test_builtin_jarvis_input_staging.py` (new, #176) | 9 |
| `test_bounded_command_package.py` (3 → 12, #176) | 12 |
| `test_mcp_input_staging.py` | 12 |
| `test_session_api.py` | 11 |
| `test_session_lifecycle.py` | 105 |
| `test_mcp_server.py` | 111 |
| `test_http_api.py` | 59 |
| `test_jarvis_service_runtime.py` | 78 |
| `test_transport_probe.py` | 19 |
| `test_input_artifact_ingest.py` | 13 |

Full suite: 3,078 collected (33 posix-only tests deselected by the release-platform partition on Windows). Run on this branch and on untouched `origin/main` in a separate worktree, same interpreter, same temp root, same invocation.

### Pre-existing, not from this PR

Eight errors, byte-identical on both, all from the same missing external artifact — CI stages it with `CLIO_RELAY_CLIO_KIT_WHEEL` and a local run without it cannot:

```
ERROR tests/test_clio_kit_mcp_contracts.py::test_relay_contract_pins_match_clio_kit_wheel_artifacts
ERROR tests/test_clio_kit_mcp_contracts.py::test_relay_runtime_identity_matches_exact_wheel_launcher[jarvis]
ERROR tests/test_clio_kit_mcp_contracts.py::test_relay_runtime_identity_matches_exact_wheel_launcher[spack]
ERROR tests/test_clio_kit_mcp_contracts.py::test_runner_launches_exact_wheel_only_through_verified_snapshot
ERROR tests/test_clio_kit_mcp_contracts.py::test_live_locked_stdio_matches_shipped_contract_artifact[clio-kit-jarvis-user-v3.6]
ERROR tests/test_clio_kit_mcp_contracts.py::test_live_locked_stdio_matches_shipped_contract_artifact[clio-kit-scientific-catalog-user-v1.1]
ERROR tests/test_clio_kit_mcp_contracts.py::test_live_locked_stdio_matches_shipped_contract_artifact[clio-kit-slurm-user-v3]
ERROR tests/test_clio_kit_mcp_contracts.py::test_live_locked_stdio_matches_shipped_contract_artifact[clio-kit-spack-user-v2.1]
```

Every message is `set CLIO_RELAY_CLIO_KIT_WHEEL to the exact clio-kit release wheel; found 0 sibling build artifacts`.

### Two environment effects a reviewer should not mistake for defects

Both were reproduced on untouched `origin/main` and both disappear once the environment is fixed. Neither is in the code.

- **Nearly full temp volume.** `tests/test_http_api.py::test_http_typed_submit_endpoints_create_real_jobs` returns `507 Insufficient Storage` — relay's storage admission refusing correctly. It passes on both trees once the temp directory has headroom.
- **Long temp path.** A deep temp root plus a parallel runner's per-worker subdirectory crosses Windows' 260-character path limit, and a batch of tests (`test_cli.py`, `test_bootstrap_reconcile.py`, `test_scheduler_status.py`, others) fails with `[WinError 206] The filename or extension is too long`. With a short temp root every one of them passes on both trees. Worth knowing: an earlier local characterization of "9 pre-existing `test_cli.py` failures" was this, not a real defect — `test_cli.py` is fully green on both trees here.

A small set of timing-sensitive concurrency tests (`test_bounded_process`, `test_service_runtime`, `test_mcp_call_runner_lifecycle`, `test_bootstrap_cluster_paths`) fail non-deterministically when two 6-worker suites share the box, on both trees and not the same ones twice. Every one of them passes serially on this branch, as do their whole files.

## Review notes

- Not self-merged. The owner merges.
- The deployment gate on #182 is what this unblocks: both-ends deploy, the two-sided SSH measurement (bring-up 1 / operations 0 in mode (c)), the #177 staging proof through both JARVIS doors, and one application end to end with zero new SSH or SCP activity observed.
