### PR TITLE
fix: report a failed jarvis_run and give it the registered Spack executable

### DIFF
--- a/jarvis-packages/clio_relay/clio_relay/mcp_call/runner.py
+++ b/jarvis-packages/clio_relay/clio_relay/mcp_call/runner.py
@@ -175,6 +175,14 @@ _CLIO_KIT_REQUEST_ENV_OVERRIDES = {
     # remains available outside the served MCP session.
     "CLIO_KIT_UV_CACHE_PRUNE": "0",
 }
+# The relay composes one site runtime identity for a JARVIS run from the Spack
+# executable its cluster registered, and publishes it to this runner under a
+# relay-owned name. The JARVIS MCP server reads JARVIS_MCP_SPACK_COMMAND before
+# it searches PATH, SPACK_ROOT/bin, ~/.local/spack or /opt/spack, so mapping the
+# composed value onto that variable makes `spack load` resolve the registered
+# executable rather than whichever one a search happens to reach.
+_RELAY_JARVIS_SPACK_COMMAND_ENV = "CLIO_RELAY_JARVIS_SPACK_COMMAND"
+_JARVIS_MCP_SPACK_COMMAND_CHILD_ENV = "JARVIS_MCP_SPACK_COMMAND"
 _JARVIS_CD_LOCK_BINDING_SCHEMA = "clio-relay.jarvis-cd-lock-binding.v1"
 # These values intentionally mirror clio_relay.bootstrap. A focused release test
 # prevents either copy from moving independently. The JARVIS package also runs as
@@ -4795,12 +4803,11 @@ def _run_mcp_session(
     jarvis_input_manifest: dict[str, Any] | None = None,
     wait_for_locked_launcher: bool = False,
 ) -> subprocess.CompletedProcess[str]:
+    overrides = _child_environment_overrides(wait_for_locked_launcher=wait_for_locked_launcher)
     process = _open_process(
         command,
         env_from=env_from or {},
-        environment_overrides=(
-            _CLIO_KIT_REQUEST_ENV_OVERRIDES if wait_for_locked_launcher else None
-        ),
+        environment_overrides=overrides or None,
     )
     previous_handlers = _install_parent_termination_handlers(process)
     stdout_queue: Queue[_StreamEvent] = Queue()
@@ -5258,6 +5265,30 @@ def _drain_available(queue: Queue[_StreamEvent], lines: list[str]) -> None:
             lines.append(f"\n[{line.message}]\n")
         elif line is not None:
             lines.append(line)
+
+
+def _child_environment_overrides(*, wait_for_locked_launcher: bool) -> dict[str, str]:
+    """Return every relay-owned value applied on top of the referenced child env."""
+    overrides: dict[str, str] = {}
+    if wait_for_locked_launcher:
+        overrides.update(_CLIO_KIT_REQUEST_ENV_OVERRIDES)
+    overrides.update(_relay_composed_run_environment())
+    return overrides
+
+
+def _relay_composed_run_environment() -> dict[str, str]:
+    """Map the relay-composed site Spack identity onto the JARVIS child variable.
+
+    Returns:
+        The child overrides, empty when the relay composed no site identity for
+        this call. The relay publishes the variable only for a JARVIS run whose
+        cluster registered a Spack executable, so an unregistered cluster keeps
+        the previous child environment exactly.
+    """
+    composed = os.environ.get(_RELAY_JARVIS_SPACK_COMMAND_ENV)
+    if not composed:
+        return {}
+    return {_JARVIS_MCP_SPACK_COMMAND_CHILD_ENV: composed}
 
 
 def _open_process(

--- a/src/clio_relay/endpoint.py
+++ b/src/clio_relay/endpoint.py
@@ -2513,11 +2513,7 @@ class EndpointWorker:
             return McpRuntimeIngestOutcome(ingested=False)
         trusted, reason = _trusted_jarvis_mcp_result(job, result_document)
         if not trusted:
-            identity_matched, _identity_reason = _jarvis_mcp_result_identity_matches(
-                job,
-                result_document,
-            )
-            refusal = jarvis_dispatch_refusal(result_document) if identity_matched else None
+            refusal = _attributed_jarvis_dispatch_refusal(job, result_document)
             self.queue.append_event(
                 job.job_id,
                 "runtime.metadata_refused",
@@ -3210,6 +3206,32 @@ class EndpointWorker:
                 },
             )
         return values
+
+    def _recorded_jarvis_dispatch_refusal(
+        self,
+        job: RelayJob,
+        *,
+        spool: JobSpool,
+    ) -> JarvisDispatchRefusal | None:
+        """Return the typed refusal an earlier dispatch already persisted.
+
+        A worker that restarts, or one reconciling an attempt another worker
+        abandoned, reads the same durable answer the original dispatch recorded
+        rather than querying JARVIS for an execution the refusal proves absent.
+        """
+        storage_result_path = internal_filesystem_path(spool.path / "mcp-result.json")
+        if not storage_result_path.is_file():
+            return None
+        try:
+            document = json.loads(storage_result_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            self.queue.append_event(
+                job.job_id,
+                "runtime.metadata_read_failed",
+                f"MCP runtime result could not be read: {exc}",
+            )
+            return None
+        return _attributed_jarvis_dispatch_refusal(job, document)
 
     def _refuse_jarvis_execution_recovery(
         self,
@@ -4485,15 +4507,28 @@ class EndpointWorker:
                         relay_job_id=job.job_id,
                         task_id=task.task_id,
                     )
+                    recorded_refusal = self._recorded_jarvis_dispatch_refusal(
+                        job,
+                        spool=recovery_spool,
+                    )
                     with self._jarvis_execution_recovery_claim(job, task=task):
-                        recovered_dispatch = self._recover_jarvis_execution(
-                            job,
-                            task_id=task.task_id,
-                            spool=recovery_spool,
-                            state=recovered_state,
-                            digests=previous_digests,
-                            scheduler_job_ids=recovered_scheduler_job_ids,
-                        )
+                        if recorded_refusal is not None:
+                            self._refuse_jarvis_execution_recovery(
+                                job,
+                                task_id=task.task_id,
+                                spool=recovery_spool,
+                                refusal=recorded_refusal,
+                            )
+                            dispatch_refused = True
+                        else:
+                            recovered_dispatch = self._recover_jarvis_execution(
+                                job,
+                                task_id=task.task_id,
+                                spool=recovery_spool,
+                                state=recovered_state,
+                                digests=previous_digests,
+                                scheduler_job_ids=recovered_scheduler_job_ids,
+                            )
                     recovered_runtime = recovered_state[0]
                     task = self.queue.get_task(task.task_id)
                     recovery_intent = _durable_jarvis_execution_recovery(job, task)
@@ -6155,6 +6190,17 @@ def _jarvis_execution_recovery_is_pending(job: RelayJob, task: RelayTask) -> boo
     """Return whether scheduler identity is awaiting an exact JARVIS query."""
     intent = _durable_jarvis_execution_recovery(job, task)
     return intent is not None and intent["state"] == "pending"
+
+
+def _attributed_jarvis_dispatch_refusal(
+    job: RelayJob,
+    document: object,
+) -> JarvisDispatchRefusal | None:
+    """Return the typed refusal only when the result came from this job's route."""
+    identity_matched, _identity_reason = _jarvis_mcp_result_identity_matches(job, document)
+    if not identity_matched:
+        return None
+    return jarvis_dispatch_refusal(document)
 
 
 def _durable_jarvis_dispatch_refusal_detail(task: RelayTask) -> str:

--- a/src/clio_relay/endpoint.py
+++ b/src/clio_relay/endpoint.py
@@ -43,6 +43,12 @@ from clio_relay.filesystem_paths import (
 )
 from clio_relay.identifiers import filesystem_key
 from clio_relay.installation import installation_info
+from clio_relay.jarvis_dispatch_failure import (
+    JARVIS_DISPATCH_REFUSAL_RESOLUTION,
+    JarvisDispatchRefusal,
+    McpRuntimeIngestOutcome,
+    jarvis_dispatch_refusal,
+)
 from clio_relay.jarvis_execution import RUNTIME_SCHEDULER_PROVIDER_ENV
 from clio_relay.jarvis_mcp import (
     jarvis_cd_lock_binding_expectation,
@@ -1167,7 +1173,7 @@ class EndpointWorker:
                 package_progress_provider=package_log_progress_adapter,
                 source_authority=PackageProgressSourceAuthority.PACKAGE_LOG,
             )
-        mcp_runtime_ingested = self._ingest_mcp_runtime_metadata(
+        mcp_runtime_outcome = self._ingest_mcp_runtime_metadata(
             job,
             task_id=task.task_id,
             spool=spool,
@@ -1176,15 +1182,24 @@ class EndpointWorker:
             scheduler_job_ids=scheduler_job_ids,
         )
         dispatch_recovered = False
-        if jarvis_execution_recovery is not None and not mcp_runtime_ingested:
-            dispatch_recovered = self._recover_jarvis_execution(
-                job,
-                task_id=task.task_id,
-                spool=spool,
-                state=runtime_metadata_state,
-                digests=runtime_metadata_digests,
-                scheduler_job_ids=scheduler_job_ids,
-            )
+        dispatch_refusal = mcp_runtime_outcome.refusal
+        if jarvis_execution_recovery is not None and not mcp_runtime_outcome.ingested:
+            if dispatch_refusal is not None:
+                self._refuse_jarvis_execution_recovery(
+                    job,
+                    task_id=task.task_id,
+                    spool=spool,
+                    refusal=dispatch_refusal,
+                )
+            else:
+                dispatch_recovered = self._recover_jarvis_execution(
+                    job,
+                    task_id=task.task_id,
+                    spool=spool,
+                    state=runtime_metadata_state,
+                    digests=runtime_metadata_digests,
+                    scheduler_job_ids=scheduler_job_ids,
+                )
         scheduler_identity_reconciled = False
         if not endpoint_mcp_call or jarvis_execution_recovery is not None:
             scheduler_identity_reconciled = self._resolve_execution_ownership(
@@ -1229,7 +1244,14 @@ class EndpointWorker:
         self.queue.append_artifact(spool.artifact_for(spool.path / "stderr.log", kind="stderr"))
         self.queue.append_artifact(spool.artifact_for(spool.log_capture_path, kind="log_capture"))
         self._append_optional_result_artifacts(job, spool)
-        effective_returncode = 0 if dispatch_recovered else result.returncode
+        if dispatch_recovered:
+            effective_returncode = 0
+        elif dispatch_refusal is not None and result.returncode == 0:
+            # A recorded refusal is the run's answer. It stays the terminal
+            # outcome even if the transport that carried it exited cleanly.
+            effective_returncode = 1
+        else:
+            effective_returncode = result.returncode
         terminal_state = (
             JobState.CANCELED
             if self._job_cancellation_requested(job.job_id)
@@ -1288,19 +1310,30 @@ class EndpointWorker:
                 ),
             )
             return
+        failure_metadata: dict[str, object] = {"returncode": effective_returncode}
+        if dispatch_refusal is not None:
+            failure_metadata["jarvis_dispatch_refusal"] = dispatch_refusal.as_payload()
         self.queue.update_task_state(
             task.task_id,
             JobState.FAILED,
             message=f"Task failed: {task.name}",
-            metadata={"returncode": effective_returncode},
+            metadata=failure_metadata,
         )
         self.queue.update_job_state(
             job.job_id,
             JobState.FAILED,
             message=(
-                "Endpoint MCP operation failed" if endpoint_mcp_call else "JARVIS-CD run failed"
+                "JARVIS run failed"
+                if dispatch_refusal is not None
+                else "Endpoint MCP operation failed"
+                if endpoint_mcp_call
+                else "JARVIS-CD run failed"
             ),
-            error=f"exit code {effective_returncode}",
+            error=(
+                bounded_error_detail(dispatch_refusal.as_error_detail())
+                if dispatch_refusal is not None
+                else f"exit code {effective_returncode}"
+            ),
         )
 
     def _append_provenance_artifact(
@@ -2448,15 +2481,20 @@ class EndpointWorker:
         state: list[JarvisRuntimeMetadata | None],
         digests: set[str],
         scheduler_job_ids: list[str],
-    ) -> bool:
-        """Ingest structured runtime metadata returned by a remote MCP call."""
+    ) -> McpRuntimeIngestOutcome:
+        """Ingest structured runtime metadata returned by a remote MCP call.
+
+        Returns:
+            Whether native runtime metadata was adopted, together with the typed
+            refusal when the pinned route answered with an explicit tool error.
+        """
         route_valid, _route_reason = _trusted_jarvis_mcp_route(job)
         if not route_valid:
-            return False
+            return McpRuntimeIngestOutcome(ingested=False)
         result_path = spool.path / "mcp-result.json"
         storage_result_path = internal_filesystem_path(result_path)
         if not storage_result_path.exists():
-            return False
+            return McpRuntimeIngestOutcome(ingested=False)
         try:
             result_document = json.loads(storage_result_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
@@ -2465,9 +2503,14 @@ class EndpointWorker:
                 "runtime.metadata_read_failed",
                 f"MCP runtime result could not be read: {exc}",
             )
-            return False
+            return McpRuntimeIngestOutcome(ingested=False)
         trusted, reason = _trusted_jarvis_mcp_result(job, result_document)
         if not trusted:
+            identity_matched, _identity_reason = _jarvis_mcp_result_identity_matches(
+                job,
+                result_document,
+            )
+            refusal = jarvis_dispatch_refusal(result_document) if identity_matched else None
             self.queue.append_event(
                 job.job_id,
                 "runtime.metadata_refused",
@@ -2476,9 +2519,10 @@ class EndpointWorker:
                     "source": RuntimeMetadataSource.JARVIS_MCP.value,
                     "ownership_verified": False,
                     "reason": reason,
+                    "dispatch_refused": refusal is not None,
                 },
             )
-            return False
+            return McpRuntimeIngestOutcome(ingested=False, refusal=refusal)
         try:
             metadata = runtime_metadata_from_mcp_result_document(result_document)
         except ValueError as exc:
@@ -2496,7 +2540,7 @@ class EndpointWorker:
                 f"native JARVIS execution documents were invalid: {exc}"
             ) from exc
         if metadata is None:
-            return False
+            return McpRuntimeIngestOutcome(ingested=False)
         if not _runtime_metadata_is_native(metadata):
             self.queue.append_event(
                 job.job_id,
@@ -2508,7 +2552,7 @@ class EndpointWorker:
                     "reason": "native handle, record, and progress documents are required",
                 },
             )
-            return False
+            return McpRuntimeIngestOutcome(ingested=False)
         expected_pipeline_id = (
             job.spec.arguments.get("pipeline_id") if isinstance(job.spec, McpCallSpec) else None
         )
@@ -2565,7 +2609,7 @@ class EndpointWorker:
             resolution="dispatch_result",
             result_path=result_path,
         )
-        return True
+        return McpRuntimeIngestOutcome(ingested=True)
 
     def _recover_jarvis_execution(
         self,
@@ -3126,6 +3170,61 @@ class EndpointWorker:
                 "scheduler_job_id": metadata.scheduler_job_id,
                 "resolution": resolution,
                 "result_sha256": result_sha256,
+            },
+        )
+
+    def _refuse_jarvis_execution_recovery(
+        self,
+        job: RelayJob,
+        *,
+        task_id: str,
+        spool: JobSpool,
+        refusal: JarvisDispatchRefusal,
+    ) -> None:
+        """Settle ownership from one explicit JARVIS tool error on the dispatch.
+
+        The JARVIS user contract issues a durable execution handle only when a
+        run starts, so an ``isError`` answer proves no execution exists to query
+        or adopt. Recording it resolves the recovery intent instead of leaving
+        the durable job nonterminal behind an ownership question that cannot be
+        answered.
+        """
+        task = self.queue.get_task(task_id)
+        intent = _durable_jarvis_execution_recovery(job, task)
+        if intent is None:
+            return
+        if intent["state"] != "pending" or intent["dispatch_state"] != "started":
+            raise RelayError("JARVIS dispatch refusal did not match a released dispatch")
+        storage_result_path = internal_filesystem_path(spool.path / "mcp-result.json")
+        if not storage_result_path.is_file():
+            raise RelayError("JARVIS dispatch refusal has no durable result artifact")
+        result_sha256 = hashlib.sha256(storage_result_path.read_bytes()).hexdigest()
+        self.queue.update_task_metadata(
+            task_id,
+            {
+                "jarvis_execution_recovery": {
+                    **intent,
+                    "state": "resolved",
+                    "last_error": None,
+                    "next_retry_at": None,
+                    "result_sha256": result_sha256,
+                    "resolved_at": utc_now().isoformat(),
+                    "resolution": JARVIS_DISPATCH_REFUSAL_RESOLUTION,
+                    "scheduler_provider": None,
+                    "scheduler_job_id": None,
+                    "query_process": None,
+                },
+                "jarvis_dispatch_refusal": refusal.as_payload(),
+            },
+        )
+        self.queue.append_event(
+            job.job_id,
+            "jarvis.dispatch_refused",
+            f"JARVIS refused the run: {refusal.as_error_detail()}",
+            payload={
+                "task_id": task_id,
+                "result_sha256": result_sha256,
+                **refusal.as_payload(),
             },
         )
 
@@ -4307,6 +4406,7 @@ class EndpointWorker:
             try:
                 recovered_dispatch = False
                 dispatch_not_released = False
+                dispatch_refused = False
                 recovered_runtime: JarvisRuntimeMetadata | None = None
                 recovery_spool: JobSpool | None = None
                 process_id = self._terminate_recorded_execution(
@@ -4359,6 +4459,11 @@ class EndpointWorker:
                     recovered_runtime = recovered_state[0]
                     task = self.queue.get_task(task.task_id)
                     recovery_intent = _durable_jarvis_execution_recovery(job, task)
+                elif (
+                    recovery_intent is not None
+                    and recovery_intent.get("resolution") == JARVIS_DISPATCH_REFUSAL_RESOLUTION
+                ):
+                    dispatch_refused = True
                 elif recovery_intent is not None:
                     recovery_spool = JobSpool(
                         self.settings.spool_dir,
@@ -4374,7 +4479,7 @@ class EndpointWorker:
                     recovered_dispatch = True
                 if recovery_intent is None:
                     self._reconcile_recorded_scheduler_submission(job, task)
-                elif dispatch_not_released:
+                elif dispatch_not_released or dispatch_refused:
                     pass
                 elif recovery_intent["state"] != "resolved" or not recovered_dispatch:
                     raise SchedulerSubmissionUnresolvedError(
@@ -4389,6 +4494,7 @@ class EndpointWorker:
                     and self._scheduler_cancel_was_requested(job.job_id)
                     and recovery_intent is not None
                     and not dispatch_not_released
+                    and not dispatch_refused
                 ):
                     owned_ids = self._durable_scheduler_job_ids(
                         job,
@@ -4446,6 +4552,18 @@ class EndpointWorker:
                             job.job_id,
                             JobState.SUCCEEDED,
                             message="JARVIS MCP response recovered from durable execution",
+                        )
+                elif dispatch_refused and not cancellation_requested:
+                    current_job = self.queue.get_job(job.job_id)
+                    if current_job.state not in {
+                        JobState.FAILED,
+                        JobState.CANCELED,
+                    }:
+                        self.queue.update_job_state(
+                            job.job_id,
+                            JobState.FAILED,
+                            message="JARVIS run failed",
+                            error=_durable_jarvis_dispatch_refusal_detail(task),
                         )
                 elif dispatch_not_released and not cancellation_requested:
                     current_job = self.queue.get_job(job.job_id)
@@ -5917,7 +6035,13 @@ def _durable_jarvis_execution_recovery(
                 or re.fullmatch(r"[0-9a-f]{64}", result_sha256) is None
             )
         )
-        or resolution not in {None, "dispatch_result", "execution_query"}
+        or resolution
+        not in {
+            None,
+            "dispatch_result",
+            "execution_query",
+            JARVIS_DISPATCH_REFUSAL_RESOLUTION,
+        }
         or (
             scheduler_provider is not None
             and (not isinstance(scheduler_provider, str) or not scheduler_provider)
@@ -5995,6 +6119,20 @@ def _jarvis_execution_recovery_is_pending(job: RelayJob, task: RelayTask) -> boo
     return intent is not None and intent["state"] == "pending"
 
 
+def _durable_jarvis_dispatch_refusal_detail(task: RelayTask) -> str:
+    """Return the typed reason recorded when JARVIS refused one durable run."""
+    payload = task.metadata.get("jarvis_dispatch_refusal")
+    if isinstance(payload, dict):
+        typed = cast(dict[str, object], payload)
+        code = typed.get("code")
+        message = typed.get("message")
+        if isinstance(code, str) and code and isinstance(message, str) and message:
+            bounded = bounded_error_detail(f"{code}: {message}")
+            if bounded is not None:
+                return bounded
+    return "JARVIS refused the run without a recorded typed reason"
+
+
 def _durable_runtime_recovery_state(
     task: RelayTask,
 ) -> tuple[JarvisRuntimeMetadata | None, set[str]]:
@@ -6013,13 +6151,18 @@ def _durable_runtime_recovery_state(
     return runtime, {digest}
 
 
-def _trusted_jarvis_mcp_result(
+def _jarvis_mcp_result_identity_matches(
     job: RelayJob,
     document: object,
     *,
     expected_tool: str = "jarvis_run",
 ) -> tuple[bool, str]:
-    """Verify runtime identity came from the configured owned JARVIS MCP call."""
+    """Verify one MCP result document came from this durable job's pinned route.
+
+    Identity is independent of the call's outcome: a dispatch that answered with
+    a tool error still proves which route produced it, which is what lets the
+    worker record that answer as this job's typed failure.
+    """
     route_valid, route_reason = _trusted_jarvis_mcp_route(
         job,
         expected_tool=expected_tool,
@@ -6063,6 +6206,24 @@ def _trusted_jarvis_mcp_result(
         artifact_failure = "MCP result server artifact identity is not the exact relay release pin"
     if not artifact_verified:
         return False, artifact_failure
+    return True, "configured JARVIS MCP command and durable route matched"
+
+
+def _trusted_jarvis_mcp_result(
+    job: RelayJob,
+    document: object,
+    *,
+    expected_tool: str = "jarvis_run",
+) -> tuple[bool, str]:
+    """Verify runtime identity came from the configured owned JARVIS MCP call."""
+    identity_matched, identity_reason = _jarvis_mcp_result_identity_matches(
+        job,
+        document,
+        expected_tool=expected_tool,
+    )
+    if not identity_matched:
+        return False, identity_reason
+    typed = cast(dict[str, object], document)
     if (
         typed.get("returncode") != 0
         or typed.get("timed_out") is True

--- a/src/clio_relay/endpoint.py
+++ b/src/clio_relay/endpoint.py
@@ -56,6 +56,10 @@ from clio_relay.jarvis_mcp import (
     jarvis_mcp_server_artifact_binding_verified,
 )
 from clio_relay.jarvis_provider import JarvisCdProvider
+from clio_relay.jarvis_run_environment import (
+    jarvis_run_environment_values,
+    registered_site_spack_command,
+)
 from clio_relay.models import (
     CLIO_PROVENANCE_METADATA_KEY,
     REGISTERED_JARVIS_USER_CONTRACT,
@@ -1014,6 +1018,9 @@ class EndpointWorker:
         if endpoint_mcp_call:
             assert isinstance(job.spec, McpCallSpec)
             execution_environment_values = _minimal_mcp_runner_environment(job.spec.env_from)
+            execution_environment_values.update(
+                self._jarvis_run_environment_values(job, task_id=task.task_id)
+            )
             if progress_sidecar_enabled:
                 execution_environment_values.update(
                     {
@@ -3172,6 +3179,37 @@ class EndpointWorker:
                 "result_sha256": result_sha256,
             },
         )
+
+    def _jarvis_run_environment_values(
+        self,
+        job: RelayJob,
+        *,
+        task_id: str,
+    ) -> dict[str, str]:
+        """Compose the site runtime identity this cluster registered for JARVIS.
+
+        A ``jarvis_run`` resolves its ``spack_specs`` inside the JARVIS MCP child
+        this worker spawns, so the child needs the same Spack executable the
+        cluster registered and the Spack route already receives. A cluster that
+        declares none keeps the previous environment exactly.
+        """
+        route_valid, _route_reason = _trusted_jarvis_mcp_route(job)
+        if not route_valid:
+            return {}
+        spack_command = registered_site_spack_command(job.cluster)
+        values = jarvis_run_environment_values(spack_command)
+        if values:
+            self.queue.append_event(
+                job.job_id,
+                "jarvis.run_environment_composed",
+                "Registered cluster Spack executable composed into the JARVIS run environment",
+                payload={
+                    "task_id": task_id,
+                    "cluster": job.cluster,
+                    "spack_command": spack_command,
+                },
+            )
+        return values
 
     def _refuse_jarvis_execution_recovery(
         self,

--- a/src/clio_relay/jarvis_dispatch_failure.py
+++ b/src/clio_relay/jarvis_dispatch_failure.py
@@ -1,0 +1,121 @@
+"""Typed JARVIS dispatch refusals carried by a durable ``jarvis_run`` result.
+
+The registered JARVIS user contract returns a durable execution handle from
+``jarvis_run`` and resolves every requested Spack runtime *before* direct or
+scheduler execution. An explicit ``isError`` answer therefore settles ownership:
+no execution handle was issued, so there is no durable execution for the relay
+to query or adopt. The worker records that answer as a typed refusal and
+terminalizes the durable job with it instead of entering the lost-response
+recovery loop, which can only ever fail for an execution that was never created.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import cast
+
+JARVIS_DISPATCH_REFUSAL_SCHEMA = "clio-relay.jarvis-dispatch-refusal.v1"
+"""Schema of the durable event payload recording one refusal."""
+
+JARVIS_ERROR_PAYLOAD_SCHEMA = "jarvis.error.v1"
+"""Schema of the typed error document the JARVIS MCP server returns."""
+
+JARVIS_DISPATCH_REFUSAL_RESOLUTION = "dispatch_refusal"
+"""Recovery-intent resolution recorded when the dispatch itself answered."""
+
+UNTYPED_REFUSAL_CODE = "jarvis_tool_error"
+"""Code used when an ``isError`` answer carries no typed JARVIS payload."""
+
+MAX_REFUSAL_MESSAGE_CHARS = 2_000
+
+
+@dataclass(frozen=True)
+class JarvisDispatchRefusal:
+    """One explicit JARVIS tool error returned by a durable run dispatch."""
+
+    code: str
+    message: str
+    pipeline_id: str | None
+    execution_id: str | None
+    payload_schema_version: str | None
+
+    def as_payload(self) -> dict[str, object]:
+        """Return the durable event payload describing this refusal."""
+        return {
+            "schema_version": JARVIS_DISPATCH_REFUSAL_SCHEMA,
+            "code": self.code,
+            "message": self.message,
+            "pipeline_id": self.pipeline_id,
+            "execution_id": self.execution_id,
+            "payload_schema_version": self.payload_schema_version,
+        }
+
+    def as_error_detail(self) -> str:
+        """Return the typed reason recorded on the terminal durable job."""
+        return f"{self.code}: {self.message}"
+
+
+@dataclass(frozen=True)
+class McpRuntimeIngestOutcome:
+    """Result of reading one durable MCP dispatch result for runtime metadata."""
+
+    ingested: bool
+    refusal: JarvisDispatchRefusal | None = None
+
+
+def jarvis_dispatch_refusal(document: object) -> JarvisDispatchRefusal | None:
+    """Return the typed refusal when a JARVIS dispatch answered with a tool error.
+
+    Args:
+        document: The persisted ``mcp-result.json`` document. Its route identity
+            must already have been matched against the durable job spec.
+
+    Returns:
+        The typed refusal, or ``None`` when the dispatch did not return an
+        explicit tool error. A dispatch that timed out is never a refusal: the
+        response was lost rather than answered, so ownership stays unresolved.
+    """
+    if not isinstance(document, dict):
+        return None
+    typed = cast(dict[str, object], document)
+    if typed.get("timed_out") is True:
+        return None
+    protocol_result = typed.get("protocol_result")
+    if not isinstance(protocol_result, dict):
+        return None
+    if cast(dict[str, object], protocol_result).get("isError") is not True:
+        return None
+    structured = typed.get("structured_result")
+    if isinstance(structured, dict):
+        payload = cast(dict[str, object], structured)
+        error = payload.get("error")
+        if payload.get("schema_version") == JARVIS_ERROR_PAYLOAD_SCHEMA and isinstance(error, dict):
+            fields = cast(dict[str, object], error)
+            code = fields.get("code")
+            message = fields.get("message")
+            if isinstance(code, str) and code and isinstance(message, str) and message:
+                return JarvisDispatchRefusal(
+                    code=code,
+                    message=message[:MAX_REFUSAL_MESSAGE_CHARS],
+                    pipeline_id=_optional_text(fields.get("pipeline_id")),
+                    execution_id=_optional_text(fields.get("execution_id")),
+                    payload_schema_version=JARVIS_ERROR_PAYLOAD_SCHEMA,
+                )
+    protocol_error = typed.get("protocol_error")
+    message = (
+        protocol_error
+        if isinstance(protocol_error, str) and protocol_error
+        else "the JARVIS MCP tool returned isError without a typed payload"
+    )
+    return JarvisDispatchRefusal(
+        code=UNTYPED_REFUSAL_CODE,
+        message=message[:MAX_REFUSAL_MESSAGE_CHARS],
+        pipeline_id=None,
+        execution_id=None,
+        payload_schema_version=None,
+    )
+
+
+def _optional_text(value: object) -> str | None:
+    """Return one non-empty string field, or ``None`` when it is absent."""
+    return value if isinstance(value, str) and value else None

--- a/src/clio_relay/jarvis_run_environment.py
+++ b/src/clio_relay/jarvis_run_environment.py
@@ -1,0 +1,90 @@
+"""Site runtime identity composed by the relay for one JARVIS MCP child.
+
+The relay spawns the JARVIS MCP server itself, so it — not the operator's per
+server registration — composes that child's environment. A cluster registers one
+``spack_executable``; that path is the single Spack identity for every route on
+the cluster that needs Spack. The Spack route already receives it through its
+registered ``--spack-command`` argument. This module carries the same registered
+path to the JARVIS run environment, where ``spack load`` runs inside the JARVIS
+MCP child.
+
+The JARVIS MCP server resolves Spack from ``JARVIS_MCP_SPACK_COMMAND`` first and
+only then searches ``PATH``, ``SPACK_ROOT/bin``, ``~/.local/spack`` and
+``/opt/spack``, so an explicitly composed variable is the typed mechanism rather
+than an ambient search hit. The worker publishes the registered path under a
+relay-owned name; the bundled MCP runner maps that name onto the child variable
+the JARVIS server reads.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from clio_relay.cluster_config import ClusterRegistry, default_registry_path
+from clio_relay.errors import ConfigurationError, RelayError
+from clio_relay.remote_values import expand_remote_value_on_host
+
+RELAY_JARVIS_SPACK_COMMAND_ENV = "CLIO_RELAY_JARVIS_SPACK_COMMAND"
+"""Relay-owned worker variable carrying one cluster's registered Spack path."""
+
+JARVIS_MCP_SPACK_COMMAND_CHILD_ENV = "JARVIS_MCP_SPACK_COMMAND"
+"""Variable the JARVIS MCP server reads before any filesystem search."""
+
+
+def registered_site_spack_command(
+    cluster: str,
+    *,
+    registry_path: Path | None = None,
+) -> str | None:
+    """Return the Spack executable one cluster registered, expanded for this host.
+
+    Args:
+        cluster: Name of the cluster whose registration is being executed.
+        registry_path: Explicit registry location; defaults to the configured
+            cluster registry of the running endpoint.
+
+    Returns:
+        The registered absolute path, or ``None`` when no registry is configured
+        on this host, it does not describe this cluster, or the cluster declares
+        no Spack executable. An absent declaration never invents a default.
+
+    Raises:
+        ConfigurationError: If a configured registry cannot be read, or the
+            declared value cannot be expanded on this host. A registry that
+            exists but cannot be understood is a refusal, never a quiet
+            downgrade to an unresolved Spack runtime.
+    """
+    resolved_path = registry_path or default_registry_path()
+    if not resolved_path.exists():
+        return None
+    try:
+        registry = ClusterRegistry.load(resolved_path)
+    except (OSError, ValueError, RelayError) as error:
+        raise ConfigurationError(
+            f"configured cluster registry could not be read for {cluster}: {error}"
+        ) from error
+    definition = registry.clusters.get(cluster)
+    if definition is None or definition.spack_executable is None:
+        return None
+    return expand_remote_value_on_host(
+        definition.spack_executable,
+        field="spack_executable",
+        home=os.path.expanduser("~"),
+    )
+
+
+def jarvis_run_environment_values(spack_command: str | None) -> dict[str, str]:
+    """Return the relay-composed run-environment values for a JARVIS MCP call.
+
+    Args:
+        spack_command: The cluster's registered Spack executable, or ``None``
+            when the cluster declares none.
+
+    Returns:
+        A mapping to merge into the MCP runner environment. It is empty when the
+        cluster declares no Spack executable, leaving behavior unchanged.
+    """
+    if spack_command is None:
+        return {}
+    return {RELAY_JARVIS_SPACK_COMMAND_ENV: spack_command}

--- a/src/clio_relay/remote_values.py
+++ b/src/clio_relay/remote_values.py
@@ -45,6 +45,30 @@ def remote_value_expands_home(value: str) -> bool:
     return _leading_home_suffix(value) is not None
 
 
+def expand_remote_value_on_host(value: str, *, field: str, home: str) -> str:
+    """Expand a leading remote ``$HOME`` token against the host that runs the value.
+
+    Args:
+        value: The operator-configured remote value.
+        field: Configuration field name used in refusal messages.
+        home: Absolute home directory of the account executing on that host.
+
+    Returns:
+        The value with only an exact leading ``$HOME`` token replaced.
+
+    Raises:
+        ConfigurationError: If the value carries control characters, or requests
+            HOME expansion while the executing account has no home directory.
+    """
+    _validate_remote_value(value, field=field)
+    home_suffix = _leading_home_suffix(value)
+    if home_suffix is None:
+        return value
+    if not home:
+        raise ConfigurationError(f"remote {field} requires a home directory to expand $HOME")
+    return f"{home.rstrip('/')}{home_suffix}"
+
+
 def validate_remote_path(value: str, *, field: str) -> None:
     """Require an absolute POSIX path or one anchored by an exact leading HOME token."""
     _validate_remote_value(value, field=field)

--- a/tests/test_jarvis_run_failure_reporting.py
+++ b/tests/test_jarvis_run_failure_reporting.py
@@ -437,6 +437,86 @@ def test_refusal_outranks_a_clean_transport_exit(
     assert result.last_error == f"{SPECIMEN_ERROR_CODE}: {SPECIMEN_ERROR_MESSAGE}"
 
 
+def test_restart_cleanup_settles_a_run_left_stuck_by_an_earlier_build(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A job already stuck behind a failed recovery query settles on the next pass.
+
+    This reproduces the live specimen's durable state: the errored dispatch is in
+    the spool, the recovery intent is still pending, and the job never left
+    ``running``. Restart cleanup must read the recorded answer instead of
+    querying JARVIS again for an execution that was never created.
+    """
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    command = ["clio-kit", "mcp-server", "jarvis"]
+    server_artifact = {
+        **verified_jarvis_server_artifact(),
+        "install_spec": "/releases/clio-kit.whl",
+    }
+    digest = remote_mcp_server_artifact_digest(server_artifact)
+    monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
+    job = _submit_registered_run(
+        queue,
+        command=command,
+        digest=digest,
+        idempotency_key="copper-elastic-v1-run-007",
+    )
+    spec = cast(McpCallSpec, job.spec)
+    provider = _DispatchProvider(
+        document=_specimen_error_result_document(
+            command=command,
+            digest=digest,
+            server_artifact=server_artifact,
+            arguments=spec.arguments,
+            expected_registered_contract=spec.expected_registered_contract,
+            execution_id=cast(str, spec.arguments["execution_id"]),
+        ),
+        returncode=1,
+    )
+    worker = _worker(settings, queue, provider)
+
+    def _blind_to_refusals(_document: object) -> None:
+        return None
+
+    def _failed_recovery_query(*_args: object, **_kwargs: object) -> bool:
+        raise endpoint_module.SchedulerSubmissionUnresolvedError(
+            "artifact-pinned JARVIS execution recovery result was not trusted"
+        )
+
+    monkeypatch.setattr(endpoint_module, "jarvis_dispatch_refusal", _blind_to_refusals)
+    monkeypatch.setattr(
+        endpoint_module.EndpointWorker,
+        "_recover_jarvis_execution",
+        _failed_recovery_query,
+    )
+
+    stuck = worker.run_once()
+
+    assert stuck is not None
+    assert stuck.state is JobState.RUNNING
+    stuck_task = queue.list_tasks(job.job_id)[0]
+    stuck_intent = cast(dict[str, object], stuck_task.metadata["jarvis_execution_recovery"])
+    assert stuck_intent["state"] == "pending"
+
+    monkeypatch.undo()
+    monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
+
+    assert worker.run_once() is None
+
+    settled = queue.get_job(job.job_id)
+    assert settled.state is JobState.FAILED
+    assert settled.last_error == f"{SPECIMEN_ERROR_CODE}: {SPECIMEN_ERROR_MESSAGE}"
+    settled_task = queue.get_task(stuck_task.task_id)
+    assert settled_task.state is JobState.FAILED
+    settled_intent = cast(dict[str, object], settled_task.metadata["jarvis_execution_recovery"])
+    assert settled_intent["state"] == "resolved"
+    assert settled_intent["resolution"] == "dispatch_refusal"
+    events, _cursor = queue.drain_events(Cursor(job_id=job.job_id), limit=300)
+    assert "jarvis.dispatch_refused" in {event.event_type for event in events}
+
+
 def test_successful_jarvis_run_still_terminalizes_as_succeeded(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/test_jarvis_run_failure_reporting.py
+++ b/tests/test_jarvis_run_failure_reporting.py
@@ -1,4 +1,4 @@
-"""A refused JARVIS run reaches a terminal state carrying its typed reason.
+"""A refused JARVIS run terminalizes, and a registered Spack path reaches it.
 
 The MCP result documents below reproduce the shapes captured on the isolated
 ``p5run2`` deployment for durable job ``job_63d173b2bf8a47d2b811860ac26af569``:
@@ -19,14 +19,23 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, cast
 
+import pytest
 from pytest import MonkeyPatch
 
 from clio_relay import endpoint as endpoint_module
+from clio_relay import jarvis_run_environment as jarvis_run_environment_module
+from clio_relay.cluster_config import ClusterDefinition, ClusterRegistry
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.endpoint import EndpointWorker
+from clio_relay.errors import ConfigurationError
 from clio_relay.jarvis_dispatch_failure import jarvis_dispatch_refusal
 from clio_relay.jarvis_provider import JarvisCdProvider
+from clio_relay.jarvis_run_environment import (
+    RELAY_JARVIS_SPACK_COMMAND_ENV,
+    jarvis_run_environment_values,
+    registered_site_spack_command,
+)
 from clio_relay.models import (
     Cursor,
     EndpointRole,
@@ -47,6 +56,7 @@ SPECIMEN_ERROR_MESSAGE = (
     "Run failed: Spack executable was not found in PATH, SPACK_ROOT/bin, "
     "~/.local/spack, or /opt/spack"
 )
+SITE_SPACK_COMMAND = "/home/operator/.local/share/clio-relay/site-profiles/ares-spack-v1/bin/spack"
 
 
 def _specimen_error_result_document(
@@ -547,3 +557,169 @@ def test_successful_protocol_result_is_not_a_refusal() -> None:
     }
 
     assert jarvis_dispatch_refusal(document) is None
+
+
+def _registry_with(tmp_path: Path, *, spack_executable: str | None) -> Path:
+    registry_path = tmp_path / "clusters.json"
+    ClusterRegistry(
+        clusters={
+            CLUSTER: ClusterDefinition(
+                name=CLUSTER,
+                ssh_host="localhost",
+                spack_executable=spack_executable,
+            )
+        }
+    ).save(registry_path)
+    return registry_path
+
+
+def test_registered_spack_executable_reaches_the_run_environment(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A declared cluster Spack executable is composed for the JARVIS child."""
+    registry_path = _registry_with(tmp_path, spack_executable=SITE_SPACK_COMMAND)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+
+    resolved = registered_site_spack_command(CLUSTER)
+
+    assert resolved == SITE_SPACK_COMMAND
+    assert jarvis_run_environment_values(resolved) == {
+        RELAY_JARVIS_SPACK_COMMAND_ENV: SITE_SPACK_COMMAND
+    }
+
+
+def test_home_anchored_spack_executable_expands_on_the_executing_host(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A ``$HOME``-anchored registration resolves against the worker's account."""
+    registry_path = _registry_with(
+        tmp_path,
+        spack_executable="$HOME/.local/share/clio-relay/site-profiles/ares-spack-v1/bin/spack",
+    )
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+
+    def _fake_expanduser(_value: str) -> str:
+        return "/home/operator"
+
+    monkeypatch.setattr(jarvis_run_environment_module.os.path, "expanduser", _fake_expanduser)
+
+    assert registered_site_spack_command(CLUSTER) == SITE_SPACK_COMMAND
+
+
+def test_cluster_without_a_declaration_composes_nothing(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """An undeclared Spack executable never invents a default."""
+    registry_path = _registry_with(tmp_path, spack_executable=None)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+
+    assert registered_site_spack_command(CLUSTER) is None
+    assert jarvis_run_environment_values(None) == {}
+    assert registered_site_spack_command("another-cluster") is None
+
+
+def test_unreadable_registry_refuses_instead_of_downgrading(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A configured registry that cannot be read is a refusal, not a quiet skip."""
+    registry_path = tmp_path / "clusters.json"
+    registry_path.write_text("{not json", encoding="utf-8")
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+
+    with pytest.raises(ConfigurationError, match="cluster registry could not be read"):
+        registered_site_spack_command(CLUSTER)
+
+
+def test_worker_publishes_the_registered_spack_command_to_the_mcp_runner(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The dispatched runner environment carries the cluster's Spack identity."""
+    registry_path = _registry_with(tmp_path, spack_executable=SITE_SPACK_COMMAND)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    command = ["clio-kit", "mcp-server", "jarvis"]
+    server_artifact = {
+        **verified_jarvis_server_artifact(),
+        "install_spec": "/releases/clio-kit.whl",
+    }
+    digest = remote_mcp_server_artifact_digest(server_artifact)
+    monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
+    job = _submit_registered_run(
+        queue,
+        command=command,
+        digest=digest,
+        idempotency_key="copper-elastic-v1-run-004",
+    )
+    spec = cast(McpCallSpec, job.spec)
+    provider = _DispatchProvider(
+        document=_successful_result_document(
+            command=command,
+            digest=digest,
+            server_artifact=server_artifact,
+            arguments=spec.arguments,
+            expected_registered_contract=spec.expected_registered_contract,
+            execution_id=cast(str, spec.arguments["execution_id"]),
+        ),
+        returncode=0,
+    )
+
+    result = _worker(settings, queue, provider).run_once()
+
+    assert result is not None
+    assert result.state is JobState.SUCCEEDED
+    assert provider.environments
+    assert provider.environments[0][RELAY_JARVIS_SPACK_COMMAND_ENV] == SITE_SPACK_COMMAND
+    events, _cursor = queue.drain_events(Cursor(job_id=job.job_id), limit=200)
+    composed = [event for event in events if event.event_type == "jarvis.run_environment_composed"]
+    assert len(composed) == 1
+    assert composed[0].payload["spack_command"] == SITE_SPACK_COMMAND
+
+
+def test_worker_without_a_declaration_leaves_the_run_environment_unchanged(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """No declaration keeps the previously composed runner environment exactly."""
+    registry_path = _registry_with(tmp_path, spack_executable=None)
+    monkeypatch.setenv("CLIO_RELAY_CLUSTER_REGISTRY", str(registry_path))
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    command = ["clio-kit", "mcp-server", "jarvis"]
+    server_artifact = {
+        **verified_jarvis_server_artifact(),
+        "install_spec": "/releases/clio-kit.whl",
+    }
+    digest = remote_mcp_server_artifact_digest(server_artifact)
+    monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
+    job = _submit_registered_run(
+        queue,
+        command=command,
+        digest=digest,
+        idempotency_key="copper-elastic-v1-run-005",
+    )
+    spec = cast(McpCallSpec, job.spec)
+    provider = _DispatchProvider(
+        document=_successful_result_document(
+            command=command,
+            digest=digest,
+            server_artifact=server_artifact,
+            arguments=spec.arguments,
+            expected_registered_contract=spec.expected_registered_contract,
+            execution_id=cast(str, spec.arguments["execution_id"]),
+        ),
+        returncode=0,
+    )
+
+    result = _worker(settings, queue, provider).run_once()
+
+    assert result is not None
+    assert provider.environments
+    assert RELAY_JARVIS_SPACK_COMMAND_ENV not in provider.environments[0]
+    events, _cursor = queue.drain_events(Cursor(job_id=job.job_id), limit=200)
+    assert not [event for event in events if event.event_type == "jarvis.run_environment_composed"]

--- a/tests/test_jarvis_run_failure_reporting.py
+++ b/tests/test_jarvis_run_failure_reporting.py
@@ -1,0 +1,549 @@
+"""A refused JARVIS run reaches a terminal state carrying its typed reason.
+
+The MCP result documents below reproduce the shapes captured on the isolated
+``p5run2`` deployment for durable job ``job_63d173b2bf8a47d2b811860ac26af569``:
+``relay-spool/job_63d1.../mcp-result.json`` recorded ``returncode`` 1,
+``protocol_error`` ``"tools/call returned isError=true"``, ``timed_out`` false,
+``protocol_result.isError`` true and a ``jarvis.error.v1`` structured payload
+carrying ``jarvis_run_failed`` with the message
+``"Run failed: Spack executable was not found in PATH, SPACK_ROOT/bin,
+~/.local/spack, or /opt/spack"``. The durable job stayed ``running`` with
+``updated_at`` frozen two seconds after creation.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+from pytest import MonkeyPatch
+
+from clio_relay import endpoint as endpoint_module
+from clio_relay.config import RelaySettings
+from clio_relay.core_queue import ClioCoreQueue
+from clio_relay.endpoint import EndpointWorker
+from clio_relay.jarvis_dispatch_failure import jarvis_dispatch_refusal
+from clio_relay.jarvis_provider import JarvisCdProvider
+from clio_relay.models import (
+    Cursor,
+    EndpointRole,
+    JobKind,
+    JobState,
+    McpCallSpec,
+    RelayJob,
+    deterministic_jarvis_execution_id,
+)
+from clio_relay.remote_mcp import remote_mcp_server_artifact_digest
+from tests.jarvis_mcp_fakes import verified_jarvis_server_artifact
+
+CLUSTER = "ares-p5run2"
+PIPELINE_ID = "copper-elastic-v1"
+SPACK_LOAD_SPEC = "/p5gjmq4rseitqanua7mdd2zdnag4v3u2"
+SPECIMEN_ERROR_CODE = "jarvis_run_failed"
+SPECIMEN_ERROR_MESSAGE = (
+    "Run failed: Spack executable was not found in PATH, SPACK_ROOT/bin, "
+    "~/.local/spack, or /opt/spack"
+)
+
+
+def _specimen_error_result_document(
+    *,
+    command: list[str],
+    digest: str,
+    server_artifact: dict[str, Any],
+    arguments: dict[str, object],
+    expected_registered_contract: str | None,
+    execution_id: str,
+) -> dict[str, object]:
+    """Return the errored dispatch document captured from the live specimen."""
+    structured: dict[str, object] = {
+        "schema_version": "jarvis.error.v1",
+        "error": {
+            "code": SPECIMEN_ERROR_CODE,
+            "execution_id": execution_id,
+            "message": SPECIMEN_ERROR_MESSAGE,
+            "pipeline_id": PIPELINE_ID,
+        },
+    }
+    return {
+        "server": command[0],
+        "server_args": command[1:],
+        "expected_server_artifact_digest": digest,
+        "expected_registered_contract": expected_registered_contract,
+        "expected_jarvis_cd_lock_binding": (
+            None
+            if expected_registered_contract is not None
+            else endpoint_module.jarvis_cd_lock_binding_expectation()
+        ),
+        "observed_server_artifact_digest": digest,
+        "server_artifact": server_artifact,
+        "operation": "tools/call",
+        "tool": "jarvis_run",
+        "arguments": arguments,
+        "env_from": {},
+        "protocol_result": {
+            "content": [{"type": "text", "text": json.dumps(structured, sort_keys=True)}],
+            "isError": True,
+        },
+        "structured_result": structured,
+        "protocol_error": "tools/call returned isError=true",
+        "protocol_version": "2024-11-05",
+        "result_validation": None,
+        "returncode": 1,
+        "timed_out": False,
+        "duration_seconds": 5.603851318359375,
+    }
+
+
+def _successful_result_document(
+    *,
+    command: list[str],
+    digest: str,
+    server_artifact: dict[str, Any],
+    arguments: dict[str, object],
+    expected_registered_contract: str | None,
+    execution_id: str,
+) -> dict[str, object]:
+    """Return the handle-first success document a completed run persists."""
+    handle: dict[str, object] = {
+        "schema_version": "jarvis.execution.handle.v1",
+        "execution_id": execution_id,
+        "pipeline_id": PIPELINE_ID,
+        "mode": "direct",
+        "scheduler_provider": None,
+        "scheduler_native_id": None,
+        "cluster": None,
+    }
+    record: dict[str, object] = {
+        "schema_version": "jarvis.execution.record.v1",
+        "execution_id": execution_id,
+        "pipeline_id": PIPELINE_ID,
+        "pipeline_name": PIPELINE_ID,
+        "mode": "direct",
+        "scheduler_provider": None,
+        "scheduler_native_id": None,
+        "cluster": None,
+        "state": "completed",
+        "submitted": False,
+        "terminal": True,
+        "created_at": "2026-08-07T06:11:44Z",
+        "updated_at": "2026-08-07T06:11:49Z",
+        "return_code": 0,
+        "error": None,
+        "metadata": {},
+    }
+    progress: dict[str, object] = {
+        "schema_version": "jarvis.execution.progress.v1",
+        "execution_id": execution_id,
+        "pipeline_id": PIPELINE_ID,
+        "execution_state": "completed",
+        "terminal": True,
+        "packages": [],
+    }
+    structured: dict[str, object] = {
+        "execution_handle": handle,
+        "execution_record": record,
+        "progress": progress,
+        "runtime_metadata": {
+            "schema_version": "jarvis.runtime.v1",
+            "source": "jarvis_mcp",
+            "execution_id": execution_id,
+            "pipeline_id": PIPELINE_ID,
+            "mode": "direct",
+            "scheduler_provider": None,
+            "scheduler_native_id": None,
+            "cluster": None,
+            "scheduler_type": None,
+            "scheduler_job_id": None,
+            "scheduler_phase": None,
+            "script_path": None,
+            "hostfile_path": None,
+            "output_path": f"/runs/{PIPELINE_ID}/stdout.log",
+            "error_path": f"/runs/{PIPELINE_ID}/stderr.log",
+            "package_provenance": [
+                {
+                    "pkg_id": "copper-elastic-step1",
+                    "pkg_type": "builtin.lammps",
+                    "global_id": "builtin.lammps.copper-elastic-step1",
+                    "config_path": f"/runs/{PIPELINE_ID}/copper-elastic-step1.yaml",
+                }
+            ],
+            "terminal": {
+                "state": "completed",
+                "terminal": True,
+                "returncode": 0,
+                "reason": None,
+                "started_at": "2026-08-07T06:11:44Z",
+                "finished_at": "2026-08-07T06:11:49Z",
+            },
+            "details": {
+                "execution_owner": "jarvis_cd.execution_record",
+                "submit": None,
+                "wait": True,
+                "environment": {
+                    "schema_version": "jarvis.environment.v1",
+                    "spack_specs": [SPACK_LOAD_SPEC],
+                },
+                "execution_handle": handle,
+                "execution_record": record,
+                "scheduler_submission": None,
+            },
+        },
+    }
+    return {
+        "server": command[0],
+        "server_args": command[1:],
+        "expected_server_artifact_digest": digest,
+        "expected_registered_contract": expected_registered_contract,
+        "expected_jarvis_cd_lock_binding": (
+            None
+            if expected_registered_contract is not None
+            else endpoint_module.jarvis_cd_lock_binding_expectation()
+        ),
+        "observed_server_artifact_digest": digest,
+        "server_artifact": server_artifact,
+        "operation": "tools/call",
+        "tool": "jarvis_run",
+        "arguments": arguments,
+        "env_from": {},
+        "protocol_result": {"structuredContent": structured},
+        "structured_result": structured,
+        "protocol_error": None,
+        "protocol_version": "2024-11-05",
+        "result_validation": None,
+        "returncode": 0,
+        "timed_out": False,
+    }
+
+
+class _DispatchProvider(JarvisCdProvider):
+    """Run the endpoint MCP transport and persist one prepared result document."""
+
+    def __init__(
+        self,
+        *,
+        document: dict[str, object] | None,
+        returncode: int,
+    ) -> None:
+        super().__init__(jarvis_bin="jarvis")
+        self._document = document
+        self._returncode = returncode
+        self.environments: list[dict[str, str]] = []
+
+    def run_command_streaming(
+        self,
+        command: list[str],
+        *,
+        process_label: str = "JARVIS-CD",
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        credential_payload: str | None = None,
+        on_stdout: Callable[[str], None] | None = None,
+        on_stderr: Callable[[str], None] | None = None,
+        on_start: Callable[[int], None] | None = None,
+        should_cancel: Callable[[], bool] | None = None,
+        on_poll: Callable[[], None] | None = None,
+        timeout_seconds: int | None = None,
+        on_timeout: Callable[[], None] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        del command, credential_payload, on_stderr, should_cancel, on_poll
+        del timeout_seconds, on_timeout
+        assert process_label == "endpoint MCP operation"
+        assert cwd is not None
+        if env is not None:
+            self.environments.append(dict(env))
+        if on_start is not None:
+            on_start(4242)
+        if on_stdout is not None:
+            on_stdout("relay mcp transport\n")
+        if self._document is not None:
+            (cwd / "mcp-result.json").write_text(
+                json.dumps(self._document, sort_keys=True),
+                encoding="utf-8",
+            )
+        return subprocess.CompletedProcess(["endpoint-mcp-runner"], self._returncode, "", "")
+
+
+def _submit_registered_run(
+    queue: ClioCoreQueue,
+    *,
+    command: list[str],
+    digest: str,
+    idempotency_key: str,
+) -> RelayJob:
+    """Submit the registered handle-first ``jarvis_run`` the specimen recorded."""
+    job_id = "job_63d173b2bf8a47d2b811860ac26af569"
+    execution_id = deterministic_jarvis_execution_id(
+        cluster=CLUSTER,
+        idempotency_key=idempotency_key,
+        job_id=job_id,
+    )
+    return queue.submit_job(
+        RelayJob(
+            job_id=job_id,
+            cluster=CLUSTER,
+            kind=JobKind.MCP_CALL,
+            spec=McpCallSpec(
+                server=command[0],
+                server_args=command[1:],
+                expected_server_artifact_digest=digest,
+                expected_registered_contract="clio-kit-jarvis-user-v3.6",
+                tool="jarvis_run",
+                arguments={
+                    "pipeline_id": PIPELINE_ID,
+                    "spack_specs": [SPACK_LOAD_SPEC],
+                    "execution_id": execution_id,
+                },
+                timeout_seconds=14_400,
+            ),
+            idempotency_key=idempotency_key,
+        )
+    )
+
+
+def _worker(
+    settings: RelaySettings,
+    queue: ClioCoreQueue,
+    provider: _DispatchProvider,
+) -> EndpointWorker:
+    worker = EndpointWorker(
+        role=EndpointRole.WORKER,
+        settings=settings,
+        cluster=CLUSTER,
+        queue=queue,
+        provider=provider,
+    )
+    worker.register()
+    return worker
+
+
+def test_errored_jarvis_run_terminalizes_with_its_typed_reason(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The specimen's errored dispatch fails the durable job with its reason."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    command = ["clio-kit", "mcp-server", "jarvis"]
+    server_artifact = {
+        **verified_jarvis_server_artifact(),
+        "install_spec": "/releases/clio-kit.whl",
+    }
+    digest = remote_mcp_server_artifact_digest(server_artifact)
+    monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
+    job = _submit_registered_run(
+        queue,
+        command=command,
+        digest=digest,
+        idempotency_key="copper-elastic-v1-run-001",
+    )
+    spec = cast(McpCallSpec, job.spec)
+    provider = _DispatchProvider(
+        document=_specimen_error_result_document(
+            command=command,
+            digest=digest,
+            server_artifact=server_artifact,
+            arguments=spec.arguments,
+            expected_registered_contract=spec.expected_registered_contract,
+            execution_id=cast(str, spec.arguments["execution_id"]),
+        ),
+        returncode=1,
+    )
+
+    result = _worker(settings, queue, provider).run_once()
+
+    assert result is not None
+    assert result.state is JobState.FAILED
+    durable_job = queue.get_job(job.job_id)
+    assert durable_job.state is JobState.FAILED
+    assert durable_job.last_error == f"{SPECIMEN_ERROR_CODE}: {SPECIMEN_ERROR_MESSAGE}"
+    assert durable_job.updated_at > durable_job.created_at
+    task = queue.list_tasks(job.job_id)[0]
+    assert task.state is JobState.FAILED
+    refusal = task.metadata["jarvis_dispatch_refusal"]
+    assert isinstance(refusal, dict)
+    typed = cast(dict[str, object], refusal)
+    assert typed["schema_version"] == "clio-relay.jarvis-dispatch-refusal.v1"
+    assert typed["code"] == SPECIMEN_ERROR_CODE
+    assert typed["message"] == SPECIMEN_ERROR_MESSAGE
+    assert typed["pipeline_id"] == PIPELINE_ID
+    assert typed["execution_id"] == spec.arguments["execution_id"]
+    recovery = task.metadata["jarvis_execution_recovery"]
+    assert isinstance(recovery, dict)
+    intent = cast(dict[str, object], recovery)
+    assert intent["state"] == "resolved"
+    assert intent["resolution"] == "dispatch_refusal"
+    assert intent["attempts"] == 0
+    events, _cursor = queue.drain_events(Cursor(job_id=job.job_id), limit=200)
+    event_types = [event.event_type for event in events]
+    assert "jarvis.dispatch_refused" in event_types
+    assert "jarvis.execution_recovery_started" not in event_types
+    assert "jarvis.execution_reconciliation_deferred" not in event_types
+    refused = next(event for event in events if event.event_type == "jarvis.dispatch_refused")
+    assert refused.payload["code"] == SPECIMEN_ERROR_CODE
+    assert refused.payload["message"] == SPECIMEN_ERROR_MESSAGE
+
+
+def test_refusal_outranks_a_clean_transport_exit(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The run's own answer decides the outcome, not the transport's exit code."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    command = ["clio-kit", "mcp-server", "jarvis"]
+    server_artifact = {
+        **verified_jarvis_server_artifact(),
+        "install_spec": "/releases/clio-kit.whl",
+    }
+    digest = remote_mcp_server_artifact_digest(server_artifact)
+    monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
+    job = _submit_registered_run(
+        queue,
+        command=command,
+        digest=digest,
+        idempotency_key="copper-elastic-v1-run-006",
+    )
+    spec = cast(McpCallSpec, job.spec)
+    provider = _DispatchProvider(
+        document=_specimen_error_result_document(
+            command=command,
+            digest=digest,
+            server_artifact=server_artifact,
+            arguments=spec.arguments,
+            expected_registered_contract=spec.expected_registered_contract,
+            execution_id=cast(str, spec.arguments["execution_id"]),
+        ),
+        returncode=0,
+    )
+
+    result = _worker(settings, queue, provider).run_once()
+
+    assert result is not None
+    assert result.state is JobState.FAILED
+    assert result.last_error == f"{SPECIMEN_ERROR_CODE}: {SPECIMEN_ERROR_MESSAGE}"
+
+
+def test_successful_jarvis_run_still_terminalizes_as_succeeded(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A dispatch that returned its execution handle keeps succeeding."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    command = ["clio-kit", "mcp-server", "jarvis"]
+    server_artifact = {
+        **verified_jarvis_server_artifact(),
+        "install_spec": "/releases/clio-kit.whl",
+    }
+    digest = remote_mcp_server_artifact_digest(server_artifact)
+    monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
+    job = _submit_registered_run(
+        queue,
+        command=command,
+        digest=digest,
+        idempotency_key="copper-elastic-v1-run-002",
+    )
+    spec = cast(McpCallSpec, job.spec)
+    provider = _DispatchProvider(
+        document=_successful_result_document(
+            command=command,
+            digest=digest,
+            server_artifact=server_artifact,
+            arguments=spec.arguments,
+            expected_registered_contract=spec.expected_registered_contract,
+            execution_id=cast(str, spec.arguments["execution_id"]),
+        ),
+        returncode=0,
+    )
+
+    result = _worker(settings, queue, provider).run_once()
+
+    assert result is not None
+    assert result.state is JobState.SUCCEEDED
+    task = queue.list_tasks(job.job_id)[0]
+    assert "jarvis_dispatch_refusal" not in task.metadata
+    recovery = cast(dict[str, object], task.metadata["jarvis_execution_recovery"])
+    assert recovery["resolution"] == "dispatch_result"
+
+
+def test_run_without_any_result_stays_nonterminal_for_recovery(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A lost run response still defers rather than inventing a terminal answer."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    command = ["clio-kit", "mcp-server", "jarvis"]
+    server_artifact = {
+        **verified_jarvis_server_artifact(),
+        "install_spec": "/releases/clio-kit.whl",
+    }
+    digest = remote_mcp_server_artifact_digest(server_artifact)
+    monkeypatch.setattr(endpoint_module, "jarvis_mcp_command", lambda: command)
+    job = _submit_registered_run(
+        queue,
+        command=command,
+        digest=digest,
+        idempotency_key="copper-elastic-v1-run-003",
+    )
+    provider = _DispatchProvider(document=None, returncode=1)
+
+    result = _worker(settings, queue, provider).run_once()
+
+    assert result is not None
+    assert result.state is JobState.RUNNING
+    task = queue.list_tasks(job.job_id)[0]
+    recovery = cast(dict[str, object], task.metadata["jarvis_execution_recovery"])
+    assert recovery["state"] == "pending"
+    assert "jarvis_dispatch_refusal" not in task.metadata
+    events, _cursor = queue.drain_events(Cursor(job_id=job.job_id), limit=200)
+    event_types = {event.event_type for event in events}
+    assert "jarvis.dispatch_refused" not in event_types
+    assert "jarvis.execution_reconciliation_deferred" in event_types
+
+
+def test_timed_out_dispatch_is_never_read_as_an_answered_refusal() -> None:
+    """A lost response carries no answer even when the transport recorded an error."""
+    document: dict[str, object] = {
+        "returncode": 1,
+        "timed_out": True,
+        "protocol_error": "tools/call timed out",
+        "protocol_result": {"isError": True},
+        "structured_result": None,
+    }
+
+    assert jarvis_dispatch_refusal(document) is None
+
+
+def test_untyped_tool_error_still_reports_a_typed_refusal() -> None:
+    """An isError answer without a JARVIS payload still reaches the caller typed."""
+    document: dict[str, object] = {
+        "returncode": 1,
+        "timed_out": False,
+        "protocol_error": "tools/call returned isError=true",
+        "protocol_result": {"isError": True},
+        "structured_result": {"schema_version": "jarvis.unexpected.v9"},
+    }
+
+    refusal = jarvis_dispatch_refusal(document)
+
+    assert refusal is not None
+    assert refusal.code == "jarvis_tool_error"
+    assert refusal.message == "tools/call returned isError=true"
+    assert refusal.payload_schema_version is None
+
+
+def test_successful_protocol_result_is_not_a_refusal() -> None:
+    """A dispatch that answered without an error is never recorded as refused."""
+    document: dict[str, object] = {
+        "returncode": 0,
+        "timed_out": False,
+        "protocol_error": None,
+        "protocol_result": {"isError": False},
+    }
+
+    assert jarvis_dispatch_refusal(document) is None

--- a/tests/test_mcp_call_runner.py
+++ b/tests/test_mcp_call_runner.py
@@ -1634,6 +1634,44 @@ def test_mcp_call_runner_refuses_unverified_builtin_jarvis_launcher_before_launc
     assert "launcher digest did not verify" in result["protocol_error"]
 
 
+def test_relay_composed_spack_identity_reaches_the_jarvis_child(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The composed cluster Spack path is applied as the child's JARVIS variable."""
+    runner = _load_runner()
+    monkeypatch.setenv("CLIO_RELAY_JARVIS_SPACK_COMMAND", "/site/spack/bin/spack")
+    overrides = cast(Any, runner)._child_environment_overrides(wait_for_locked_launcher=False)
+    captured: dict[str, dict[str, str]] = {}
+
+    class _RecordedPopen:
+        def __init__(self, *_args: object, **kwargs: object) -> None:
+            captured["env"] = cast(dict[str, str], kwargs["env"])
+
+    monkeypatch.setattr(cast(Any, runner).subprocess, "Popen", _RecordedPopen)
+    cast(Any, runner)._open_process(
+        ["server"],
+        env_from={},
+        environment_overrides=overrides,
+    )
+
+    assert overrides == {"JARVIS_MCP_SPACK_COMMAND": "/site/spack/bin/spack"}
+    assert captured["env"]["JARVIS_MCP_SPACK_COMMAND"] == "/site/spack/bin/spack"
+    assert "CLIO_RELAY_JARVIS_SPACK_COMMAND" not in captured["env"]
+
+
+def test_child_overrides_are_empty_without_a_composed_spack_identity(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """An unregistered cluster leaves the child environment exactly as before."""
+    runner = _load_runner()
+    monkeypatch.delenv("CLIO_RELAY_JARVIS_SPACK_COMMAND", raising=False)
+
+    assert cast(Any, runner)._child_environment_overrides(wait_for_locked_launcher=False) == {}
+    assert cast(Any, runner)._child_environment_overrides(wait_for_locked_launcher=True) == {
+        "CLIO_KIT_UV_CACHE_PRUNE": "0"
+    }
+
+
 def test_registered_jarvis_server_uses_artifact_binding_without_relay_dependency_pin(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,


### PR DESCRIPTION
Fixes #183, Fixes #184 — stacked on `rc/design-restoration` (PR #185), so they close when the RC merges to `main`.

## What changed

- an `mcp_call`/`jarvis_run` whose result carries an explicit tool error now reaches a terminal state carrying the typed reason, instead of entering the lost-response recovery loop for an execution that was never created
- restart cleanup reads that recorded answer before it queries JARVIS again, so a job an earlier build already stranded settles on the next worker pass
- the Spack executable a cluster registers is composed into the JARVIS run environment, so `spack_specs` load with the same executable `spack_locate` resolves

## #183 — root cause

The dispatch answer was recorded, typed, and unreachable. Live specimen `job_63d173b2bf8a47d2b811860ac26af569`, event chain from its durable log:

```
43  runtime.metadata_refused                   Refused JARVIS MCP runtime metadata: MCP call did not complete successfully
44  jarvis.execution_recovery_started          Querying the durable JARVIS execution after its run response was unavailable
45  jarvis.execution_recovery_pending          JARVIS execution recovery remains pending for endpoint reconciliation
46  scheduler.reconciliation_pending           Execution evidence is retained until scheduler or direct intent resolves
47  jarvis.execution_reconciliation_deferred   Relay response remains nonterminal while JARVIS ownership is queried
```

1. `_trusted_jarvis_mcp_result` (`src/clio_relay/endpoint.py:6316`) refuses the result because `returncode != 0`, `protocol_error` is set, and `protocol_result.isError` is true. That refusal is correct — the document carries no native runtime metadata.
2. `_ingest_mcp_runtime_metadata` (`endpoint.py:2482`) returned a bare `False` for every rejection, and `_run_job_impl` (`endpoint.py:1183`) read that `False` as *"the run response was unavailable"*. Two different situations — no result, and a result that says the run failed — took the same branch.
3. `_recover_jarvis_execution` (`endpoint.py:2617`) then queried `jarvis_get_execution` for an execution the failed run never created. The query answered `jarvis_execution_query_failed` (`No such file or directory: .../executions/jarvis_e0ef...`), so `_record_jarvis_recovery_failure` (`endpoint.py:3046`) rescheduled with exponential backoff and raised `SchedulerSubmissionUnresolvedError`.
4. `_record_unhandled_job_failure` (`endpoint.py:507`) saw that error type with a pending intent and emitted `jarvis.execution_reconciliation_deferred` **without terminalizing** (`endpoint.py:533`). `_resolve_execution_ownership` (`endpoint.py:3805`) would also have refused, since a pending intent has no resolved scheduler identity.
5. `_reconcile_pending_execution_cleanup` (`endpoint.py:4425`) retried the same query forever, capped at a 300s interval, with no terminal outcome. The job stayed `running` with `updated_at` frozen at creation + 2s.

**Why the answer is terminal.** The registered contract (`src/clio_relay/_contracts/jarvis-user-v3.6.json:3116`) states that `jarvis_run` returns a durable execution handle, and that JARVIS "resolves those specs into a filtered environment and persists it **before** direct or scheduler execution". The success schema requires `execution_handle`. An `isError` answer therefore means no handle was issued and no execution exists to query or adopt — ownership is settled, not unknown.

**Fix.** `_jarvis_mcp_result_identity_matches` (`endpoint.py:6238`) is split out of `_trusted_jarvis_mcp_result` so an errored result can still be attributed to the job's pinned route (server, args, tool, arguments, `env_from`, contract, expected and observed artifact digest, artifact binding). When identity matches, `jarvis_dispatch_refusal` (`src/clio_relay/jarvis_dispatch_failure.py`) reads the typed `jarvis.error.v1` payload. `_refuse_jarvis_execution_recovery` (`endpoint.py:3236`) resolves the recovery intent as `dispatch_refusal` with the result's SHA-256, and the job terminalizes `FAILED` with `last_error = "<code>: <message>"`, task metadata `jarvis_dispatch_refusal`, and a `jarvis.dispatch_refused` event.

A dispatch that **timed out** is still a lost response and keeps the recovery path — `jarvis_dispatch_refusal` returns `None` for `timed_out`. A refusal also outranks a clean transport exit, so the run's own answer decides the outcome.

`_recorded_jarvis_dispatch_refusal` (`endpoint.py:3210`) applies the same discriminator at the restart-cleanup seam (`endpoint.py:4510`), which is what lets the live specimen settle on redeploy rather than only fixing new runs.

## #184 — root cause

`jarvis_run` performs `spack load` inside the JARVIS MCP child the worker spawns, and that child's environment never received the cluster's registered `spack_executable`.

- The Spack route gets it as an operator-authored registration argument: `args: ["mcp-server", "spack", "--", "--spack-command", "<path>"]`. That is why `spack_locate` works.
- The JARVIS route is dispatched with `env_from: {}`. The runner composes the child environment from `env_from` plus a fixed base name set (`runner.py:_child_env`), so nothing carried the site path.
- `clio-kit`'s JARVIS server reads `JARVIS_MCP_SPACK_COMMAND` first in `jarvis_mcp/capabilities/jarvis_handler.py::_spack_executable`, and only then searches `PATH`, `SPACK_ROOT/bin`, `~/.local/spack`, `/opt/spack` — the exact search order in the observed error. The relay already exports that variable for the **built-in** route (`jarvis_mcp.py::jarvis_mcp_env_from`); only the registered route lacked it.

**Which layer owns this.** The relay spawns the JARVIS child through its own bundled MCP runner, so the relay composes that environment. The registration's `env_from` is route identity, compared against the registration in the admission path (`remote_mcp.py:1898`, `:1824`, `:1854`) and against the discovery artifact (`remote_mcp.py:1736`); injecting a cluster-level site path there would fail admission or force a discovery refresh. No change was needed in clio-kit — the JARVIS server already exposes the typed knob and consults it first.

**Fix.** `registered_site_spack_command` (`src/clio_relay/jarvis_run_environment.py`) reads the executable the worker's cluster registered, expanding a leading `$HOME` against the executing account. `_jarvis_run_environment_values` (`endpoint.py:3179`) publishes it to the MCP runner as the relay-owned `CLIO_RELAY_JARVIS_SPACK_COMMAND` for trusted JARVIS routes only (`endpoint.py:1021`), with a `jarvis.run_environment_composed` event. `_relay_composed_run_environment` (`runner.py:5279`) maps it onto the child's `JARVIS_MCP_SPACK_COMMAND` through the existing relay-owned override channel. A cluster that declares no executable composes nothing. A configured registry that cannot be read raises a typed `ConfigurationError` rather than downgrading quietly to an unresolved runtime.

## Specimen-derived fixture provenance

Test documents in `tests/test_jarvis_run_failure_reporting.py` are built from the bytes preserved on the isolated `p5run2` deployment, read read-only:

- `relay-spool/job_63d173b2bf8a47d2b811860ac26af569/mcp-result.json` — `returncode: 1`, `timed_out: false`, `protocol_error: "tools/call returned isError=true"`, `protocol_result.isError: true`, `duration_seconds: 5.6038…`, and `structured_result` = `{"schema_version": "jarvis.error.v1", "error": {"code": "jarvis_run_failed", "execution_id": "jarvis_e0ef179d9f25c14d9a63c05b49dd8878", "message": "Run failed: Spack executable was not found in PATH, SPACK_ROOT/bin, ~/.local/spack, or /opt/spack", "pipeline_id": "copper-elastic-v1"}}`
- the same directory's `metadata.json` — the registered `jarvis_run` spec (`expected_registered_contract: clio-kit-jarvis-user-v3.6`, `spack_specs: ["/p5gjmq4rseitqanua7mdd2zdnag4v3u2"]`, `env_from: {}`, `timeout_seconds: 14400`), reproduced by `_submit_registered_run`
- `.jarvis-execution-recovery-*/mcp-result.json` — the recovery query's own error (`jarvis_execution_query_failed`, `No such file or directory: .../executions/jarvis_e0ef…`), which is why the loop could never resolve
- the durable job record and its 47 events, quoted above
- `clusters.json` — `spack_executable`, and the Spack registration's `--spack-command`, which the `#184` fixtures mirror

Nothing on the deployment was modified; the specimen is intact for redeploy-day verification.

## Test evidence

New failing-first tests, each verified red against `origin/rc/design-restoration` before the fix:

| test | baseline result |
| --- | --- |
| `test_errored_jarvis_run_terminalizes_with_its_typed_reason` | `assert <JobState.RUNNING> is <JobState.FAILED>`, `last_error=None`, `attempts=1` — the live specimen's state exactly |
| `test_restart_cleanup_settles_a_run_left_stuck_by_an_earlier_build` | `assert <JobState.RUNNING> is <JobState.FAILED>` after the second worker pass |
| `test_worker_publishes_the_registered_spack_command_to_the_mcp_runner` | `KeyError: 'CLIO_RELAY_JARVIS_SPACK_COMMAND'` |
| `test_relay_composed_spack_identity_reaches_the_jarvis_child` | helper absent; child env never receives `JARVIS_MCP_SPACK_COMMAND` |
| `test_child_overrides_are_empty_without_a_composed_spack_identity` | helper absent |

Tests that must keep passing, and do on both trees: a successful handle-first run still terminalizes `SUCCEEDED` with `resolution: dispatch_result`; a run with no result yet stays `RUNNING` with a pending intent and still emits `jarvis.execution_reconciliation_deferred`; a timed-out dispatch is never read as an answer; an `isError` answer with no typed payload still reports a typed refusal; a cluster with no declaration composes nothing and emits no event; an unreadable registry refuses.

Suites: `test_jarvis_run_failure_reporting` (14), `test_jarvis_execution_recovery_guards`, `test_endpoint`, `test_mcp_call_runner`, `test_mcp_input_staging`, `test_builtin_jarvis_input_staging`, `test_owned_session_channel`, `test_mcp_server`, `test_endpoint_mcp_direct`, `test_endpoint_service_recovery`, `test_endpoint_storage`, `test_endpoint_bounded_reads` — all green. `ruff check`, `ruff format`, `pyright` strict clean.

Full-suite A/B against pristine `origin/rc/design-restoration` on the same box: **zero failures unique to this branch** (32 on this branch, 38 on the baseline, all 32 present in the baseline set). The remainder are the known environment-dependent classes — `test_clio_kit_mcp_contracts` needs the external clio-kit wheel, and the box's `C:` volume is at 886 MB free, which surfaces as `507 Insufficient Storage` in the storage-reservation suites.

## Compatibility

No wire contract or durable record schema changed shape. The recovery intent's `resolution` field accepts one additional value, `dispatch_refusal`, alongside `dispatch_result` and `execution_query`; `state` stays `pending`/`resolved` and every other field keeps its validator. The value is only ever written on a job the same worker is terminalizing in the same pass, so an older worker never meets it on an active job, and `_jarvis_execution_recovery_is_pending` already treats an unreadable intent as not pending.

## Redeploy-day verification

The live specimen is the acceptance case. After deploying this build to `p5run2` and restarting the worker, the stuck job settles on the first restart-cleanup pass:

```
clio-relay job show job_63d173b2bf8a47d2b811860ac26af569 --cluster ares-p5run2
```

Expected: `state: failed`, `updated_at` moved off `2026-08-07T06:11:44Z`, and
`last_error: jarvis_run_failed: Run failed: Spack executable was not found in PATH, SPACK_ROOT/bin, ~/.local/spack, or /opt/spack`.

The durable event log should carry `jarvis.dispatch_refused` with that `code` and `message` and the `mcp-result.json` SHA-256, and no new `jarvis.execution_recovery_started`.

For #184, the next `jarvis_run` with `spack_specs` on that cluster should emit `jarvis.run_environment_composed` with
`spack_command: /home/jcernudagarcia/.local/share/clio-relay/site-profiles/ares-spack-v1/bin/spack`, and reach the scheduler instead of failing at load.

## Note on `fix/jarvis-runtime-terminalization`

Despite its name, that branch (PR #172, commits `b21b18f`, `548d439`) does **not** address the terminalization defect. It changes agent-facing tool descriptions so an agent is told to call the Spack locate tool and pass `load_spec` in `spack_specs`, tightens the remote-MCP catalog to hide verified-but-mutable server installations, and scopes the generated reconciliation idempotency key per owner session. None of it touches the worker's result handling or job-state transitions, so there was nothing to cherry-pick. It is complementary: it makes an agent supply the `load_spec` that #184 now makes loadable.
