### PR TITLE
fix: scope the bootstrap writer proof + default clio-kit 2.7.2 (#189, #190)

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -433,7 +433,7 @@ For the legacy clio-kit 2.2.6 compatibility path, a successful synchronous
 `jarvis_run` MCP return is normalized to a terminal `completed` record even
 though that release labels the result `status=running`; the original status and
 completion basis remain in `details.completion_normalization` for auditability.
-The pinned clio-kit 2.6.6 production path removes that ambiguity upstream and
+The pinned clio-kit 2.7.2 production path removes that ambiguity upstream and
 returns a structured durable execution handle immediately. The legacy normalization is
 diagnostic compatibility evidence and cannot satisfy the 1.0 gate. Scheduler
 submissions remain non-terminal and are observed through `jarvis_get_execution`.
@@ -716,7 +716,7 @@ Install the cluster-side server once, then launch its persistent executable:
 
 ```bash
 uv tool install --python 3.12 --no-config \
-  https://github.com/iowarp/clio-kit/releases/download/v2.6.6/clio_kit-2.6.6-py3-none-any.whl
+  https://github.com/iowarp/clio-kit/releases/download/v2.7.2/clio_kit-2.7.2-py3-none-any.whl
 clio-kit mcp-server jarvis
 ```
 

--- a/docs/remote-mcp-federation.md
+++ b/docs/remote-mcp-federation.md
@@ -434,7 +434,7 @@ that returns the handle, never for workload completion. Use
 an explicit `idempotency_key` only when retry de-duplication is intentional; an
 identical second `jarvis_run` is otherwise a new execution.
 
-The released clio-kit 2.6.6 artifact carries the pinned six-tool JARVIS v3.6
+The released clio-kit 2.7.2 artifact carries the pinned six-tool JARVIS v3.6
 contract.
 Bootstrap
 downloads and hashes the exact coordinated wheel, installs it once with
@@ -468,14 +468,18 @@ The release gate requires that exact 2.6.6 artifact to be rerun on every target
 selected by the release policy. Other servers use the operator registry and
 generated `remote_...` aliases.
 
-The exact release wheel is
-`clio_kit-2.6.6-py3-none-any.whl` with SHA-256
-`fe68111035be10fac8c291c1b5b802263524884f92eacd88123390dc3666ad91`.
-Its canonical contract is `clio-kit-jarvis-user-v3.6`, with contract SHA-256
-`055c6697dc9a25fb033c949db92c928aee8d5673f7b2e3a4d90a237f4f87a40d`
-and canonical tools-wire SHA-256
-`c69db36bda5d1cc97043d7b7cee88cabcf044d506865046537e0fb17ab0b2023`.
-The bundled contract artifact SHA-256 is
+The exact release wheel bootstrap installs by default is
+`clio_kit-2.7.2-py3-none-any.whl` with SHA-256
+`8ebe41bf366e475a7da703a52c968231780d5d9013fc5fc913fe0f0539c6b6b5`.
+Its canonical contract is `clio-kit-jarvis-user-v3.6`. The relay's own
+vendored certification snapshot of that contract (used to cross-check the
+bundled `_contracts/jarvis-user-v3.6.json` copy against a known-good
+clio-kit release, independent of which wheel bootstrap installs) remains
+pinned to the clio-kit 2.6.6 build: contract SHA-256
+`055c6697dc9a25fb033c949db92c928aee8d5673f7b2e3a4d90a237f4f87a40d`,
+canonical tools-wire SHA-256
+`c69db36bda5d1cc97043d7b7cee88cabcf044d506865046537e0fb17ab0b2023`, and
+bundled contract artifact SHA-256
 `6e839f3ac975f247053ef4b6a048c53686882c2ab6a1b103f91dfc744ed29ed5`.
 The nested runtime lock is bound to the public
 [`jarvis_cd-1.8.0-py3-none-any.whl`](https://github.com/grc-iit/jarvis-cd/releases/download/v1.8.0/jarvis_cd-1.8.0-py3-none-any.whl)

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -1847,18 +1847,30 @@ def vanished(error: OSError) -> bool:
     return error.errno in {errno.ENOENT, errno.ESRCH}
 
 
+def read_capped(path: Path) -> bytes:
+    """Read one proc pseudo-file's bytes, enforcing the bounded read-size invariant.
+
+    Unlike read_bounded, a non-vanished OSError is raised to the caller
+    un-translated.  Every caller except the writer-proof environ evidence
+    treats any such error as immediately fatal (see read_bounded below); the
+    writer proof instead treats an unreadable environ as best-effort evidence
+    that a non-target candidate can still be dismissed without it.
+    """
+    with path.open("rb") as stream:
+        value = stream.read(MAX_PROC_FILE_BYTES + 1)
+    if len(value) > MAX_PROC_FILE_BYTES:
+        fail(f"{path} exceeds the bounded inspection size")
+    return value
+
+
 def read_bounded(path: Path) -> bytes | None:
     """Read one proc pseudo-file without accepting an unbounded value."""
     try:
-        with path.open("rb") as stream:
-            value = stream.read(MAX_PROC_FILE_BYTES + 1)
+        return read_capped(path)
     except OSError as error:
         if vanished(error):
             return None
         fail(f"cannot inspect {path}: {error}")
-    if len(value) > MAX_PROC_FILE_BYTES:
-        fail(f"{path} exceeds the bounded inspection size")
-    return value
 
 
 def decode_nul_values(value: bytes) -> list[str]:
@@ -2226,9 +2238,25 @@ def prove_no_writer(cluster: str, expected_core: str, proc_root: Path) -> None:
                 writer_kind = "mcp-server"
                 options = command[1:]
             process_cluster = option_value(options, "--cluster")
-            raw_environment = read_bounded(process / "environ")
-            if raw_environment is None:
-                continue
+            environ_path = process / "environ"
+            try:
+                raw_environment = read_capped(environ_path)
+            except OSError as error:
+                if vanished(error):
+                    continue
+                if process_cluster is not None and process_cluster != cluster:
+                    # environ is best-effort evidence for writer-proof, not a
+                    # mandatory one.  A candidate whose cmdline names a
+                    # cluster other than the one being bootstrapped is
+                    # provably not our concern even when its environment
+                    # cannot be inspected -- e.g. a same-uid peer hardened by
+                    # our own process_containment.enforce_linux_secret_memory_gate
+                    # non-dumpable gate, whose environ is root-only.  A
+                    # candidate that matches our cluster, or leaves it
+                    # ambiguous (no --cluster in its cmdline), still cannot
+                    # be dismissed without proof: keep failing closed.
+                    continue
+                fail(f"cannot inspect {environ_path}: {error}")
             candidates = process_core_candidates(
                 process,
                 environment(raw_environment),

--- a/src/clio_relay/jarvis_mcp.py
+++ b/src/clio_relay/jarvis_mcp.py
@@ -26,14 +26,14 @@ from clio_relay.remote_mcp import (
 if TYPE_CHECKING:
     from clio_relay.installation import ComponentArtifactIdentity, InstallReceipt
 
-CLIO_KIT_JARVIS_MCP_VERSION = "2.6.6"
+CLIO_KIT_JARVIS_MCP_VERSION = "2.7.2"
 CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME = f"clio_kit-{CLIO_KIT_JARVIS_MCP_VERSION}-py3-none-any.whl"
 CLIO_KIT_JARVIS_MCP_WHEEL_URL = (
     "https://github.com/iowarp/clio-kit/releases/download/"
     f"v{CLIO_KIT_JARVIS_MCP_VERSION}/{CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME}"
 )
 CLIO_KIT_JARVIS_MCP_WHEEL_SHA256 = (
-    "fe68111035be10fac8c291c1b5b802263524884f92eacd88123390dc3666ad91"
+    "8ebe41bf366e475a7da703a52c968231780d5d9013fc5fc913fe0f0539c6b6b5"
 )
 CLIO_KIT_JARVIS_USER_CONTRACT_ID = "clio-kit-jarvis-user-v3.6"
 DEFAULT_JARVIS_MCP_COMMAND = [

--- a/tests/test_bootstrap_cluster_paths.py
+++ b/tests/test_bootstrap_cluster_paths.py
@@ -997,10 +997,19 @@ def test_embedded_writer_proof_allows_other_cluster_worker_on_different_core(
 
 
 @pytest.mark.release_platform("posix")
-def test_embedded_writer_proof_fails_closed_when_environment_is_unreadable(
+def test_embedded_writer_proof_skips_unreadable_environment_for_a_different_cluster(
     tmp_path: Path,
 ) -> None:
-    """Bootstrap never substitutes service metadata for an unreadable process contract."""
+    """A hardened same-uid peer bootstrapping a DIFFERENT cluster cannot block bootstrap.
+
+    Regression for clio-relay#189: clio-relay's own
+    process_containment.enforce_linux_secret_memory_gate() makes a worker
+    process non-dumpable, so its /proc/<pid>/environ becomes root-only even
+    for the owning same-uid account.  environ is best-effort writer-proof
+    evidence, not mandatory: once the candidate's own cmdline proves it is
+    bootstrapping a different cluster, an unreadable environ can no longer
+    abort bootstrap for every cluster name on the host.
+    """
     proc_root = tmp_path / "proc"
     process_id = 1735
     _fake_proc_process(
@@ -1011,8 +1020,76 @@ def test_embedded_writer_proof_fails_closed_when_environment_is_unreadable(
             "endpoint",
             "start",
             "--role=worker",
-            "--cluster=protected",
+            "--cluster=ares-demo",
         ],
+        environment={"HOME": str(tmp_path)},
+    )
+    process = proc_root / str(process_id)
+    process.joinpath("environ").chmod(0)
+
+    result = _run_writer_proof(
+        proc_root,
+        cluster="ares-p5run2",
+        core_dir=tmp_path / "expected-core",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "relay_worker_writer_proof=clear"
+
+
+@pytest.mark.release_platform("posix")
+def test_embedded_writer_proof_fails_closed_when_target_cluster_environment_is_unreadable(
+    tmp_path: Path,
+) -> None:
+    """An unreadable environ for a candidate that MATCHES our cluster still hard-fails.
+
+    Environ only becomes dismissable once cmdline proves the candidate targets
+    a different cluster; a same-cluster candidate can never be dismissed
+    without reading it, preserving today's exclusivity guarantee.
+    """
+    proc_root = tmp_path / "proc"
+    process_id = 1736
+    _fake_proc_process(
+        proc_root,
+        pid=process_id,
+        argv=[
+            "/home/operator/.local/bin/clio-relay",
+            "endpoint",
+            "start",
+            "--role=worker",
+            "--cluster=custom",
+        ],
+        environment={"HOME": str(tmp_path)},
+    )
+    process = proc_root / str(process_id)
+    process.joinpath("environ").chmod(0)
+
+    result = _run_writer_proof(
+        proc_root,
+        cluster="custom",
+        core_dir=tmp_path / "expected-core",
+    )
+
+    assert result.returncode != 0
+    assert f"cannot inspect {process / 'environ'}" in result.stderr
+
+
+@pytest.mark.release_platform("posix")
+def test_embedded_writer_proof_fails_closed_when_ambiguous_environment_is_unreadable(
+    tmp_path: Path,
+) -> None:
+    """A candidate whose cmdline exposes no --cluster stays a hard failure when unreadable.
+
+    api/mcp-server invocations carry no --cluster argument, so their target
+    core cannot be ruled out from cmdline alone; an unreadable environ on one
+    of them must remain fail-closed exactly like today.
+    """
+    proc_root = tmp_path / "proc"
+    process_id = 1737
+    _fake_proc_process(
+        proc_root,
+        pid=process_id,
+        argv=["/home/operator/.local/bin/clio-relay", "api", "start", "--host", "127.0.0.1"],
         environment={"HOME": str(tmp_path)},
     )
     process = proc_root / str(process_id)

--- a/tests/test_ci_clio_kit_wheel.py
+++ b/tests/test_ci_clio_kit_wheel.py
@@ -21,19 +21,57 @@ from clio_relay.remote_mcp import (
 ROOT = Path(__file__).resolve().parents[1]
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
-WHEEL_FILENAME = "clio_kit-2.6.6-py3-none-any.whl"
-WHEEL_SHA256 = "fe68111035be10fac8c291c1b5b802263524884f92eacd88123390dc3666ad91"
-WHEEL_URL = f"https://github.com/iowarp/clio-kit/releases/download/v2.6.6/{WHEEL_FILENAME}"
+
+# The bootstrap default install pin (clio-relay#190): the exact clio-kit
+# release a *fresh* deployment installs for its built-in JARVIS MCP server.
+# This is the runtime dependency pin, not a certification snapshot: it moves
+# independently of CONTRACT_CERTIFICATION_WHEEL_* below.
+JARVIS_MCP_WHEEL_FILENAME = "clio_kit-2.7.2-py3-none-any.whl"
+JARVIS_MCP_WHEEL_SHA256 = "8ebe41bf366e475a7da703a52c968231780d5d9013fc5fc913fe0f0539c6b6b5"
+JARVIS_MCP_WHEEL_URL = (
+    f"https://github.com/iowarp/clio-kit/releases/download/v2.7.2/{JARVIS_MCP_WHEEL_FILENAME}"
+)
+
+# The exact upstream wheel CI stages before the local release gate, which
+# includes the cross-repository contract-certification suite
+# (test_clio_kit_mcp_contracts.py). That suite vendors byte-exact copies of
+# clio-kit's spack-user and scientific-catalog-user contracts under
+# src/clio_relay/_contracts/ and re-verifies them against a live wheel;
+# clio-kit 2.7.2 shifted the wire/contract bytes for every locked MCP
+# surface (jarvis, spack, scientific-catalog, slurm), not only the jarvis
+# package-search ranking fix that motivated #190. Re-certifying the vendored
+# spack/scientific-catalog fixtures (and the shared live ares-cluster
+# acceptance policy in docs/release-gate-1.0.yaml, which separately pins a
+# worker's installed clio-kit distribution_version) against 2.7.2 is
+# deliberately out of scope for this bootstrap-pin hotfix.
+CONTRACT_CERTIFICATION_WHEEL_FILENAME = "clio_kit-2.6.6-py3-none-any.whl"
+CONTRACT_CERTIFICATION_WHEEL_SHA256 = (
+    "fe68111035be10fac8c291c1b5b802263524884f92eacd88123390dc3666ad91"
+)
+CONTRACT_CERTIFICATION_WHEEL_URL = (
+    "https://github.com/iowarp/clio-kit/releases/download/v2.6.6/"
+    f"{CONTRACT_CERTIFICATION_WHEEL_FILENAME}"
+)
 
 
-def test_runtime_and_ci_share_one_exact_clio_kit_release_pin() -> None:
-    """Keep bootstrap, JARVIS MCP, and CI on the same exact release wheel bytes."""
-    assert CLIO_KIT_JARVIS_MCP_VERSION == "2.6.6"
+def test_bootstrap_jarvis_mcp_install_pin_is_self_consistent() -> None:
+    """The bootstrap default JARVIS MCP install pin resolves to one exact wheel (#190)."""
+    assert CLIO_KIT_JARVIS_MCP_VERSION == "2.7.2"
+    assert CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME == JARVIS_MCP_WHEEL_FILENAME
+    assert CLIO_KIT_JARVIS_MCP_WHEEL_SHA256 == JARVIS_MCP_WHEEL_SHA256
+    assert CLIO_KIT_JARVIS_MCP_WHEEL_URL == JARVIS_MCP_WHEEL_URL
+
+
+def test_contract_certification_pin_is_independent_of_the_bootstrap_install_pin() -> None:
+    """spack/scientific-catalog stay certified against their existing wheel.
+
+    clio-kit 2.7.2 shifted every locked MCP contract's wire/contract bytes,
+    not only jarvis's; re-certifying relay's vendored spack and
+    scientific-catalog fixtures against it is separate follow-up work, so
+    their wheel-version labels intentionally do not move with #190.
+    """
     assert CLIO_KIT_SPACK_USER_WHEEL_VERSION == "2.6.6"
     assert CLIO_KIT_SCIENTIFIC_CATALOG_USER_WHEEL_VERSION == "2.6.6"
-    assert CLIO_KIT_JARVIS_MCP_WHEEL_FILENAME == WHEEL_FILENAME
-    assert CLIO_KIT_JARVIS_MCP_WHEEL_SHA256 == WHEEL_SHA256
-    assert CLIO_KIT_JARVIS_MCP_WHEEL_URL == WHEEL_URL
 
 
 def _ci_workflow() -> dict[str, Any]:
@@ -61,9 +99,9 @@ def test_ci_jobs_stage_exact_clio_kit_wheel_before_evidence_gate() -> None:
         assert steps.index(stage) < steps.index(by_name[gate_name])
         assert stage["shell"] == "bash"
         assert stage["env"] == {
-            "CLIO_KIT_WHEEL_FILENAME": WHEEL_FILENAME,
-            "CLIO_KIT_WHEEL_SHA256": WHEEL_SHA256,
-            "CLIO_KIT_WHEEL_URL": WHEEL_URL,
+            "CLIO_KIT_WHEEL_FILENAME": CONTRACT_CERTIFICATION_WHEEL_FILENAME,
+            "CLIO_KIT_WHEEL_SHA256": CONTRACT_CERTIFICATION_WHEEL_SHA256,
+            "CLIO_KIT_WHEEL_URL": CONTRACT_CERTIFICATION_WHEEL_URL,
         }
 
     assert jobs["validate"]["needs"] == "build"


### PR DESCRIPTION
## Summary

Two source-verified 1.6.1 hotfix defects, batched per #189's comment thread.

### #189 -- writer-proof preflight fails on unrelated same-uid relay processes

`prove_no_writer()` (`src/clio_relay/bootstrap.py`) iterated every same-uid
`/proc` entry and read `/proc/<pid>/environ` for any relay-invocation cmdline
match, treating any non-ENOENT/ESRCH `OSError` as a fatal bootstrap abort.
clio-relay's own `process_containment.enforce_linux_secret_memory_gate()`
makes worker processes non-dumpable, so their `environ` becomes root-only
(`-r-------- root root`) even for the owning same-uid account -- meaning on
any host running one hardened same-uid relay worker, bootstrap of every
cluster failed unconditionally. Live evidence: bootstrap of a fresh
`ares-p5run2` generation blocked by PID 668909, which belonged to the
unrelated `ares-demo` tenant.

**Fix**: environ is now best-effort writer-proof evidence, not mandatory.
The proof is reordered per candidate: cmdline is always read (still
reliably available for a non-dumpable same-uid process); if the candidate's
`--cluster` provably differs from the target cluster being bootstrapped, an
unreadable environ is tolerated and the candidate is skipped. A candidate
that matches the target cluster, or leaves it ambiguous (no `--cluster` in
its cmdline -- e.g. `api start` / `mcp-server` invocations), still hard-fails
on an unreadable environ with today's exact message. The target-matching
exclusivity guarantee (catching a misconfigured worker writing to our own
core dir) is unweakened; only the "not our concern" path changes.

Implementation refactors `read_bounded()` into a shared `read_capped()` plus
a thin `read_bounded()` wrapper so every other caller (stat, cmdline,
boot_id, endpoint-record files) keeps byte-identical behavior; only the
writer proof's own environ read gets the new conditional handling.

### #190 -- default clio-kit pin (2.6.6) predates the 2.7.2 ranking fix

The bootstrap default jarvis-mcp install pin
(`CLIO_KIT_JARVIS_MCP_VERSION`/`WHEEL_URL`/`WHEEL_SHA256` in
`src/clio_relay/jarvis_mcp.py`, consumed by `bootstrap.py`) resolved
`clio_kit==2.6.6`, predating the released 2.7.2 that carries the kit#353
package-search ranking fix. A fresh deployment therefore shipped a
server-side kit that cannot rank `bounded_command` into capability search.

**Fix**: bumped to clio-kit 2.7.2. Verified independently against both
PyPI's release metadata and a fresh download of the actual GitHub release
asset: `clio_kit-2.7.2-py3-none-any.whl`, sha256
`8ebe41bf366e475a7da703a52c968231780d5d9013fc5fc913fe0f0539c6b6b5`.

**Scope note (please review)**: clio-kit 2.7.2 shifted the wire/contract
bytes for every locked MCP surface shipped in the wheel (jarvis, spack,
scientific-catalog, slurm), not only jarvis -- confirmed by diffing the
2.6.6 and 2.7.2 wheels' embedded `_mcp_contracts/*.json` directly. Every
detailed tool-schema assertion in `tests/test_clio_kit_mcp_contracts.py`
still passes against the real 2.7.2 content (verified offline against both
downloaded wheels: 33/33 structural checks pass, only the byte-level
fingerprints moved), but clio-relay separately vendors byte-exact
spack-user/scientific-catalog-user contract copies
(`src/clio_relay/_contracts/`, cross-checked against a live-staged wheel by
that test file) and a shared live ares-cluster acceptance policy
(`docs/release-gate-1.0.yaml`, admin-governed, gates
`live-validation-attest.yml`/`released-validation-attest.yml`) that
separately pins a worker's installed clio-kit distribution_version/sha256.

I confirmed no `src/` runtime path checks a live-discovered spack/
scientific-catalog contract against the `CLIO_KIT_SPACK_USER_*`/
`CLIO_KIT_SCIENTIFIC_CATALOG_USER_*` constants (they are test-only vendoring
fixtures), so leaving them at 2.6.6 is safe. This PR therefore deliberately
does not touch: the vendored spack/scientific-catalog contract fixtures,
the CI-staged contract-certification wheel (`.github/workflows/ci.yml`), or
`docs/release-gate-1.0.yaml`. `tests/test_ci_clio_kit_wheel.py`'s former
"one shared pin" test is split into a JARVIS-install-pin self-consistency
check and a contract-certification-pin-is-unchanged check reflecting this.
Re-certifying the vendored spack/scientific-catalog fixtures and the
ares-cluster policy against 2.7.2 is separate follow-up work -- flagging for
explicit sign-off rather than doing it unilaterally, since the live policy
gates shared, admin-governed infrastructure.

## Tests (failing-first)

- `test_embedded_writer_proof_skips_unreadable_environment_for_a_different_cluster`
  (new, in `tests/test_bootstrap_cluster_paths.py`) -- unrelated hardened
  process, different `--cluster`, environ `chmod(0)` (EACCES) -- fails
  against pre-fix code with the exact production error (`relay worker
  writer proof failed: cannot inspect .../environ: [Errno 13] Permission
  denied`), passes after the fix. Verified failing-first by re-running it
  against the unmodified bootstrap.py.
- `test_embedded_writer_proof_fails_closed_when_target_cluster_environment_is_unreadable`
  (new) -- same-cluster candidate, unreadable environ -- still hard-fails
  with today's message (regression lock on the target-matching path).
- `test_embedded_writer_proof_fails_closed_when_ambiguous_environment_is_unreadable`
  (new) -- `api start` candidate (no `--cluster` in cmdline), unreadable
  environ -- still hard-fails (regression lock on the ambiguous path).
- The prior `test_embedded_writer_proof_fails_closed_when_environment_is_unreadable`
  (which asserted the buggy different-cluster-fails behavior) is
  renamed/rewritten into the first test above rather than left encoding the
  defect.
- `tests/test_ci_clio_kit_wheel.py`: `test_bootstrap_jarvis_mcp_install_pin_is_self_consistent`
  (renamed/rewritten) and new
  `test_contract_certification_pin_is_independent_of_the_bootstrap_install_pin`.

## Gate results

- `uv run ruff check` -- all checks passed
- `uv run ruff format --check` -- 213 files already formatted
- `uv run pyright` -- 0 errors, 0 warnings, 0 informations
- `pytest tests/test_bootstrap*.py tests/test_ci_clio_kit_wheel.py` (WSL,
  posix partition, exercises the `chmod(0)`-based tests) -- all green except
  one pre-existing, unrelated failure reproduced identically against
  unmodified HEAD:
  `test_bootstrap_fast_path.py::test_packaged_payload_archive_has_only_safe_canonical_modes`
  (tar member mode-bit assertion; fails the same way before this branch's
  changes, in an area neither fix touches -- looks like a WSL/DrvFs
  artifact, not something introduced here).
- `pytest tests/test_release_workflows.py tests/test_jarvis_mcp_validation.py tests/test_cli.py`
  (Windows venv) -- all green, confirming `docs/release-gate-1.0.yaml` and
  every constant-importing test remain self-consistent untouched.
- Module import sanity check: `clio_relay.jarvis_mcp` imports cleanly with
  the new pin (its own `_load_bundled_jarvis_user_contract()` self-check
  passes, since it verifies a different, untouched constant).

Not merging/tagging/bumping the version -- per instructions, that's a
separate authorized step.
