### PR TITLE
chore: bump release version to 1.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.6.0"
+version = "1.6.1"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"


### PR DESCRIPTION
1.6.1 hotfix release: #189 (writer-proof scoped to the target cluster — unblocks bootstrap on multi-tenant hardened hosts) + #190 (default clio-kit pin 2.7.2). Both landed via #191.