### PR TITLE
chore: refresh uv.lock for the 1.6.1 version bump

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -301,7 +301,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "clio-schemas" },


### PR DESCRIPTION
The 1.6.1 bump (#192) updated pyproject/__init__ but not uv.lock; the tag CI's uv sync --locked refused. Completes the bump.