### PR TITLE
chore: bump release version to 1.6.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.6.1"
+version = "1.6.2"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.6.1"
+__version__ = "1.6.2"

--- a/uv.lock
+++ b/uv.lock
@@ -301,7 +301,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.6.1"
+version = "1.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "clio-schemas" },


### PR DESCRIPTION
1.6.2 = the 1.6.1 hotfix content (#189 writer-proof scoping, #190 clio-kit 2.7.2 default pin, via #191) re-cut with a complete version bump (pyproject + __init__ + uv.lock together). v1.6.1's tag points at a commit whose stale uv.lock failed release CI; tag deletion is blocked by repository rules, so 1.6.1 is abandoned unpublished.