### PR TITLE
chore: bump release version to 1.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a piece of the federation layer for [`clio-agent`](https://github.com/iowarp/clio-agent): a local CLIO experience can delegate work to a remote machine, keep observing it, detach, reconnect, and clean up after itself. The project is also designed for use outside CLIO. Any client that can call the CLI, HTTP API, or MCP tools can use the same relay model.
 
-> Version `1.6.3` uses a release-first patch process. A maintainer builds the
+> Version `1.6.4` uses a release-first patch process. A maintainer builds the
 > wheel and source distribution once, attaches those exact bytes and their
 > checksums to a GitHub Release, and publishes the release immediately. Tag
 > regression jobs and the trusted PyPI upload then run asynchronously; they do

--- a/docs/release-acceptance-1.0.md
+++ b/docs/release-acceptance-1.0.md
@@ -84,7 +84,7 @@ around by moving the protected tag.
 
 ```powershell
 $ErrorActionPreference = "Stop"
-$Version = "1.6.3"
+$Version = "1.6.4"
 $Tag = "v$Version"
 $Stage = "candidate" # Use "released" for the second complete pass.
 if ($Stage -notin @("candidate", "released")) { throw "invalid stage" }

--- a/docs/release-gate-1.0.yaml
+++ b/docs/release-gate-1.0.yaml
@@ -3,9 +3,9 @@
 # registry and may require them for a later release by adding policy requirements;
 # neither action requires a clio-relay code change.
 schema_version: "1.0"
-release_version: "1.6.3"
+release_version: "1.6.4"
 acceptance_matrix_path: examples/release-gate/report-matrix-1.0.json
-acceptance_matrix_sha256: 963ca64fcd3cec80d0d56c2eb748be91a6ad6a2b9e5c1fbc886ec23aba458a9c
+acceptance_matrix_sha256: 806437d985658832bf1479e851bf05369192c20d781299bcd44da0f4e20f2b0d
 artifact_stage: published
 evidence_trust_model: maintainer_sealed_operator_evidence
 require_released_artifact: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -62,7 +62,7 @@ gh pr create --title "fix: ..." --body-file PR.md
 gh pr merge --squash --delete-branch
 git switch main
 git pull --ff-only origin main
-$Tag = "v1.6.3"
+$Tag = "v1.6.4"
 $Commit = (git rev-parse HEAD).Trim()
 if (git status --porcelain) { throw "release checkout is dirty" }
 if (git tag --list $Tag) { throw "release tag already exists locally: $Tag" }
@@ -118,7 +118,7 @@ publish those already-built bytes:
 
 ```powershell
 git push origin $Tag
-gh release create $Tag --draft --target $Commit --title "clio-relay 1.6.3" `
+gh release create $Tag --draft --target $Commit --title "clio-relay 1.6.4" `
   dist/*.whl dist/*.tar.gz dist/SHA256SUMS --notes-file RELEASE.md
 gh release edit $Tag --draft=false
 ```

--- a/examples/release-gate/report-matrix-1.0.json
+++ b/examples/release-gate/report-matrix-1.0.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "clio-relay.release-acceptance-matrix.v1",
-  "release_version": "1.6.3",
-  "matrix_sha256": "963ca64fcd3cec80d0d56c2eb748be91a6ad6a2b9e5c1fbc886ec23aba458a9c",
+  "release_version": "1.6.4",
+  "matrix_sha256": "806437d985658832bf1479e851bf05369192c20d781299bcd44da0f4e20f2b0d",
   "report_count_per_stage": 19,
   "target_labels_are_policy_evidence_instances": true,
   "stages": [
@@ -22,7 +22,10 @@
       "id": "ares-bootstrap",
       "cluster": "ares",
       "scenario": "cluster-bootstrap",
-      "command": ["cluster", "bootstrap"],
+      "command": [
+        "cluster",
+        "bootstrap"
+      ],
       "report_option": "--report"
     },
     {
@@ -30,7 +33,9 @@
       "id": "ares-cluster-bootstrap-live-test",
       "cluster": "ares",
       "scenario": "cluster-bootstrap",
-      "command": ["live-test"],
+      "command": [
+        "live-test"
+      ],
       "report_option": "--report"
     },
     {
@@ -38,7 +43,10 @@
       "id": "ares-queue-management",
       "cluster": "ares",
       "scenario": "queue-management",
-      "command": ["queue", "validate"],
+      "command": [
+        "queue",
+        "validate"
+      ],
       "report_option": "--report"
     },
     {
@@ -46,7 +54,9 @@
       "id": "ares-jarvis-gray-scott",
       "cluster": "ares",
       "scenario": "remote-mcp",
-      "command": ["jarvis-mcp-validate"],
+      "command": [
+        "jarvis-mcp-validate"
+      ],
       "report_option": "--report",
       "package": "builtin.gray_scott"
     },
@@ -55,7 +65,9 @@
       "id": "ares-jarvis-lammps",
       "cluster": "ares",
       "scenario": "remote-mcp",
-      "command": ["jarvis-mcp-validate"],
+      "command": [
+        "jarvis-mcp-validate"
+      ],
       "report_option": "--report",
       "package": "builtin.lammps"
     },
@@ -64,7 +76,10 @@
       "id": "ares-scientific-catalog-describe",
       "cluster": "ares",
       "scenario": "remote-mcp",
-      "command": ["remote-mcp", "validate"],
+      "command": [
+        "remote-mcp",
+        "validate"
+      ],
       "report_option": "--validation-report",
       "remote_tool": "scientific_dataset_describe",
       "arguments": {
@@ -77,7 +92,10 @@
       "id": "ares-spack-find",
       "cluster": "ares",
       "scenario": "remote-mcp",
-      "command": ["remote-mcp", "validate"],
+      "command": [
+        "remote-mcp",
+        "validate"
+      ],
       "report_option": "--validation-report",
       "remote_tool": "spack_find",
       "package": "lammps",
@@ -88,7 +106,10 @@
       "id": "ares-spack-locate",
       "cluster": "ares",
       "scenario": "remote-mcp",
-      "command": ["remote-mcp", "validate"],
+      "command": [
+        "remote-mcp",
+        "validate"
+      ],
       "report_option": "--validation-report",
       "remote_tool": "spack_locate",
       "package": "lammps",
@@ -99,7 +120,10 @@
       "id": "ares-spack-install",
       "cluster": "ares",
       "scenario": "remote-mcp",
-      "command": ["remote-mcp", "validate"],
+      "command": [
+        "remote-mcp",
+        "validate"
+      ],
       "report_option": "--validation-report",
       "remote_tool": "spack_install",
       "package": "libsigsegv@2.14",
@@ -110,7 +134,10 @@
       "id": "ares-slurm-lifecycle",
       "cluster": "ares",
       "scenario": "scheduler-lifecycle",
-      "command": ["scheduler", "validate-lifecycle"],
+      "command": [
+        "scheduler",
+        "validate-lifecycle"
+      ],
       "report_option": "--report"
     },
     {
@@ -118,7 +145,10 @@
       "id": "ares-cleanup-detach",
       "cluster": "ares",
       "scenario": "cleanup",
-      "command": ["session", "detach"],
+      "command": [
+        "session",
+        "detach"
+      ],
       "report_option": "--validation-report",
       "evidence_group": "ares-default-cleanup-session"
     },
@@ -127,7 +157,10 @@
       "id": "ares-cleanup-teardown",
       "cluster": "ares",
       "scenario": "cleanup",
-      "command": ["session", "teardown"],
+      "command": [
+        "session",
+        "teardown"
+      ],
       "report_option": "--validation-report",
       "evidence_group": "ares-default-cleanup-session"
     },
@@ -136,7 +169,10 @@
       "id": "ares-explicit-cancel-teardown",
       "cluster": "ares",
       "scenario": "cleanup",
-      "command": ["session", "teardown"],
+      "command": [
+        "session",
+        "teardown"
+      ],
       "report_option": "--validation-report",
       "evidence_group": "ares-explicit-cancel-session"
     },
@@ -145,7 +181,10 @@
       "id": "homelab-cleanup-detach",
       "cluster": "homelab",
       "scenario": "cleanup",
-      "command": ["session", "detach"],
+      "command": [
+        "session",
+        "detach"
+      ],
       "report_option": "--validation-report",
       "evidence_group": "homelab-default-cleanup-session"
     },
@@ -154,7 +193,10 @@
       "id": "homelab-cleanup-teardown",
       "cluster": "homelab",
       "scenario": "cleanup",
-      "command": ["session", "teardown"],
+      "command": [
+        "session",
+        "teardown"
+      ],
       "report_option": "--validation-report",
       "evidence_group": "homelab-default-cleanup-session"
     },
@@ -163,7 +205,9 @@
       "id": "homelab-transport",
       "cluster": "homelab",
       "scenario": "transport",
-      "command": ["live-test"],
+      "command": [
+        "live-test"
+      ],
       "report_option": "--report"
     },
     {
@@ -171,7 +215,10 @@
       "id": "ares-gateway-start",
       "cluster": "ares",
       "scenario": "gateway-runtime",
-      "command": ["gateway", "start-runtime"],
+      "command": [
+        "gateway",
+        "start-runtime"
+      ],
       "report_option": "--validation-report",
       "evidence_group": "ares-dedicated-gateway"
     },
@@ -180,7 +227,10 @@
       "id": "ares-gateway-stop",
       "cluster": "ares",
       "scenario": "gateway-runtime",
-      "command": ["gateway", "stop-runtime"],
+      "command": [
+        "gateway",
+        "stop-runtime"
+      ],
       "report_option": "--validation-report",
       "evidence_group": "ares-dedicated-gateway"
     },
@@ -189,7 +239,9 @@
       "id": "ares-secure-runtime",
       "cluster": "ares",
       "scenario": "secure-runtime",
-      "command": ["live-test"],
+      "command": [
+        "live-test"
+      ],
       "report_option": "--report",
       "evidence_group": "ares-secure-jarvis-runtime"
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clio-relay"
-version = "1.6.3"
+version = "1.6.4"
 description = "Cluster relay endpoints backed by clio-core and JARVIS-CD."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/clio_relay/__init__.py
+++ b/src/clio_relay/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.6.3"
+__version__ = "1.6.4"

--- a/tests/test_release_acceptance_runbook.py
+++ b/tests/test_release_acceptance_runbook.py
@@ -53,7 +53,7 @@ def test_release_identity_is_consistent_across_package_policy_matrix_and_runbook
     init_source = (ROOT / "src" / "clio_relay" / "__init__.py").read_text(encoding="utf-8")
     release_process = RELEASE_PROCESS.read_text(encoding="utf-8")
 
-    assert version == "1.6.3"
+    assert version == "1.6.4"
     assert relay_lock["version"] == version
     assert f'__version__ = "{version}"' in init_source
     assert policy["release_version"] == version

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -2499,7 +2499,7 @@ def test_default_report_path_sanitizes_cluster_name(tmp_path: Path) -> None:
 def test_repository_release_policy_is_machine_readable() -> None:
     policy = load_release_gate_policy(Path("docs/release-gate-1.0.yaml"))
 
-    assert policy.release_version == "1.6.0"
+    assert policy.release_version == "1.6.4"
     assert policy.acceptance_matrix is not None
     assert policy.acceptance_matrix["report_count_per_stage"] == 19
     assert policy.acceptance_matrix["matrix_sha256"] == policy.acceptance_matrix_sha256

--- a/uv.lock
+++ b/uv.lock
@@ -301,7 +301,7 @@ wheels = [
 
 [[package]]
 name = "clio-relay"
-version = "1.6.3"
+version = "1.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "clio-schemas" },


### PR DESCRIPTION
Fourth cut of the #189/#190 hotfix content (#191). Adds the two sites 1.6.3 missed: the acceptance matrix's recomputed matrix_sha256 (+ release_version) with the policy's acceptance_matrix_sha256 pin, and the machine-readability test's version literal. Local proof: tests/test_release_acceptance_runbook.py + test_validation_report.py + test_ci_clio_kit_wheel.py = 60/60. v1.6.1-v1.6.3 tags are protected and remain unpublished.