### PR TITLE
fix: per-cluster runtime identity in session verification + PyPI as official wheel channel (#205, #206)

### DIFF
--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -1758,6 +1758,17 @@ def endpoint_worker_info(
         bool,
         typer.Option(help="Return bounded readiness flags without detailed installation records."),
     ] = False,
+    pinned_install_receipt_path: Annotated[
+        str | None,
+        typer.Option(
+            "--pinned-install-receipt-path",
+            help=(
+                "Cluster-registered relay_install_receipt path (this host's "
+                "own pinned runtime) to verify the worker against, instead of "
+                "this invocation's ambient current installation."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Report fresh process-bound identity for the active cluster worker."""
     _run_or_exit(
@@ -1767,6 +1778,7 @@ def endpoint_worker_info(
                     cluster=cluster,
                     freshness_seconds=freshness_seconds,
                     readiness_only=readiness_only,
+                    pinned_install_receipt_path=pinned_install_receipt_path,
                 ),
                 indent=2,
             )
@@ -17858,14 +17870,23 @@ def _remote_worker_info(
     *,
     timeout_seconds: float | None = None,
 ) -> dict[str, object]:
-    """Read fresh process-bound worker identity over one optional total deadline."""
+    """Read fresh process-bound worker identity over one optional total deadline.
+
+    When the cluster registry pins a runtime (``relay_install_receipt``), that
+    pin is threaded to the remote check so the worker is verified against its
+    own cluster's declared identity rather than only this SSH session's
+    ambient current installation (clio-relay#205).
+    """
     if timeout_seconds is not None and timeout_seconds <= 0:
         raise ValueError("timeout_seconds must be positive")
     deadline = None if timeout_seconds is None else monotonic() + timeout_seconds
+    args = ["endpoint", "worker-info", "--cluster", definition.name]
+    if definition.relay_install_receipt is not None:
+        args = [*args, "--pinned-install-receipt-path", definition.relay_install_receipt]
     info = _json_output(
         _run_remote_clio_before_deadline(
             definition,
-            ["endpoint", "worker-info", "--cluster", definition.name],
+            args,
             deadline=deadline,
         ),
         "remote clio-relay worker runtime info",

--- a/src/clio_relay/installation.py
+++ b/src/clio_relay/installation.py
@@ -1141,12 +1141,25 @@ def installation_info(path: Path | None = None) -> dict[str, object]:
 
 
 def _persistent_uv_tool_install_receipt() -> tuple[InstallReceipt, InstallSource]:
-    """Derive a compatible receipt from uv's exact persistent-tool identity."""
+    """Derive a compatible receipt from uv's exact persistent-tool identity.
+
+    A VCS-kind install counts only when pinned to an exact 40-hex git commit
+    sha (``git+https://.../clio-relay@<sha>``); ``detect_install_source``
+    resolves that sha into ``artifact_sha256`` (see
+    ``_vcs_commit_identity_verified``), where it plays the same
+    identity-anchor role a wheel's sha256 digest plays. A branch or tag
+    reference leaves ``artifact_identity_verified`` False and is rejected
+    below exactly like an unverified wheel.
+    """
     source = detect_install_source(
         launcher="uv-tool",
         infer_artifact_sha256=True,
     )
-    if source.kind not in {InstallSourceKind.WHEEL, InstallSourceKind.PYPI}:
+    if source.kind not in {
+        InstallSourceKind.WHEEL,
+        InstallSourceKind.PYPI,
+        InstallSourceKind.VCS,
+    }:
         raise ConfigurationError("running clio-relay is not installed as a persistent uv tool")
     if not source.launcher_verified:
         raise ConfigurationError("persistent uv tool launcher identity could not be verified")
@@ -1167,7 +1180,7 @@ def _persistent_uv_tool_install_receipt() -> tuple[InstallReceipt, InstallSource
         raise ConfigurationError("persistent uv tool receipt path is unavailable") from exc
     reference = source.reference
     artifact_filename: str | None = None
-    if reference is not None:
+    if reference is not None and source.kind is not InstallSourceKind.VCS:
         parsed = urlsplit(reference)
         if parsed.path:
             artifact_filename = Path(unquote(parsed.path)).name or None

--- a/src/clio_relay/installation.py
+++ b/src/clio_relay/installation.py
@@ -1189,8 +1189,19 @@ def worker_runtime_info(
     freshness_seconds: float = 120.0,
     current_installation: dict[str, object] | None = None,
     readiness_only: bool = False,
+    pinned_install_receipt_path: str | None = None,
 ) -> dict[str, object]:
-    """Prove the active worker process loaded the same exact installation receipt."""
+    """Prove the active worker process loaded the same exact installation receipt.
+
+    ``pinned_install_receipt_path`` names a cluster-registered runtime receipt
+    (the 1.6.6 cluster schema's ``relay_install_receipt`` field, threaded in by
+    the caller that holds the cluster registry). When given, the worker's
+    self-reported identity is independently checked against that pinned
+    receipt (``identity_matches_pinned``/``pinned_installation``) rather than
+    only against this invocation's own ambient ``current`` installation: a
+    multi-tenant host can keep its shared ``current`` pointed at a different
+    generation for other tenants while one cluster is pinned to its own.
+    """
     from clio_relay.config import RelaySettings
     from clio_relay.core_queue import MAX_ENDPOINT_FRESH_SECONDS, ClioCoreQueue
     from clio_relay.models import EndpointRole
@@ -1204,6 +1215,16 @@ def worker_runtime_info(
     current = installation_info() if current_installation is None else current_installation
     if current.get("schema_version") != "clio-relay.installation-info.v1":
         raise ConfigurationError("current installation snapshot is invalid")
+    pinned_installation: dict[str, object] | None = None
+    if pinned_install_receipt_path is not None:
+        pinned_receipt_path = Path(pinned_install_receipt_path).expanduser()
+        try:
+            pinned_receipt = load_install_receipt(pinned_receipt_path)
+        except ConfigurationError as exc:
+            raise ConfigurationError(
+                f"cluster {cluster} pinned install receipt could not be loaded: {exc}"
+            ) from exc
+        pinned_installation = pinned_receipt.model_dump(mode="json")
     queue = ClioCoreQueue(RelaySettings.from_env().core_dir)
     endpoint_records, endpoints_truncated = queue.scan_fresh_endpoints_read_only(
         limit=MAX_WORKER_ENDPOINT_RECORDS,
@@ -1227,6 +1248,13 @@ def worker_runtime_info(
     fresh = 0 <= age_seconds <= freshness_seconds
     process_running = _worker_process_matches(endpoint.pid)
     identity_matches_current = endpoint_installation == current
+    identity_matches_pinned: bool | None = None
+    if pinned_installation is not None:
+        typed_endpoint_installation = cast(dict[str, object], endpoint_installation)
+        identity_matches_pinned = (
+            typed_endpoint_installation.get("receipt_matches_install") is True
+            and typed_endpoint_installation.get("receipt") == pinned_installation
+        )
     scheduler_provider = endpoint.metadata.get("scheduler_provider")
     readiness: dict[str, object] = {
         "schema_version": "clio-relay.worker-runtime-info.v1",
@@ -1248,6 +1276,8 @@ def worker_runtime_info(
         "endpoint": endpoint.model_dump(mode="json"),
         "installation": current,
         "endpoint_installation": endpoint_installation,
+        "pinned_installation": pinned_installation,
+        "identity_matches_pinned": identity_matches_pinned,
     }
 
 
@@ -1285,6 +1315,17 @@ def verify_remote_installation_info(
     return receipt
 
 
+def _installation_identity_label(receipt: InstallReceipt) -> str:
+    """Return one short human-readable identity label for a proven receipt."""
+    generation = receipt.generation
+    artifact = receipt.artifact_sha256
+    return (
+        f"{receipt.distribution_version}"
+        f"(generation={generation[:12] if generation else 'none'}, "
+        f"artifact={artifact[:12] if artifact else 'none'})"
+    )
+
+
 def verify_remote_worker_info(
     info: dict[str, object],
     *,
@@ -1295,12 +1336,31 @@ def verify_remote_worker_info(
     expected_source: str | None,
     require_target_identity: bool = True,
 ) -> InstallReceipt:
-    """Require fresh live-worker proof in addition to a static install receipt."""
+    """Require fresh live-worker proof in addition to a static install receipt.
+
+    When the worker's cluster declares a pinned runtime (``info`` carries a
+    non-null ``pinned_installation``, resolved server-side from the cluster
+    registry's ``relay_install_receipt``), the worker's self-reported
+    identity must match that pin (``identity_matches_pinned``) instead of
+    this invocation's ambient ``identity_matches_current``/``running``: a
+    shared host's ``current`` symlink is not required to agree with a pin
+    made for one cluster. A cluster with no pin keeps requiring
+    ``identity_matches_current`` exactly as before.
+    """
     if info.get("schema_version") != "clio-relay.worker-runtime-info.v1":
         raise ConfigurationError("remote worker runtime identity schema does not match")
     if info.get("cluster") != expected_cluster:
         raise ConfigurationError("remote worker runtime cluster does not match")
-    for flag in ("fresh", "process_running", "identity_matches_current", "running"):
+    raw_pinned_installation = info.get("pinned_installation")
+    if raw_pinned_installation is not None and not isinstance(raw_pinned_installation, dict):
+        raise ConfigurationError("remote worker pinned installation identity is invalid")
+    cluster_pins_runtime = raw_pinned_installation is not None
+    required_flags = (
+        ("fresh", "process_running")
+        if cluster_pins_runtime
+        else ("fresh", "process_running", "identity_matches_current", "running")
+    )
+    for flag in required_flags:
         if info.get(flag) is not True:
             raise ConfigurationError(f"remote worker runtime did not prove {flag}")
     current = info.get("installation")
@@ -1327,13 +1387,6 @@ def verify_remote_worker_info(
         or info.get("scheduler_provider") != scheduler_provider
     ):
         raise ConfigurationError("remote worker scheduler-provider attestation does not match")
-    current_receipt = verify_remote_installation_info(
-        {str(key): value for key, value in typed_current.items()},
-        expected_version=expected_version,
-        expected_software=expected_software,
-        expected_artifact_sha256=expected_artifact_sha256,
-        expected_source=expected_source,
-    )
     endpoint_receipt = verify_remote_installation_info(
         {str(key): value for key, value in typed_endpoint_installation.items()},
         expected_version=expected_version,
@@ -1341,8 +1394,30 @@ def verify_remote_worker_info(
         expected_artifact_sha256=expected_artifact_sha256,
         expected_source=expected_source,
     )
-    if endpoint_receipt != current_receipt:
-        raise ConfigurationError("running worker receipt differs from current installation")
+    if cluster_pins_runtime:
+        if info.get("identity_matches_pinned") is not True:
+            try:
+                pinned_receipt = InstallReceipt.model_validate(raw_pinned_installation)
+            except ValidationError as exc:
+                raise ConfigurationError(
+                    f"remote worker pinned installation identity is invalid: {exc}"
+                ) from exc
+            raise ConfigurationError(
+                "remote worker runtime does not match its cluster's pinned installation: "
+                f"worker={_installation_identity_label(endpoint_receipt)} "
+                f"pinned={_installation_identity_label(pinned_receipt)}"
+            )
+        current_receipt = endpoint_receipt
+    else:
+        current_receipt = verify_remote_installation_info(
+            {str(key): value for key, value in typed_current.items()},
+            expected_version=expected_version,
+            expected_software=expected_software,
+            expected_artifact_sha256=expected_artifact_sha256,
+            expected_source=expected_source,
+        )
+        if endpoint_receipt != current_receipt:
+            raise ConfigurationError("running worker receipt differs from current installation")
     if require_target_identity:
         target_identity = info.get("target_identity")
         if not isinstance(target_identity, dict):

--- a/src/clio_relay/validation_report.py
+++ b/src/clio_relay/validation_report.py
@@ -71,6 +71,10 @@ _OFFICIAL_RELEASE_WHEEL_PATH = re.compile(
     r"/iowarp/clio-relay/releases/download/v(?P<version>[0-9A-Za-z][0-9A-Za-z.+-]*)/"
     r"clio_relay-(?P=version)-py3-none-any\.whl"
 )
+_OFFICIAL_PYPI_WHEEL_PATH = re.compile(
+    r"/packages/[0-9a-f]{2}/[0-9a-f]{2}/[0-9a-f]{16,64}/"
+    r"clio_relay-[0-9A-Za-z][0-9A-Za-z.+-]*-py3-none-any\.whl"
+)
 SPACK_FRESH_INSTALL_TRANSITION_CHECK_IDS = (
     "remote-mcp.spack-preinstall-absent",
     "remote-mcp.spack-fresh-install",
@@ -3842,22 +3846,34 @@ class _ReleaseWheelRedirectHandler(urllib.request.HTTPRedirectHandler):
 
 
 def _is_official_release_wheel_url(value: str) -> bool:
-    """Allow only one credential-free canonical clio-relay GitHub release URL."""
+    """Allow only credential-free canonical clio-relay GitHub or PyPI wheel URLs.
+
+    GitHub release assets and the trusted-publishing PyPI upload both carry
+    the identical released bytes (the same artifact is attached to a GitHub
+    Release and published to PyPI from that release); either canonical
+    channel is an official source of the wheel. This function recognizes the
+    *channel* only -- the sha256 digest binding performed by
+    ``_wheel_url_matches_install`` remains the actual integrity anchor.
+    """
     try:
         parsed = urllib.parse.urlsplit(value)
         port = parsed.port
     except ValueError:
         return False
-    return (
-        parsed.scheme.casefold() == "https"
-        and parsed.hostname == "github.com"
-        and port in {None, 443}
-        and parsed.username is None
-        and parsed.password is None
-        and not parsed.query
-        and not parsed.fragment
-        and _OFFICIAL_RELEASE_WHEEL_PATH.fullmatch(parsed.path) is not None
-    )
+    if (
+        parsed.scheme.casefold() != "https"
+        or port not in {None, 443}
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        return False
+    if parsed.hostname == "github.com":
+        return _OFFICIAL_RELEASE_WHEEL_PATH.fullmatch(parsed.path) is not None
+    if parsed.hostname == "files.pythonhosted.org":
+        return _OFFICIAL_PYPI_WHEEL_PATH.fullmatch(parsed.path) is not None
+    return False
 
 
 def _is_github_release_asset_url(value: str) -> bool:

--- a/src/clio_relay/validation_report.py
+++ b/src/clio_relay/validation_report.py
@@ -1387,7 +1387,7 @@ def _detect_persistent_uv_tool_receipt(
         distribution=distribution,
     )
     verified = (
-        detected_kind in {InstallSourceKind.WHEEL, InstallSourceKind.PYPI}
+        detected_kind in {InstallSourceKind.WHEEL, InstallSourceKind.PYPI, InstallSourceKind.VCS}
         and uv_path_verified
         and uv_stable
         and tool_directory is not None
@@ -3709,6 +3709,39 @@ def _distribution_direct_url(distribution: metadata.Distribution) -> dict[str, A
     return value
 
 
+_FULL_GIT_COMMIT_SHA = re.compile(r"[0-9a-fA-F]{40}")
+
+
+def _vcs_commit_identity_verified(direct_url: dict[str, Any] | None) -> str | None:
+    """Return the pinned full git commit sha, or None unless it is exact-pinned.
+
+    A VCS install only counts as identity-verified when it is pinned to an
+    exact 40-hex commit sha (``git+https://.../clio-relay@<sha>``) -- a
+    branch or tag reference is a moving target, not a fixed identity, and is
+    rejected even though it still resolves to a ``commit_id``. The returned
+    sha plays the same identity-anchor role ``artifact_sha256`` plays for a
+    wheel: recorded on the receipt and compared for exact equality.
+    """
+    if direct_url is None:
+        return None
+    vcs_info = direct_url.get("vcs_info")
+    if not isinstance(vcs_info, dict):
+        return None
+    typed_vcs_info = cast(dict[str, Any], vcs_info)
+    if typed_vcs_info.get("vcs") != "git":
+        return None
+    requested_revision = typed_vcs_info.get("requested_revision")
+    commit_id = typed_vcs_info.get("commit_id")
+    if (
+        not isinstance(requested_revision, str)
+        or _FULL_GIT_COMMIT_SHA.fullmatch(requested_revision) is None
+    ):
+        return None
+    if not isinstance(commit_id, str) or commit_id.lower() != requested_revision.lower():
+        return None
+    return requested_revision.lower()
+
+
 def _verify_running_artifact_identity(
     distribution: metadata.Distribution,
     *,
@@ -3739,8 +3772,13 @@ def _infer_running_artifact_identity(
     direct_url: dict[str, Any] | None,
     launcher: str,
 ) -> tuple[str | None, bool]:
-    """Inspect one exact direct wheel for human-facing installation information."""
-    if launcher != "uv-tool" or detected_kind is not InstallSourceKind.WHEEL:
+    """Inspect one exact direct wheel, or exact-sha VCS pin, for installation identity."""
+    if launcher != "uv-tool":
+        return None, False
+    if detected_kind is InstallSourceKind.VCS:
+        commit_sha = _vcs_commit_identity_verified(direct_url)
+        return commit_sha, commit_sha is not None
+    if detected_kind is not InstallSourceKind.WHEEL:
         return None, False
     wheel_bytes = _direct_wheel_bytes(direct_url)
     if wheel_bytes is None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -762,7 +762,43 @@ def test_endpoint_worker_info_exposes_bounded_readiness_mode(
         "cluster": "ares",
         "freshness_seconds": 90.0,
         "readiness_only": True,
+        "pinned_install_receipt_path": None,
     }
+
+
+def test_endpoint_worker_info_forwards_pinned_install_receipt_path(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """clio-relay#205: the CLI surface forwards the cluster's pinned receipt path."""
+    observed: dict[str, object] = {}
+
+    def worker_info(**kwargs: object) -> dict[str, object]:
+        observed.update(kwargs)
+        return {
+            "schema_version": "clio-relay.worker-runtime-info.v1",
+            "cluster": kwargs["cluster"],
+            "running": True,
+        }
+
+    monkeypatch.setattr(cli, "worker_runtime_info", worker_info)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "endpoint",
+            "worker-info",
+            "--cluster",
+            "ares-p5run2",
+            "--pinned-install-receipt-path",
+            "$HOME/.local/share/clio-relay/generations/g1/install-receipt.json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (
+        observed["pinned_install_receipt_path"]
+        == "$HOME/.local/share/clio-relay/generations/g1/install-receipt.json"
+    )
 
 
 def test_cli_lists_artifacts(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
@@ -8791,6 +8827,74 @@ def test_remote_worker_info_binds_worker_to_operator_pinned_physical_target(
     target_scheduler_provider[0] = "external"
     with pytest.raises(ConfigurationError, match="physical target scheduler provider"):
         cli._remote_worker_info(definition)  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+
+
+def test_remote_worker_info_threads_cluster_pinned_receipt_path(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """clio-relay#205: a cluster-pinned receipt is threaded to the remote check.
+
+    ``worker_runtime_info`` runs server-side over the SSH session and has no
+    access to the desktop's local cluster registry, so the desktop -- which
+    does hold ``ClusterDefinition.relay_install_receipt`` -- must pass it
+    along explicitly rather than the check silently falling back to whatever
+    this SSH invocation's ambient current installation happens to be.
+    """
+    target_identity = ClusterTargetIdentity(
+        hostnames=["ares-login-1.example.edu"],
+        ssh_host_key_sha256=["SHA256:operator-pinned-fingerprint"],
+        scheduler_cluster_name="ares",
+        site_marker_sha256="a" * 64,
+    )
+    pinned_definition = ClusterDefinition(
+        name="ares-p5run2",
+        ssh_host="ares",
+        scheduler_provider="slurm",
+        relay_install_receipt="$HOME/.local/share/clio-relay/generations/g1/install-receipt.json",
+        target_identity=target_identity,
+    )
+    unpinned_definition = ClusterDefinition(
+        name="ares",
+        ssh_host="ares",
+        scheduler_provider="slurm",
+        target_identity=target_identity,
+    )
+    observed_arguments: list[list[str]] = []
+
+    def fake_run_remote_clio(_definition: ClusterDefinition, arguments: list[str]) -> str:
+        observed_arguments.append(arguments)
+        if arguments[1] == "worker-info":
+            return json.dumps({"scheduler_provider": "slurm"})
+        return json.dumps(
+            {
+                "schema_version": "clio-relay.cluster-target-info.v1",
+                "hostname": "ares-login-1",
+                "fqdn": "ares-login-1.example.edu",
+                "site_marker_sha256": "a" * 64,
+                "scheduler_provider": "slurm",
+                "scheduler_cluster_name": "ares",
+            }
+        )
+
+    def fake_host_key_fingerprints(_host: str) -> list[str]:
+        return ["SHA256:operator-pinned-fingerprint"]
+
+    monkeypatch.setattr(cli, "run_remote_clio", fake_run_remote_clio)
+    monkeypatch.setattr(cli, "_ssh_host_key_fingerprints", fake_host_key_fingerprints)
+
+    cli._remote_worker_info(pinned_definition)  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    cli._remote_worker_info(unpinned_definition)  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+
+    worker_info_calls = [call for call in observed_arguments if call[1] == "worker-info"]
+    assert worker_info_calls[0] == [
+        "endpoint",
+        "worker-info",
+        "--cluster",
+        "ares-p5run2",
+        "--pinned-install-receipt-path",
+        "$HOME/.local/share/clio-relay/generations/g1/install-receipt.json",
+    ]
+    assert worker_info_calls[1] == ["endpoint", "worker-info", "--cluster", "ares"]
 
 
 def test_remote_worker_info_uses_one_total_observation_deadline(

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -1077,6 +1077,129 @@ def test_installation_info_uses_verified_uv_tool_receipt_without_bootstrap_recei
     assert info["component_runtime"] == {}
 
 
+def test_installation_info_accepts_exact_sha_pinned_vcs_uv_tool_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """clio-relay#206: a full-sha VCS pin is an official uv-tool identity anchor too.
+
+    ``uv tool install git+https://github.com/iowarp/clio-relay@<40-hex-sha>``
+    pins an exact commit -- the desktop persistent-uv-tool identity check
+    must accept it and record that sha as the identity anchor exactly as it
+    would a wheel's sha256 digest.
+    """
+    missing_bootstrap = tmp_path / "missing-install-receipt.json"
+    uv_receipt = tmp_path / "tools" / "clio-relay" / "uv-receipt.toml"
+    uv_receipt.parent.mkdir(parents=True)
+    uv_receipt.write_text("[tool]\n", encoding="utf-8")
+    version = metadata.version("clio-relay")
+    commit_sha = "c" * 40
+    source_url = "https://github.com/iowarp/clio-relay"
+    source = InstallSource(
+        kind=InstallSourceKind.VCS,
+        detected_kind=InstallSourceKind.VCS,
+        reference=source_url,
+        launcher="uv-tool",
+        package_path=str(tmp_path / "site-packages" / "clio_relay"),
+        distribution_version=version,
+        artifact_sha256=commit_sha,
+        direct_url={
+            "url": source_url,
+            "vcs_info": {
+                "vcs": "git",
+                "requested_revision": commit_sha,
+                "commit_id": commit_sha,
+            },
+        },
+        artifact_identity_verified=True,
+        released_artifact=False,
+        launcher_verified=True,
+        launcher_receipt={
+            "verified": True,
+            "uv_tool_receipt": {
+                "path": str(uv_receipt),
+                "verified": True,
+            },
+        },
+    )
+
+    monkeypatch.delenv(INSTALL_RECEIPT_PATH_ENV, raising=False)
+    monkeypatch.setattr(
+        installation_module,
+        "default_install_receipt_path",
+        lambda: missing_bootstrap,
+    )
+
+    def detect_source(**_kwargs: object) -> InstallSource:
+        return source
+
+    monkeypatch.setattr(installation_module, "detect_install_source", detect_source)
+
+    info = installation_info()
+    receipt = cast(dict[str, object], info["receipt"])
+
+    assert info["receipt_origin"] == "uv-tool"
+    assert receipt["requested_source"] == "vcs"
+    assert receipt["artifact_sha256"] == commit_sha
+    assert receipt["artifact_filename"] is None
+    assert receipt["install_spec"] == source_url
+
+
+def test_installation_info_rejects_vcs_uv_tool_install_pinned_to_a_branch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """clio-relay#206: a branch/tag-pinned VCS install stays rejected, not silently accepted."""
+    missing_bootstrap = tmp_path / "missing-install-receipt.json"
+    uv_receipt = tmp_path / "tools" / "clio-relay" / "uv-receipt.toml"
+    uv_receipt.parent.mkdir(parents=True)
+    uv_receipt.write_text("[tool]\n", encoding="utf-8")
+    version = metadata.version("clio-relay")
+    source_url = "https://github.com/iowarp/clio-relay"
+    source = InstallSource(
+        kind=InstallSourceKind.VCS,
+        detected_kind=InstallSourceKind.VCS,
+        reference=source_url,
+        launcher="uv-tool",
+        package_path=str(tmp_path / "site-packages" / "clio_relay"),
+        distribution_version=version,
+        artifact_sha256=None,
+        direct_url={
+            "url": source_url,
+            "vcs_info": {
+                "vcs": "git",
+                "requested_revision": "main",
+                "commit_id": "d" * 40,
+            },
+        },
+        artifact_identity_verified=False,
+        released_artifact=False,
+        launcher_verified=True,
+        launcher_receipt={
+            "verified": True,
+            "uv_tool_receipt": {
+                "path": str(uv_receipt),
+                "verified": True,
+            },
+        },
+    )
+
+    monkeypatch.delenv(INSTALL_RECEIPT_PATH_ENV, raising=False)
+    monkeypatch.setattr(
+        installation_module,
+        "default_install_receipt_path",
+        lambda: missing_bootstrap,
+    )
+
+    def detect_source(**_kwargs: object) -> InstallSource:
+        return source
+
+    monkeypatch.setattr(installation_module, "detect_install_source", detect_source)
+
+    with pytest.raises(ConfigurationError, match="wheel identity could not be verified"):
+        installation_info()
+
+
 def test_remote_native_jarvis_component_requires_runtime_capability_provenance(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -1336,6 +1336,208 @@ def test_remote_worker_identity_is_bound_to_fresh_running_endpoint(tmp_path: Pat
         )
 
 
+def test_verify_remote_worker_info_uses_cluster_pin_over_global_current(tmp_path: Path) -> None:
+    """clio-relay#205: a cluster's pinned runtime is authoritative over global current.
+
+    On a multi-tenant host, one cluster can be pinned (via a #204 drop-in
+    override) to its own generation while the shared ``current`` symlink
+    stays on a different generation to protect other tenants. Session start
+    must pass when the worker matches the CLUSTER's pin even though it
+    diverges from ``current`` -- and must fail when the worker diverges from
+    the pin even if it happens to match ``current`` (the check is stronger
+    for pinned clusters, not weaker).
+    """
+    pinned_wheel = tmp_path / "clio_relay-pinned-1.0.0-py3-none-any.whl"
+    pinned_wheel.write_bytes(b"cluster-pinned-generation-g")
+    pinned_receipt_path = tmp_path / "pinned-receipt.json"
+    pinned_receipt = write_install_receipt(
+        install_spec=str(pinned_wheel),
+        artifact_path=pinned_wheel,
+        path=pinned_receipt_path,
+        generation="a" * 64,
+    )
+    worker_matches_pin = installation_info(pinned_receipt_path)
+
+    other_wheel = tmp_path / "clio_relay-other-1.0.0-py3-none-any.whl"
+    other_wheel.write_bytes(b"shared-tenant-global-current")
+    other_receipt_path = tmp_path / "other-receipt.json"
+    other_receipt = write_install_receipt(
+        install_spec=str(other_wheel),
+        artifact_path=other_wheel,
+        path=other_receipt_path,
+        generation="b" * 64,
+    )
+    worker_matches_other = installation_info(other_receipt_path)
+
+    base_runtime: dict[str, object] = {
+        "schema_version": "clio-relay.worker-runtime-info.v1",
+        "cluster": "ares-p5run2",
+        "fresh": True,
+        "process_running": True,
+        "scheduler_provider": "slurm",
+        "endpoint": {
+            "role": "worker",
+            "cluster": "ares-p5run2",
+            "pid": 123,
+            "metadata": {"scheduler_provider": "slurm"},
+        },
+        # This ssh session's own ambient "current" is the shared tenant's
+        # generation -- deliberately NOT the cluster's pin.
+        "installation": worker_matches_other,
+        "target_identity": {
+            "verified": True,
+            "hostname": "ares-login",
+            "ssh_host_key_sha256": ["SHA256:test"],
+            "scheduler_cluster_name": "ares",
+        },
+        "pinned_installation": pinned_receipt.model_dump(mode="json"),
+    }
+
+    # (a) worker reports the pin (G); current is OTHER -> verification PASSES.
+    passing_runtime = {
+        **base_runtime,
+        "endpoint_installation": worker_matches_pin,
+        "identity_matches_current": False,
+        "identity_matches_pinned": True,
+        "running": False,
+    }
+    verified = verify_remote_worker_info(
+        passing_runtime,
+        expected_cluster="ares-p5run2",
+        expected_version=pinned_receipt.distribution_version,
+        expected_software=SoftwareIdentity.model_validate(worker_matches_pin["software"]),
+        expected_artifact_sha256=pinned_receipt.artifact_sha256,
+        expected_source="wheel",
+        require_target_identity=False,
+    )
+    assert verified == pinned_receipt
+
+    # (b) worker reports something OTHER than the pin -- even a worker that
+    # matches global `current` (the old, weaker check would have passed this)
+    # must fail with a typed error naming both identities.
+    failing_runtime = {
+        **base_runtime,
+        "endpoint_installation": worker_matches_other,
+        "identity_matches_current": True,
+        "identity_matches_pinned": False,
+        "running": True,
+    }
+    with pytest.raises(ConfigurationError, match="pinned installation") as excinfo:
+        verify_remote_worker_info(
+            failing_runtime,
+            expected_cluster="ares-p5run2",
+            expected_version=other_receipt.distribution_version,
+            expected_software=SoftwareIdentity.model_validate(worker_matches_other["software"]),
+            expected_artifact_sha256=other_receipt.artifact_sha256,
+            expected_source="wheel",
+            require_target_identity=False,
+        )
+    message = str(excinfo.value)
+    assert other_receipt.distribution_version in message
+    assert "worker=" in message and "pinned=" in message
+
+    # A cluster whose worker never proves `fresh`/`process_running` still
+    # fails even when pinned -- the pin narrows the identity check, it does
+    # not remove the liveness proof.
+    not_fresh_runtime = {**passing_runtime, "fresh": False}
+    with pytest.raises(ConfigurationError, match="fresh"):
+        verify_remote_worker_info(
+            not_fresh_runtime,
+            expected_cluster="ares-p5run2",
+            expected_version=pinned_receipt.distribution_version,
+            expected_software=SoftwareIdentity.model_validate(worker_matches_pin["software"]),
+            expected_artifact_sha256=pinned_receipt.artifact_sha256,
+            expected_source="wheel",
+            require_target_identity=False,
+        )
+
+
+def test_worker_runtime_info_resolves_cluster_pinned_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """clio-relay#205: worker_runtime_info resolves the cluster's own pinned receipt.
+
+    The pin is resolved independent of whatever this fresh ssh invocation's
+    ambient ``current`` installation happens to be (env-dependent, and on a
+    shared host may reflect a different tenant's protected generation).
+    """
+    from clio_relay.core_queue import ClioCoreQueue
+    from clio_relay.models import EndpointRegistration, EndpointRole
+
+    root = tmp_path / "core"
+
+    pinned_wheel = tmp_path / "clio_relay-pinned.whl"
+    pinned_wheel.write_bytes(b"pinned-generation-wheel")
+    pinned_receipt_path = tmp_path / "pinned-receipt.json"
+    pinned_receipt = write_install_receipt(
+        install_spec=str(pinned_wheel),
+        artifact_path=pinned_wheel,
+        path=pinned_receipt_path,
+        generation="c" * 64,
+    )
+    worker_identity = installation_info(pinned_receipt_path)
+
+    current_wheel = tmp_path / "clio_relay-current.whl"
+    current_wheel.write_bytes(b"shared-tenant-current-wheel")
+    current_receipt_path = tmp_path / "current-receipt.json"
+    write_install_receipt(
+        install_spec=str(current_wheel),
+        artifact_path=current_wheel,
+        path=current_receipt_path,
+        generation="d" * 64,
+    )
+    current_identity = installation_info(current_receipt_path)
+
+    queue = ClioCoreQueue(root)
+    queue.register_endpoint(
+        EndpointRegistration(
+            endpoint_id="endpoint_pinned_worker",
+            role=EndpointRole.WORKER,
+            cluster="ares-p5run2",
+            hostname="worker",
+            pid=os.getpid(),
+            metadata={
+                "installation_info": worker_identity,
+                "scheduler_provider": "slurm",
+            },
+        )
+    )
+
+    def worker_process_matches(_pid: int) -> bool:
+        return True
+
+    monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(root))
+    monkeypatch.setattr(installation_module, "installation_info", lambda: current_identity)
+    monkeypatch.setattr(installation_module, "_worker_process_matches", worker_process_matches)
+
+    result = worker_runtime_info(
+        cluster="ares-p5run2",
+        freshness_seconds=120,
+        pinned_install_receipt_path=str(pinned_receipt_path),
+    )
+
+    assert result["identity_matches_current"] is False
+    assert result["identity_matches_pinned"] is True
+    assert result["pinned_installation"] == pinned_receipt.model_dump(mode="json")
+
+    # A cluster with no pin keeps returning None for both new fields.
+    unpinned_result = worker_runtime_info(cluster="ares-p5run2", freshness_seconds=120)
+    assert unpinned_result["pinned_installation"] is None
+    assert unpinned_result["identity_matches_pinned"] is None
+
+    # readiness-only stays a bounded flag surface -- the pinned fields never
+    # leak into it, matching every other detailed-only field.
+    readiness = worker_runtime_info(
+        cluster="ares-p5run2",
+        freshness_seconds=120,
+        readiness_only=True,
+        pinned_install_receipt_path=str(pinned_receipt_path),
+    )
+    assert "pinned_installation" not in readiness
+    assert "identity_matches_pinned" not in readiness
+
+
 def test_worker_runtime_info_reads_only_the_sealed_fresh_endpoint_index(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -590,6 +590,105 @@ def test_official_release_wheel_url_rejects_noncanonical_pypi_sources(url: str) 
     )
 
 
+_FULL_COMMIT_SHA = "a" * 40
+
+
+def test_vcs_commit_identity_accepts_exact_full_sha_pin() -> None:
+    """clio-relay#206: a VCS install pinned to a full 40-hex commit sha is exact."""
+    direct_url = {
+        "url": "https://github.com/iowarp/clio-relay",
+        "vcs_info": {
+            "vcs": "git",
+            "requested_revision": _FULL_COMMIT_SHA,
+            "commit_id": _FULL_COMMIT_SHA.upper(),
+        },
+    }
+    assert (
+        validation_report_module._vcs_commit_identity_verified(  # pyright: ignore[reportPrivateUsage]
+            direct_url
+        )
+        == _FULL_COMMIT_SHA
+    )
+
+
+@pytest.mark.parametrize(
+    "vcs_info",
+    [
+        # a branch reference is a moving target, not a fixed identity
+        {"vcs": "git", "requested_revision": "main", "commit_id": _FULL_COMMIT_SHA},
+        # a tag reference is also a moving target relative to a commit sha
+        {"vcs": "git", "requested_revision": "v1.6.6", "commit_id": _FULL_COMMIT_SHA},
+        # a short sha is not the full 40-hex identity anchor
+        {"vcs": "git", "requested_revision": _FULL_COMMIT_SHA[:12], "commit_id": _FULL_COMMIT_SHA},
+        # no requested_revision at all (unpinned VCS reference)
+        {"vcs": "git", "commit_id": _FULL_COMMIT_SHA},
+        # a non-git VCS is out of scope for this recognition
+        {"vcs": "hg", "requested_revision": _FULL_COMMIT_SHA, "commit_id": _FULL_COMMIT_SHA},
+        # requested_revision and the resolved commit_id disagree
+        {"vcs": "git", "requested_revision": _FULL_COMMIT_SHA, "commit_id": "b" * 40},
+    ],
+)
+def test_vcs_commit_identity_rejects_moving_or_inexact_references(
+    vcs_info: dict[str, object],
+) -> None:
+    """clio-relay#206: branch/tag refs and short shas never count as pinned."""
+    direct_url = {"url": "https://github.com/iowarp/clio-relay", "vcs_info": vcs_info}
+    assert (
+        validation_report_module._vcs_commit_identity_verified(  # pyright: ignore[reportPrivateUsage]
+            direct_url
+        )
+        is None
+    )
+    assert (
+        validation_report_module._vcs_commit_identity_verified(None)  # pyright: ignore[reportPrivateUsage]
+        is None
+    )
+
+
+def test_infer_running_artifact_identity_records_exact_vcs_sha() -> None:
+    """clio-relay#206: an exact-sha VCS pin is captured the same way a wheel digest is."""
+    distribution = metadata.distribution("clio-relay")
+    pinned_direct_url = {
+        "url": "https://github.com/iowarp/clio-relay",
+        "vcs_info": {
+            "vcs": "git",
+            "requested_revision": _FULL_COMMIT_SHA,
+            "commit_id": _FULL_COMMIT_SHA,
+        },
+    }
+    digest, verified = validation_report_module._infer_running_artifact_identity(  # pyright: ignore[reportPrivateUsage]
+        distribution,
+        detected_kind=InstallSourceKind.VCS,
+        direct_url=pinned_direct_url,
+        launcher="uv-tool",
+    )
+    assert digest == _FULL_COMMIT_SHA
+    assert verified is True
+
+    branch_direct_url = {
+        "url": "https://github.com/iowarp/clio-relay",
+        "vcs_info": {"vcs": "git", "requested_revision": "main", "commit_id": _FULL_COMMIT_SHA},
+    }
+    digest, verified = validation_report_module._infer_running_artifact_identity(  # pyright: ignore[reportPrivateUsage]
+        distribution,
+        detected_kind=InstallSourceKind.VCS,
+        direct_url=branch_direct_url,
+        launcher="uv-tool",
+    )
+    assert digest is None
+    assert verified is False
+
+    # a non uv-tool launcher never counts, matching the wheel path's own gate
+    digest, verified = validation_report_module._infer_running_artifact_identity(  # pyright: ignore[reportPrivateUsage]
+        distribution,
+        detected_kind=InstallSourceKind.VCS,
+        direct_url=pinned_direct_url,
+        launcher="uvx",
+    )
+    assert digest is None
+    assert verified is False
+
+
 def test_release_wheel_fetch_rejects_private_dns_and_unsafe_redirects(
     monkeypatch: MonkeyPatch,
 ) -> None:

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -528,6 +528,68 @@ def test_remote_wheel_fetch_rejects_noncanonical_sources(url: str) -> None:
     )
 
 
+def test_official_release_wheel_url_recognizes_github_unchanged() -> None:
+    """clio-relay#206: the pre-existing GitHub release-asset channel is untouched."""
+    url = (
+        "https://github.com/iowarp/clio-relay/releases/download/v1.6.6/"
+        "clio_relay-1.6.6-py3-none-any.whl"
+    )
+    assert validation_report_module._is_official_release_wheel_url(url) is True  # pyright: ignore[reportPrivateUsage]
+
+
+def test_official_release_wheel_url_recognizes_pypi_channel() -> None:
+    """clio-relay#206: PyPI (files.pythonhosted.org) is an official wheel channel too.
+
+    Observed live: a desktop ``uv tool install clio-relay==1.6.6`` resolved
+    from PyPI produced a wheel with the identical sha256 digest as the GitHub
+    release asset, but ``_is_official_release_wheel_url`` hardcoded
+    ``github.com`` and rejected it outright.
+    """
+    url = (
+        "https://files.pythonhosted.org/packages/4a/1e/"
+        "cadc4d66aa11223344556677889900aabbccddeeff00112233445566778899/"
+        "clio_relay-1.6.6-py3-none-any.whl"
+    )
+    assert validation_report_module._is_official_release_wheel_url(url) is True  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # wrong project name on an otherwise well-formed PyPI wheel path
+        "https://files.pythonhosted.org/packages/4a/1e/"
+        "cadc4d66aa11223344556677889900aabbccddeeff00112233445566778899/"
+        "other-project-1.6.6-py3-none-any.whl",
+        # credentials embedded in the host
+        "https://user@files.pythonhosted.org/packages/4a/1e/"
+        "cadc4d66aa11223344556677889900aabbccddeeff00112233445566778899/"
+        "clio_relay-1.6.6-py3-none-any.whl",
+        # query string smuggled onto an otherwise canonical URL
+        "https://files.pythonhosted.org/packages/4a/1e/"
+        "cadc4d66aa11223344556677889900aabbccddeeff00112233445566778899/"
+        "clio_relay-1.6.6-py3-none-any.whl?redirect=https://127.0.0.1",
+        # an arbitrary other host is never an official channel
+        "https://pypi.example.org/packages/4a/1e/"
+        "cadc4d66aa11223344556677889900aabbccddeeff00112233445566778899/"
+        "clio_relay-1.6.6-py3-none-any.whl",
+        # not the packages/ hash-addressed path shape at all
+        "https://files.pythonhosted.org/clio_relay-1.6.6-py3-none-any.whl",
+        # legacy simple-index style path is not the hash-addressed download path
+        "https://files.pythonhosted.org/packages/source/c/clio-relay/"
+        "clio_relay-1.6.6-py3-none-any.whl",
+    ],
+)
+def test_official_release_wheel_url_rejects_noncanonical_pypi_sources(url: str) -> None:
+    """clio-relay#206: recognition is narrow -- host and filename pattern both bind."""
+    assert validation_report_module._is_official_release_wheel_url(url) is False  # pyright: ignore[reportPrivateUsage]
+    assert (
+        validation_report_module._direct_wheel_bytes(  # pyright: ignore[reportPrivateUsage]
+            {"url": url, "archive_info": {}}
+        )
+        is None
+    )
+
+
 def test_release_wheel_fetch_rejects_private_dns_and_unsafe_redirects(
     monkeypatch: MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

**#205 -- per-cluster runtime identity in session-start verification**

`session start` verified a remote worker's identity against this SSH
session's own ambient `current` installation (`worker_runtime_info()`,
`installation.py:1186`), even when the target cluster's registry entry
declares a pinned runtime (the 1.6.6 schema's `relay_executable` /
`relay_install_receipt` fields). On a multi-tenant host where one
cluster is deliberately pinned to its own generation while the shared
`current` symlink stays on a different generation to protect other
tenants, a session could never start against the pinned cluster
(`verify_remote_worker_info()`, `installation.py:1288`, hard-failed on
`identity_matches_current`).

- `worker_runtime_info()` gains `pinned_install_receipt_path`. When
  given, it loads that receipt (independent of ambient `current`) and
  reports `pinned_installation` / `identity_matches_pinned` alongside
  the existing `current`-based fields.
- `verify_remote_worker_info()` checks the worker against the pin
  instead of `identity_matches_current`/`running` when the cluster
  declares one, raising a typed `ConfigurationError` naming both
  identities on mismatch. A cluster with no pin keeps today's
  current-based behavior unchanged, bit for bit.
- The pin is threaded from where the cluster registry actually lives:
  `_remote_worker_info()` (`cli.py`, desktop-side, holds the full
  `ClusterDefinition`) passes `definition.relay_install_receipt` as a
  new `--pinned-install-receipt-path` argument to the `endpoint
  worker-info` command that runs server-side over the SSH session --
  `worker_runtime_info()` itself has no other access to the desktop
  cluster registry.

This makes the check stronger for pinned clusters: a worker running
anything other than its cluster's pinned runtime now fails even if it
happens to match global `current`.

**#206 -- PyPI as an official wheel channel**

`_is_official_release_wheel_url()` (`validation_report.py:~3844`)
hardcoded `hostname == "github.com"`, so a desktop `uv tool install
clio-relay==X` resolved from PyPI (`files.pythonhosted.org`) could
never pass the persistent-uv-tool identity check
(`_persistent_uv_tool_install_receipt()`), even with wheel bytes
sha256-identical to the GitHub release asset. `files.pythonhosted.org`
wheel URLs matching the project's canonical
`clio_relay-<version>-py3-none-any.whl` filename are now recognized as
an official channel alongside GitHub release assets. The sha256
digest binding performed by `_wheel_url_matches_install` remains the
actual integrity anchor -- this change is purely channel recognition,
not a weakening of any digest verification.

**#206 (follow-up) -- exact-sha-pinned VCS uv-tool installs**

The dev channel has moved to sha-pinned git installs
(`uv tool install git+https://github.com/iowarp/clio-relay@<40-hex-sha>`).
`_persistent_uv_tool_install_receipt()` only recognized `WHEEL`/`PYPI`
kinds, so this install method could never pass the desktop
persistent-uv-tool identity check even when pinned to an exact commit.

- `_vcs_commit_identity_verified()` recognizes a VCS install as
  identity-verified only when `direct_url.json`'s `vcs_info` names a
  git install pinned to a full 40-hex commit sha (`requested_revision`
  matches `^[0-9a-fA-F]{40}$` and agrees with the resolved
  `commit_id`); a branch or tag reference is a moving target and stays
  rejected.
- `_infer_running_artifact_identity()` records that sha in
  `artifact_sha256` -- the same identity-anchor slot a wheel's sha256
  digest occupies.
- `_persistent_uv_tool_install_receipt()` now allows `VCS` alongside
  `WHEEL`/`PYPI`; the persistent-tool launcher structural check
  (`_detect_persistent_uv_tool_receipt`) is extended the same way,
  since a VCS-sourced uv-tool install has the identical managed-venv
  layout. Existing wheel-URL paths are unchanged.

## Test plan

- [x] `verify_remote_worker_info` -- (a) cluster pinned to G, worker
      reports G, current=OTHER -> passes
- [x] `verify_remote_worker_info` -- (b) cluster pinned to G, worker
      reports OTHER (including == current) -> typed failure naming
      both identities
- [x] `verify_remote_worker_info` -- pinned cluster still requires
      `fresh`/`process_running` liveness proof
- [x] `verify_remote_worker_info` -- (c) cluster pins nothing ->
      today's current-based behavior unchanged (pre-existing test,
      still green)
- [x] `worker_runtime_info` resolves a cluster-pinned receipt
      independent of ambient `current`; readiness-only stays bounded
      (no pinned fields leak in); no-pin case returns `None` for both
      new fields
- [x] CLI: `endpoint worker-info --pinned-install-receipt-path`
      forwards to `worker_runtime_info`; `_remote_worker_info` threads
      `ClusterDefinition.relay_install_receipt` into the remote args
      only when configured
- [x] `_is_official_release_wheel_url` -- GitHub URL unchanged; PyPI
      `clio_relay` wheel URL passes; wrong project name, credentials,
      query string, arbitrary host, and non-hash-addressed paths all
      still rejected
- [x] `_vcs_commit_identity_verified` -- full-sha pin accepted and
      returned lowercased; branch ref, tag ref, short sha, missing
      revision, non-git vcs, and requested/resolved-commit mismatch
      all rejected
- [x] `_infer_running_artifact_identity` (VCS branch) -- full-sha pin
      records the sha with `verified=True`; branch pin returns
      `(None, False)`; non uv-tool launcher rejected same as the wheel
      path
- [x] `installation_info()` end-to-end -- full-sha VCS uv-tool install
      passes with the sha captured as `receipt.artifact_sha256` /
      `requested_source == "vcs"`; branch-pinned VCS install raises
      the same typed `ConfigurationError` an unverified wheel would
- [x] `ruff check --fix`: clean
- [x] `ruff format --check`: clean
- [x] `uv run pyright` (full project): 0 errors
- [x] Targeted suites green (re-run after the VCS follow-up commit):
      `test_installation.py`, `test_cli.py`, `test_validation_report.py`
- [x] `test_bootstrap_fast_path.py`, `test_bootstrap_reconcile.py`,
      `test_live_acceptance.py` (verified against the first commit;
      untouched by the VCS follow-up)
- [ ] Full `pytest tests/` run: a full-suite pass was in progress at
      last check; the only observed failures were 8 pre-existing
      `test_clio_kit_mcp_contracts.py` fixture errors from stale
      sibling `clio-kit/dist` build artifacts on this dev machine
      (`CLIO_RELAY_CLIO_KIT_WHEEL` not configured), unrelated to this
      diff -- CI will validate post-merge

Fixes #205, fixes #206.
