### PR TITLE
feat(cli): add cluster pin-runtime and installation-write-receipt (#205)

### DIFF
--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -99,6 +99,7 @@ from clio_relay.installation import (
     verified_session_api_install_receipt,
     verify_remote_worker_info,
     worker_runtime_info,
+    write_self_install_receipt,
 )
 from clio_relay.jarvis_mcp import (
     CLIO_KIT_JARVIS_MCP_VERSION,
@@ -2120,6 +2121,104 @@ def cluster_pin_target(
                 ),
             },
             indent=2,
+        )
+    )
+
+
+@cluster_app.command("pin-runtime")
+def cluster_pin_runtime(
+    cluster: Annotated[str, typer.Option(help="Existing configured cluster name.")],
+    relay_executable: Annotated[
+        str | None,
+        typer.Option(help="Remote clio-relay executable path pinned to one generation."),
+    ] = None,
+    install_receipt: Annotated[
+        str | None,
+        typer.Option(help="Remote pinned install-receipt.json path for this cluster's generation."),
+    ] = None,
+    clear: Annotated[
+        bool,
+        typer.Option(help="Remove only the existing pinned runtime identity."),
+    ] = False,
+) -> None:
+    """Pin or clear one cluster's runtime identity without replacing its config.
+
+    Updates only ``relay_executable``/``relay_install_receipt`` on the
+    existing entry -- every other field (``remote_mcp_servers``,
+    ``target_identity``, worker capacity, transport config, ...) is
+    preserved exactly. Unlike ``cluster add``, this never replaces the
+    entry wholesale, so it is the sanctioned way to declare the per-cluster
+    pin that session-start verification honors (clio-relay#205).
+    """
+    identity_arguments_present = relay_executable is not None or install_receipt is not None
+    if clear and identity_arguments_present:
+        raise typer.BadParameter("--clear cannot be combined with pinned runtime values")
+    if not clear and not identity_arguments_present:
+        raise typer.BadParameter(
+            "--relay-executable or --install-receipt is required unless --clear is used"
+        )
+    default_relay_executable = cast(str, ClusterDefinition.model_fields["relay_executable"].default)
+
+    def update_pinned_runtime(registry: ClusterRegistry) -> None:
+        definition = registry.require(cluster)
+        if clear:
+            definition.relay_executable = default_relay_executable
+            definition.relay_install_receipt = None
+        else:
+            if relay_executable is not None:
+                definition.relay_executable = relay_executable
+            if install_receipt is not None:
+                definition.relay_install_receipt = install_receipt
+
+    try:
+        registry = ClusterRegistry.mutate(default_registry_path(), update_pinned_runtime)
+    except ValidationError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    definition = registry.require(cluster)
+    typer.echo(
+        json.dumps(
+            {
+                "cluster": cluster,
+                "relay_executable": definition.relay_executable,
+                "relay_install_receipt": definition.relay_install_receipt,
+            },
+            indent=2,
+        )
+    )
+
+
+@app.command("installation-write-receipt")
+def installation_write_receipt(
+    output: Annotated[Path, typer.Option(help="Destination install-receipt.json path.")],
+    self_flag: Annotated[
+        bool,
+        typer.Option(
+            "--self",
+            help="Describe this process's own running installation (currently the only mode).",
+        ),
+    ] = False,
+    force: Annotated[
+        bool,
+        typer.Option(help="Overwrite an existing receipt already at the destination path."),
+    ] = False,
+) -> None:
+    """Mint a durable install receipt describing this process's own running identity.
+
+    A cluster's pinned runtime (``cluster pin-runtime --install-receipt``,
+    clio-relay#205) points at a receipt written this way. Identity is
+    resolved exactly as the persistent-uv-tool identity check already
+    trusts it: a wheel's sha256 for a WHEEL/PYPI install, or the exact
+    pinned commit sha for an exact-sha VCS install (clio-relay#206).
+    """
+    if not self_flag:
+        raise typer.BadParameter("--self is required; only self-description is supported")
+    _run_or_exit(
+        lambda: typer.echo(
+            json.dumps(
+                write_self_install_receipt(output, force=force).model_dump(mode="json"),
+                indent=2,
+                default=str,
+            )
         )
     )
 

--- a/src/clio_relay/installation.py
+++ b/src/clio_relay/installation.py
@@ -1196,6 +1196,38 @@ def _persistent_uv_tool_install_receipt() -> tuple[InstallReceipt, InstallSource
     return receipt, source
 
 
+def write_self_install_receipt(path: Path, *, force: bool = False) -> InstallReceipt:
+    """Mint a durable receipt describing the RUNNING installation's own identity.
+
+    A dev-tool install has no receipt describing itself: ``installation_info()``
+    prefers any existing on-disk receipt at the default bootstrap-style path,
+    so a stale receipt left over from an earlier bootstrap deployment shadows
+    the actual running identity. A cluster's pinned runtime
+    (``cluster pin-runtime --install-receipt``, clio-relay#205) needs an
+    explicit, accurate receipt file to point at -- this mints one.
+
+    Identity is resolved exactly the way the persistent-uv-tool identity
+    check already trusts it: a wheel's sha256 digest for a WHEEL/PYPI
+    install, or the exact pinned commit sha for an exact-sha VCS install
+    (``_vcs_commit_identity_verified``, clio-relay#206). Never re-derived a
+    second, potentially divergent way.
+    """
+    if path.exists() and not force:
+        raise ConfigurationError(
+            f"install receipt already exists: {path} (use --force to overwrite)"
+        )
+    receipt, _source = _persistent_uv_tool_install_receipt()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(receipt.model_dump(mode="json"), indent=2, sort_keys=True) + "\n"
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    with temporary.open("w", encoding="utf-8", newline="\n") as stream:
+        stream.write(payload)
+        stream.flush()
+        os.fsync(stream.fileno())
+    os.replace(temporary, path)
+    return receipt
+
+
 def worker_runtime_info(
     *,
     cluster: str,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ import sys
 import time
 from contextlib import nullcontext
 from datetime import UTC, datetime, timedelta
+from importlib import metadata
 from pathlib import Path
 from threading import Thread
 from types import SimpleNamespace
@@ -22,6 +23,7 @@ from click import unstyle
 from filelock import FileLock
 from typer.testing import CliRunner
 
+import clio_relay.installation as installation_module
 import clio_relay.session_lifecycle as session_lifecycle
 from clio_relay import __version__, cli
 from clio_relay.cli import app
@@ -40,6 +42,7 @@ from clio_relay.errors import (
     QueueConflictError,
     RelayError,
 )
+from clio_relay.installation import verify_remote_worker_info, write_self_install_receipt
 from clio_relay.jarvis_mcp import (
     CLIO_KIT_JARVIS_MCP_VERSION,
     CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
@@ -86,7 +89,10 @@ from clio_relay.session_lifecycle import (
 )
 from clio_relay.validation_report import (
     EvidenceReference,
+    InstallSource,
+    InstallSourceKind,
     LiveValidationReport,
+    SoftwareIdentity,
     ValidationCheck,
     ValidationRecorder,
     ValidationResource,
@@ -8543,6 +8549,344 @@ def test_cli_cluster_pin_target_clear_is_exclusive_and_preserves_cluster_config(
     updated = ClusterRegistry.load(registry_path).require("frontier")
     assert updated.target_identity is None
     assert updated.model_copy(update={"target_identity": definition.target_identity}) == definition
+
+
+def test_cli_cluster_pin_runtime_preserves_every_unrelated_cluster_setting(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """clio-relay#205 follow-up: pin-runtime is a partial update, not a wholesale replace."""
+    monkeypatch.chdir(tmp_path)
+    registry_path = tmp_path / ".clio-relay" / "clusters.json"
+    definition = ClusterDefinition.model_validate(
+        {
+            "name": "ares-p5run2",
+            "ssh_host": "ares-login",
+            "bootstrap_profile": "site-profile",
+            "core_dir": "/srv/clio/core",
+            "spool_dir": "/scratch/clio/spool",
+            "jarvis_bin": "/opt/jarvis/bin/jarvis",
+            "spack_executable": "/opt/site/spack/bin/spack",
+            "frpc_bin": "/opt/frp/frpc",
+            "agent_bin": "/opt/agent/bin/agent",
+            "agent_adapter": "exec",
+            "agent_npm_package": "@example/agent",
+            "agent_npm_bin": "example-agent",
+            "agent_args": ["--profile", "science"],
+            "scheduler_provider": "slurm",
+            "remote_mcp_servers": {
+                "spack": {
+                    "command": "uvx",
+                    "args": [
+                        "--from",
+                        "/opt/clio/clio_kit-2.3.1-py3-none-any.whl",
+                        "clio-kit",
+                        "mcp-server",
+                        "spack",
+                    ],
+                    "namespace": "software",
+                    "allow_tools": ["spack_find", "spack_install"],
+                    "profiles": ["user"],
+                }
+            },
+            "frp_transport": {
+                "protocol": "tcp",
+                "server_addr": "relay.example.edu",
+                "server_port": 7000,
+                "token_env": "SITE_FRP_TOKEN",
+                "stcp_secret_env": "SITE_STCP_SECRET",
+                "direct": {
+                    "enabled": True,
+                    "mode": "xtcp",
+                    "fallback_order": ["xtcp", "frp_stcp", "queue"],
+                    "probe_timeout_seconds": 14,
+                },
+            },
+            "target_identity": {
+                "hostnames": ["ares-login.example.edu"],
+                "ssh_host_key_sha256": ["SHA256:pinned-key"],
+                "scheduler_cluster_name": "ares",
+                "site_marker_sha256": "a" * 64,
+            },
+        }
+    )
+    ClusterRegistry(clusters={"ares-p5run2": definition}).save(registry_path)
+    expected_unrelated = definition.model_dump(mode="json")
+    expected_unrelated.pop("relay_executable")
+    expected_unrelated.pop("relay_install_receipt")
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "cluster",
+            "pin-runtime",
+            "--cluster",
+            "ares-p5run2",
+            "--relay-executable",
+            "$HOME/.local/share/clio-relay/generations/g1/bin/clio-relay",
+            "--install-receipt",
+            "$HOME/.local/share/clio-relay/generations/g1/install-receipt.json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    updated = ClusterRegistry.load(registry_path).require("ares-p5run2")
+    actual_unrelated = updated.model_dump(mode="json")
+    actual_unrelated.pop("relay_executable")
+    actual_unrelated.pop("relay_install_receipt")
+    assert actual_unrelated == expected_unrelated
+    assert updated.relay_executable == "$HOME/.local/share/clio-relay/generations/g1/bin/clio-relay"
+    assert (
+        updated.relay_install_receipt
+        == "$HOME/.local/share/clio-relay/generations/g1/install-receipt.json"
+    )
+
+
+def test_cli_cluster_pin_runtime_clear_is_exclusive_and_preserves_cluster_config(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    registry_path = tmp_path / ".clio-relay" / "clusters.json"
+    definition = ClusterDefinition(
+        name="frontier",
+        ssh_host="frontier-login",
+        agent_args=["--keep-this"],
+        relay_executable="$HOME/.local/share/clio-relay/generations/g1/bin/clio-relay",
+        relay_install_receipt="$HOME/.local/share/clio-relay/generations/g1/install-receipt.json",
+    )
+    ClusterRegistry(clusters={"frontier": definition}).save(registry_path)
+
+    rejected = CliRunner().invoke(
+        app,
+        [
+            "cluster",
+            "pin-runtime",
+            "--cluster",
+            "frontier",
+            "--clear",
+            "--install-receipt",
+            "$HOME/unexpected/install-receipt.json",
+        ],
+    )
+    assert rejected.exit_code == 2
+    assert ClusterRegistry.load(registry_path).require("frontier") == definition
+
+    cleared = CliRunner().invoke(
+        app,
+        ["cluster", "pin-runtime", "--cluster", "frontier", "--clear"],
+    )
+    assert cleared.exit_code == 0, cleared.output
+    updated = ClusterRegistry.load(registry_path).require("frontier")
+    assert updated.relay_install_receipt is None
+    assert updated.relay_executable == ClusterDefinition.model_fields["relay_executable"].default
+    assert (
+        updated.model_copy(
+            update={
+                "relay_executable": definition.relay_executable,
+                "relay_install_receipt": definition.relay_install_receipt,
+            }
+        )
+        == definition
+    )
+
+
+def test_cli_cluster_pin_runtime_rejects_an_unconfigured_cluster(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """clio-relay#205 follow-up: a typed error, not a silently-created entry."""
+    monkeypatch.chdir(tmp_path)
+    registry_path = tmp_path / ".clio-relay" / "clusters.json"
+    ClusterRegistry(clusters={}).save(registry_path)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "cluster",
+            "pin-runtime",
+            "--cluster",
+            "nonexistent",
+            "--install-receipt",
+            "$HOME/.local/share/clio-relay/install-receipt.json",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert result.exception is not None
+    assert isinstance(result.exception, ConfigurationError)
+    assert "nonexistent" in str(result.exception)
+    assert ClusterRegistry.load(registry_path).clusters == {}
+
+
+def test_mint_receipt_then_pin_runtime_passes_verify_remote_worker_info_matrix(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """clio-relay#205/#206 end-to-end: dev-tool VCS install -> write-receipt -> pin-runtime.
+
+    Closes the loop the live deployment finding surfaced: a dev-tool VCS
+    install (exact-sha pinned) has no receipt describing its own identity,
+    so ``installation-write-receipt --self`` mints one; ``cluster
+    pin-runtime --install-receipt`` points the cluster's pin at it; and a
+    worker self-reporting that exact same sha then passes
+    ``verify_remote_worker_info`` even though this ssh session's own ambient
+    ``current`` is a different (stale) generation.
+    """
+    monkeypatch.chdir(tmp_path)
+    commit_sha = "9" * 40
+    version = metadata.version("clio-relay")
+    source_url = "https://github.com/iowarp/clio-relay"
+    uv_receipt = tmp_path / "tools" / "clio-relay" / "uv-receipt.toml"
+    uv_receipt.parent.mkdir(parents=True)
+    uv_receipt.write_text("[tool]\n", encoding="utf-8")
+    source = InstallSource(
+        kind=InstallSourceKind.VCS,
+        detected_kind=InstallSourceKind.VCS,
+        reference=source_url,
+        launcher="uv-tool",
+        package_path=str(tmp_path / "site-packages" / "clio_relay"),
+        distribution_version=version,
+        artifact_sha256=commit_sha,
+        direct_url={
+            "url": source_url,
+            "vcs_info": {
+                "vcs": "git",
+                "requested_revision": commit_sha,
+                "commit_id": commit_sha,
+            },
+        },
+        artifact_identity_verified=True,
+        released_artifact=False,
+        launcher_verified=True,
+        launcher_receipt={
+            "verified": True,
+            "uv_tool_receipt": {"path": str(uv_receipt), "verified": True},
+        },
+    )
+
+    def detect_source(**_kwargs: object) -> InstallSource:
+        return source
+
+    monkeypatch.setattr(installation_module, "detect_install_source", detect_source)
+
+    # 1. mint a receipt describing this dev-tool VCS install's own identity.
+    receipt_path = tmp_path / "generations" / "g1" / "install-receipt.json"
+    minted = write_self_install_receipt(receipt_path)
+    assert minted.artifact_sha256 == commit_sha
+
+    # 2. pin the cluster's runtime at that receipt (partial update, no wholesale replace).
+    # relay_install_receipt names a path on the CLUSTER host, not this test's local
+    # tmp_path -- `receipt_path` above is only where this test minted the bytes.
+    remote_receipt_path = "$HOME/.local/share/clio-relay/generations/g1/install-receipt.json"
+    registry_path = tmp_path / ".clio-relay" / "clusters.json"
+    definition = ClusterDefinition(
+        name="ares-p5run2",
+        ssh_host="ares-login",
+        scheduler_provider="slurm",
+        remote_mcp_servers={
+            "spack": RemoteMcpServerConfig(command="uvx", args=["spack"]),
+        },
+    )
+    ClusterRegistry(clusters={"ares-p5run2": definition}).save(registry_path)
+    pinned = CliRunner().invoke(
+        app,
+        [
+            "cluster",
+            "pin-runtime",
+            "--cluster",
+            "ares-p5run2",
+            "--install-receipt",
+            remote_receipt_path,
+        ],
+    )
+    assert pinned.exit_code == 0, pinned.output
+    updated = ClusterRegistry.load(registry_path).require("ares-p5run2")
+    assert updated.relay_install_receipt == remote_receipt_path
+    assert updated.remote_mcp_servers == definition.remote_mcp_servers
+
+    # 3. a worker self-reporting the exact same pinned sha passes verification,
+    #    even though this ssh session's own ambient `current` is a stale, different
+    #    generation -- the pin is authoritative, not `current`.
+    worker_matches_pin = {
+        "schema_version": "clio-relay.installation-info.v1",
+        "distribution_version": minted.distribution_version,
+        "software": minted.software.model_dump(mode="json"),
+        "receipt": minted.model_dump(mode="json"),
+        "receipt_origin": "uv-tool",
+        "install_source": None,
+        "receipt_matches_install": True,
+        "component_runtime": {},
+    }
+    stale_current = {
+        "schema_version": "clio-relay.installation-info.v1",
+        "distribution_version": "1.5.10",
+        "software": minted.software.model_dump(mode="json"),
+        "receipt": {**minted.model_dump(mode="json"), "artifact_sha256": "0" * 40},
+        "receipt_origin": "bootstrap",
+        "install_source": None,
+        "receipt_matches_install": True,
+        "component_runtime": {},
+    }
+    runtime: dict[str, object] = {
+        "schema_version": "clio-relay.worker-runtime-info.v1",
+        "cluster": "ares-p5run2",
+        "fresh": True,
+        "process_running": True,
+        "identity_matches_current": False,
+        "running": False,
+        "scheduler_provider": "slurm",
+        "endpoint": {
+            "role": "worker",
+            "cluster": "ares-p5run2",
+            "pid": 123,
+            "metadata": {"scheduler_provider": "slurm"},
+        },
+        "installation": stale_current,
+        "endpoint_installation": worker_matches_pin,
+        "target_identity": {
+            "verified": True,
+            "hostname": "ares-login",
+            "ssh_host_key_sha256": ["SHA256:test"],
+            "scheduler_cluster_name": "ares",
+        },
+        "pinned_installation": minted.model_dump(mode="json"),
+        "identity_matches_pinned": True,
+    }
+
+    verified = verify_remote_worker_info(
+        runtime,
+        expected_cluster="ares-p5run2",
+        expected_version=minted.distribution_version,
+        expected_software=SoftwareIdentity.model_validate(minted.software.model_dump(mode="json")),
+        expected_artifact_sha256=minted.artifact_sha256,
+        expected_source="vcs",
+        require_target_identity=False,
+    )
+    assert verified == minted
+
+    # a worker reporting anything other than the pin fails even though it now
+    # matches this session's `current` -- the pin remains authoritative.
+    drifted_runtime = {
+        **runtime,
+        "endpoint_installation": stale_current,
+        "installation": stale_current,
+        "identity_matches_current": True,
+        "running": True,
+        "identity_matches_pinned": False,
+    }
+    with pytest.raises(ConfigurationError, match="pinned installation"):
+        verify_remote_worker_info(
+            drifted_runtime,
+            expected_cluster="ares-p5run2",
+            expected_version="1.5.10",
+            expected_software=SoftwareIdentity.model_validate(
+                minted.software.model_dump(mode="json")
+            ),
+            expected_artifact_sha256="0" * 40,
+            expected_source="vcs",
+            require_target_identity=False,
+        )
 
 
 def test_ssh_host_key_fingerprints_prefers_all_configured_known_hosts_files(

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -38,6 +38,7 @@ from clio_relay.installation import (
     verify_remote_worker_info,
     worker_runtime_info,
     write_install_receipt,
+    write_self_install_receipt,
 )
 from clio_relay.jarvis_mcp import (
     CLIO_KIT_JARVIS_USER_CONTRACT_SHA256,
@@ -1198,6 +1199,91 @@ def test_installation_info_rejects_vcs_uv_tool_install_pinned_to_a_branch(
 
     with pytest.raises(ConfigurationError, match="wheel identity could not be verified"):
         installation_info()
+
+
+def _vcs_full_sha_install_source(
+    *, tmp_path: Path, commit_sha: str, uv_receipt: Path
+) -> InstallSource:
+    """Build a synthetic exact-sha-pinned VCS InstallSource for identity-minting tests."""
+    version = metadata.version("clio-relay")
+    source_url = "https://github.com/iowarp/clio-relay"
+    return InstallSource(
+        kind=InstallSourceKind.VCS,
+        detected_kind=InstallSourceKind.VCS,
+        reference=source_url,
+        launcher="uv-tool",
+        package_path=str(tmp_path / "site-packages" / "clio_relay"),
+        distribution_version=version,
+        artifact_sha256=commit_sha,
+        direct_url={
+            "url": source_url,
+            "vcs_info": {
+                "vcs": "git",
+                "requested_revision": commit_sha,
+                "commit_id": commit_sha,
+            },
+        },
+        artifact_identity_verified=True,
+        released_artifact=False,
+        launcher_verified=True,
+        launcher_receipt={
+            "verified": True,
+            "uv_tool_receipt": {"path": str(uv_receipt), "verified": True},
+        },
+    )
+
+
+def test_write_self_install_receipt_mints_exact_vcs_sha_and_refuses_to_clobber(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dev-tool VCS install has no on-disk receipt of its own; this mints one.
+
+    The minted receipt carries the exact pinned commit sha as its identity
+    anchor (clio-relay#206's ``_vcs_commit_identity_verified``), and the
+    command refuses to silently clobber an existing receipt without
+    ``--force`` -- a cluster's runtime pin (clio-relay#205) depends on this
+    file being trustworthy, not overwritten by accident.
+    """
+    commit_sha = "e" * 40
+    uv_receipt = tmp_path / "tools" / "clio-relay" / "uv-receipt.toml"
+    uv_receipt.parent.mkdir(parents=True)
+    uv_receipt.write_text("[tool]\n", encoding="utf-8")
+    source = _vcs_full_sha_install_source(
+        tmp_path=tmp_path, commit_sha=commit_sha, uv_receipt=uv_receipt
+    )
+
+    def detect_source(**_kwargs: object) -> InstallSource:
+        return source
+
+    monkeypatch.setattr(installation_module, "detect_install_source", detect_source)
+
+    output = tmp_path / "generations" / "g1" / "install-receipt.json"
+    receipt = write_self_install_receipt(output)
+
+    assert receipt.artifact_sha256 == commit_sha
+    assert receipt.requested_source == "vcs"
+    reloaded = load_install_receipt(output)
+    assert reloaded == receipt
+
+    with pytest.raises(ConfigurationError, match="already exists"):
+        write_self_install_receipt(output)
+
+    # a stale receipt from an earlier generation must not be clobbered silently
+    assert load_install_receipt(output) == receipt
+
+    other_sha = "f" * 40
+    other_source = _vcs_full_sha_install_source(
+        tmp_path=tmp_path, commit_sha=other_sha, uv_receipt=uv_receipt
+    )
+
+    def detect_other_source(**_kwargs: object) -> InstallSource:
+        return other_source
+
+    monkeypatch.setattr(installation_module, "detect_install_source", detect_other_source)
+    forced = write_self_install_receipt(output, force=True)
+    assert forced.artifact_sha256 == other_sha
+    assert load_install_receipt(output).artifact_sha256 == other_sha
 
 
 def test_remote_native_jarvis_component_requires_runtime_capability_provenance(


### PR DESCRIPTION
## Summary

PR #207 shipped the READ side of the per-cluster runtime pin (session-start
verification honors `relay_install_receipt` when set), but there was no
sanctioned command that WRITES that field. `cluster add` wholesale-replaces
the entry (dangerous -- wipes `remote_mcp_servers` and every other field not
passed on the command line), and direct `clusters.json` editing is against
deployment discipline.

**`cluster pin-runtime`** -- a minimal partial-update command mirroring
`cluster pin-target`'s update-in-place semantics:

```
clio-relay cluster pin-runtime --cluster <name> \
  [--relay-executable PATH] [--install-receipt PATH] [--clear]
```

- Touches only `relay_executable`/`relay_install_receipt` on the existing
  entry inside one locked read-modify-write (`ClusterRegistry.mutate`);
  every other field (`remote_mcp_servers`, `target_identity`, worker
  capacity, transport config, ...) is preserved exactly.
- `--clear` resets both fields to their un-pinned defaults
  (`relay_executable` back to the global `$HOME/.local/bin/clio-relay`,
  `relay_install_receipt` back to `None`); mutually exclusive with the
  pin values, matching `pin-target --clear`.
- Raises a typed `ConfigurationError` if the cluster is not configured
  (`ClusterRegistry.require`), rather than silently creating an entry.

**`installation-write-receipt`** -- the second half of the gap found live:
a dev-tool install has no receipt describing its own identity.
`installation_info()` prefers any existing on-disk receipt at the default
bootstrap-style path, so a stale receipt left over from an earlier
bootstrap deployment shadows the actual running identity -- `cluster
pin-runtime --install-receipt` needs a real file to point at.

```
clio-relay installation-write-receipt --self --output PATH [--force]
```

- Mints a durable `InstallReceipt` describing the running installation's
  own identity, reusing the persistent-uv-tool identity resolution
  (`_persistent_uv_tool_install_receipt`) so the minted receipt can never
  diverge from what the identity check already trusts: a wheel's sha256
  digest for a WHEEL/PYPI install, or the exact pinned commit sha for an
  exact-sha VCS install (`_vcs_commit_identity_verified`, #206).
- Refuses to overwrite an existing receipt without `--force`.

## Test plan

- [x] `cluster pin-runtime` preserves every unrelated field
      (`remote_mcp_servers`, transport config, target identity, ...) byte
      for byte; only `relay_executable`/`relay_install_receipt` change
- [x] `cluster pin-runtime --clear` is mutually exclusive with pin values
      (exit 2, config untouched) and resets both fields to their defaults
      when used alone, preserving everything else
- [x] `cluster pin-runtime` against an unconfigured cluster raises a typed
      `ConfigurationError` naming the cluster; registry stays untouched
- [x] `write_self_install_receipt` mints a receipt carrying the exact VCS
      commit sha as `artifact_sha256`; refuses to overwrite without
      `--force`; `--force` overwrites and the new content round-trips
- [x] End-to-end matrix: dev-tool VCS install -> `write_self_install_receipt`
      -> `cluster pin-runtime --install-receipt` (preserving
      `remote_mcp_servers`) -> `verify_remote_worker_info` passes against a
      worker self-reporting that exact sha even though this session's own
      ambient `current` is a stale, different generation -- and correctly
      fails when the worker instead matches `current` but diverges from
      the pin
- [x] `ruff check --fix`: clean
- [x] `ruff format`: clean
- [x] `uv run pyright` on all touched files: 0 errors
- [x] `test_cluster_config.py`: green
- [x] Full `test_installation.py`: green
- [x] Full `test_cli.py`: green (211+ tests)

Follow-up to #205/#206 (PR #207).
