### PR TITLE
feat(cli): installation-write-receipt --components-from for mixed installs

### DIFF
--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -2201,6 +2201,17 @@ def installation_write_receipt(
         bool,
         typer.Option(help="Overwrite an existing receipt already at the destination path."),
     ] = False,
+    components_from: Annotated[
+        Path | None,
+        typer.Option(
+            help=(
+                "Copy components/component_artifacts verbatim from this generation "
+                "receipt, for a mixed install where relay is self-described but "
+                "components (clio-kit, jarvis-cd, ...) still come from a bootstrap "
+                "generation's locked runtime."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Mint a durable install receipt describing this process's own running identity.
 
@@ -2209,13 +2220,23 @@ def installation_write_receipt(
     resolved exactly as the persistent-uv-tool identity check already
     trusts it: a wheel's sha256 for a WHEEL/PYPI install, or the exact
     pinned commit sha for an exact-sha VCS install (clio-relay#206).
+
+    ``--components-from`` supports a legitimate mixed dev-channel install:
+    relay identity is minted for this process (self), while
+    components/component_artifacts are inherited verbatim from another
+    receipt -- the generation that genuinely installed them -- with the
+    source path recorded on the minted receipt for provenance.
     """
     if not self_flag:
         raise typer.BadParameter("--self is required; only self-description is supported")
     _run_or_exit(
         lambda: typer.echo(
             json.dumps(
-                write_self_install_receipt(output, force=force).model_dump(mode="json"),
+                write_self_install_receipt(
+                    output,
+                    force=force,
+                    components_from=components_from,
+                ).model_dump(mode="json"),
                 indent=2,
                 default=str,
             )

--- a/src/clio_relay/installation.py
+++ b/src/clio_relay/installation.py
@@ -302,6 +302,11 @@ class InstallReceipt(BaseModel):
     deployment_fingerprint: str | None = None
     deployment_manifest: dict[str, object] | None = None
     generation: str | None = None
+    # Provenance note for a mixed install (e.g. relay identity minted from a
+    # local build, components inherited from a bootstrap generation): the
+    # source receipt path components/component_artifacts were copied
+    # verbatim from. None when this receipt's own process derived them.
+    components_source_receipt: str | None = None
 
     @model_validator(mode="after")
     def validate_deployment_identity(self) -> InstallReceipt:
@@ -1196,7 +1201,12 @@ def _persistent_uv_tool_install_receipt() -> tuple[InstallReceipt, InstallSource
     return receipt, source
 
 
-def write_self_install_receipt(path: Path, *, force: bool = False) -> InstallReceipt:
+def write_self_install_receipt(
+    path: Path,
+    *,
+    force: bool = False,
+    components_from: Path | None = None,
+) -> InstallReceipt:
     """Mint a durable receipt describing the RUNNING installation's own identity.
 
     A dev-tool install has no receipt describing itself: ``installation_info()``
@@ -1211,12 +1221,41 @@ def write_self_install_receipt(path: Path, *, force: bool = False) -> InstallRec
     install, or the exact pinned commit sha for an exact-sha VCS install
     (``_vcs_commit_identity_verified``, clio-relay#206). Never re-derived a
     second, potentially divergent way.
+
+    ``components_from`` names another receipt -- the generation receipt
+    that genuinely installed components such as clio-kit/jarvis-cd -- whose
+    ``components``/``component_artifacts`` blocks are copied verbatim into
+    the minted receipt. This is for a legitimate mixed dev-channel install:
+    relay identity is this process's own (self), while its components are
+    still served by a bootstrap generation's locked runtime. The source
+    path is recorded on ``components_source_receipt`` so the mix is
+    traceable, never silent. Refuses when the source receipt carries no
+    component artifacts to inherit.
     """
     if path.exists() and not force:
         raise ConfigurationError(
             f"install receipt already exists: {path} (use --force to overwrite)"
         )
     receipt, _source = _persistent_uv_tool_install_receipt()
+    if components_from is not None:
+        try:
+            source_receipt = load_install_receipt(components_from)
+        except ConfigurationError as exc:
+            raise ConfigurationError(
+                f"components source receipt could not be loaded: {components_from}: {exc}"
+            ) from exc
+        if not source_receipt.component_artifacts:
+            raise ConfigurationError(
+                "components source receipt has no component artifacts to inherit: "
+                f"{components_from}"
+            )
+        receipt = receipt.model_copy(
+            update={
+                "components": dict(source_receipt.components),
+                "component_artifacts": dict(source_receipt.component_artifacts),
+                "components_source_receipt": str(components_from),
+            }
+        )
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = json.dumps(receipt.model_dump(mode="json"), indent=2, sort_keys=True) + "\n"
     temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,7 +42,11 @@ from clio_relay.errors import (
     QueueConflictError,
     RelayError,
 )
-from clio_relay.installation import verify_remote_worker_info, write_self_install_receipt
+from clio_relay.installation import (
+    InstallReceipt,
+    verify_remote_worker_info,
+    write_self_install_receipt,
+)
 from clio_relay.jarvis_mcp import (
     CLIO_KIT_JARVIS_MCP_VERSION,
     CLIO_KIT_JARVIS_MCP_WHEEL_SHA256,
@@ -805,6 +809,46 @@ def test_endpoint_worker_info_forwards_pinned_install_receipt_path(
         observed["pinned_install_receipt_path"]
         == "$HOME/.local/share/clio-relay/generations/g1/install-receipt.json"
     )
+
+
+def test_installation_write_receipt_forwards_components_from(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The CLI surface forwards --components-from to write_self_install_receipt."""
+    observed: dict[str, object] = {}
+    output_path = tmp_path / "generations" / "mixed" / "install-receipt.json"
+    source_path = tmp_path / "generation-install-receipt.json"
+
+    def write_receipt(path: Path, **kwargs: object) -> InstallReceipt:
+        observed["path"] = path
+        observed.update(kwargs)
+        return InstallReceipt(
+            installed_at=datetime.now(UTC),
+            install_spec="checkout",
+            requested_source="vcs",
+            distribution_version="0.0.0",
+            software=SoftwareIdentity(version="0.0.0"),
+        )
+
+    monkeypatch.setattr(cli, "write_self_install_receipt", write_receipt)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "installation-write-receipt",
+            "--self",
+            "--output",
+            str(output_path),
+            "--components-from",
+            str(source_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert observed["path"] == output_path
+    assert observed["components_from"] == source_path
+    assert observed["force"] is False
 
 
 def test_cli_lists_artifacts(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -1286,6 +1286,164 @@ def test_write_self_install_receipt_mints_exact_vcs_sha_and_refuses_to_clobber(
     assert load_install_receipt(output).artifact_sha256 == other_sha
 
 
+def test_write_self_install_receipt_inherits_components_from_source_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mixed dev-channel install: relay identity is self, components are inherited.
+
+    ``jarvis_mcp_command()`` requires ``component_artifacts.clio-kit`` on
+    the receipt and fails typed without it -- blocking the door's JARVIS
+    catalog refresh whenever relay is minted from a local build/VCS pin but
+    clio-kit/jarvis-cd still come from a bootstrap generation's locked
+    runtime. ``--components-from`` copies that generation receipt's
+    components/component_artifacts verbatim into the minted receipt.
+    """
+    # --- the source ("generation") receipt that genuinely installed clio-kit ---
+    relay_wheel = tmp_path / "clio_relay-1.0.0-py3-none-any.whl"
+    relay_wheel.write_bytes(b"relay-wheel")
+    clio_kit_wheel = tmp_path / "clio_kit-2.3.1-py3-none-any.whl"
+    clio_kit_wheel.write_bytes(b"clio-kit-wheel")
+    tool = tmp_path / "clio-kit.exe"
+    tool.write_bytes(b"persistent-tool")
+    uv = tmp_path / "uv.exe"
+    uv.write_bytes(b"uv")
+    persistent_tool = PersistentUvToolIdentity(
+        uv_executable=str(uv.resolve()),
+        uv_version="0.11.28",
+        uv_executable_sha256=hashlib.sha256(b"uv").hexdigest(),
+        tool_directory=str(tmp_path / "tools"),
+        tool_bin_directory=str(tmp_path),
+        environment_prefix=str(tmp_path / "tools" / "clio-kit"),
+        provider_interpreter=sys.executable,
+        provider_interpreter_sha256="a" * 64,
+        tool_executable=str(tool.resolve()),
+        tool_executable_resolved=str(tool.resolve()),
+        tool_executable_sha256=hashlib.sha256(b"persistent-tool").hexdigest(),
+        distribution_console_script_path=str(tool.resolve()),
+        distribution_console_script_sha256=hashlib.sha256(b"persistent-tool").hexdigest(),
+        uv_receipt_path=str(tmp_path / "tools" / "clio-kit" / "uv-receipt.toml"),
+        uv_receipt_sha256="d" * 64,
+        distribution="clio-kit",
+        distribution_version="2.3.1",
+        distribution_metadata_path=str(tmp_path / "clio-kit.dist-info"),
+        entry_point="clio-kit",
+        source_artifact_path=str(clio_kit_wheel.resolve()),
+        source_artifact_sha256=hashlib.sha256(b"clio-kit-wheel").hexdigest(),
+        record_path=str(tmp_path / "clio-kit.dist-info" / "RECORD"),
+        record_sha256="b" * 64,
+        runtime_closure_sha256="c" * 64,
+        runtime_file_count=10,
+        runtime_bytes=1_024,
+        pyvenv_uv_version="0.11.28",
+    )
+    command = [str(tool), "mcp-server", "jarvis"]
+    source_receipt_path = tmp_path / "generation-install-receipt.json"
+    write_install_receipt(
+        install_spec=str(relay_wheel),
+        artifact_path=relay_wheel,
+        path=source_receipt_path,
+        components={"clio-kit": "2.3.1"},
+        component_artifacts={
+            "clio-kit": ComponentArtifactIdentity(
+                distribution="clio-kit",
+                distribution_version="2.3.1",
+                install_spec="clio-kit==2.3.1",
+                requested_source="pypi",
+                artifact_filename=clio_kit_wheel.name,
+                artifact_sha256=hashlib.sha256(b"clio-kit-wheel").hexdigest(),
+                runtime_artifact_path=str(clio_kit_wheel),
+                runtime_command=command,
+                runtime_interpreters={"provider": sys.executable},
+                runtime_executables={"clio-kit": str(tool), "uv": str(uv)},
+                persistent_tool=persistent_tool,
+                locked_server_runtime=_verified_locked_jarvis_runtime(),
+            )
+        },
+    )
+
+    def persistent_identity(**_kwargs: object) -> PersistentUvToolIdentity:
+        return persistent_tool
+
+    monkeypatch.setattr(
+        "clio_relay.installation.probe_persistent_uv_tool_identity",
+        persistent_identity,
+    )
+
+    # --- mint a receipt describing THIS process's own (self) identity: a
+    #     VCS exact-sha pin, inheriting components from the generation receipt ---
+    commit_sha = "7" * 40
+    uv_receipt = tmp_path / "tools" / "clio-relay" / "uv-receipt.toml"
+    uv_receipt.parent.mkdir(parents=True)
+    uv_receipt.write_text("[tool]\n", encoding="utf-8")
+    self_source = _vcs_full_sha_install_source(
+        tmp_path=tmp_path, commit_sha=commit_sha, uv_receipt=uv_receipt
+    )
+
+    def detect_self_source(**_kwargs: object) -> InstallSource:
+        return self_source
+
+    monkeypatch.setattr(installation_module, "detect_install_source", detect_self_source)
+
+    minted_path = tmp_path / "generations" / "mixed" / "install-receipt.json"
+    minted = write_self_install_receipt(minted_path, components_from=source_receipt_path)
+
+    # (a) self identity is correct AND the clio-kit component is present verbatim.
+    assert minted.artifact_sha256 == commit_sha
+    assert minted.requested_source == "vcs"
+    assert minted.components == {"clio-kit": "2.3.1"}
+    assert minted.component_artifacts["clio-kit"] == ComponentArtifactIdentity(
+        distribution="clio-kit",
+        distribution_version="2.3.1",
+        install_spec="clio-kit==2.3.1",
+        requested_source="pypi",
+        artifact_filename=clio_kit_wheel.name,
+        artifact_sha256=hashlib.sha256(b"clio-kit-wheel").hexdigest(),
+        runtime_artifact_path=str(clio_kit_wheel),
+        runtime_command=command,
+        runtime_interpreters={"provider": sys.executable},
+        runtime_executables={"clio-kit": str(tool), "uv": str(uv)},
+        persistent_tool=persistent_tool,
+        locked_server_runtime=_verified_locked_jarvis_runtime(),
+    )
+    assert minted.components_source_receipt == str(source_receipt_path)
+
+    # (c) the load-bearing proof: jarvis_mcp_command() derives successfully
+    #     against the MINTED (mixed) receipt, mirroring how
+    #     test_jarvis_mcp_defaults_to_persistent_receipt_bound_clio_kit_tool
+    #     consumes an ordinary (non-mixed) receipt.
+    monkeypatch.setenv(INSTALL_RECEIPT_PATH_ENV, str(minted_path))
+    monkeypatch.delenv(JARVIS_MCP_COMMAND_ENV, raising=False)
+    assert jarvis_mcp_command() == command
+
+
+def test_write_self_install_receipt_refuses_components_from_without_component_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """(b) a source receipt with nothing to inherit is a typed refusal, not a silent no-op."""
+    commit_sha = "8" * 40
+    uv_receipt = tmp_path / "tools" / "clio-relay" / "uv-receipt.toml"
+    uv_receipt.parent.mkdir(parents=True)
+    uv_receipt.write_text("[tool]\n", encoding="utf-8")
+    source = _vcs_full_sha_install_source(
+        tmp_path=tmp_path, commit_sha=commit_sha, uv_receipt=uv_receipt
+    )
+
+    def detect_source(**_kwargs: object) -> InstallSource:
+        return source
+
+    monkeypatch.setattr(installation_module, "detect_install_source", detect_source)
+
+    empty_source_receipt_path = tmp_path / "empty-receipt.json"
+    write_install_receipt(install_spec="checkout", path=empty_source_receipt_path)
+
+    minted_path = tmp_path / "generations" / "mixed" / "install-receipt.json"
+    with pytest.raises(ConfigurationError, match="no component artifacts to inherit"):
+        write_self_install_receipt(minted_path, components_from=empty_source_receipt_path)
+    assert not minted_path.exists()
+
+
 def test_remote_native_jarvis_component_requires_runtime_capability_provenance(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

PR #208's `installation-write-receipt --self` mints `component_artifacts: {}`
-- but a dev-channel install legitimately mixes components: relay identity
comes from a locally built wheel or an exact-sha VCS pin (#206), while
clio-kit/jarvis-cd still come from a bootstrap generation's locked runtime.
`jarvis_mcp_command()` (`jarvis_mcp.py` ~225-231, via
`jarvis_mcp_runtime_identity`) requires `component_artifacts.clio-kit` on
the receipt and fails typed (`"install receipt has no clio-kit component
artifact"`) without it -- blocking the door's JARVIS catalog refresh on a
mixed-install redeploy.

**`installation-write-receipt --self --output PATH --components-from
<source-receipt-path>`**

- Loads the source receipt and copies its `components`/`component_artifacts`
  blocks verbatim into the minted receipt. The source is the generation
  receipt that genuinely installed those components, so the minted receipt
  truthfully describes the mix: relay identity = self (this process's own),
  components = inherited.
- Records the source path on a new `InstallReceipt.components_source_receipt`
  provenance field, so a mixed receipt is always traceable, never silently
  assembled.
- Refuses (typed `ConfigurationError`) when the source receipt has no
  `component_artifacts` to inherit -- copying nothing would misrepresent an
  ordinary self-only install as a verified mix.
- `--force` continues to govern only whether the *destination* receipt may
  be overwritten, unchanged from #208.

## Test plan

- [x] (a) mint with `--components-from` a fixture generation receipt (built
      with the same fixture shape the existing
      `test_jarvis_mcp_defaults_to_persistent_receipt_bound_clio_kit_tool`
      test proves works) -> `component_artifacts.clio-kit` present verbatim,
      `components` present verbatim, self identity (VCS exact-sha) correct,
      `components_source_receipt` records the source path
- [x] (b) source receipt with no `component_artifacts` -> typed refusal
      (`"no component artifacts to inherit"`); destination file never
      created
- [x] (c) the load-bearing proof: `jarvis_mcp_command()` derives
      successfully against the minted mixed receipt (via
      `INSTALL_RECEIPT_PATH_ENV`), returning the exact clio-kit runtime
      command -- mirroring `jarvis_mcp_runtime_identity`'s own consumption
      rather than only asserting the receipt's shape
- [x] CLI-level: `--components-from` forwards to
      `write_self_install_receipt` unchanged
- [x] `ruff check --fix`: clean
- [x] `ruff format`: clean
- [x] `uv run pyright` on all touched files: 0 errors
- [x] Full `test_installation.py`: green
- [x] Full `test_jarvis_mcp_validation.py`: green
- [x] Full `test_cli.py`: green (all tests)

Follow-up to #205/#206/#207/#208.
