### PR TITLE
feat: first-class DEV MODE downgrades install/identity/receipt verification to warnings (#211)

### DIFF
--- a/src/clio_relay/cli.py
+++ b/src/clio_relay/cli.py
@@ -77,6 +77,7 @@ from clio_relay.deployment import (
     restart_endpoint_user_service_over_ssh,
     write_endpoint_user_service,
 )
+from clio_relay.dev_mode import VerificationFindings, dev_mode_enabled
 from clio_relay.doctor import run_cluster_doctor, run_doctor
 from clio_relay.endpoint import EndpointWorker
 from clio_relay.endpoint_service_status import endpoint_service_readiness_over_ssh
@@ -1770,6 +1771,15 @@ def endpoint_worker_info(
             ),
         ),
     ] = None,
+    dev_mode: Annotated[
+        bool,
+        typer.Option(
+            help=(
+                "clio-relay#211: cluster-registered dev_mode, threaded in by the "
+                "caller. Combined with CLIO_RELAY_DEV_MODE on this host either way."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Report fresh process-bound identity for the active cluster worker."""
     _run_or_exit(
@@ -1780,6 +1790,7 @@ def endpoint_worker_info(
                     freshness_seconds=freshness_seconds,
                     readiness_only=readiness_only,
                     pinned_install_receipt_path=pinned_install_receipt_path,
+                    dev_mode=dev_mode_enabled(cluster_dev_mode=dev_mode),
                 ),
                 indent=2,
             )
@@ -1981,6 +1992,16 @@ def cluster_add(
         str | None,
         typer.Option(help="Expected SHA-256 of the remote /etc/machine-id site marker."),
     ] = None,
+    dev_mode: Annotated[
+        bool,
+        typer.Option(
+            "--dev-mode/--no-dev-mode",
+            help=(
+                "clio-relay#211: downgrade this cluster's install/identity/receipt/sha "
+                "verification chain to warnings instead of raising. Never for production."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Add or update a local cluster definition."""
     if (target_hostname is None) != (ssh_host_key_sha256 is None):
@@ -2002,6 +2023,7 @@ def cluster_add(
             agent_bin=_none_if_blank(agent_bin),
             agent_adapter=agent_adapter,
             scheduler_provider=scheduler_provider,
+            dev_mode=dev_mode,
             worker_capacity=WorkerCapacityPolicy(
                 concurrency=worker_concurrency,
                 control_query_concurrency=worker_control_query_concurrency,
@@ -2212,6 +2234,16 @@ def installation_write_receipt(
             ),
         ),
     ] = None,
+    dev_mode: Annotated[
+        bool,
+        typer.Option(
+            help=(
+                "clio-relay#211: mint a best-effort receipt even when identity "
+                "derivation would otherwise fail, recording each finding as a "
+                "warning instead. Never for production."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Mint a durable install receipt describing this process's own running identity.
 
@@ -2229,19 +2261,24 @@ def installation_write_receipt(
     """
     if not self_flag:
         raise typer.BadParameter("--self is required; only self-description is supported")
-    _run_or_exit(
-        lambda: typer.echo(
-            json.dumps(
-                write_self_install_receipt(
-                    output,
-                    force=force,
-                    components_from=components_from,
-                ).model_dump(mode="json"),
-                indent=2,
-                default=str,
-            )
+    resolved_dev_mode = dev_mode_enabled(cluster_dev_mode=dev_mode)
+    findings = VerificationFindings()
+
+    def action() -> None:
+        receipt = write_self_install_receipt(
+            output,
+            force=force,
+            components_from=components_from,
+            dev_mode=resolved_dev_mode,
+            findings=findings,
         )
-    )
+        payload: dict[str, object] = receipt.model_dump(mode="json")
+        dev_mode_payload = findings.payload()
+        if dev_mode_payload is not None:
+            payload.update(dev_mode_payload)
+        typer.echo(json.dumps(payload, indent=2, default=str))
+
+    _run_or_exit(action)
 
 
 @remote_mcp_app.command("register")
@@ -4082,7 +4119,13 @@ def session_plan_start(
     settings = RelaySettings.from_env()
 
     def action() -> None:
-        release_identity = _verify_session_start_worker_release_identity(definition)
+        dev_mode_findings = VerificationFindings()
+        release_identity = _verify_session_start_worker_release_identity(
+            definition,
+            dev_mode=dev_mode_enabled(cluster_dev_mode=definition.dev_mode),
+            findings=dev_mode_findings,
+        )
+        _echo_dev_mode_findings(dev_mode_findings)
         typer.echo(
             plan_remote_session_start(
                 cluster=cluster,
@@ -4148,7 +4191,13 @@ def session_start(
             expected_api_release_identity_sha256=expected_api_release_identity_sha256,
         )
         with _session_transition_lock(cluster=cluster, session_id=session_id):
-            api_release_identity = _verify_session_start_worker_release_identity(definition)
+            dev_mode_findings = VerificationFindings()
+            api_release_identity = _verify_session_start_worker_release_identity(
+                definition,
+                dev_mode=dev_mode_enabled(cluster_dev_mode=definition.dev_mode),
+                findings=dev_mode_findings,
+            )
+            _echo_dev_mode_findings(dev_mode_findings)
             if (
                 expected_api_release_identity_sha256 is not None
                 and api_release_identity.sha256() != expected_api_release_identity_sha256
@@ -5212,8 +5261,24 @@ def _persist_verified_cleanup_report_before_closure(
 
 def _verify_session_start_worker_release_identity(
     definition: ClusterDefinition,
+    *,
+    dev_mode: bool = False,
+    findings: VerificationFindings | None = None,
 ) -> SessionApiReleaseIdentity:
-    """Require one exact live worker/install identity before session mutation."""
+    """Require one exact live worker/install identity before session mutation.
+
+    ``dev_mode`` (clio-relay#211) downgrades the REMOTE worker's identity
+    comparison to a recorded warning instead of raising -- this is the
+    "identity_matches_current" wall observed live on a cluster pinned to a
+    dev sha. The local desktop identity resolution is unaffected by this
+    parameter (it already honors ``CLIO_RELAY_DEV_MODE`` on its own via
+    ``installation_info``'s default): session start still requires *a*
+    session-API process-attestation identity to bind to, so when the
+    downgraded remote receipt has no artifact sha at all, one is derived
+    deterministically from what IS known and clearly marked advisory rather
+    than silently treated as a real release digest.
+    """
+    findings = findings if findings is not None else VerificationFindings()
     local_identity = _session_api_release_identity_from_installation(
         installation_info(),
         label="local clio-relay",
@@ -5225,15 +5290,39 @@ def _verify_session_start_worker_release_identity(
         expected_software=local_identity.software,
         expected_artifact_sha256=local_identity.artifact_sha256,
         expected_source=None,
+        dev_mode=dev_mode,
+        findings=findings,
     )
     artifact_sha256 = remote_receipt.artifact_sha256
     if artifact_sha256 is None:
-        raise ConfigurationError("remote worker receipt omitted its artifact SHA-256")
+        if not dev_mode:
+            raise ConfigurationError("remote worker receipt omitted its artifact SHA-256")
+        message = "remote worker receipt omitted its artifact SHA-256"
+        findings.record(message)
+        artifact_sha256 = hashlib.sha256(
+            f"dev-mode-advisory:{remote_receipt.distribution_version}:"
+            f"{remote_receipt.install_spec}".encode()
+        ).hexdigest()
     return SessionApiReleaseIdentity(
         distribution_version=remote_receipt.distribution_version,
         artifact_sha256=artifact_sha256,
         software=remote_receipt.software,
     )
+
+
+def _echo_dev_mode_findings(findings: VerificationFindings) -> None:
+    """Print the DEV MODE banner + downgraded findings to stderr, when present.
+
+    clio-relay#211 requires every status/info surface a downgraded check
+    can reach to carry an unmissable marker; commands that return a typed,
+    ``extra="forbid"`` payload (a session start plan, an install receipt)
+    cannot have arbitrary keys merged in, so this prints the same banner
+    payload as a companion line instead of silently dropping it.
+    """
+    dev_mode_payload = findings.payload()
+    if dev_mode_payload is None:
+        return
+    typer.echo(json.dumps(dev_mode_payload, indent=2), err=True)
 
 
 def _session_api_release_identity_from_installation(
@@ -18003,6 +18092,8 @@ def _remote_worker_info(
     args = ["endpoint", "worker-info", "--cluster", definition.name]
     if definition.relay_install_receipt is not None:
         args = [*args, "--pinned-install-receipt-path", definition.relay_install_receipt]
+    if definition.dev_mode:
+        args = [*args, "--dev-mode"]
     info = _json_output(
         _run_remote_clio_before_deadline(
             definition,

--- a/src/clio_relay/cluster_config.py
+++ b/src/clio_relay/cluster_config.py
@@ -433,6 +433,13 @@ class ClusterDefinition(BaseModel):
     spool_dir: str = "$HOME/.local/share/clio-relay/spool"
     relay_executable: str = "$HOME/.local/bin/clio-relay"
     relay_install_receipt: str | None = None
+    # clio-relay#211: downgrades this cluster's install/identity/receipt/sha
+    # verification chain to typed warnings instead of raising. CLIO_RELAY_DEV_MODE=1
+    # (environment) is equivalent; either is sufficient. See dev_mode.py --
+    # checks protecting live state (writer proof, worker-lifetime lock, storage
+    # admission, teardown scoping) and physical target identity never consult
+    # this flag and stay hard regardless.
+    dev_mode: bool = Field(default=False, strict=True)
     jarvis_bin: str | None = None
     jarvis_resource_graph_profile: str | None = None
     allow_jarvis_resource_graph_build: bool = Field(default=False, strict=True)

--- a/src/clio_relay/dev_mode.py
+++ b/src/clio_relay/dev_mode.py
@@ -1,0 +1,109 @@
+"""First-class DEV MODE: downgrades install/identity/receipt verification to warnings.
+
+Owner directive (clio-relay#211): during development, no sha/identity check
+should block iteration -- push a git sha, install it, restart, retest. This
+module is the ONE place dev mode is detected and the ONE shape a downgraded
+finding takes; every verification call site that participates imports from
+here rather than re-deriving the env/cluster-flag logic itself.
+
+``CLIO_RELAY_DEV_MODE=1`` (environment) and/or ``dev_mode=True`` on a
+cluster registry entry both enable the downgrade; either is sufficient.
+
+Checks protecting live state or other tenants -- writer proof, the
+worker-lifetime lock, storage admission, teardown scoping -- never import
+from this module and stay hard regardless of dev mode. Physical target
+identity (operator-pinned hostname/ssh-host-key/site-marker) also stays
+hard: dev mode relaxes release-integrity ceremony for a trusted git sha
+already being iterated on, not which physical machine a session trusts.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+from clio_relay.errors import ConfigurationError
+
+DEV_MODE_ENV = "CLIO_RELAY_DEV_MODE"
+
+#: Rendered into every status/info surface that ran a downgraded check, so
+#: the mode can never be left on silently (clio-relay#211's explicit
+#: requirement). Keep this exact text stable -- callers and tests match it.
+DEV_MODE_BANNER = (
+    "DEV MODE — verification advisory: install/identity/receipt/sha/"
+    "contract-digest checks below were downgraded to warnings and did not "
+    "block. Never use in production."
+)
+
+_TRUTHY_VALUES = {"1", "true", "yes", "on"}
+
+
+def _env_dev_mode() -> bool:
+    value = os.environ.get(DEV_MODE_ENV)
+    if value is None:
+        return False
+    return value.strip().lower() in _TRUTHY_VALUES
+
+
+def dev_mode_enabled(*, cluster_dev_mode: bool = False) -> bool:
+    """Return whether the verification downgrade applies.
+
+    True when ``CLIO_RELAY_DEV_MODE`` is truthy in the environment, OR the
+    caller's cluster registry entry has ``dev_mode=True``. Callers that hold
+    cluster context thread ``cluster_dev_mode`` in explicitly -- this never
+    reaches into the registry itself.
+    """
+    return bool(cluster_dev_mode) or _env_dev_mode()
+
+
+@dataclass
+class VerificationFindings:
+    """Collects would-have-failed checks when dev mode downgrades them.
+
+    In production mode (the default), a verification failure raises
+    immediately and nothing is ever recorded here. In dev mode, each check
+    that would have raised instead appends its exact production error
+    message and verification proceeds; the caller renders ``.warnings``
+    into its status/info payload behind :data:`DEV_MODE_BANNER` so the
+    downgrade is always visible, never silent.
+    """
+
+    warnings: list[str] = field(default_factory=list[str])
+
+    def record(self, message: str) -> None:
+        """Record one would-have-failed check instead of letting it raise."""
+        self.warnings.append(message)
+
+    def payload(self) -> dict[str, object] | None:
+        """Return the status/info fragment to merge in, or None when clean.
+
+        ``None`` when nothing was downgraded (including when dev mode is
+        off, since nothing is ever recorded then) -- callers merge this
+        conditionally so an unaffected surface stays exactly as it always
+        has been, byte for byte.
+        """
+        if not self.warnings:
+            return None
+        return {"dev_mode_banner": DEV_MODE_BANNER, "dev_mode_warnings": list(self.warnings)}
+
+
+def enforce(
+    findings: VerificationFindings,
+    *,
+    dev_mode: bool,
+    condition: bool,
+    message: str,
+) -> None:
+    """Require ``condition``; downgrade to a recorded warning only in dev mode.
+
+    The single choke point every downgradable check in the verification
+    chain routes through: production behavior (raise) is unchanged, and dev
+    mode substitutes "record and keep going" for "raise and stop" -- never
+    the reverse, and never silent either way.
+    """
+    if condition:
+        return
+    if dev_mode:
+        findings.record(message)
+        return
+    raise ConfigurationError(message)

--- a/src/clio_relay/installation.py
+++ b/src/clio_relay/installation.py
@@ -21,6 +21,7 @@ from packaging.utils import InvalidWheelFilename, canonicalize_name, parse_wheel
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from clio_relay.bounded_process import BoundedProcessError, run_bounded_process
+from clio_relay.dev_mode import VerificationFindings, dev_mode_enabled, enforce
 from clio_relay.errors import ConfigurationError
 from clio_relay.validation_report import (
     EvidenceReference,
@@ -1087,6 +1088,9 @@ def _path_within(path: Path, root: Path) -> bool:
 
 def _current_install_receipt(
     path: Path | None = None,
+    *,
+    dev_mode: bool = False,
+    findings: VerificationFindings | None = None,
 ) -> tuple[InstallReceipt, Literal["bootstrap", "uv-tool"], InstallSource | None]:
     """Load the durable receipt that owns the current relay installation."""
     receipt_path = path or default_install_receipt_path()
@@ -1095,7 +1099,9 @@ def _current_install_receipt(
     if receipt_path.exists() or path is not None or os.environ.get(INSTALL_RECEIPT_PATH_ENV):
         receipt = load_install_receipt(receipt_path)
     else:
-        receipt, install_source = _persistent_uv_tool_install_receipt()
+        receipt, install_source = _persistent_uv_tool_install_receipt(
+            dev_mode=dev_mode, findings=findings
+        )
         receipt_origin = "uv-tool"
     return receipt, receipt_origin, install_source
 
@@ -1123,13 +1129,29 @@ def verified_session_api_install_receipt(path: Path | None = None) -> InstallRec
     return receipt
 
 
-def installation_info(path: Path | None = None) -> dict[str, object]:
-    """Return current package identity together with its durable install receipt."""
-    receipt, receipt_origin, install_source = _current_install_receipt(path)
+def installation_info(
+    path: Path | None = None,
+    *,
+    dev_mode: bool | None = None,
+) -> dict[str, object]:
+    """Return current package identity together with its durable install receipt.
+
+    ``dev_mode`` defaults to :func:`clio_relay.dev_mode.dev_mode_enabled` (the
+    ``CLIO_RELAY_DEV_MODE`` environment switch) when omitted, so every
+    existing caller of this function honors the environment switch for
+    free; a caller holding cluster context (e.g. ``worker_runtime_info``)
+    passes the resolved value explicitly to also honor a cluster's
+    ``dev_mode`` registry flag (clio-relay#211).
+    """
+    resolved_dev_mode = dev_mode_enabled() if dev_mode is None else dev_mode
+    findings = VerificationFindings()
+    receipt, receipt_origin, install_source = _current_install_receipt(
+        path, dev_mode=resolved_dev_mode, findings=findings
+    )
     current_software = detect_software_identity()
     current_version = metadata.version("clio-relay")
     component_runtime = _component_runtime_identity(receipt)
-    return {
+    info: dict[str, object] = {
         "schema_version": "clio-relay.installation-info.v1",
         "distribution_version": current_version,
         "software": current_software.model_dump(mode="json"),
@@ -1143,9 +1165,17 @@ def installation_info(path: Path | None = None) -> dict[str, object]:
         ),
         "component_runtime": component_runtime,
     }
+    dev_mode_payload = findings.payload()
+    if dev_mode_payload is not None:
+        info.update(dev_mode_payload)
+    return info
 
 
-def _persistent_uv_tool_install_receipt() -> tuple[InstallReceipt, InstallSource]:
+def _persistent_uv_tool_install_receipt(
+    *,
+    dev_mode: bool = False,
+    findings: VerificationFindings | None = None,
+) -> tuple[InstallReceipt, InstallSource]:
     """Derive a compatible receipt from uv's exact persistent-tool identity.
 
     A VCS-kind install counts only when pinned to an exact 40-hex git commit
@@ -1155,34 +1185,66 @@ def _persistent_uv_tool_install_receipt() -> tuple[InstallReceipt, InstallSource
     identity-anchor role a wheel's sha256 digest plays. A branch or tag
     reference leaves ``artifact_identity_verified`` False and is rejected
     below exactly like an unverified wheel.
+
+    In dev mode (clio-relay#211) a failed check is recorded on ``findings``
+    instead of raising, and derivation still produces a best-effort receipt
+    -- honestly less-verified (``artifact_sha256`` may be ``None``, the
+    install timestamp may fall back to now) rather than blocking a
+    non-generation dev install from getting a receipt at all.
     """
+    findings = findings if findings is not None else VerificationFindings()
     source = detect_install_source(
         launcher="uv-tool",
         infer_artifact_sha256=True,
     )
-    if source.kind not in {
-        InstallSourceKind.WHEEL,
-        InstallSourceKind.PYPI,
-        InstallSourceKind.VCS,
-    }:
-        raise ConfigurationError("running clio-relay is not installed as a persistent uv tool")
-    if not source.launcher_verified:
-        raise ConfigurationError("persistent uv tool launcher identity could not be verified")
-    if not source.artifact_identity_verified or source.artifact_sha256 is None:
-        raise ConfigurationError("persistent uv tool wheel identity could not be verified")
+    enforce(
+        findings,
+        dev_mode=dev_mode,
+        condition=source.kind
+        in {InstallSourceKind.WHEEL, InstallSourceKind.PYPI, InstallSourceKind.VCS},
+        message="running clio-relay is not installed as a persistent uv tool",
+    )
+    enforce(
+        findings,
+        dev_mode=dev_mode,
+        condition=source.launcher_verified,
+        message="persistent uv tool launcher identity could not be verified",
+    )
+    enforce(
+        findings,
+        dev_mode=dev_mode,
+        condition=source.artifact_identity_verified and source.artifact_sha256 is not None,
+        message="persistent uv tool wheel identity could not be verified",
+    )
     raw_uv_receipt = source.launcher_receipt.get("uv_tool_receipt")
-    if not isinstance(raw_uv_receipt, dict):
-        raise ConfigurationError("persistent uv tool receipt could not be verified")
-    uv_receipt = cast(dict[str, object], raw_uv_receipt)
-    if uv_receipt.get("verified") is not True:
-        raise ConfigurationError("persistent uv tool receipt could not be verified")
+    uv_receipt: dict[str, object] = (
+        cast(dict[str, object], raw_uv_receipt) if isinstance(raw_uv_receipt, dict) else {}
+    )
+    enforce(
+        findings,
+        dev_mode=dev_mode,
+        condition=isinstance(raw_uv_receipt, dict) and uv_receipt.get("verified") is True,
+        message="persistent uv tool receipt could not be verified",
+    )
     receipt_path_value = uv_receipt.get("path")
-    if not isinstance(receipt_path_value, str):
-        raise ConfigurationError("persistent uv tool receipt path is missing")
-    try:
-        installed_at = datetime.fromtimestamp(Path(receipt_path_value).stat().st_mtime, tz=UTC)
-    except OSError as exc:
-        raise ConfigurationError("persistent uv tool receipt path is unavailable") from exc
+    installed_at = datetime.now(UTC)
+    if isinstance(receipt_path_value, str):
+        try:
+            installed_at = datetime.fromtimestamp(Path(receipt_path_value).stat().st_mtime, tz=UTC)
+        except OSError as exc:
+            enforce(
+                findings,
+                dev_mode=dev_mode,
+                condition=False,
+                message=f"persistent uv tool receipt path is unavailable: {exc}",
+            )
+    else:
+        enforce(
+            findings,
+            dev_mode=dev_mode,
+            condition=False,
+            message="persistent uv tool receipt path is missing",
+        )
     reference = source.reference
     artifact_filename: str | None = None
     if reference is not None and source.kind is not InstallSourceKind.VCS:
@@ -1206,6 +1268,8 @@ def write_self_install_receipt(
     *,
     force: bool = False,
     components_from: Path | None = None,
+    dev_mode: bool = False,
+    findings: VerificationFindings | None = None,
 ) -> InstallReceipt:
     """Mint a durable receipt describing the RUNNING installation's own identity.
 
@@ -1231,12 +1295,18 @@ def write_self_install_receipt(
     path is recorded on ``components_source_receipt`` so the mix is
     traceable, never silent. Refuses when the source receipt carries no
     component artifacts to inherit.
+
+    ``dev_mode`` (clio-relay#211) downgrades identity derivation to a
+    best-effort receipt with recorded warnings instead of raising -- for a
+    non-generation dev install (a checkout, an unverified launcher, ...)
+    that still needs *a* receipt to iterate against. ``force`` still
+    governs overwriting the destination path unconditionally.
     """
     if path.exists() and not force:
         raise ConfigurationError(
             f"install receipt already exists: {path} (use --force to overwrite)"
         )
-    receipt, _source = _persistent_uv_tool_install_receipt()
+    receipt, _source = _persistent_uv_tool_install_receipt(dev_mode=dev_mode, findings=findings)
     if components_from is not None:
         try:
             source_receipt = load_install_receipt(components_from)
@@ -1274,6 +1344,7 @@ def worker_runtime_info(
     current_installation: dict[str, object] | None = None,
     readiness_only: bool = False,
     pinned_install_receipt_path: str | None = None,
+    dev_mode: bool = False,
 ) -> dict[str, object]:
     """Prove the active worker process loaded the same exact installation receipt.
 
@@ -1285,6 +1356,12 @@ def worker_runtime_info(
     only against this invocation's own ambient ``current`` installation: a
     multi-tenant host can keep its shared ``current`` pointed at a different
     generation for other tenants while one cluster is pinned to its own.
+
+    ``dev_mode`` (clio-relay#211, resolved by the caller from
+    ``CLIO_RELAY_DEV_MODE``/the cluster's ``dev_mode`` flag) is threaded
+    into the ``current`` self-check so a non-generation dev install here
+    still produces a readable status instead of raising; it never affects
+    freshness/liveness or the fresh-endpoint scan below, which stay hard.
     """
     from clio_relay.config import RelaySettings
     from clio_relay.core_queue import MAX_ENDPOINT_FRESH_SECONDS, ClioCoreQueue
@@ -1296,7 +1373,11 @@ def worker_runtime_info(
         raise ConfigurationError(
             "worker freshness_seconds exceeds the bounded fresh endpoint window"
         )
-    current = installation_info() if current_installation is None else current_installation
+    current = (
+        installation_info(dev_mode=dev_mode)
+        if current_installation is None
+        else current_installation
+    )
     if current.get("schema_version") != "clio-relay.installation-info.v1":
         raise ConfigurationError("current installation snapshot is invalid")
     pinned_installation: dict[str, object] | None = None
@@ -1372,12 +1453,30 @@ def verify_remote_installation_info(
     expected_software: SoftwareIdentity,
     expected_artifact_sha256: str | None,
     expected_source: str | None,
+    dev_mode: bool = False,
+    findings: VerificationFindings | None = None,
 ) -> InstallReceipt:
-    """Require a remote receipt to match the exact local acceptance artifact."""
-    if info.get("distribution_version") != expected_version:
-        raise ConfigurationError("remote clio-relay distribution version does not match")
-    if info.get("receipt_matches_install") is not True:
-        raise ConfigurationError("remote installation receipt does not match the running package")
+    """Require a remote receipt to match the exact local acceptance artifact.
+
+    In dev mode (clio-relay#211) every semantic identity comparison below
+    is downgraded to a recorded warning instead of raising, and the parsed
+    receipt is still returned. Payload shape (the receipt must parse as a
+    valid ``InstallReceipt``) stays hard either way -- a malformed payload
+    is corruption, not a would-have-failed release check.
+    """
+    findings = findings if findings is not None else VerificationFindings()
+    enforce(
+        findings,
+        dev_mode=dev_mode,
+        condition=info.get("distribution_version") == expected_version,
+        message="remote clio-relay distribution version does not match",
+    )
+    enforce(
+        findings,
+        dev_mode=dev_mode,
+        condition=info.get("receipt_matches_install") is True,
+        message="remote installation receipt does not match the running package",
+    )
     raw_software = info.get("software")
     raw_receipt = info.get("receipt")
     try:
@@ -1385,16 +1484,35 @@ def verify_remote_installation_info(
         receipt = InstallReceipt.model_validate(raw_receipt)
     except ValidationError as exc:
         raise ConfigurationError(f"remote installation identity is invalid: {exc}") from exc
-    if software != expected_software:
-        raise ConfigurationError("remote worker commit/tag identity does not match")
+    enforce(
+        findings,
+        dev_mode=dev_mode,
+        condition=software == expected_software,
+        message="remote worker commit/tag identity does not match",
+    )
     if expected_artifact_sha256 is None:
-        raise ConfigurationError("acceptance did not identify the tested artifact SHA-256")
-    if receipt.artifact_sha256 != expected_artifact_sha256:
-        raise ConfigurationError("remote worker wheel SHA-256 does not match")
-    if expected_source is not None and receipt.requested_source != expected_source:
-        raise ConfigurationError(
-            "remote worker install source does not match: "
-            f"{receipt.requested_source} != {expected_source}"
+        enforce(
+            findings,
+            dev_mode=dev_mode,
+            condition=False,
+            message="acceptance did not identify the tested artifact SHA-256",
+        )
+    else:
+        enforce(
+            findings,
+            dev_mode=dev_mode,
+            condition=receipt.artifact_sha256 == expected_artifact_sha256,
+            message="remote worker wheel SHA-256 does not match",
+        )
+    if expected_source is not None:
+        enforce(
+            findings,
+            dev_mode=dev_mode,
+            condition=receipt.requested_source == expected_source,
+            message=(
+                "remote worker install source does not match: "
+                f"{receipt.requested_source} != {expected_source}"
+            ),
         )
     return receipt
 
@@ -1419,6 +1537,8 @@ def verify_remote_worker_info(
     expected_artifact_sha256: str | None,
     expected_source: str | None,
     require_target_identity: bool = True,
+    dev_mode: bool = False,
+    findings: VerificationFindings | None = None,
 ) -> InstallReceipt:
     """Require fresh live-worker proof in addition to a static install receipt.
 
@@ -1430,7 +1550,17 @@ def verify_remote_worker_info(
     shared host's ``current`` symlink is not required to agree with a pin
     made for one cluster. A cluster with no pin keeps requiring
     ``identity_matches_current`` exactly as before.
+
+    In dev mode (clio-relay#211) every identity/receipt/sha comparison below
+    is downgraded to a recorded warning instead of raising, and the best
+    receipt available is still returned. Liveness (``fresh``,
+    ``process_running``) and every structural/shape check (schema, cluster
+    and role match, scheduler-provider attestation, physical target
+    identity) stay hard regardless -- dev mode relaxes release-integrity
+    ceremony for a trusted git sha, not proof the worker process is real,
+    live, and the one this call actually asked about.
     """
+    findings = findings if findings is not None else VerificationFindings()
     if info.get("schema_version") != "clio-relay.worker-runtime-info.v1":
         raise ConfigurationError("remote worker runtime identity schema does not match")
     if info.get("cluster") != expected_cluster:
@@ -1439,14 +1569,17 @@ def verify_remote_worker_info(
     if raw_pinned_installation is not None and not isinstance(raw_pinned_installation, dict):
         raise ConfigurationError("remote worker pinned installation identity is invalid")
     cluster_pins_runtime = raw_pinned_installation is not None
-    required_flags = (
-        ("fresh", "process_running")
-        if cluster_pins_runtime
-        else ("fresh", "process_running", "identity_matches_current", "running")
-    )
-    for flag in required_flags:
+    for flag in ("fresh", "process_running"):
         if info.get(flag) is not True:
             raise ConfigurationError(f"remote worker runtime did not prove {flag}")
+    if not cluster_pins_runtime:
+        for flag in ("identity_matches_current", "running"):
+            enforce(
+                findings,
+                dev_mode=dev_mode,
+                condition=info.get(flag) is True,
+                message=f"remote worker runtime did not prove {flag}",
+            )
     current = info.get("installation")
     endpoint_installation = info.get("endpoint_installation")
     endpoint = info.get("endpoint")
@@ -1477,20 +1610,25 @@ def verify_remote_worker_info(
         expected_software=expected_software,
         expected_artifact_sha256=expected_artifact_sha256,
         expected_source=expected_source,
+        dev_mode=dev_mode,
+        findings=findings,
     )
     if cluster_pins_runtime:
         if info.get("identity_matches_pinned") is not True:
             try:
                 pinned_receipt = InstallReceipt.model_validate(raw_pinned_installation)
+                message = (
+                    "remote worker runtime does not match its cluster's pinned installation: "
+                    f"worker={_installation_identity_label(endpoint_receipt)} "
+                    f"pinned={_installation_identity_label(pinned_receipt)}"
+                )
             except ValidationError as exc:
-                raise ConfigurationError(
-                    f"remote worker pinned installation identity is invalid: {exc}"
-                ) from exc
-            raise ConfigurationError(
-                "remote worker runtime does not match its cluster's pinned installation: "
-                f"worker={_installation_identity_label(endpoint_receipt)} "
-                f"pinned={_installation_identity_label(pinned_receipt)}"
-            )
+                if not dev_mode:
+                    raise ConfigurationError(
+                        f"remote worker pinned installation identity is invalid: {exc}"
+                    ) from exc
+                message = f"remote worker pinned installation identity is invalid: {exc}"
+            enforce(findings, dev_mode=dev_mode, condition=False, message=message)
         current_receipt = endpoint_receipt
     else:
         current_receipt = verify_remote_installation_info(
@@ -1499,9 +1637,15 @@ def verify_remote_worker_info(
             expected_software=expected_software,
             expected_artifact_sha256=expected_artifact_sha256,
             expected_source=expected_source,
+            dev_mode=dev_mode,
+            findings=findings,
         )
-        if endpoint_receipt != current_receipt:
-            raise ConfigurationError("running worker receipt differs from current installation")
+        enforce(
+            findings,
+            dev_mode=dev_mode,
+            condition=endpoint_receipt == current_receipt,
+            message="running worker receipt differs from current installation",
+        )
     if require_target_identity:
         target_identity = info.get("target_identity")
         if not isinstance(target_identity, dict):

--- a/src/clio_relay/jarvis_mcp.py
+++ b/src/clio_relay/jarvis_mcp.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
+from clio_relay.dev_mode import VerificationFindings, dev_mode_enabled
 from clio_relay.remote_mcp import (
     CLIO_KIT_JARVIS_USER_CONTRACT_SHA256,
     CLIO_KIT_JARVIS_USER_WIRE_SHA256,
@@ -211,8 +212,24 @@ def require_handle_first_jarvis_run_schema(
 _VIRTUAL_JARVIS_TOOLS, _VIRTUAL_JARVIS_TOOL_TITLES = _load_bundled_jarvis_user_contract()
 
 
-def jarvis_mcp_command() -> list[str]:
-    """Return the command used on the cluster to launch the JARVIS MCP server."""
+def jarvis_mcp_command(
+    *,
+    dev_mode: bool | None = None,
+    findings: VerificationFindings | None = None,
+) -> list[str]:
+    """Return the command used on the cluster to launch the JARVIS MCP server.
+
+    ``dev_mode`` defaults to :func:`clio_relay.dev_mode.dev_mode_enabled` (the
+    ``CLIO_RELAY_DEV_MODE`` environment switch) when omitted, so every
+    existing caller honors the environment switch for free (clio-relay#211).
+    When the receipt-bound clio-kit contract/digest identity does not
+    verify, dev mode records the exact production error on ``findings`` and
+    falls back to :data:`DEFAULT_JARVIS_MCP_COMMAND` -- the same fallback
+    already used when no receipt exists at all -- instead of raising and
+    blocking the worker's JARVIS MCP server from starting at all.
+    """
+    resolved_dev_mode = dev_mode_enabled() if dev_mode is None else dev_mode
+    findings = findings if findings is not None else VerificationFindings()
     configured = os.environ.get(JARVIS_MCP_COMMAND_ENV)
     if configured is not None and configured.strip():
         return _decode_command(configured)
@@ -225,7 +242,10 @@ def jarvis_mcp_command() -> list[str]:
     identity = jarvis_mcp_runtime_identity(receipt)
     if identity.get("artifact_identity_verified") is not True:
         reason = identity.get("error") or "receipt-bound clio-kit runtime identity did not verify"
-        raise ValueError(str(reason))
+        if not resolved_dev_mode:
+            raise ValueError(str(reason))
+        findings.record(str(reason))
+        return list(DEFAULT_JARVIS_MCP_COMMAND)
     command = identity.get("command")
     if not isinstance(command, list):
         raise ValueError("install receipt has no valid clio-kit runtime command")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -773,6 +773,7 @@ def test_endpoint_worker_info_exposes_bounded_readiness_mode(
         "freshness_seconds": 90.0,
         "readiness_only": True,
         "pinned_install_receipt_path": None,
+        "dev_mode": False,
     }
 
 
@@ -809,6 +810,62 @@ def test_endpoint_worker_info_forwards_pinned_install_receipt_path(
         observed["pinned_install_receipt_path"]
         == "$HOME/.local/share/clio-relay/generations/g1/install-receipt.json"
     )
+
+
+def test_endpoint_worker_info_dev_mode_flag_resolves_env_and_cluster_pin(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """clio-relay#211: --dev-mode (cluster pin) combines with CLIO_RELAY_DEV_MODE either way."""
+    observed: list[bool] = []
+
+    def worker_info(**kwargs: object) -> dict[str, object]:
+        observed.append(cast(bool, kwargs["dev_mode"]))
+        return {
+            "schema_version": "clio-relay.worker-runtime-info.v1",
+            "cluster": kwargs["cluster"],
+            "running": True,
+        }
+
+    monkeypatch.setattr(cli, "worker_runtime_info", worker_info)
+    monkeypatch.delenv("CLIO_RELAY_DEV_MODE", raising=False)
+
+    off = CliRunner().invoke(app, ["endpoint", "worker-info", "--cluster", "ares"])
+    assert off.exit_code == 0, off.output
+
+    on_via_flag = CliRunner().invoke(
+        app, ["endpoint", "worker-info", "--cluster", "ares", "--dev-mode"]
+    )
+    assert on_via_flag.exit_code == 0, on_via_flag.output
+
+    monkeypatch.setenv("CLIO_RELAY_DEV_MODE", "1")
+    on_via_env = CliRunner().invoke(app, ["endpoint", "worker-info", "--cluster", "ares"])
+    assert on_via_env.exit_code == 0, on_via_env.output
+
+    assert observed == [False, True, True]
+
+
+def test_cluster_add_dev_mode_flag_persists_on_the_registry_entry(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """clio-relay#211: cluster add --dev-mode is the CLI path to pin a cluster's dev mode."""
+    monkeypatch.chdir(tmp_path)
+    registry_path = tmp_path / ".clio-relay" / "clusters.json"
+
+    result = CliRunner().invoke(
+        app,
+        ["cluster", "add", "--name", "ares-p5run2", "--ssh-host", "ares-login", "--dev-mode"],
+    )
+    assert result.exit_code == 0, result.output
+    definition = ClusterRegistry.load(registry_path).require("ares-p5run2")
+    assert definition.dev_mode is True
+
+    result = CliRunner().invoke(
+        app,
+        ["cluster", "add", "--name", "ares", "--ssh-host", "ares-login"],
+    )
+    assert result.exit_code == 0, result.output
+    assert ClusterRegistry.load(registry_path).require("ares").dev_mode is False
 
 
 def test_installation_write_receipt_forwards_components_from(
@@ -1978,6 +2035,7 @@ def test_cli_session_lifecycle_commands(tmp_path: Path, monkeypatch: MonkeyPatch
 
     def accept_worker_compatibility(
         _definition: ClusterDefinition,
+        **_kwargs: object,
     ) -> SessionApiReleaseIdentity:
         return _session_api_release_identity()
 
@@ -4152,6 +4210,7 @@ def test_cli_session_start_does_not_reopen_intake_when_process_start_fails(
 
     def accept_worker_compatibility(
         _definition: ClusterDefinition,
+        **_kwargs: object,
     ) -> SessionApiReleaseIdentity:
         return _session_api_release_identity()
 
@@ -4306,6 +4365,7 @@ def test_cli_session_start_fresh_session_proceeds_after_uninitialized_cleanup_pr
 
     def verify_worker_compatibility(
         _definition: ClusterDefinition,
+        **_kwargs: object,
     ) -> SessionApiReleaseIdentity:
         return _session_api_release_identity()
 
@@ -4362,6 +4422,7 @@ def test_cli_session_start_returns_self_contained_current_selector(
 
     def verify_worker_compatibility(
         _definition: ClusterDefinition,
+        **_kwargs: object,
     ) -> SessionApiReleaseIdentity:
         return release
 
@@ -4435,6 +4496,7 @@ def test_cli_session_start_nonready_handle_exits_two_and_is_unusable(
 
     def verify_worker_compatibility(
         _definition: ClusterDefinition,
+        **_kwargs: object,
     ) -> SessionApiReleaseIdentity:
         return release
 
@@ -4525,6 +4587,7 @@ def test_cli_session_start_rejects_stale_plan_before_cleanup_mutation(
 
     def verify_worker_compatibility(
         _definition: ClusterDefinition,
+        **_kwargs: object,
     ) -> SessionApiReleaseIdentity:
         return release
 

--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -33,6 +33,18 @@ from clio_relay.errors import ConfigurationError
 from clio_relay.remote_mcp import default_remote_mcp_cache_path
 
 
+def test_cluster_definition_dev_mode_defaults_off_and_is_strict_bool() -> None:
+    """clio-relay#211: a cluster's dev_mode pin defaults off and rejects non-bool input."""
+    definition = ClusterDefinition(name="ares", ssh_host="ares-login")
+    assert definition.dev_mode is False
+
+    dev_definition = ClusterDefinition(name="ares", ssh_host="ares-login", dev_mode=True)
+    assert dev_definition.dev_mode is True
+
+    with pytest.raises(Exception, match="bool"):
+        ClusterDefinition(name="ares", ssh_host="ares-login", dev_mode="1")  # type: ignore[arg-type]
+
+
 @pytest.mark.parametrize("profile", ["", " ares", "ares ", ".", "..", "a/res", "a\\res"])
 def test_cluster_definition_rejects_unsafe_jarvis_graph_profile(profile: str) -> None:
     """A profile is one explicit JARVIS catalog key, never a relay-owned path."""

--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -1,0 +1,107 @@
+"""Tests for the DEV MODE verification-downgrade core (clio-relay#211)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clio_relay.dev_mode import (
+    DEV_MODE_BANNER,
+    DEV_MODE_ENV,
+    VerificationFindings,
+    dev_mode_enabled,
+    enforce,
+)
+from clio_relay.errors import ConfigurationError
+
+#: Modules protecting live state/other tenants -- clio-relay#211 requires these
+#: to stay hard regardless of dev mode. Zero coupling to clio_relay.dev_mode is
+#: proof by construction: these modules cannot consult a flag they never import.
+_HARD_CHECK_MODULES = (
+    "worker_lifetime_lock.py",  # exclusive worker lock per cluster
+    "storage_policy.py",  # storage admission/reservation limits
+    "session_lifecycle.py",  # teardown scoping and cleanup policy
+)
+
+
+def test_hard_check_modules_never_import_dev_mode() -> None:
+    """clio-relay#211: writer proof, worker-lifetime lock, storage admission,
+    and teardown scoping stay hard -- proven here by zero coupling: none of
+    these modules import anything from clio_relay.dev_mode, so none of them
+    can possibly consult it to downgrade a check, now or by future accident.
+    """
+    src_root = Path(__file__).resolve().parents[1] / "src" / "clio_relay"
+    for module_name in _HARD_CHECK_MODULES:
+        source = (src_root / module_name).read_text(encoding="utf-8")
+        assert "dev_mode" not in source, (
+            f"{module_name} must never reference dev_mode -- it protects live "
+            "state/other tenants and clio-relay#211 requires it stay hard "
+            "unconditionally"
+        )
+
+
+def test_dev_mode_enabled_honors_env_and_cluster_flag_independently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(DEV_MODE_ENV, raising=False)
+    assert dev_mode_enabled() is False
+    assert dev_mode_enabled(cluster_dev_mode=True) is True
+
+    monkeypatch.setenv(DEV_MODE_ENV, "1")
+    assert dev_mode_enabled() is True
+    assert dev_mode_enabled(cluster_dev_mode=False) is True
+
+
+@pytest.mark.parametrize("value", ["1", "true", "True", "yes", "on", " 1 "])
+def test_dev_mode_env_truthy_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv(DEV_MODE_ENV, value)
+    assert dev_mode_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "   "])
+def test_dev_mode_env_falsy_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv(DEV_MODE_ENV, value)
+    assert dev_mode_enabled() is False
+
+
+def test_dev_mode_env_absent_is_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(DEV_MODE_ENV, raising=False)
+    assert dev_mode_enabled() is False
+
+
+def test_enforce_raises_in_production_and_records_in_dev_mode() -> None:
+    """The single choke point every downgradable check routes through."""
+    findings = VerificationFindings()
+
+    with pytest.raises(ConfigurationError, match="would have failed"):
+        enforce(findings, dev_mode=False, condition=False, message="would have failed")
+    assert findings.warnings == []
+
+    enforce(findings, dev_mode=True, condition=False, message="would have failed")
+    assert findings.warnings == ["would have failed"]
+
+    # a satisfied condition never records or raises, in either mode
+    enforce(findings, dev_mode=True, condition=True, message="never seen")
+    enforce(findings, dev_mode=False, condition=True, message="never seen")
+    assert findings.warnings == ["would have failed"]
+
+
+def test_verification_findings_payload_is_none_when_clean() -> None:
+    findings = VerificationFindings()
+    assert findings.payload() is None
+    findings.record("something downgraded")
+    payload = findings.payload()
+    assert payload is not None
+    assert payload["dev_mode_banner"] == DEV_MODE_BANNER
+    assert payload["dev_mode_warnings"] == ["something downgraded"]
+
+
+def test_verification_findings_payload_marker_is_unmissable() -> None:
+    """clio-relay#211: the banner text itself names DEV MODE explicitly."""
+    assert "DEV MODE" in DEV_MODE_BANNER
+    findings = VerificationFindings()
+    findings.record("x")
+    payload = findings.payload()
+    assert payload is not None
+    assert "DEV MODE" in str(payload["dev_mode_banner"])

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -19,6 +19,7 @@ from typing import cast
 import pytest
 
 import clio_relay.installation as installation_module
+from clio_relay.dev_mode import DEV_MODE_BANNER, DEV_MODE_ENV, VerificationFindings
 from clio_relay.errors import ConfigurationError
 from clio_relay.installation import (
     CLIO_KIT_JARVIS_CONTRACT_ID,
@@ -1201,6 +1202,89 @@ def test_installation_info_rejects_vcs_uv_tool_install_pinned_to_a_branch(
         installation_info()
 
 
+def test_installation_info_downgrades_to_warning_in_dev_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """clio-relay#211: the exact same failing install still derives a receipt in dev mode.
+
+    Reuses the precise fixture from
+    test_installation_info_rejects_vcs_uv_tool_install_pinned_to_a_branch
+    (a branch-pinned, therefore unverified, VCS install) -- production
+    behavior there is unchanged (still raises); with CLIO_RELAY_DEV_MODE=1
+    the identical install now returns a best-effort receipt with the exact
+    would-have-failed message carried as a warning behind the DEV MODE
+    banner, and without the env var it raises exactly as before.
+    """
+    missing_bootstrap = tmp_path / "missing-install-receipt.json"
+    uv_receipt = tmp_path / "tools" / "clio-relay" / "uv-receipt.toml"
+    uv_receipt.parent.mkdir(parents=True)
+    uv_receipt.write_text("[tool]\n", encoding="utf-8")
+    version = metadata.version("clio-relay")
+    source_url = "https://github.com/iowarp/clio-relay"
+    source = InstallSource(
+        kind=InstallSourceKind.VCS,
+        detected_kind=InstallSourceKind.VCS,
+        reference=source_url,
+        launcher="uv-tool",
+        package_path=str(tmp_path / "site-packages" / "clio_relay"),
+        distribution_version=version,
+        artifact_sha256=None,
+        direct_url={
+            "url": source_url,
+            "vcs_info": {"vcs": "git", "requested_revision": "main", "commit_id": "d" * 40},
+        },
+        artifact_identity_verified=False,
+        released_artifact=False,
+        launcher_verified=True,
+        launcher_receipt={
+            "verified": True,
+            "uv_tool_receipt": {"path": str(uv_receipt), "verified": True},
+        },
+    )
+
+    monkeypatch.delenv(INSTALL_RECEIPT_PATH_ENV, raising=False)
+    monkeypatch.setattr(
+        installation_module,
+        "default_install_receipt_path",
+        lambda: missing_bootstrap,
+    )
+
+    def detect_source(**_kwargs: object) -> InstallSource:
+        return source
+
+    monkeypatch.setattr(installation_module, "detect_install_source", detect_source)
+
+    # still raises without dev mode -- production behavior is byte-for-byte unchanged.
+    monkeypatch.delenv(DEV_MODE_ENV, raising=False)
+    with pytest.raises(ConfigurationError, match="wheel identity could not be verified"):
+        installation_info()
+
+    # dev mode via CLIO_RELAY_DEV_MODE: downgraded to a warning, receipt still returned.
+    monkeypatch.setenv(DEV_MODE_ENV, "1")
+    info = installation_info()
+    assert info["dev_mode_banner"] == DEV_MODE_BANNER
+    dev_mode_warnings = cast(list[str], info["dev_mode_warnings"])
+    assert "persistent uv tool wheel identity could not be verified" in dev_mode_warnings
+    receipt = cast(dict[str, object], info["receipt"])
+    assert receipt["requested_source"] == "vcs"
+    assert receipt["artifact_sha256"] is None
+
+    # no findings, no banner, no keys at all -- the clean case never mentions dev mode.
+    monkeypatch.delenv(DEV_MODE_ENV, raising=False)
+    verified_source = source.model_copy(
+        update={"artifact_identity_verified": True, "artifact_sha256": "a" * 40}
+    )
+
+    def detect_verified_source(**_kwargs: object) -> InstallSource:
+        return verified_source
+
+    monkeypatch.setattr(installation_module, "detect_install_source", detect_verified_source)
+    clean_info = installation_info()
+    assert "dev_mode_banner" not in clean_info
+    assert "dev_mode_warnings" not in clean_info
+
+
 def _vcs_full_sha_install_source(
     *, tmp_path: Path, commit_sha: str, uv_receipt: Path
 ) -> InstallSource:
@@ -1819,6 +1903,116 @@ def test_verify_remote_worker_info_uses_cluster_pin_over_global_current(tmp_path
         )
 
 
+def test_verify_remote_worker_info_dev_mode_downgrades_pin_mismatch_to_warning(
+    tmp_path: Path,
+) -> None:
+    """clio-relay#211: the identity_matches_pinned wall becomes advisory in dev mode.
+
+    Reuses test_verify_remote_worker_info_uses_cluster_pin_over_global_current's
+    exact "(b)" pin-mismatch scenario -- production behavior there
+    (dev_mode=False, the default) is proven unchanged; with dev_mode=True the
+    SAME payload now passes, carrying the exact would-have-failed message as
+    a warning, naming both identities exactly as the production error would.
+    """
+    pinned_wheel = tmp_path / "clio_relay-pinned-1.0.0-py3-none-any.whl"
+    pinned_wheel.write_bytes(b"cluster-pinned-generation-g")
+    pinned_receipt_path = tmp_path / "pinned-receipt.json"
+    pinned_receipt = write_install_receipt(
+        install_spec=str(pinned_wheel),
+        artifact_path=pinned_wheel,
+        path=pinned_receipt_path,
+        generation="a" * 64,
+    )
+
+    other_wheel = tmp_path / "clio_relay-other-1.0.0-py3-none-any.whl"
+    other_wheel.write_bytes(b"shared-tenant-global-current")
+    other_receipt_path = tmp_path / "other-receipt.json"
+    other_receipt = write_install_receipt(
+        install_spec=str(other_wheel),
+        artifact_path=other_wheel,
+        path=other_receipt_path,
+        generation="b" * 64,
+    )
+    worker_matches_other = installation_info(other_receipt_path)
+
+    runtime: dict[str, object] = {
+        "schema_version": "clio-relay.worker-runtime-info.v1",
+        "cluster": "ares-p5run2",
+        "fresh": True,
+        "process_running": True,
+        "scheduler_provider": "slurm",
+        "endpoint": {
+            "role": "worker",
+            "cluster": "ares-p5run2",
+            "pid": 123,
+            "metadata": {"scheduler_provider": "slurm"},
+        },
+        "installation": worker_matches_other,
+        "target_identity": {
+            "verified": True,
+            "hostname": "ares-login",
+            "ssh_host_key_sha256": ["SHA256:test"],
+            "scheduler_cluster_name": "ares",
+        },
+        "pinned_installation": pinned_receipt.model_dump(mode="json"),
+        "endpoint_installation": worker_matches_other,
+        "identity_matches_current": True,
+        "identity_matches_pinned": False,
+        "running": True,
+    }
+    call_kwargs: dict[str, object] = {
+        "expected_cluster": "ares-p5run2",
+        "expected_version": other_receipt.distribution_version,
+        "expected_software": SoftwareIdentity.model_validate(worker_matches_other["software"]),
+        "expected_artifact_sha256": other_receipt.artifact_sha256,
+        "expected_source": "wheel",
+        "require_target_identity": False,
+    }
+
+    # unchanged production behavior: still raises without dev mode.
+    with pytest.raises(ConfigurationError, match="pinned installation"):
+        verify_remote_worker_info(runtime, **call_kwargs)  # pyright: ignore[reportArgumentType]
+
+    # dev mode: the same mismatch downgrades to a warning; verification passes.
+    findings = VerificationFindings()
+    verified = verify_remote_worker_info(
+        runtime,
+        dev_mode=True,
+        findings=findings,
+        **call_kwargs,  # pyright: ignore[reportArgumentType]
+    )
+    assert verified == other_receipt
+    assert len(findings.warnings) == 1
+    assert "pinned installation" in findings.warnings[0]
+    assert other_receipt.distribution_version in findings.warnings[0]
+    assert "worker=" in findings.warnings[0] and "pinned=" in findings.warnings[0]
+
+    # hard checks stay hard even in dev mode: liveness (fresh/process_running)...
+    with pytest.raises(ConfigurationError, match="fresh"):
+        verify_remote_worker_info(
+            {**runtime, "fresh": False},
+            dev_mode=True,
+            **call_kwargs,  # pyright: ignore[reportArgumentType]
+        )
+    # ...and physical target identity.
+    unverified_target = {
+        **cast(dict[str, object], runtime["target_identity"]),
+        "verified": False,
+    }
+    unverified_target_runtime = {**runtime, "target_identity": unverified_target}
+    with pytest.raises(ConfigurationError, match="physical target identity"):
+        verify_remote_worker_info(
+            unverified_target_runtime,
+            dev_mode=True,
+            require_target_identity=True,
+            expected_cluster="ares-p5run2",
+            expected_version=other_receipt.distribution_version,
+            expected_software=SoftwareIdentity.model_validate(worker_matches_other["software"]),
+            expected_artifact_sha256=other_receipt.artifact_sha256,
+            expected_source="wheel",
+        )
+
+
 def test_worker_runtime_info_resolves_cluster_pinned_receipt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1874,8 +2068,11 @@ def test_worker_runtime_info_resolves_cluster_pinned_receipt(
     def worker_process_matches(_pid: int) -> bool:
         return True
 
+    def current_installation(**_kwargs: object) -> dict[str, object]:
+        return current_identity
+
     monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(root))
-    monkeypatch.setattr(installation_module, "installation_info", lambda: current_identity)
+    monkeypatch.setattr(installation_module, "installation_info", current_installation)
     monkeypatch.setattr(installation_module, "_worker_process_matches", worker_process_matches)
 
     result = worker_runtime_info(
@@ -1938,7 +2135,7 @@ def test_worker_runtime_info_reads_only_the_sealed_fresh_endpoint_index(
     )
     monkeypatch.setenv("CLIO_RELAY_CORE_DIR", str(root))
 
-    def current_installation() -> dict[str, object]:
+    def current_installation(**_kwargs: object) -> dict[str, object]:
         return identity
 
     monkeypatch.setattr(installation_module, "installation_info", current_installation)
@@ -2144,6 +2341,40 @@ def test_jarvis_mcp_defaults_to_persistent_receipt_bound_clio_kit_tool(
     assert runtime["clio-kit"]["command_matches_receipt"] is True
     assert runtime["clio-kit"]["launcher"] == "uv tool"
     assert runtime["clio-kit"]["persistent_tool_verified"] is True
+
+
+def test_jarvis_mcp_command_dev_mode_downgrades_missing_component_to_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """clio-relay#211/#210: a receipt with no clio-kit component becomes advisory.
+
+    ``jarvis_mcp_command()`` requires ``component_artifacts.clio-kit`` and
+    raises typed ("install receipt has no clio-kit component artifact")
+    without it -- one of the four concrete walls named in clio-relay#211.
+    Production behavior is unchanged; CLIO_RELAY_DEV_MODE=1 falls back to
+    DEFAULT_JARVIS_MCP_COMMAND (the same fallback already used when no
+    receipt exists at all) and records the exact production reason.
+    """
+    receipt_path = tmp_path / "install-receipt.json"
+    write_install_receipt(install_spec="checkout", path=receipt_path)
+    monkeypatch.setenv(INSTALL_RECEIPT_PATH_ENV, str(receipt_path))
+    monkeypatch.delenv(JARVIS_MCP_COMMAND_ENV, raising=False)
+
+    monkeypatch.delenv(DEV_MODE_ENV, raising=False)
+    with pytest.raises(ValueError, match="no clio-kit component artifact"):
+        jarvis_mcp_command()
+
+    findings = VerificationFindings()
+    fallback = ["clio-kit", "mcp-server", "jarvis"]
+    assert jarvis_mcp_command(dev_mode=True, findings=findings) == fallback
+    assert len(findings.warnings) == 1
+    assert "no clio-kit component artifact" in findings.warnings[0]
+
+    monkeypatch.setenv(DEV_MODE_ENV, "1")
+    env_findings = VerificationFindings()
+    assert jarvis_mcp_command(findings=env_findings) == ["clio-kit", "mcp-server", "jarvis"]
+    assert len(env_findings.warnings) == 1
 
 
 def test_component_runtime_identity_does_not_probe_unverified_clio_kit_launcher(


### PR DESCRIPTION
## Summary

Owner directive (clio-relay#211): during development, no sha/identity
check should block iteration. The 2026-08-11 redeploy hit four sequential
verification walls -- `identity_matches_current` (#205), receipt
derivation for non-generation installs, `receipt_matches_install`
wheel-byte equality, and `component_artifacts` requirements (#210) --
each a production-integrity check correctly defending a released
deployment, and each an hours-long obstacle to a dev loop whose
provenance is already the git sha being iterated.

**The switch**: `CLIO_RELAY_DEV_MODE=1` (environment) and/or
`dev_mode=True` on a cluster registry entry (`cluster add --dev-mode`)
either enable the downgrade. `src/clio_relay/dev_mode.py` is the one
place detection happens and the one shape a downgraded finding takes
(`VerificationFindings`, the `enforce()` choke point every downgradable
check routes through, and the `DEV_MODE_BANNER` marker).

**Converted to typed warnings instead of raises** (still runs the check,
still reports the exact production error, carried as `dev_mode_warnings`
behind the unmissable `dev_mode_banner` in every status/info payload it
reaches):

- `verify_remote_worker_info` + `verify_remote_installation_info`
  (`installation.py`) -- the semantic identity/receipt/sha comparisons
  (`identity_matches_current`/`running`, `identity_matches_pinned`,
  `receipt_matches_install`, version/software/artifact-sha/source
  equality, the endpoint-vs-current cross-check).
- `_persistent_uv_tool_install_receipt` / `write_self_install_receipt`
  -- the persistent-tool identity checks (kind, launcher, artifact
  identity, uv-tool receipt); still derives a best-effort `InstallReceipt`
  (honestly less-verified: `artifact_sha256` may be `None`, `installed_at`
  may fall back to now) instead of refusing a non-generation dev install
  a receipt at all.
- `jarvis_mcp_command`'s `component_artifacts.clio-kit` requirement --
  falls back to `DEFAULT_JARVIS_MCP_COMMAND` (the same fallback already
  used when no receipt exists) instead of blocking the worker's JARVIS
  MCP server from starting.
- `_verify_session_start_worker_release_identity` (session
  plan-start/start) threads `dev_mode` into the remote worker check; when
  the downgraded receipt has no artifact sha at all, a deterministic
  advisory sha is derived so the session-API process-attestation identity
  (which requires a real 64-hex value) can still be minted, clearly
  labeled as a dev-mode finding rather than pretending to be a release
  digest.

**Status/info surfaces carrying the banner**: `installation-info` and
`endpoint worker-info` embed it directly in their JSON (worker-info
inherits it for free through its nested `installation`/
`endpoint_installation` fields, since those already embed
`installation_info()`'s own output). `session plan-start`/`session
start` echo it as a companion JSON line to stderr before the plan,
since the plan itself is a strict `extra="forbid"` schema that can't
carry arbitrary extra keys.

**Stays hard unconditionally, regardless of dev mode**:

- Liveness (`fresh`, `process_running`) and every structural/shape check
  (schema version, cluster/role match, scheduler-provider attestation,
  malformed-payload `ValidationError`s).
- Physical target identity (operator-pinned hostname/ssh-host-key/site
  marker) -- dev mode relaxes release-integrity ceremony for a trusted
  git sha already being iterated on, not which physical machine a
  session trusts.
- Writer proof, the worker-lifetime lock, storage admission, teardown
  scoping -- proven by a structural test that none of those modules
  import anything from `clio_relay.dev_mode` at all, not just by
  omission.
- `verified_session_api_install_receipt` (the running API *process's*
  own identity binding) -- a deliberate scoping call: this protects the
  actively-running session process's self-consistency, closer to
  "protecting live state" than "release ceremony blocking dev
  iteration," and isn't one of the four walls named above.

## Explicitly out of scope for this slice

`remote_mcp.py`'s discovery/execution-binding artifact checks at refresh
time (~30 raises spanning tool-call/artifact-digest TOCTOU binding during
actual MCP execution) are a materially different, much more tightly
state-coupled subsystem than the other four areas -- not one of the
concrete walls the owner hit, and genuinely risky to downgrade correctly
under this timeline (an advisory-only artifact-binding check could let an
MCP call execute against mismatched bytes). This needs its own dedicated
slice with real understanding of the discovery/execution state machine,
not a rushed pass appended here.

## Test plan

- [x] `dev_mode_enabled` -- env var truthy/falsy parsing, cluster-flag
      OR env-var combination, independently
- [x] `enforce` -- the choke point: raises in production, records (never
      raises) in dev mode, never touches a satisfied condition either way
- [x] `VerificationFindings.payload()` -- `None` when clean, the exact
      banner + warnings dict when not
- [x] `installation_info` -- the identical branch-pinned-VCS fixture that
      hard-fails today still hard-fails without dev mode; with
      `CLIO_RELAY_DEV_MODE=1` it derives a best-effort receipt carrying
      the exact production message as a warning; a fully-verified install
      carries no dev-mode keys at all
- [x] `verify_remote_worker_info` -- the identical pin-mismatch fixture
      from the #205 test still raises without dev mode; with
      `dev_mode=True` it passes, the finding names both identities
      exactly as the production error would; `fresh=False` and
      unverified `target_identity` still raise even with `dev_mode=True`
- [x] `jarvis_mcp_command` -- a receipt with no clio-kit component raises
      without dev mode; with dev mode (both explicit flag and
      `CLIO_RELAY_DEV_MODE`) it falls back to the default command and
      records the exact production reason
- [x] Structural test: `worker_lifetime_lock.py`, `storage_policy.py`,
      `session_lifecycle.py` contain zero references to `dev_mode` --
      proof by construction that live-state protection cannot consult a
      flag it never imports
- [x] `ClusterDefinition.dev_mode` defaults `False`, strict-bool
      validated, `cluster add --dev-mode`/`--no-dev-mode` persists it
      without disturbing anything else on the entry
- [x] CLI wiring: `endpoint worker-info --dev-mode` combines with
      `CLIO_RELAY_DEV_MODE` either way; `installation-write-receipt
      --dev-mode` forwards through
- [x] `ruff check --fix`: clean
- [x] `ruff format`: clean
- [x] `uv run pyright` on all touched files: 0 errors
- [x] Full suites green: `test_dev_mode.py` (new), `test_cluster_config.py`,
      `test_installation.py`, `test_cli.py` (all ~216 tests),
      `test_jarvis_mcp_validation.py`, `test_live_acceptance.py`,
      `test_bootstrap_reconcile.py`, `test_bootstrap_fast_path.py`,
      `test_validation_report.py`

Fixes #211 for the scope described above; the `remote_mcp.py` refresh-time
digest comparisons remain a named follow-up.
