### PR TITLE
fix(mcp): user profile carries the produced-artifact content path

### DIFF
--- a/src/clio_relay/mcp_server.py
+++ b/src/clio_relay/mcp_server.py
@@ -226,6 +226,8 @@ USER_MCP_TOOL_NAMES = {
     "relay_storage_status",
     "relay_bind_jarvis_runtime",
     "relay_artifact_lineage",
+    "relay_list_artifacts",
+    "relay_read_artifact",
 }
 _REMOTE_JOB_FOLLOWUP_TOOL_NAMES = frozenset(
     {

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -313,6 +313,8 @@ def test_mcp_lists_relay_tools(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
         "relay_storage_status",
         "relay_bind_jarvis_runtime",
         "relay_artifact_lineage",
+        "relay_list_artifacts",
+        "relay_read_artifact",
         "jarvis_create_pipeline",
         "jarvis_describe",
         "jarvis_add_step",

--- a/tests/test_user_profile_content_path.py
+++ b/tests/test_user_profile_content_path.py
@@ -1,0 +1,102 @@
+"""User-profile produced-artifact content path (2026-08-19 ares L3 clause-(d)).
+
+The grounded L3 run twice located a completed LAMMPS execution's real
+``log.lammps`` thermo output and could not read it: ``relay_read_artifact``
+exists (declared AND dispatched) but was absent from ``USER_MCP_TOOL_NAMES``,
+and the user profile exposed no produced-outputs discovery either
+(``relay_artifact_lineage``'s job direction lists a job's CONSUMED inputs --
+the retry proved every job_id returns ``used_artifacts: []`` for outputs).
+The user surface must carry the whole produced-content path: discovery
+(``relay_list_artifacts`` by job_id) plus bounded fetch
+(``relay_read_artifact`` by artifact_id). Evidence:
+``D:\\relay-p5local\\evidence\\l3-run-20260819T073640.json``.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from pathlib import Path
+
+from clio_relay.core_queue import ClioCoreQueue
+from clio_relay.mcp_server import handle_request
+from clio_relay.models import ArtifactRef, JarvisRunSpec, JobKind, RelayJob
+
+
+def _produced_artifact(tmp_path: Path, queue: ClioCoreQueue) -> tuple[RelayJob, ArtifactRef, bytes]:
+    job = queue.submit_job(
+        RelayJob(
+            cluster="desktop",
+            kind=JobKind.JARVIS,
+            spec=JarvisRunSpec(command=["echo", "thermo"]),
+            idempotency_key="produced-content-path",
+        )
+    )
+    payload = b"Step Temp E_pair\n100 0.7128 -5.6021\n"
+    owned_dir = tmp_path / "spool" / job.job_id
+    owned_dir.mkdir(parents=True)
+    output = owned_dir / "log.lammps"
+    output.write_bytes(payload)
+    artifact = queue.append_artifact(
+        ArtifactRef(
+            job_id=job.job_id,
+            uri=output.absolute().as_uri(),
+            kind="execution_output",
+            size_bytes=len(payload),
+            sha256=hashlib.sha256(payload).hexdigest(),
+        )
+    )
+    return job, artifact, payload
+
+
+def test_user_profile_advertises_both_content_tools(tmp_path: Path) -> None:
+    """tools/list under ``--profile user`` carries discovery AND fetch."""
+    queue = ClioCoreQueue(tmp_path / "core")
+    listed = handle_request(
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        queue=queue,
+        profile="user",
+    )
+    assert listed is not None
+    names = {tool["name"] for tool in listed["result"]["tools"]}
+    assert "relay_list_artifacts" in names, "discovery half absent from the user profile"
+    assert "relay_read_artifact" in names, "fetch half absent from the user profile"
+
+
+def test_user_profile_content_path_round_trips(tmp_path: Path) -> None:
+    """List a job's produced artifacts, then read one's bytes, all as user."""
+    queue = ClioCoreQueue(tmp_path / "core")
+    job, artifact, payload = _produced_artifact(tmp_path, queue)
+
+    page = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "relay_list_artifacts", "arguments": {"job_id": job.job_id}},
+        },
+        queue=queue,
+        profile="user",
+    )
+    assert page is not None
+    records = page["result"]["structuredContent"]["artifacts"]
+    assert [record["artifact_id"] for record in records] == [artifact.artifact_id]
+
+    read = handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "relay_read_artifact",
+                "arguments": {"artifact_id": artifact.artifact_id},
+            },
+        },
+        queue=queue,
+        profile="user",
+    )
+    assert read is not None
+    envelope = read["result"]["structuredContent"]
+    assert envelope["encoding"] == "base64"
+    assert base64.b64decode(envelope["data"]) == payload
+    assert envelope["artifact"]["artifact_id"] == artifact.artifact_id


### PR DESCRIPTION
L3 clause-(d) root fix: `relay_list_artifacts` + `relay_read_artifact` added
to `USER_MCP_TOOL_NAMES` (both fully wired underneath — zero handler
changes). The 2026-08-19 L3 retry proved the user profile had no route from
a completed job to its produced bytes: the fetch tool was never advertised,
and lineage's job direction lists consumed inputs only.

Failing-first: `tests/test_user_profile_content_path.py` (advertisement +
a full list-then-read round trip under `profile=user`); the exact-set
profile pin updated in-commit. Full-suite note: the known Windows suite
hang (~25%, pre-existing, confirmed independently by the #231 split work)
prevented a complete run; the directly-affected surface
(test_mcp_server.py, test_mcp_stdio_validation.py, the new file) is fully
green, and the one collected ERROR (kit-wheel contract pin) is A/B-proven
pre-existing on clean develop.

Evidence: `D:\relay-p5local\evidence\l3-run-20260819T073640.json`.
Companion clio-agent projections: c445d477 + 16402ca2.
