### PR TITLE
fix(bootstrap): state-aware forward recovery + jarvis-venv staging (#247, #254)

### DIFF
--- a/scripts/check_file_size.py
+++ b/scripts/check_file_size.py
@@ -97,7 +97,14 @@ RATCHET_BASELINE: dict[str, int] = {
     # real .dynstr (CPython 3.12.13 as shipped by uv) spans two contiguous
     # segments, so the old form found zero candidates and refused every staged
     # upgrade as "ambiguous". Mostly the comments recording that layout.
-    "src/clio_relay/bootstrap.py": 8896,
+    # clio-relay#247/#254: -629 net lines -- receipt-shape/JARVIS-repository-
+    # provenance validation (`_validate_bootstrap_receipt` and its four
+    # helpers) moved to the new owner module bootstrap_receipt_validation.py,
+    # offsetting the #247 state-aware forward-recovery dispatch (delegates to
+    # the new bootstrap_recovery.py) and the #254 jarvis-venv staging guard
+    # and promotion wiring (delegates to the new bootstrap_jarvis_staging.py).
+    # A net ratchet-down even after both fixes' own new call sites.
+    "src/clio_relay/bootstrap.py": 8356,
     # #158 journal hardening (site-prefix walk + cross-call swap refusal): 1534
     # measured; restored after a merge-resolution slip dropped the entry.
     "src/clio_relay/bootstrap_journal.py": 1534,

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -28,12 +28,9 @@ from uuid import uuid4
 from packaging.utils import InvalidWheelFilename, canonicalize_name, parse_wheel_filename
 from packaging.version import InvalidVersion, Version
 
-from clio_relay import __version__, bootstrap_pin
+from clio_relay import __version__, bootstrap_pin, bootstrap_receipt_validation
 from clio_relay.bootstrap_reconcile import (
-    LEGACY_MANAGED_JARVIS_REPO_PATH,
-    MANAGED_JARVIS_REPO_PATH,
     BootstrapDesiredState,
-    validate_jarvis_builtin_result,
 )
 from clio_relay.bounded_process import (
     BoundedProcessError,
@@ -1811,8 +1808,10 @@ _BOOTSTRAP_CANDIDATE_PACKAGE_OVERLAY = (
     b"    pass\n"
 )
 _BOOTSTRAP_CANDIDATE_SOURCE_NAMES = (
+    "bootstrap_jarvis_staging.py",
     "bootstrap_provider_build_info.py",
     "bootstrap_reconcile.py",
+    "bootstrap_recovery.py",
     "bounded_process.py",
     "errors.py",
     "process_containment.py",
@@ -2410,7 +2409,7 @@ def bootstrap_relay_identity(
             raise ConfigurationError(
                 "a relay bootstrap wheel requires its expected SHA-256 before preflight"
             )
-        if not _is_sha256_value(relay_artifact_sha256):
+        if not bootstrap_receipt_validation.is_sha256_value(relay_artifact_sha256):
             raise ConfigurationError("relay bootstrap wheel SHA-256 must be lowercase hex")
         if (
             relay_wheel.name != str(relay_wheel.name).strip()
@@ -2448,7 +2447,7 @@ def bootstrap_relay_identity(
             "released bootstrap requires --relay-artifact-sha256 from the exact wheel; "
             "this preserves offline identity and distinguishes rebuilt artifacts"
         )
-    if not _is_sha256_value(relay_artifact_sha256):
+    if not bootstrap_receipt_validation.is_sha256_value(relay_artifact_sha256):
         raise ConfigurationError("relay release artifact SHA-256 must be lowercase hex")
     install_spec = f"clio-relay=={__version__}"
     return BootstrapRelayIdentity(
@@ -2874,7 +2873,7 @@ def bootstrap_cluster_over_ssh(
             else ""
         ),
     )
-    if not _is_sha256_value(expected_jarvis_mcp_sha256):
+    if not bootstrap_receipt_validation.is_sha256_value(expected_jarvis_mcp_sha256):
         raise ConfigurationError("clio-kit bootstrap source requires its expected SHA-256")
     planned_identity = bootstrap_relay_identity(
         source_root=source_root,
@@ -2936,7 +2935,7 @@ def bootstrap_cluster_over_ssh(
             != planned_identity
         ):
             raise ConfigurationError("bootstrap source identity changed during preflight")
-        _validate_bootstrap_receipt(
+        bootstrap_receipt_validation.validate_bootstrap_receipt(
             preflight_receipt,
             bootstrap_profile=bootstrap_profile,
             relay_install_spec=planned_identity.install_spec,
@@ -3064,7 +3063,7 @@ def bootstrap_cluster_over_ssh(
         receipt = cast(dict[str, object], raw_receipt)
         if receipt.get("invocation_id") != invocation_id:
             raise RelayError("bootstrap receipt does not match the completed invocation")
-        _validate_bootstrap_receipt(
+        bootstrap_receipt_validation.validate_bootstrap_receipt(
             receipt,
             bootstrap_profile=bootstrap_profile,
             relay_install_spec=planned_identity.install_spec,
@@ -3137,637 +3136,6 @@ def _remaining_public_deadline(deadline: float, *, action: str) -> float:
 def package_source_root() -> Path:
     """Return the project root for editable installs, or the package root for wheels."""
     return Path(__file__).resolve().parents[2]
-
-
-def _validate_bootstrap_receipt(
-    receipt: dict[str, object],
-    *,
-    bootstrap_profile: str,
-    relay_install_spec: str,
-    desired_fingerprint: str,
-    expected_jarvis_resource_graph_profile: str | None,
-    expected_allow_jarvis_resource_graph_build: bool,
-    expected_worker_service: str | None,
-) -> None:
-    """Validate action-specific v2 evidence from the current remote invocation."""
-    install_receipt_sha256 = receipt.get("install_receipt_sha256")
-    outcome = receipt.get("outcome")
-    duration = receipt.get("duration_seconds")
-    components = receipt.get("components")
-    operations = receipt.get("operations")
-    preservation = receipt.get("preservation")
-    worker = receipt.get("worker")
-    generation = receipt.get("generation")
-    queue_operation = receipt.get("queue_operation")
-    jarvis_initialization = receipt.get("jarvis_initialization")
-    jarvis_resource_graph = receipt.get("jarvis_resource_graph")
-    jarvis_commands = receipt.get("jarvis_commands")
-    jarvis_preservation = receipt.get("jarvis_preservation")
-    service = receipt.get("service")
-    contract = {
-        "schema_version": receipt.get("schema_version") == "clio-relay.bootstrap-receipt.v2",
-        "bootstrap_profile": receipt.get("bootstrap_profile") == bootstrap_profile,
-        "relay_install_spec": receipt.get("relay_install_spec") == relay_install_spec,
-        "desired_fingerprint": receipt.get("desired_fingerprint") == desired_fingerprint,
-        "outcome": outcome
-        in {
-            "noop_verified",
-            "verified_after_transfer",
-            "repaired",
-            "reconciled",
-            "full",
-        },
-        "install_receipt_sha256": _is_sha256_value(install_receipt_sha256),
-        "duration_seconds": (
-            not isinstance(duration, bool) and isinstance(duration, (int, float)) and duration >= 0
-        ),
-        "completed_at": isinstance(receipt.get("completed_at"), str)
-        and bool(receipt.get("completed_at")),
-        "components": isinstance(components, dict)
-        and len(cast(dict[object, object], components)) > 0,
-        "operations": isinstance(operations, dict),
-        "preservation": isinstance(preservation, dict),
-        "worker": isinstance(worker, dict),
-        "generation": isinstance(generation, dict),
-        "queue_operation": isinstance(queue_operation, dict),
-        "jarvis_initialization": isinstance(jarvis_initialization, dict),
-        "jarvis_resource_graph": isinstance(jarvis_resource_graph, dict),
-        "jarvis_commands": isinstance(jarvis_commands, dict),
-        "jarvis_preservation": isinstance(jarvis_preservation, dict),
-        "service": isinstance(service, dict),
-    }
-    failed = sorted(name for name, passed in contract.items() if not passed)
-    if failed:
-        raise RelayError(f"bootstrap receipt contract failed: {failed}")
-    assert isinstance(components, dict)
-    typed_components = cast(dict[str, object], components)
-    required_components = {"clio-relay", "clio-kit", "jarvis-cd", "jarvis-util", "frp", "uv"}
-    if not required_components.issubset(typed_components):
-        raise RelayError("bootstrap receipt omitted required component evidence")
-    component_actions: dict[str, str] = {}
-    for name, raw_evidence in typed_components.items():
-        if not isinstance(raw_evidence, dict):
-            raise RelayError(f"bootstrap component evidence is invalid: {name}")
-        evidence = cast(dict[str, object], raw_evidence)
-        action = evidence.get("action")
-        component_duration = evidence.get("duration_seconds")
-        if (
-            action not in {"reused", "prepared", "materialized", "replaced"}
-            or not isinstance(evidence.get("observed_identity"), dict)
-            or isinstance(component_duration, bool)
-            or not isinstance(component_duration, (int, float))
-            or component_duration < 0
-        ):
-            raise RelayError(f"bootstrap component action evidence is invalid: {name}")
-        component_actions[name] = cast(str, action)
-    assert isinstance(operations, dict)
-    typed_operations = cast(dict[str, object], operations)
-    count_fields = (
-        "download_count",
-        "service_restart_count",
-        "service_start_count",
-        "service_stop_count",
-        "service_enable_count",
-        "scheduler_submission_count",
-        "scheduler_cancellation_count",
-        "generation_gc_count",
-        "payload_transfer_count",
-        "payload_transfer_bytes",
-    )
-    for field in count_fields:
-        value = typed_operations.get(field)
-        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
-            raise RelayError(f"bootstrap operation count is invalid: {field}")
-    downloads = typed_operations.get("downloads")
-    if not isinstance(downloads, list) or len(cast(list[object], downloads)) != cast(
-        int, typed_operations["download_count"]
-    ):
-        raise RelayError("bootstrap download evidence does not match its count")
-    if any(
-        typed_operations[field] != 0
-        for field in (
-            "scheduler_submission_count",
-            "scheduler_cancellation_count",
-            "generation_gc_count",
-        )
-    ):
-        raise RelayError("bootstrap performed a forbidden scheduler or generation operation")
-    payload_count = cast(int, typed_operations["payload_transfer_count"])
-    payload_bytes = cast(int, typed_operations["payload_transfer_bytes"])
-    if payload_count not in {0, 2} or (payload_count == 0) != (payload_bytes == 0):
-        raise RelayError("bootstrap payload transfer evidence is inconsistent")
-    assert isinstance(preservation, dict)
-    typed_preservation = cast(dict[str, object], preservation)
-    if typed_preservation != {
-        "scheduler_jobs_cancelled": False,
-        "old_generations_retained": True,
-        "jarvis_init_on_existing_root": False,
-    }:
-        raise RelayError("bootstrap preservation evidence is invalid")
-    assert isinstance(worker, dict)
-    typed_worker = cast(dict[str, object], worker)
-    if typed_worker.get("service_name") != expected_worker_service:
-        raise RelayError("bootstrap worker service evidence does not match")
-    assert isinstance(service, dict)
-    typed_service = cast(dict[str, object], service)
-    service_pending_install = typed_service.get("pending_install")
-    if not isinstance(service_pending_install, bool):
-        raise RelayError("bootstrap service pending-install evidence is invalid")
-    if expected_worker_service is not None:
-        if outcome == "full" and service_pending_install:
-            if (
-                typed_worker.get("service_was_active") is not False
-                or typed_worker.get("service_was_enabled") is not False
-                or typed_worker.get("worker_ready") is not False
-            ):
-                raise RelayError("fresh bootstrap service-pending evidence is inconsistent")
-        elif (
-            typed_worker.get("service_was_active") is not True
-            or typed_worker.get("worker_ready") is not True
-            or service_pending_install
-        ):
-            raise RelayError("managed bootstrap did not leave a ready endpoint service")
-    assert isinstance(generation, dict)
-    typed_generation = cast(dict[str, object], generation)
-    if (
-        typed_generation.get("active") != desired_fingerprint
-        or not isinstance(typed_generation.get("current_target"), str)
-        or not cast(str, typed_generation["current_target"])
-    ):
-        raise RelayError("bootstrap generation evidence does not prove desired activation")
-    assert isinstance(queue_operation, dict)
-    typed_queue_operation = cast(dict[str, object], queue_operation)
-    queue_action = typed_queue_operation.get("action")
-    queue_duration = typed_queue_operation.get("duration_seconds")
-    if (
-        queue_action not in {"verified_read_only", "audited_and_sealed"}
-        or isinstance(queue_duration, bool)
-        or not isinstance(queue_duration, (int, float))
-        or queue_duration < 0
-        or (queue_action == "audited_and_sealed" and queue_duration <= 0)
-    ):
-        raise RelayError("bootstrap queue action evidence is invalid")
-    assert isinstance(jarvis_initialization, dict)
-    typed_jarvis_initialization = cast(dict[str, object], jarvis_initialization)
-    jarvis_init_action = typed_jarvis_initialization.get("action")
-    jarvis_init_duration = typed_jarvis_initialization.get("duration_seconds")
-    if (
-        jarvis_init_action not in {"preserved", "initialized"}
-        or isinstance(jarvis_init_duration, bool)
-        or not isinstance(jarvis_init_duration, (int, float))
-        or jarvis_init_duration < 0
-        or (jarvis_init_action == "initialized" and jarvis_init_duration <= 0)
-        or (jarvis_init_action == "preserved" and jarvis_init_duration != 0)
-    ):
-        raise RelayError("bootstrap JARVIS initialization evidence is invalid")
-    assert isinstance(jarvis_resource_graph, dict)
-    typed_jarvis_graph = cast(dict[str, object], jarvis_resource_graph)
-    jarvis_graph_action = typed_jarvis_graph.get("action")
-    jarvis_graph_duration = typed_jarvis_graph.get("duration_seconds")
-    jarvis_builtin_result = typed_jarvis_graph.get("builtin_result")
-    if (
-        set(typed_jarvis_graph)
-        != {
-            "action",
-            "duration_seconds",
-            "benchmark_enabled",
-            "selected_profile",
-            "allow_build_fallback",
-            "builtin_result",
-        }
-        or jarvis_graph_action not in {"preserved", "loaded", "built"}
-        or typed_jarvis_graph.get("benchmark_enabled") is not False
-        or typed_jarvis_graph.get("selected_profile") != expected_jarvis_resource_graph_profile
-        or typed_jarvis_graph.get("allow_build_fallback")
-        is not expected_allow_jarvis_resource_graph_build
-        or isinstance(jarvis_graph_duration, bool)
-        or not isinstance(jarvis_graph_duration, (int, float))
-        or jarvis_graph_duration < 0
-        or (jarvis_graph_action in {"loaded", "built"} and jarvis_graph_duration <= 0)
-        or (jarvis_graph_action == "preserved" and jarvis_graph_duration != 0)
-    ):
-        raise RelayError("bootstrap JARVIS resource graph evidence is invalid")
-    if jarvis_graph_action == "preserved":
-        if jarvis_builtin_result is not None:
-            raise RelayError("preserved JARVIS graph claimed builtin activation evidence")
-    else:
-        if expected_jarvis_resource_graph_profile is None or not isinstance(
-            jarvis_builtin_result, dict
-        ):
-            raise RelayError("JARVIS graph activation omitted builtin result evidence")
-        try:
-            validate_jarvis_builtin_result(
-                cast(dict[str, object], jarvis_builtin_result),
-                requested_profile=expected_jarvis_resource_graph_profile,
-            )
-        except ValueError as exc:
-            raise RelayError(f"bootstrap JARVIS builtin graph evidence is invalid: {exc}") from exc
-        expected_builtin_action = "loaded" if jarvis_graph_action == "loaded" else "unavailable"
-        if cast(dict[str, object], jarvis_builtin_result).get("action") != expected_builtin_action:
-            raise RelayError("bootstrap JARVIS graph action contradicts builtin evidence")
-        if jarvis_graph_action == "built" and not expected_allow_jarvis_resource_graph_build:
-            raise RelayError("bootstrap reported an unauthorized JARVIS graph build")
-    assert isinstance(jarvis_commands, dict)
-    typed_jarvis_commands = cast(dict[str, object], jarvis_commands)
-    command_count = typed_jarvis_commands.get("count")
-    command_argv = typed_jarvis_commands.get("argv")
-    typed_command_argv = cast(list[object], command_argv) if isinstance(command_argv, list) else []
-    if (
-        isinstance(command_count, bool)
-        or not isinstance(command_count, int)
-        or command_count < 0
-        or not isinstance(command_argv, list)
-        or len(typed_command_argv) != command_count
-        or any(
-            not isinstance(raw_command, list)
-            or not raw_command
-            or any(
-                not isinstance(value, str) or not value for value in cast(list[object], raw_command)
-            )
-            for raw_command in typed_command_argv
-        )
-    ):
-        raise RelayError("bootstrap JARVIS command evidence is invalid")
-    assert isinstance(jarvis_preservation, dict)
-    typed_jarvis_preservation = cast(dict[str, object], jarvis_preservation)
-    if not isinstance(typed_jarvis_preservation.get("before"), dict) or not isinstance(
-        typed_jarvis_preservation.get("after"), dict
-    ):
-        raise RelayError("bootstrap JARVIS preservation evidence is invalid")
-    raw_binding = typed_jarvis_preservation.get("repositories")
-    if not isinstance(raw_binding, dict):
-        raise RelayError("bootstrap JARVIS repository binding evidence is invalid")
-    binding = cast(dict[str, object], raw_binding)
-    if set(binding) != {"link_action", "link", "target", "repositories"} or binding.get(
-        "link_action"
-    ) not in {"reused", "created", "retargeted"}:
-        raise RelayError("bootstrap JARVIS repository link evidence is invalid")
-    raw_repository_update = binding.get("repositories")
-    if not isinstance(raw_repository_update, dict):
-        raise RelayError("bootstrap JARVIS repository update evidence is invalid")
-    repository_update = cast(dict[str, object], raw_repository_update)
-    if set(repository_update) != {
-        "action",
-        "managed_repo",
-        "added_managed_repos",
-        "removed_previous_managed_repos",
-        "before_sha256",
-        "after_sha256",
-    } or repository_update.get("action") not in {"reused", "updated"}:
-        raise RelayError("bootstrap JARVIS repository update evidence is invalid")
-    before_state = cast(dict[str, object], typed_jarvis_preservation["before"])
-    after_state = cast(dict[str, object], typed_jarvis_preservation["after"])
-    if (
-        repository_update.get("before_sha256") != before_state.get("repos_sha256")
-        or repository_update.get("after_sha256") != after_state.get("repos_sha256")
-        or after_state.get("managed_repo_registered") is not True
-        or after_state.get("managed_builtin_repo_registered") is not True
-        or not isinstance(repository_update.get("added_managed_repos"), list)
-        or not isinstance(repository_update.get("removed_previous_managed_repos"), list)
-    ):
-        raise RelayError("bootstrap JARVIS repository hashes do not bind preservation evidence")
-    if jarvis_graph_action == "loaded" and not _is_sha256_value(
-        after_state.get("resource_graph_sha256")
-    ):
-        # The activated graph is JARVIS's normalized derivative of the packaged
-        # builtin, so its digest legitimately differs from source_sha256 and
-        # cannot be bound by equality here (#158). Source identity is proven
-        # remotely, where the packaged file actually lives -- the cluster-side
-        # step hashes the source JARVIS names and fails closed on a mismatch.
-        # What the host binds is that activation evidence was recorded at all.
-        raise RelayError("loaded JARVIS graph did not record its activated resource graph digest")
-    if outcome == "noop_verified":
-        if (
-            any(action != "reused" for action in component_actions.values())
-            or typed_operations["download_count"] != 0
-            or typed_operations["service_restart_count"] != 0
-            or typed_operations["service_start_count"] != 0
-            or typed_operations["service_stop_count"] != 0
-            or typed_operations["service_enable_count"] != 0
-            or typed_operations["payload_transfer_count"] != 0
-            or typed_operations["payload_transfer_bytes"] != 0
-            or queue_action != "verified_read_only"
-            or queue_duration != 0
-            or jarvis_init_action != "preserved"
-            or jarvis_graph_action != "preserved"
-            or command_count != 0
-            or typed_jarvis_preservation.get("config_byte_identical") is not True
-            or typed_jarvis_preservation.get("resource_graph_byte_identical") is not True
-            or typed_jarvis_preservation.get("repositories_byte_identical") is not True
-            or binding.get("link_action") != "reused"
-            or repository_update.get("action") != "reused"
-        ):
-            raise RelayError("bootstrap no-op receipt reported mutation")
-    elif outcome == "verified_after_transfer":
-        if (
-            any(action != "reused" for action in component_actions.values())
-            or typed_operations["download_count"] != 0
-            or typed_operations["service_restart_count"] != 0
-            or typed_operations["service_start_count"] != 0
-            or typed_operations["service_stop_count"] != 0
-            or typed_operations["service_enable_count"] != 0
-            or payload_count != 2
-            or payload_bytes <= 0
-            or queue_action != "verified_read_only"
-            or queue_duration != 0
-            or jarvis_init_action != "preserved"
-            or jarvis_graph_action != "preserved"
-            or command_count != 0
-            or typed_jarvis_preservation.get("config_byte_identical") is not True
-            or typed_jarvis_preservation.get("resource_graph_byte_identical") is not True
-            or typed_jarvis_preservation.get("repositories_byte_identical") is not True
-            or binding.get("link_action") != "reused"
-            or repository_update.get("action") != "reused"
-        ):
-            raise RelayError("post-transfer verification receipt reported mutation")
-    elif outcome == "repaired":
-        if (
-            any(action != "reused" for action in component_actions.values())
-            or typed_operations["download_count"] != 0
-        ):
-            raise RelayError("bootstrap repair receipt reported component replacement")
-        if jarvis_init_action != "preserved":
-            raise RelayError("bootstrap repair receipt reported JARVIS initialization")
-        if jarvis_graph_action != "preserved" or command_count != 0:
-            raise RelayError("bootstrap repair receipt reported JARVIS commands")
-        managed_repo = repository_update.get("managed_repo")
-        added_repositories = repository_update.get("added_managed_repos")
-        removed_repositories = repository_update.get("removed_previous_managed_repos")
-        if (
-            typed_jarvis_preservation.get("config_byte_identical") is not True
-            or typed_jarvis_preservation.get("resource_graph_byte_identical") is not True
-        ):
-            raise RelayError("bootstrap repair receipt reported JARVIS state mutation")
-        if (
-            not isinstance(managed_repo, str)
-            or not PurePosixPath(managed_repo).is_absolute()
-            or any(character in managed_repo for character in "\x00\r\n")
-            or binding.get("link") != managed_repo
-            or binding.get("link_action") not in {"reused", "created", "retargeted"}
-            or not isinstance(added_repositories, list)
-            or not isinstance(removed_repositories, list)
-            or not _is_sha256_value(typed_generation.get("previous"))
-        ):
-            raise RelayError("bootstrap managed JARVIS binding repair is invalid")
-        managed_suffix = MANAGED_JARVIS_REPO_PATH.removeprefix("~")
-        if not managed_repo.endswith(managed_suffix):
-            raise RelayError("bootstrap managed JARVIS binding repair is invalid")
-        remote_home = managed_repo[: -len(managed_suffix)]
-        expected_target = (
-            remote_home + "/.local/share/clio-relay/current/source/jarvis-packages/clio_relay"
-        )
-        expected_previous = remote_home + "/.local/src/clio-relay/jarvis-packages/clio_relay"
-        expected_legacy = remote_home + LEGACY_MANAGED_JARVIS_REPO_PATH.removeprefix("~")
-        expected_builtin = remote_home + "/.ppi-jarvis/builtin"
-        typed_removed_repositories = cast(list[object], removed_repositories)
-        removed_repositories_are_proven = _jarvis_repository_removals_are_proven(
-            typed_removed_repositories,
-            remote_home=remote_home,
-            exact_paths={expected_previous, expected_legacy},
-        )
-        repository_action = repository_update.get("action")
-        if binding.get("target") != expected_target:
-            raise RelayError("bootstrap managed JARVIS binding repair is invalid")
-        if repository_action == "reused":
-            if (
-                typed_jarvis_preservation.get("repositories_byte_identical") is not True
-                or added_repositories
-                or removed_repositories
-            ):
-                raise RelayError("bootstrap managed JARVIS repository reuse is invalid")
-        elif repository_action == "updated":
-            if (
-                typed_jarvis_preservation.get("repositories_byte_identical") is not False
-                or not _jarvis_repository_additions_are_proven(
-                    cast(list[object], added_repositories),
-                    managed_repo=managed_repo,
-                    managed_builtin_repo=expected_builtin,
-                )
-                or not removed_repositories_are_proven
-                or (not added_repositories and not removed_repositories)
-            ):
-                raise RelayError("bootstrap managed JARVIS repository repair is invalid")
-        else:
-            raise RelayError("bootstrap managed JARVIS repository repair is invalid")
-    elif outcome == "reconciled":
-        raw_transaction = receipt.get("transaction")
-        transaction_mode = (
-            cast(dict[str, object], raw_transaction).get("mode")
-            if isinstance(raw_transaction, dict)
-            else None
-        )
-        if transaction_mode == "component-upgrade":
-            expected_actions = {
-                "clio-relay": "replaced",
-                "clio-kit": "replaced",
-                "jarvis-cd": "replaced",
-                "jarvis-util": "reused",
-                "frp": "reused",
-                "uv": "reused",
-            }
-        elif transaction_mode == "relay-only":
-            expected_actions = {
-                "clio-relay": "prepared",
-                "clio-kit": "reused",
-                "jarvis-cd": "reused",
-                "jarvis-util": "reused",
-                "frp": "reused",
-                "uv": "reused",
-            }
-        else:
-            raise RelayError("reconciled bootstrap receipt has an invalid transaction mode")
-        if any(component_actions.get(name) != action for name, action in expected_actions.items()):
-            raise RelayError("staged reconcile receipt has invalid component actions")
-        if jarvis_init_action != "preserved":
-            raise RelayError("staged reconcile reported JARVIS initialization")
-        if jarvis_graph_action != "preserved" or command_count != 0:
-            raise RelayError("staged reconcile reported JARVIS commands")
-        previous_generation = typed_generation.get("previous")
-        link_action = binding.get("link_action")
-        previous_generation_is_proven = bool(
-            previous_generation == "legacy" or _is_sha256_value(previous_generation)
-        )
-        link_action_is_proven = bool(
-            link_action == "reused"
-            or (link_action in {"created", "retargeted"} and previous_generation_is_proven)
-        )
-        if (
-            typed_jarvis_preservation.get("config_byte_identical") is not True
-            or typed_jarvis_preservation.get("resource_graph_byte_identical") is not True
-            or not link_action_is_proven
-        ):
-            raise RelayError("staged reconcile did not preserve existing JARVIS state")
-        managed_repo = repository_update.get("managed_repo")
-        added_repositories = repository_update.get("added_managed_repos")
-        removed_repositories = repository_update.get("removed_previous_managed_repos")
-        if (
-            not isinstance(managed_repo, str)
-            or not PurePosixPath(managed_repo).is_absolute()
-            or any(character in managed_repo for character in "\x00\r\n")
-            or binding.get("link") != managed_repo
-        ):
-            raise RelayError("staged reconcile repository binding is invalid")
-        managed_suffix = MANAGED_JARVIS_REPO_PATH.removeprefix("~")
-        if not managed_repo.endswith(managed_suffix):
-            raise RelayError("staged reconcile repository binding is invalid")
-        remote_home = managed_repo[: -len(managed_suffix)]
-        expected_target = (
-            remote_home + "/.local/share/clio-relay/current/source/jarvis-packages/clio_relay"
-        )
-        expected_previous = remote_home + "/.local/src/clio-relay/jarvis-packages/clio_relay"
-        expected_legacy = remote_home + LEGACY_MANAGED_JARVIS_REPO_PATH.removeprefix("~")
-        expected_builtin = remote_home + "/.ppi-jarvis/builtin"
-        typed_removed_repositories = cast(list[object], removed_repositories)
-        removed_repositories_are_proven = _jarvis_repository_removals_are_proven(
-            typed_removed_repositories,
-            remote_home=remote_home,
-            exact_paths={expected_previous, expected_legacy},
-        )
-        repository_action = repository_update.get("action")
-        if (
-            binding.get("target") != expected_target
-            or not isinstance(added_repositories, list)
-            or not isinstance(removed_repositories, list)
-        ):
-            raise RelayError("staged reconcile repository binding is invalid")
-        if repository_action == "reused":
-            if (
-                typed_jarvis_preservation.get("repositories_byte_identical") is not True
-                or added_repositories
-                or removed_repositories
-            ):
-                raise RelayError("staged reconcile repository reuse is invalid")
-        elif repository_action == "updated":
-            if (
-                typed_jarvis_preservation.get("repositories_byte_identical") is not False
-                or not _jarvis_repository_additions_are_proven(
-                    cast(list[object], added_repositories),
-                    managed_repo=managed_repo,
-                    managed_builtin_repo=expected_builtin,
-                )
-                or not removed_repositories_are_proven
-                or (not added_repositories and not removed_repositories)
-            ):
-                raise RelayError("staged reconcile repository migration is invalid")
-        else:  # pragma: no cover - rejected by the generic evidence contract above
-            raise RelayError("staged reconcile repository action is invalid")
-        if payload_count != 2 or payload_bytes <= 0:
-            raise RelayError("staged reconcile omitted its transferred payload evidence")
-    elif outcome == "full":
-        if any(action != "prepared" for action in component_actions.values()):
-            raise RelayError("fresh bootstrap receipt has invalid component actions")
-        if jarvis_init_action != "initialized":
-            raise RelayError("fresh bootstrap did not report JARVIS initialization")
-        expected_command_count = 2 if jarvis_graph_action == "loaded" else 3
-        if (
-            jarvis_graph_action not in {"loaded", "built"}
-            or command_count != expected_command_count
-        ):
-            raise RelayError("fresh bootstrap did not report exact graph activation commands")
-        expected_graph_commands: list[list[str]] = [
-            [
-                "jarvis",
-                "rg",
-                "load-builtin",
-                cast(str, expected_jarvis_resource_graph_profile),
-                "+json",
-            ]
-        ]
-        if jarvis_graph_action == "built":
-            expected_graph_commands.append(["jarvis", "rg", "build", "+no_benchmark"])
-        if cast(list[object], command_argv)[1:] != expected_graph_commands:
-            raise RelayError("fresh bootstrap reported unexpected graph commands")
-        if payload_count != 2 or payload_bytes <= 0:
-            raise RelayError("fresh bootstrap omitted its transferred payload evidence")
-
-
-def _is_sha256_value(value: object) -> bool:
-    return bool(
-        isinstance(value, str)
-        and len(value) == 64
-        and value == value.lower()
-        and all(character in "0123456789abcdef" for character in value)
-    )
-
-
-def _jarvis_repository_removals_are_proven(
-    values: list[object],
-    *,
-    remote_home: str,
-    exact_paths: set[str],
-) -> bool:
-    """Accept only exact historical relay repository paths in bootstrap evidence."""
-    if not all(isinstance(value, str) for value in values):
-        return False
-    repositories = cast(list[str], values)
-    return bool(
-        repositories == sorted(set(repositories))
-        and all(
-            value in exact_paths
-            or _is_relay_owned_jarvis_builtin_repository(value, remote_home=remote_home)
-            for value in repositories
-        )
-    )
-
-
-def _jarvis_repository_additions_are_proven(
-    values: list[object],
-    *,
-    managed_repo: str,
-    managed_builtin_repo: str,
-) -> bool:
-    """Accept only the ordered relay and JARVIS stable repository bindings."""
-    allowed = [managed_repo, managed_builtin_repo]
-    if not all(isinstance(value, str) for value in values):
-        return False
-    repositories = cast(list[str], values)
-    return bool(
-        len(repositories) <= len(allowed)
-        and len(repositories) == len(set(repositories))
-        and all(value in allowed for value in repositories)
-        and repositories == [value for value in allowed if value in repositories]
-    )
-
-
-def _is_relay_owned_jarvis_builtin_repository(value: str, *, remote_home: str) -> bool:
-    """Recognize the exact legacy or content-addressed relay venv builtin path."""
-    if any(character in value for character in "\x00\r\n"):
-        return False
-    path = PurePosixPath(value)
-    home = PurePosixPath(remote_home)
-    if not path.is_absolute() or str(path) != value or not home.is_absolute():
-        return False
-    try:
-        relative = path.relative_to(home / ".local/share/clio-relay")
-    except ValueError:
-        return False
-    parts = relative.parts
-    legacy_prefix = ("jarvis-venv",)
-    generation_prefix = (
-        ("generations", parts[1], "jarvis-venv")
-        if len(parts) >= 3 and _is_sha256_value(parts[1])
-        else ()
-    )
-    for prefix in (legacy_prefix, generation_prefix):
-        if not prefix or parts[: len(prefix)] != prefix:
-            continue
-        suffix = parts[len(prefix) :]
-        if (
-            len(suffix) == 4
-            and suffix[0] in {"lib", "lib64"}
-            and _is_python_library_directory_name(suffix[1])
-            and suffix[2:] == ("site-packages", "builtin")
-        ):
-            return True
-    return False
-
-
-def _is_python_library_directory_name(value: str) -> bool:
-    """Recognize one CPython virtual-environment library component."""
-    if not value.startswith("python"):
-        return False
-    major, separator, minor = value.removeprefix("python").partition(".")
-    return bool(separator and major.isdigit() and minor.isdigit())
 
 
 def _worker_writer_proof_shell(*, rendered_core_dir: str, success_variable: str) -> str:
@@ -4171,6 +3539,7 @@ else:
     module = importlib.util.module_from_spec(spec)
     sys.modules[name] = module
     spec.loader.exec_module(module)
+from clio_relay import bootstrap_jarvis_staging, bootstrap_recovery
 journal_path = Path(os.environ["BOOTSTRAP_TRANSACTION_JOURNAL"])
 if action == "journal-create":
     service_value = os.environ["BOOTSTRAP_SERVICE_ACTIVE_BEFORE"]
@@ -4213,7 +3582,49 @@ elif action == "recovery-plan":
     journal = module.BootstrapTransactionJournal.load(journal_path)
     payload = journal.model_dump(mode="json")
     payload["recovery_mode"] = journal.recovery_mode
+    payload["recovery_needs_staged_identity"] = (
+        bootstrap_recovery.recovery_needs_staged_identity(journal)
+    )
+    payload["recovery_needs_jarvis_swap"] = (
+        bootstrap_jarvis_staging.JARVIS_VENV_STAGED_OWNED_NAME in journal.owned_paths
+    )
     print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+elif action == "recovery-prepared-manifest":
+    journal = module.BootstrapTransactionJournal.load(journal_path)
+    try:
+        print(
+            bootstrap_recovery.require_phase_identity(
+                journal, arguments[0], journal_path=journal_path
+            )
+        )
+    except module.ConfigurationError as exc:
+        raise SystemExit(str(exc)) from None
+elif action == "recovery-complete-active":
+    journal = module.BootstrapTransactionJournal.load(journal_path)
+    desired_payload = json.loads(os.environ["BOOTSTRAP_DESIRED_STATE"])
+    desired_payload["agent_npm_package"] = os.environ["AGENT_NPM_PACKAGE"] or None
+    desired_payload["agent_npm_bin"] = os.environ["AGENT_NPM_BIN"] or None
+    desired = module.BootstrapDesiredState.model_validate(desired_payload)
+    try:
+        evidence = bootstrap_recovery.complete_active_generation_recovery(journal, desired)
+    except module.ConfigurationError as exc:
+        raise SystemExit(str(exc)) from None
+    print(json.dumps(evidence, sort_keys=True, separators=(",", ":")))
+elif action == "recovery-jarvis-venv-promote":
+    journal = module.BootstrapTransactionJournal.load(journal_path)
+    owned = journal.owned_paths.get(bootstrap_jarvis_staging.JARVIS_VENV_STAGED_OWNED_NAME)
+    identity = owned.identity if owned is not None else None
+    if identity is None:
+        raise SystemExit("bootstrap transaction omitted its staged jarvis-venv identity")
+    try:
+        evidence = bootstrap_jarvis_staging.promote_staged_jarvis_venv(
+            invocation_id=arguments[0],
+            retired_at=arguments[1],
+            staged_identity=(identity.device, identity.inode),
+        )
+    except module.ConfigurationError as exc:
+        raise SystemExit(str(exc)) from None
+    print(json.dumps(evidence, sort_keys=True, separators=(",", ":")))
 elif action == "recovery-complete":
     journal = module.BootstrapTransactionJournal.load(journal_path)
     journal.complete_recovery()
@@ -4634,96 +4045,105 @@ bootstrap_recover_previous_transaction() {{
         bootstrap_recover_interrupted_repair \
           "$service_was_active" "$cluster_name" "$service_name"
       else
-        local prepared_generation prepared_manifest_sha256 recovery_generation
-        prepared_generation="$(bootstrap_recovery_value prepared_generation)"
-      case "$prepared_generation" in
-        (*[!0-9a-f]*|'')
-          echo "bootstrap forward recovery has an invalid generation" >&2
-          return 1
-          ;;
-      esac
-      [ "${{#prepared_generation}}" -eq 64 ] || return 1
-      prepared_manifest_sha256="$(
-        python3 - <<'__CLIO_RELAY_RECOVERY_MANIFEST__'
-import json
-import os
-
-value = json.loads(os.environ["BOOTSTRAP_RECOVERY_JSON"])
-identity = value.get("phase_identities", {{}}).get("prepared_manifest")
-if not isinstance(identity, str):
-    raise SystemExit("bootstrap recovery omitted prepared manifest identity")
-print(identity)
-__CLIO_RELAY_RECOVERY_MANIFEST__
-      )"
-      case "$prepared_manifest_sha256" in
-        (*[!0-9a-f]*|'')
-          echo "bootstrap forward recovery has an invalid manifest identity" >&2
-          return 1
-          ;;
-      esac
-      [ "${{#prepared_manifest_sha256}}" -eq 64 ] || return 1
-      recovery_generation="$HOME/.local/share/clio-relay/generations/$prepared_generation"
-      if [ -L "$recovery_generation" ] || [ ! -d "$recovery_generation" ]; then
-        echo "bootstrap forward recovery generation identity changed" >&2
-        return 1
-      fi
-      if [ "$JARVIS_EXISTING_FILE_COUNT" -ne 3 ] || \
-         [ -z "$BOOTSTRAP_JARVIS_CONFIG_SHA256_BEFORE" ] || \
-         [ -z "$BOOTSTRAP_JARVIS_GRAPH_SHA256_BEFORE" ]; then
-        echo "bootstrap forward recovery cannot prove preserved JARVIS state" >&2
-        return 1
-      fi
-      echo "$BOOTSTRAP_JARVIS_CONFIG_SHA256_BEFORE *$JARVIS_CONFIG_FILE" | \
-        sha256sum --check --strict -
-      echo "$BOOTSTRAP_JARVIS_GRAPH_SHA256_BEFORE *$JARVIS_GRAPH_FILE" | \
-        sha256sum --check --strict -
-      bootstrap_fence_recovered_service "$service_name"
-      bootstrap_use_staged_provider "$recovery_generation" "$prepared_manifest_sha256"
-      bootstrap_candidate_action finish-activation \
-        "$recovery_generation" "$prepared_manifest_sha256" >/dev/null
-      bootstrap_verify_stable_activation_links
-      echo "$BOOTSTRAP_JARVIS_CONFIG_SHA256_BEFORE *$JARVIS_CONFIG_FILE" | \
-        sha256sum --check --strict -
-      echo "$BOOTSTRAP_JARVIS_GRAPH_SHA256_BEFORE *$JARVIS_GRAPH_FILE" | \
-        sha256sum --check --strict -
-      mkdir -p -- {rendered_core_dir}
-      exec 8<>"{rendered_core_dir}/{WORKER_LIFETIME_LOCK_NAME}"
-      WORKER_LIFETIME_GUARD_FD=8
-      if ! flock -n 8; then
-        echo "bootstrap forward recovery cannot prove exclusive queue ownership" >&2
-        return 1
-      fi
-      {WORKER_LIFETIME_GUARD_FD_ENV}="$WORKER_LIFETIME_GUARD_FD" \
-        bootstrap_candidate_action repair-legacy-cursors {rendered_core_dir} >/dev/null
-      CLIO_RELAY_CORE_DIR={rendered_core_dir} \
-      CLIO_RELAY_SPOOL_DIR={rendered_spool_dir} \
-      {WORKER_LIFETIME_GUARD_FD_ENV}="$WORKER_LIFETIME_GUARD_FD" \
-        "$HOME/.local/bin/clio-relay" init --migrate-legacy-output
-      CLIO_RELAY_CORE_DIR={rendered_core_dir} \
-        "$HOME/.local/bin/clio-relay" queue readiness-info >/dev/null
-      exec 8>&-
-        if [ "$service_was_active" = "1" ] && [ -n "$service_name" ]; then
-        bootstrap_recover_service "$service_name"
-        local recovery_worker recovery_worker_ready
-        recovery_worker_ready=0
-        for _BOOTSTRAP_RECOVERY_WORKER_ATTEMPT in $(seq 1 90); do
-          recovery_worker="$(
-            CLIO_RELAY_CORE_DIR={rendered_core_dir} \
-              "$HOME/.local/bin/clio-relay" endpoint worker-info \
-                --cluster "$cluster_name" --freshness-seconds 120 2>/dev/null || true
+        local recovery_needs_staged recovery_needs_swap interrupted_state
+        recovery_needs_staged="$(bootstrap_recovery_value recovery_needs_staged_identity)"
+        recovery_needs_swap="$(bootstrap_recovery_value recovery_needs_jarvis_swap)"
+        interrupted_state="$(bootstrap_recovery_value state)"
+        if [ "$recovery_needs_staged" = "1" ]; then
+          local prepared_generation prepared_manifest_sha256 recovery_generation
+          prepared_generation="$(bootstrap_recovery_value prepared_generation)"
+          case "$prepared_generation" in
+            (*[!0-9a-f]*|'')
+              echo "bootstrap forward recovery has an invalid generation" >&2
+              return 1
+              ;;
+          esac
+          [ "${{#prepared_generation}}" -eq 64 ] || return 1
+          prepared_manifest_sha256="$(
+            bootstrap_candidate_action recovery-prepared-manifest prepared_manifest
           )"
-          if printf '%s\\n' "$recovery_worker" | python3 -c \
-            'import json,sys; value=json.load(sys.stdin); '\
-'sys.exit(0 if value.get("running") is True else 1)' 2>/dev/null; then
-            recovery_worker_ready=1
-            break
+          case "$prepared_manifest_sha256" in
+            (*[!0-9a-f]*|'')
+              echo "bootstrap forward recovery has an invalid manifest identity" >&2
+              return 1
+              ;;
+          esac
+          [ "${{#prepared_manifest_sha256}}" -eq 64 ] || return 1
+          recovery_generation="$HOME/.local/share/clio-relay/generations/$prepared_generation"
+          if [ -L "$recovery_generation" ] || [ ! -d "$recovery_generation" ]; then
+            echo "bootstrap forward recovery generation identity changed" >&2
+            return 1
           fi
-          sleep 2
-        done
-        if [ "$recovery_worker_ready" != "1" ]; then
-          echo "bootstrap forward recovery did not observe a ready worker" >&2
-          return 1
+          if [ "$JARVIS_EXISTING_FILE_COUNT" -ne 3 ] || \
+             [ -z "$BOOTSTRAP_JARVIS_CONFIG_SHA256_BEFORE" ] || \
+             [ -z "$BOOTSTRAP_JARVIS_GRAPH_SHA256_BEFORE" ]; then
+            echo "bootstrap forward recovery cannot prove preserved JARVIS state" >&2
+            return 1
+          fi
+          echo "$BOOTSTRAP_JARVIS_CONFIG_SHA256_BEFORE *$JARVIS_CONFIG_FILE" | \
+            sha256sum --check --strict -
+          echo "$BOOTSTRAP_JARVIS_GRAPH_SHA256_BEFORE *$JARVIS_GRAPH_FILE" | \
+            sha256sum --check --strict -
+          bootstrap_fence_recovered_service "$service_name"
+          bootstrap_use_staged_provider "$recovery_generation" "$prepared_manifest_sha256"
+          bootstrap_candidate_action finish-activation \
+            "$recovery_generation" "$prepared_manifest_sha256" >/dev/null
+          bootstrap_verify_stable_activation_links
+          echo "$BOOTSTRAP_JARVIS_CONFIG_SHA256_BEFORE *$JARVIS_CONFIG_FILE" | \
+            sha256sum --check --strict -
+          echo "$BOOTSTRAP_JARVIS_GRAPH_SHA256_BEFORE *$JARVIS_GRAPH_FILE" | \
+            sha256sum --check --strict -
+        else
+          # Activation (and, for a full-mode staging transaction, the
+          # jarvis-venv promotion at the same fenced boundary) already
+          # completed durably -- #247: never re-derive a staged identity
+          # once the ACTIVE generation is itself the proof.
+          bootstrap_candidate_action recovery-complete-active >/dev/null
+          if [ "$recovery_needs_swap" = "1" ]; then
+            bootstrap_candidate_action recovery-jarvis-venv-promote \
+              "$interrupted_invocation" "recovery-$(date -u +%Y%m%dT%H%M%SZ)" >/dev/null
+          fi
         fi
+        if [ "$interrupted_state" != "service_verified" ]; then
+          mkdir -p -- {rendered_core_dir}
+          exec 8<>"{rendered_core_dir}/{WORKER_LIFETIME_LOCK_NAME}"
+          WORKER_LIFETIME_GUARD_FD=8
+          if ! flock -n 8; then
+            echo "bootstrap forward recovery cannot prove exclusive queue ownership" >&2
+            return 1
+          fi
+          {WORKER_LIFETIME_GUARD_FD_ENV}="$WORKER_LIFETIME_GUARD_FD" \
+            bootstrap_candidate_action repair-legacy-cursors {rendered_core_dir} >/dev/null
+          CLIO_RELAY_CORE_DIR={rendered_core_dir} \
+          CLIO_RELAY_SPOOL_DIR={rendered_spool_dir} \
+          {WORKER_LIFETIME_GUARD_FD_ENV}="$WORKER_LIFETIME_GUARD_FD" \
+            "$HOME/.local/bin/clio-relay" init --migrate-legacy-output
+          CLIO_RELAY_CORE_DIR={rendered_core_dir} \
+            "$HOME/.local/bin/clio-relay" queue readiness-info >/dev/null
+          exec 8>&-
+          if [ "$service_was_active" = "1" ] && [ -n "$service_name" ]; then
+            bootstrap_recover_service "$service_name"
+            local recovery_worker recovery_worker_ready
+            recovery_worker_ready=0
+            for _BOOTSTRAP_RECOVERY_WORKER_ATTEMPT in $(seq 1 90); do
+              recovery_worker="$(
+                CLIO_RELAY_CORE_DIR={rendered_core_dir} \
+                  "$HOME/.local/bin/clio-relay" endpoint worker-info \
+                    --cluster "$cluster_name" --freshness-seconds 120 2>/dev/null || true
+              )"
+              if printf '%s\\n' "$recovery_worker" | python3 -c \
+                'import json,sys; value=json.load(sys.stdin); '\
+'sys.exit(0 if value.get("running") is True else 1)' 2>/dev/null; then
+                recovery_worker_ready=1
+                break
+              fi
+              sleep 2
+            done
+            if [ "$recovery_worker_ready" != "1" ]; then
+              echo "bootstrap forward recovery did not observe a ready worker" >&2
+              return 1
+            fi
+          fi
         fi
       fi
       ;;
@@ -7114,13 +6534,25 @@ if [ "$BOOTSTRAP_PLAN_MODE" = "relay-only" ] || \
   bootstrap_relay_only_reconcile
   exit 0
 fi
+BOOTSTRAP_INVOCATION_ID={shlex.quote(invocation_id)}
+JARVIS_STAGING_MODE=0
+JARVIS_VENV_LIVE_PATH="$HOME/.local/share/clio-relay/jarvis-venv"
+JARVIS_VENV_STAGED_PATH="$JARVIS_VENV_LIVE_PATH.staging-$BOOTSTRAP_INVOCATION_ID"
 if [ "$BOOTSTRAP_PLAN_MODE" = "full" ] && \
-   {{ [ "$JARVIS_EXISTING_FILE_COUNT" -eq 3 ] || \
-      [ -e "$HOME/.local/share/clio-relay/jarvis-venv" ]; }}; then
-  printf '%s\\n' "bootstrap_reconcile_plan=$BOOTSTRAP_PLAN_JSON" >&2
-  echo "full component reconcile requires a staged generation;" \
-    "refusing to clear the retained legacy JARVIS execution environment" >&2
-  exit 1
+   {{ [ "$JARVIS_EXISTING_FILE_COUNT" -eq 3 ] || [ -e "$JARVIS_VENV_LIVE_PATH" ]; }}; then
+  # clio-relay#254: a managed jarvis-venv already exists -- stage the
+  # replacement at a path this transaction owns instead of refusing. The
+  # live environment is never cleared directly: it is promoted-in with one
+  # atomic pathname exchange at the same fenced boundary that activates the
+  # rest of the generation (see JARVIS_VENV below and the migration_started
+  # promotion call), and only retired -- never deleted -- once that exchange
+  # is durable.
+  if [ -L "$JARVIS_VENV_LIVE_PATH" ] || [ ! -d "$JARVIS_VENV_LIVE_PATH" ]; then
+    printf '%s\\n' "bootstrap_reconcile_plan=$BOOTSTRAP_PLAN_JSON" >&2
+    echo "existing jarvis execution environment is not one owned directory" >&2
+    exit 1
+  fi
+  JARVIS_STAGING_MODE=1
 fi
 if [ "$BOOTSTRAP_PLAN_MODE" = "full" ] && \
    [ "$JARVIS_EXISTING_FILE_COUNT" -eq 0 ] && \
@@ -7128,7 +6560,6 @@ if [ "$BOOTSTRAP_PLAN_MODE" = "full" ] && \
   echo "fresh bootstrap requires an operator-selected JARVIS resource graph profile" >&2
   exit 1
 fi
-BOOTSTRAP_INVOCATION_ID={shlex.quote(invocation_id)}
 BOOTSTRAP_DESIRED_FINGERPRINT="$(
   python3 - <<'__CLIO_RELAY_FRESH_DESIRED_FINGERPRINT__'
 import hashlib
@@ -7174,6 +6605,7 @@ BOOTSTRAP_GENERATION="$HOME/.local/share/clio-relay/generations/$BOOTSTRAP_DESIR
 BOOTSTRAP_TRANSACTION_ROOT="$HOME/.local/share/clio-relay/transactions/$BOOTSTRAP_INVOCATION_ID"
 BOOTSTRAP_OWNED_PATHS_JSON="$(
   python3 - "$BOOTSTRAP_DESIRED_FINGERPRINT" "$BOOTSTRAP_INVOCATION_ID" \
+    "$JARVIS_STAGING_MODE" \
     <<'__CLIO_RELAY_FRESH_OWNERSHIP__'
 import hashlib
 import json
@@ -7186,6 +6618,7 @@ from pathlib import Path
 home = Path.home()
 fingerprint = sys.argv[1]
 invocation_id = sys.argv[2]
+jarvis_staging_mode = sys.argv[3] == "1"
 
 def classify(path: Path) -> os.stat_result | None:
     try:
@@ -7263,8 +6696,20 @@ else:
     if commit != "{JARVIS_UTIL_COMMIT}" or status:
         raise SystemExit("bootstrap cannot mutate an existing jarvis-util checkout")
 
+jarvis_venv_entry = (
+    # clio-relay#254: a staging transaction never claims the LIVE jarvis-venv
+    # as absent -- it owns only the staged replacement, promoted in later by
+    # one atomic exchange that never requires the live path to be absent.
+    (
+        "jarvis_venv_staged",
+        home / (".local/share/clio-relay/jarvis-venv.staging-" + invocation_id),
+        "directory",
+    )
+    if jarvis_staging_mode
+    else ("jarvis_venv", home / ".local/share/clio-relay/jarvis-venv", "directory")
+)
 for name, path, kind in (
-    ("jarvis_venv", home / ".local/share/clio-relay/jarvis-venv", "directory"),
+    jarvis_venv_entry,
     ("clio_kit_wheels", home / ".local/share/clio-relay/component-wheels/clio-kit", "directory"),
     ("jarvis_cd_wheels", home / ".local/share/clio-relay/component-wheels/jarvis-cd", "directory"),
     ("uv_tools", home / ".local/share/clio-relay/uv-tools", "directory"),
@@ -7401,8 +6846,13 @@ if [ ! -x "$AGENT_BIN" ] && [ -n "$AGENT_NPM_PACKAGE" ] && command -v npm >/dev/
   npm install -g "$AGENT_NPM_PACKAGE"
 fi
 
-JARVIS_VENV="$HOME/.local/share/clio-relay/jarvis-venv"
-bootstrap_journal_action mkdir-owned "$BOOTSTRAP_TRANSACTION_JOURNAL" jarvis_venv
+if [ "$JARVIS_STAGING_MODE" = "1" ]; then
+  JARVIS_VENV="$JARVIS_VENV_STAGED_PATH"
+  bootstrap_journal_action mkdir-owned "$BOOTSTRAP_TRANSACTION_JOURNAL" jarvis_venv_staged
+else
+  JARVIS_VENV="$JARVIS_VENV_LIVE_PATH"
+  bootstrap_journal_action mkdir-owned "$BOOTSTRAP_TRANSACTION_JOURNAL" jarvis_venv
+fi
 uv venv --python 3.12 --seed "$JARVIS_VENV"
 . "$JARVIS_VENV/bin/activate"
 JARVIS_UTIL_COMMIT="{JARVIS_UTIL_COMMIT}"
@@ -8279,6 +7729,16 @@ BOOTSTRAP_FULL_PREPARE_COMPLETED_NS="$(
 
 {worker_recheck}
 bootstrap_journal_action advance "$BOOTSTRAP_TRANSACTION_JOURNAL" migration_started
+if [ "$JARVIS_STAGING_MODE" = "1" ]; then
+  # clio-relay#254: promote the built+verified staged jarvis-venv now, at
+  # the same fenced boundary that just activated the rest of the
+  # generation. `irreversible_boundary` is already durable (full mode sets
+  # it here for every transaction), so #247's state-aware forward recovery
+  # completes this exact promotion if interrupted -- idempotently, and
+  # without ever observing the live path absent or half-cleared.
+  bootstrap_candidate_action recovery-jarvis-venv-promote \
+    "$BOOTSTRAP_INVOCATION_ID" "$(date -u +%Y%m%dT%H%M%SZ)" >/dev/null
+fi
 BOOTSTRAP_QUEUE_ACTION=verified_read_only
 BOOTSTRAP_QUEUE_DURATION_NS=0
 BOOTSTRAP_QUEUE_BEFORE="$(

--- a/src/clio_relay/bootstrap_jarvis_staging.py
+++ b/src/clio_relay/bootstrap_jarvis_staging.py
@@ -1,0 +1,121 @@
+"""Full-mode jarvis-venv staging over an existing managed environment (#254).
+
+Owner module for the staging semantics a full-mode ``cluster bootstrap``
+needs when ``~/.local/share/clio-relay/jarvis-venv`` already exists (built
+by an earlier successful full bootstrap). The historical guard refused
+outright, promising "a staged generation" precondition nothing implemented
+-- the relay could never redeploy itself onto an already-bootstrapped host.
+
+The fix: build and verify the replacement environment at a path this
+transaction owns (never touching the live one), then promote it with one
+atomic pathname exchange (``renameat2(RENAME_EXCHANGE)``, via
+``bootstrap_reconcile._atomic_exchange_paths``) inside the same fenced
+activation window as the rest of the generation. An exchange swaps two
+existing pathnames in a single kernel operation, so at every instant either
+observable before or after it the live pathname names a complete
+environment -- old or new, never absent or half-cleared. The pre-exchange
+content is then given a distinct ``.retired-<timestamp>`` name (a plain
+rename of the now-vacated staged pathname, which does not touch the live
+name at all) and kept, never deleted.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from clio_relay.bootstrap_reconcile import (
+    _atomic_exchange_paths,  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+)
+from clio_relay.errors import ConfigurationError
+
+JARVIS_VENV_STAGED_OWNED_NAME = "jarvis_venv_staged"
+_LIVE_DIR_NAME = "jarvis-venv"
+
+
+def _relay_state_dir(home: Path | None) -> Path:
+    lexical_home = Path(str(home or Path.home())).expanduser().absolute()
+    return lexical_home / ".local/share/clio-relay"
+
+
+def staged_jarvis_venv_path(*, home: Path | None = None, invocation_id: str) -> Path:
+    """Return the per-invocation staging path this transaction owns."""
+    return _relay_state_dir(home) / f"{_LIVE_DIR_NAME}.staging-{invocation_id}"
+
+
+def retired_jarvis_venv_path(*, home: Path | None = None, retired_at: str) -> Path:
+    """Return the timestamped retire target for a superseded jarvis-venv."""
+    return _relay_state_dir(home) / f"{_LIVE_DIR_NAME}.retired-{retired_at}"
+
+
+def jarvis_venv_staging_plan(
+    *, home: Path | None = None, invocation_id: str
+) -> dict[str, str] | None:
+    """Return the staged jarvis-venv plan for a full-mode reconcile, or None.
+
+    None means the virgin path applies unchanged: no managed jarvis-venv
+    exists yet, so full-mode reconcile builds it directly at its live name
+    as it always has. A managed jarvis-venv existing means full-mode
+    reconcile must build+verify its replacement at a path this transaction
+    owns instead of refusing (clio-relay#254) -- this plan names that path.
+    """
+    live = _relay_state_dir(home) / _LIVE_DIR_NAME
+    if not live.exists() and not live.is_symlink():
+        return None
+    if live.is_symlink() or not live.is_dir():
+        raise ConfigurationError("existing jarvis execution environment is not one owned directory")
+    return {
+        "schema_version": "clio-relay.jarvis-venv-staging-plan.v1",
+        "live": str(live),
+        "staged": str(staged_jarvis_venv_path(home=home, invocation_id=invocation_id)),
+    }
+
+
+def promote_staged_jarvis_venv(
+    *,
+    home: Path | None = None,
+    invocation_id: str,
+    retired_at: str,
+    staged_identity: tuple[int, int],
+) -> dict[str, object]:
+    """Promote a built+verified staged jarvis-venv to live, retiring the old one.
+
+    ``staged_identity`` is the (device, inode) pair the ``mkdir-owned``
+    journal action recorded for ``jarvis_venv_staged`` the moment it was
+    created -- see ``owned_paths`` on the transaction journal (clio-relay
+    #247's recovery reasons from the same journal). Idempotent for crash
+    recovery: it proves which pathname currently holds the staged content.
+    If the live directory already carries that identity, a prior call's
+    exchange is proven complete and only the retire rename is finished --
+    the exchange is never re-attempted against an already-promoted pair,
+    which would silently swap the live environment back to the retired one.
+    """
+    base = _relay_state_dir(home)
+    live = base / _LIVE_DIR_NAME
+    staged = staged_jarvis_venv_path(home=home, invocation_id=invocation_id)
+    retired = retired_jarvis_venv_path(home=home, retired_at=retired_at)
+    if retired.exists() or retired.is_symlink():
+        raise ConfigurationError(f"jarvis-venv retire target already exists: {retired}")
+    if live.is_symlink() or not live.is_dir():
+        raise ConfigurationError("live jarvis-venv is not one owned directory")
+    live_details = live.lstat()
+    if (live_details.st_dev, live_details.st_ino) != staged_identity:
+        if staged.is_symlink() or not staged.is_dir():
+            raise ConfigurationError(f"staged jarvis-venv is unavailable for promotion: {staged}")
+        staged_details = staged.lstat()
+        if (staged_details.st_dev, staged_details.st_ino) != staged_identity:
+            raise ConfigurationError("staged jarvis-venv identity changed before promotion")
+        _atomic_exchange_paths(live, staged)
+        live_details = live.lstat()
+        if (live_details.st_dev, live_details.st_ino) != staged_identity:
+            raise ConfigurationError("jarvis-venv exchange did not promote the staged copy")
+    # The exchange is now proven complete (just now, or by an earlier
+    # interrupted call). `staged`, if still present, names the pre-swap
+    # (old, retirement-bound) content -- promoting it never touches `live`.
+    if staged.exists() or staged.is_symlink():
+        os.rename(staged, retired)
+    return {
+        "schema_version": "clio-relay.jarvis-venv-promotion.v1",
+        "live": str(live),
+        "retired": str(retired),
+    }

--- a/src/clio_relay/bootstrap_receipt_validation.py
+++ b/src/clio_relay/bootstrap_receipt_validation.py
@@ -1,0 +1,651 @@
+"""Bootstrap receipt shape/provenance validation (operator-side, post-SSH).
+
+Owner module for validating the v2 bootstrap receipt a remote invocation
+returns, plus the JARVIS repository-provenance checks that receipt
+validation depends on. Runs entirely on the operator side after the SSH
+session returns -- never inside a remotely-executed heredoc, so it carries
+no candidate-package constraint.
+"""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+from typing import cast
+
+from clio_relay.bootstrap_reconcile import (
+    LEGACY_MANAGED_JARVIS_REPO_PATH,
+    MANAGED_JARVIS_REPO_PATH,
+    validate_jarvis_builtin_result,
+)
+from clio_relay.errors import RelayError
+
+
+def validate_bootstrap_receipt(
+    receipt: dict[str, object],
+    *,
+    bootstrap_profile: str,
+    relay_install_spec: str,
+    desired_fingerprint: str,
+    expected_jarvis_resource_graph_profile: str | None,
+    expected_allow_jarvis_resource_graph_build: bool,
+    expected_worker_service: str | None,
+) -> None:
+    """Validate action-specific v2 evidence from the current remote invocation."""
+    install_receipt_sha256 = receipt.get("install_receipt_sha256")
+    outcome = receipt.get("outcome")
+    duration = receipt.get("duration_seconds")
+    components = receipt.get("components")
+    operations = receipt.get("operations")
+    preservation = receipt.get("preservation")
+    worker = receipt.get("worker")
+    generation = receipt.get("generation")
+    queue_operation = receipt.get("queue_operation")
+    jarvis_initialization = receipt.get("jarvis_initialization")
+    jarvis_resource_graph = receipt.get("jarvis_resource_graph")
+    jarvis_commands = receipt.get("jarvis_commands")
+    jarvis_preservation = receipt.get("jarvis_preservation")
+    service = receipt.get("service")
+    contract = {
+        "schema_version": receipt.get("schema_version") == "clio-relay.bootstrap-receipt.v2",
+        "bootstrap_profile": receipt.get("bootstrap_profile") == bootstrap_profile,
+        "relay_install_spec": receipt.get("relay_install_spec") == relay_install_spec,
+        "desired_fingerprint": receipt.get("desired_fingerprint") == desired_fingerprint,
+        "outcome": outcome
+        in {
+            "noop_verified",
+            "verified_after_transfer",
+            "repaired",
+            "reconciled",
+            "full",
+        },
+        "install_receipt_sha256": is_sha256_value(install_receipt_sha256),
+        "duration_seconds": (
+            not isinstance(duration, bool) and isinstance(duration, (int, float)) and duration >= 0
+        ),
+        "completed_at": isinstance(receipt.get("completed_at"), str)
+        and bool(receipt.get("completed_at")),
+        "components": isinstance(components, dict)
+        and len(cast(dict[object, object], components)) > 0,
+        "operations": isinstance(operations, dict),
+        "preservation": isinstance(preservation, dict),
+        "worker": isinstance(worker, dict),
+        "generation": isinstance(generation, dict),
+        "queue_operation": isinstance(queue_operation, dict),
+        "jarvis_initialization": isinstance(jarvis_initialization, dict),
+        "jarvis_resource_graph": isinstance(jarvis_resource_graph, dict),
+        "jarvis_commands": isinstance(jarvis_commands, dict),
+        "jarvis_preservation": isinstance(jarvis_preservation, dict),
+        "service": isinstance(service, dict),
+    }
+    failed = sorted(name for name, passed in contract.items() if not passed)
+    if failed:
+        raise RelayError(f"bootstrap receipt contract failed: {failed}")
+    assert isinstance(components, dict)
+    typed_components = cast(dict[str, object], components)
+    required_components = {"clio-relay", "clio-kit", "jarvis-cd", "jarvis-util", "frp", "uv"}
+    if not required_components.issubset(typed_components):
+        raise RelayError("bootstrap receipt omitted required component evidence")
+    component_actions: dict[str, str] = {}
+    for name, raw_evidence in typed_components.items():
+        if not isinstance(raw_evidence, dict):
+            raise RelayError(f"bootstrap component evidence is invalid: {name}")
+        evidence = cast(dict[str, object], raw_evidence)
+        action = evidence.get("action")
+        component_duration = evidence.get("duration_seconds")
+        if (
+            action not in {"reused", "prepared", "materialized", "replaced"}
+            or not isinstance(evidence.get("observed_identity"), dict)
+            or isinstance(component_duration, bool)
+            or not isinstance(component_duration, (int, float))
+            or component_duration < 0
+        ):
+            raise RelayError(f"bootstrap component action evidence is invalid: {name}")
+        component_actions[name] = cast(str, action)
+    assert isinstance(operations, dict)
+    typed_operations = cast(dict[str, object], operations)
+    count_fields = (
+        "download_count",
+        "service_restart_count",
+        "service_start_count",
+        "service_stop_count",
+        "service_enable_count",
+        "scheduler_submission_count",
+        "scheduler_cancellation_count",
+        "generation_gc_count",
+        "payload_transfer_count",
+        "payload_transfer_bytes",
+    )
+    for field in count_fields:
+        value = typed_operations.get(field)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise RelayError(f"bootstrap operation count is invalid: {field}")
+    downloads = typed_operations.get("downloads")
+    if not isinstance(downloads, list) or len(cast(list[object], downloads)) != cast(
+        int, typed_operations["download_count"]
+    ):
+        raise RelayError("bootstrap download evidence does not match its count")
+    if any(
+        typed_operations[field] != 0
+        for field in (
+            "scheduler_submission_count",
+            "scheduler_cancellation_count",
+            "generation_gc_count",
+        )
+    ):
+        raise RelayError("bootstrap performed a forbidden scheduler or generation operation")
+    payload_count = cast(int, typed_operations["payload_transfer_count"])
+    payload_bytes = cast(int, typed_operations["payload_transfer_bytes"])
+    if payload_count not in {0, 2} or (payload_count == 0) != (payload_bytes == 0):
+        raise RelayError("bootstrap payload transfer evidence is inconsistent")
+    assert isinstance(preservation, dict)
+    typed_preservation = cast(dict[str, object], preservation)
+    if typed_preservation != {
+        "scheduler_jobs_cancelled": False,
+        "old_generations_retained": True,
+        "jarvis_init_on_existing_root": False,
+    }:
+        raise RelayError("bootstrap preservation evidence is invalid")
+    assert isinstance(worker, dict)
+    typed_worker = cast(dict[str, object], worker)
+    if typed_worker.get("service_name") != expected_worker_service:
+        raise RelayError("bootstrap worker service evidence does not match")
+    assert isinstance(service, dict)
+    typed_service = cast(dict[str, object], service)
+    service_pending_install = typed_service.get("pending_install")
+    if not isinstance(service_pending_install, bool):
+        raise RelayError("bootstrap service pending-install evidence is invalid")
+    if expected_worker_service is not None:
+        if outcome == "full" and service_pending_install:
+            if (
+                typed_worker.get("service_was_active") is not False
+                or typed_worker.get("service_was_enabled") is not False
+                or typed_worker.get("worker_ready") is not False
+            ):
+                raise RelayError("fresh bootstrap service-pending evidence is inconsistent")
+        elif (
+            typed_worker.get("service_was_active") is not True
+            or typed_worker.get("worker_ready") is not True
+            or service_pending_install
+        ):
+            raise RelayError("managed bootstrap did not leave a ready endpoint service")
+    assert isinstance(generation, dict)
+    typed_generation = cast(dict[str, object], generation)
+    if (
+        typed_generation.get("active") != desired_fingerprint
+        or not isinstance(typed_generation.get("current_target"), str)
+        or not cast(str, typed_generation["current_target"])
+    ):
+        raise RelayError("bootstrap generation evidence does not prove desired activation")
+    assert isinstance(queue_operation, dict)
+    typed_queue_operation = cast(dict[str, object], queue_operation)
+    queue_action = typed_queue_operation.get("action")
+    queue_duration = typed_queue_operation.get("duration_seconds")
+    if (
+        queue_action not in {"verified_read_only", "audited_and_sealed"}
+        or isinstance(queue_duration, bool)
+        or not isinstance(queue_duration, (int, float))
+        or queue_duration < 0
+        or (queue_action == "audited_and_sealed" and queue_duration <= 0)
+    ):
+        raise RelayError("bootstrap queue action evidence is invalid")
+    assert isinstance(jarvis_initialization, dict)
+    typed_jarvis_initialization = cast(dict[str, object], jarvis_initialization)
+    jarvis_init_action = typed_jarvis_initialization.get("action")
+    jarvis_init_duration = typed_jarvis_initialization.get("duration_seconds")
+    if (
+        jarvis_init_action not in {"preserved", "initialized"}
+        or isinstance(jarvis_init_duration, bool)
+        or not isinstance(jarvis_init_duration, (int, float))
+        or jarvis_init_duration < 0
+        or (jarvis_init_action == "initialized" and jarvis_init_duration <= 0)
+        or (jarvis_init_action == "preserved" and jarvis_init_duration != 0)
+    ):
+        raise RelayError("bootstrap JARVIS initialization evidence is invalid")
+    assert isinstance(jarvis_resource_graph, dict)
+    typed_jarvis_graph = cast(dict[str, object], jarvis_resource_graph)
+    jarvis_graph_action = typed_jarvis_graph.get("action")
+    jarvis_graph_duration = typed_jarvis_graph.get("duration_seconds")
+    jarvis_builtin_result = typed_jarvis_graph.get("builtin_result")
+    if (
+        set(typed_jarvis_graph)
+        != {
+            "action",
+            "duration_seconds",
+            "benchmark_enabled",
+            "selected_profile",
+            "allow_build_fallback",
+            "builtin_result",
+        }
+        or jarvis_graph_action not in {"preserved", "loaded", "built"}
+        or typed_jarvis_graph.get("benchmark_enabled") is not False
+        or typed_jarvis_graph.get("selected_profile") != expected_jarvis_resource_graph_profile
+        or typed_jarvis_graph.get("allow_build_fallback")
+        is not expected_allow_jarvis_resource_graph_build
+        or isinstance(jarvis_graph_duration, bool)
+        or not isinstance(jarvis_graph_duration, (int, float))
+        or jarvis_graph_duration < 0
+        or (jarvis_graph_action in {"loaded", "built"} and jarvis_graph_duration <= 0)
+        or (jarvis_graph_action == "preserved" and jarvis_graph_duration != 0)
+    ):
+        raise RelayError("bootstrap JARVIS resource graph evidence is invalid")
+    if jarvis_graph_action == "preserved":
+        if jarvis_builtin_result is not None:
+            raise RelayError("preserved JARVIS graph claimed builtin activation evidence")
+    else:
+        if expected_jarvis_resource_graph_profile is None or not isinstance(
+            jarvis_builtin_result, dict
+        ):
+            raise RelayError("JARVIS graph activation omitted builtin result evidence")
+        try:
+            validate_jarvis_builtin_result(
+                cast(dict[str, object], jarvis_builtin_result),
+                requested_profile=expected_jarvis_resource_graph_profile,
+            )
+        except ValueError as exc:
+            raise RelayError(f"bootstrap JARVIS builtin graph evidence is invalid: {exc}") from exc
+        expected_builtin_action = "loaded" if jarvis_graph_action == "loaded" else "unavailable"
+        if cast(dict[str, object], jarvis_builtin_result).get("action") != expected_builtin_action:
+            raise RelayError("bootstrap JARVIS graph action contradicts builtin evidence")
+        if jarvis_graph_action == "built" and not expected_allow_jarvis_resource_graph_build:
+            raise RelayError("bootstrap reported an unauthorized JARVIS graph build")
+    assert isinstance(jarvis_commands, dict)
+    typed_jarvis_commands = cast(dict[str, object], jarvis_commands)
+    command_count = typed_jarvis_commands.get("count")
+    command_argv = typed_jarvis_commands.get("argv")
+    typed_command_argv = cast(list[object], command_argv) if isinstance(command_argv, list) else []
+    if (
+        isinstance(command_count, bool)
+        or not isinstance(command_count, int)
+        or command_count < 0
+        or not isinstance(command_argv, list)
+        or len(typed_command_argv) != command_count
+        or any(
+            not isinstance(raw_command, list)
+            or not raw_command
+            or any(
+                not isinstance(value, str) or not value for value in cast(list[object], raw_command)
+            )
+            for raw_command in typed_command_argv
+        )
+    ):
+        raise RelayError("bootstrap JARVIS command evidence is invalid")
+    assert isinstance(jarvis_preservation, dict)
+    typed_jarvis_preservation = cast(dict[str, object], jarvis_preservation)
+    if not isinstance(typed_jarvis_preservation.get("before"), dict) or not isinstance(
+        typed_jarvis_preservation.get("after"), dict
+    ):
+        raise RelayError("bootstrap JARVIS preservation evidence is invalid")
+    raw_binding = typed_jarvis_preservation.get("repositories")
+    if not isinstance(raw_binding, dict):
+        raise RelayError("bootstrap JARVIS repository binding evidence is invalid")
+    binding = cast(dict[str, object], raw_binding)
+    if set(binding) != {"link_action", "link", "target", "repositories"} or binding.get(
+        "link_action"
+    ) not in {"reused", "created", "retargeted"}:
+        raise RelayError("bootstrap JARVIS repository link evidence is invalid")
+    raw_repository_update = binding.get("repositories")
+    if not isinstance(raw_repository_update, dict):
+        raise RelayError("bootstrap JARVIS repository update evidence is invalid")
+    repository_update = cast(dict[str, object], raw_repository_update)
+    if set(repository_update) != {
+        "action",
+        "managed_repo",
+        "added_managed_repos",
+        "removed_previous_managed_repos",
+        "before_sha256",
+        "after_sha256",
+    } or repository_update.get("action") not in {"reused", "updated"}:
+        raise RelayError("bootstrap JARVIS repository update evidence is invalid")
+    before_state = cast(dict[str, object], typed_jarvis_preservation["before"])
+    after_state = cast(dict[str, object], typed_jarvis_preservation["after"])
+    if (
+        repository_update.get("before_sha256") != before_state.get("repos_sha256")
+        or repository_update.get("after_sha256") != after_state.get("repos_sha256")
+        or after_state.get("managed_repo_registered") is not True
+        or after_state.get("managed_builtin_repo_registered") is not True
+        or not isinstance(repository_update.get("added_managed_repos"), list)
+        or not isinstance(repository_update.get("removed_previous_managed_repos"), list)
+    ):
+        raise RelayError("bootstrap JARVIS repository hashes do not bind preservation evidence")
+    if jarvis_graph_action == "loaded" and not is_sha256_value(
+        after_state.get("resource_graph_sha256")
+    ):
+        # The activated graph is JARVIS's normalized derivative of the packaged
+        # builtin, so its digest legitimately differs from source_sha256 and
+        # cannot be bound by equality here (#158). Source identity is proven
+        # remotely, where the packaged file actually lives -- the cluster-side
+        # step hashes the source JARVIS names and fails closed on a mismatch.
+        # What the host binds is that activation evidence was recorded at all.
+        raise RelayError("loaded JARVIS graph did not record its activated resource graph digest")
+    if outcome == "noop_verified":
+        if (
+            any(action != "reused" for action in component_actions.values())
+            or typed_operations["download_count"] != 0
+            or typed_operations["service_restart_count"] != 0
+            or typed_operations["service_start_count"] != 0
+            or typed_operations["service_stop_count"] != 0
+            or typed_operations["service_enable_count"] != 0
+            or typed_operations["payload_transfer_count"] != 0
+            or typed_operations["payload_transfer_bytes"] != 0
+            or queue_action != "verified_read_only"
+            or queue_duration != 0
+            or jarvis_init_action != "preserved"
+            or jarvis_graph_action != "preserved"
+            or command_count != 0
+            or typed_jarvis_preservation.get("config_byte_identical") is not True
+            or typed_jarvis_preservation.get("resource_graph_byte_identical") is not True
+            or typed_jarvis_preservation.get("repositories_byte_identical") is not True
+            or binding.get("link_action") != "reused"
+            or repository_update.get("action") != "reused"
+        ):
+            raise RelayError("bootstrap no-op receipt reported mutation")
+    elif outcome == "verified_after_transfer":
+        if (
+            any(action != "reused" for action in component_actions.values())
+            or typed_operations["download_count"] != 0
+            or typed_operations["service_restart_count"] != 0
+            or typed_operations["service_start_count"] != 0
+            or typed_operations["service_stop_count"] != 0
+            or typed_operations["service_enable_count"] != 0
+            or payload_count != 2
+            or payload_bytes <= 0
+            or queue_action != "verified_read_only"
+            or queue_duration != 0
+            or jarvis_init_action != "preserved"
+            or jarvis_graph_action != "preserved"
+            or command_count != 0
+            or typed_jarvis_preservation.get("config_byte_identical") is not True
+            or typed_jarvis_preservation.get("resource_graph_byte_identical") is not True
+            or typed_jarvis_preservation.get("repositories_byte_identical") is not True
+            or binding.get("link_action") != "reused"
+            or repository_update.get("action") != "reused"
+        ):
+            raise RelayError("post-transfer verification receipt reported mutation")
+    elif outcome == "repaired":
+        if (
+            any(action != "reused" for action in component_actions.values())
+            or typed_operations["download_count"] != 0
+        ):
+            raise RelayError("bootstrap repair receipt reported component replacement")
+        if jarvis_init_action != "preserved":
+            raise RelayError("bootstrap repair receipt reported JARVIS initialization")
+        if jarvis_graph_action != "preserved" or command_count != 0:
+            raise RelayError("bootstrap repair receipt reported JARVIS commands")
+        managed_repo = repository_update.get("managed_repo")
+        added_repositories = repository_update.get("added_managed_repos")
+        removed_repositories = repository_update.get("removed_previous_managed_repos")
+        if (
+            typed_jarvis_preservation.get("config_byte_identical") is not True
+            or typed_jarvis_preservation.get("resource_graph_byte_identical") is not True
+        ):
+            raise RelayError("bootstrap repair receipt reported JARVIS state mutation")
+        if (
+            not isinstance(managed_repo, str)
+            or not PurePosixPath(managed_repo).is_absolute()
+            or any(character in managed_repo for character in "\x00\r\n")
+            or binding.get("link") != managed_repo
+            or binding.get("link_action") not in {"reused", "created", "retargeted"}
+            or not isinstance(added_repositories, list)
+            or not isinstance(removed_repositories, list)
+            or not is_sha256_value(typed_generation.get("previous"))
+        ):
+            raise RelayError("bootstrap managed JARVIS binding repair is invalid")
+        managed_suffix = MANAGED_JARVIS_REPO_PATH.removeprefix("~")
+        if not managed_repo.endswith(managed_suffix):
+            raise RelayError("bootstrap managed JARVIS binding repair is invalid")
+        remote_home = managed_repo[: -len(managed_suffix)]
+        expected_target = (
+            remote_home + "/.local/share/clio-relay/current/source/jarvis-packages/clio_relay"
+        )
+        expected_previous = remote_home + "/.local/src/clio-relay/jarvis-packages/clio_relay"
+        expected_legacy = remote_home + LEGACY_MANAGED_JARVIS_REPO_PATH.removeprefix("~")
+        expected_builtin = remote_home + "/.ppi-jarvis/builtin"
+        typed_removed_repositories = cast(list[object], removed_repositories)
+        removed_repositories_are_proven = _jarvis_repository_removals_are_proven(
+            typed_removed_repositories,
+            remote_home=remote_home,
+            exact_paths={expected_previous, expected_legacy},
+        )
+        repository_action = repository_update.get("action")
+        if binding.get("target") != expected_target:
+            raise RelayError("bootstrap managed JARVIS binding repair is invalid")
+        if repository_action == "reused":
+            if (
+                typed_jarvis_preservation.get("repositories_byte_identical") is not True
+                or added_repositories
+                or removed_repositories
+            ):
+                raise RelayError("bootstrap managed JARVIS repository reuse is invalid")
+        elif repository_action == "updated":
+            if (
+                typed_jarvis_preservation.get("repositories_byte_identical") is not False
+                or not _jarvis_repository_additions_are_proven(
+                    cast(list[object], added_repositories),
+                    managed_repo=managed_repo,
+                    managed_builtin_repo=expected_builtin,
+                )
+                or not removed_repositories_are_proven
+                or (not added_repositories and not removed_repositories)
+            ):
+                raise RelayError("bootstrap managed JARVIS repository repair is invalid")
+        else:
+            raise RelayError("bootstrap managed JARVIS repository repair is invalid")
+    elif outcome == "reconciled":
+        raw_transaction = receipt.get("transaction")
+        transaction_mode = (
+            cast(dict[str, object], raw_transaction).get("mode")
+            if isinstance(raw_transaction, dict)
+            else None
+        )
+        if transaction_mode == "component-upgrade":
+            expected_actions = {
+                "clio-relay": "replaced",
+                "clio-kit": "replaced",
+                "jarvis-cd": "replaced",
+                "jarvis-util": "reused",
+                "frp": "reused",
+                "uv": "reused",
+            }
+        elif transaction_mode == "relay-only":
+            expected_actions = {
+                "clio-relay": "prepared",
+                "clio-kit": "reused",
+                "jarvis-cd": "reused",
+                "jarvis-util": "reused",
+                "frp": "reused",
+                "uv": "reused",
+            }
+        else:
+            raise RelayError("reconciled bootstrap receipt has an invalid transaction mode")
+        if any(component_actions.get(name) != action for name, action in expected_actions.items()):
+            raise RelayError("staged reconcile receipt has invalid component actions")
+        if jarvis_init_action != "preserved":
+            raise RelayError("staged reconcile reported JARVIS initialization")
+        if jarvis_graph_action != "preserved" or command_count != 0:
+            raise RelayError("staged reconcile reported JARVIS commands")
+        previous_generation = typed_generation.get("previous")
+        link_action = binding.get("link_action")
+        previous_generation_is_proven = bool(
+            previous_generation == "legacy" or is_sha256_value(previous_generation)
+        )
+        link_action_is_proven = bool(
+            link_action == "reused"
+            or (link_action in {"created", "retargeted"} and previous_generation_is_proven)
+        )
+        if (
+            typed_jarvis_preservation.get("config_byte_identical") is not True
+            or typed_jarvis_preservation.get("resource_graph_byte_identical") is not True
+            or not link_action_is_proven
+        ):
+            raise RelayError("staged reconcile did not preserve existing JARVIS state")
+        managed_repo = repository_update.get("managed_repo")
+        added_repositories = repository_update.get("added_managed_repos")
+        removed_repositories = repository_update.get("removed_previous_managed_repos")
+        if (
+            not isinstance(managed_repo, str)
+            or not PurePosixPath(managed_repo).is_absolute()
+            or any(character in managed_repo for character in "\x00\r\n")
+            or binding.get("link") != managed_repo
+        ):
+            raise RelayError("staged reconcile repository binding is invalid")
+        managed_suffix = MANAGED_JARVIS_REPO_PATH.removeprefix("~")
+        if not managed_repo.endswith(managed_suffix):
+            raise RelayError("staged reconcile repository binding is invalid")
+        remote_home = managed_repo[: -len(managed_suffix)]
+        expected_target = (
+            remote_home + "/.local/share/clio-relay/current/source/jarvis-packages/clio_relay"
+        )
+        expected_previous = remote_home + "/.local/src/clio-relay/jarvis-packages/clio_relay"
+        expected_legacy = remote_home + LEGACY_MANAGED_JARVIS_REPO_PATH.removeprefix("~")
+        expected_builtin = remote_home + "/.ppi-jarvis/builtin"
+        typed_removed_repositories = cast(list[object], removed_repositories)
+        removed_repositories_are_proven = _jarvis_repository_removals_are_proven(
+            typed_removed_repositories,
+            remote_home=remote_home,
+            exact_paths={expected_previous, expected_legacy},
+        )
+        repository_action = repository_update.get("action")
+        if (
+            binding.get("target") != expected_target
+            or not isinstance(added_repositories, list)
+            or not isinstance(removed_repositories, list)
+        ):
+            raise RelayError("staged reconcile repository binding is invalid")
+        if repository_action == "reused":
+            if (
+                typed_jarvis_preservation.get("repositories_byte_identical") is not True
+                or added_repositories
+                or removed_repositories
+            ):
+                raise RelayError("staged reconcile repository reuse is invalid")
+        elif repository_action == "updated":
+            if (
+                typed_jarvis_preservation.get("repositories_byte_identical") is not False
+                or not _jarvis_repository_additions_are_proven(
+                    cast(list[object], added_repositories),
+                    managed_repo=managed_repo,
+                    managed_builtin_repo=expected_builtin,
+                )
+                or not removed_repositories_are_proven
+                or (not added_repositories and not removed_repositories)
+            ):
+                raise RelayError("staged reconcile repository migration is invalid")
+        else:  # pragma: no cover - rejected by the generic evidence contract above
+            raise RelayError("staged reconcile repository action is invalid")
+        if payload_count != 2 or payload_bytes <= 0:
+            raise RelayError("staged reconcile omitted its transferred payload evidence")
+    elif outcome == "full":
+        if any(action != "prepared" for action in component_actions.values()):
+            raise RelayError("fresh bootstrap receipt has invalid component actions")
+        if jarvis_init_action != "initialized":
+            raise RelayError("fresh bootstrap did not report JARVIS initialization")
+        expected_command_count = 2 if jarvis_graph_action == "loaded" else 3
+        if (
+            jarvis_graph_action not in {"loaded", "built"}
+            or command_count != expected_command_count
+        ):
+            raise RelayError("fresh bootstrap did not report exact graph activation commands")
+        expected_graph_commands: list[list[str]] = [
+            [
+                "jarvis",
+                "rg",
+                "load-builtin",
+                cast(str, expected_jarvis_resource_graph_profile),
+                "+json",
+            ]
+        ]
+        if jarvis_graph_action == "built":
+            expected_graph_commands.append(["jarvis", "rg", "build", "+no_benchmark"])
+        if cast(list[object], command_argv)[1:] != expected_graph_commands:
+            raise RelayError("fresh bootstrap reported unexpected graph commands")
+        if payload_count != 2 or payload_bytes <= 0:
+            raise RelayError("fresh bootstrap omitted its transferred payload evidence")
+
+
+def is_sha256_value(value: object) -> bool:
+    return bool(
+        isinstance(value, str)
+        and len(value) == 64
+        and value == value.lower()
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _jarvis_repository_removals_are_proven(
+    values: list[object],
+    *,
+    remote_home: str,
+    exact_paths: set[str],
+) -> bool:
+    """Accept only exact historical relay repository paths in bootstrap evidence."""
+    if not all(isinstance(value, str) for value in values):
+        return False
+    repositories = cast(list[str], values)
+    return bool(
+        repositories == sorted(set(repositories))
+        and all(
+            value in exact_paths
+            or _is_relay_owned_jarvis_builtin_repository(value, remote_home=remote_home)
+            for value in repositories
+        )
+    )
+
+
+def _jarvis_repository_additions_are_proven(
+    values: list[object],
+    *,
+    managed_repo: str,
+    managed_builtin_repo: str,
+) -> bool:
+    """Accept only the ordered relay and JARVIS stable repository bindings."""
+    allowed = [managed_repo, managed_builtin_repo]
+    if not all(isinstance(value, str) for value in values):
+        return False
+    repositories = cast(list[str], values)
+    return bool(
+        len(repositories) <= len(allowed)
+        and len(repositories) == len(set(repositories))
+        and all(value in allowed for value in repositories)
+        and repositories == [value for value in allowed if value in repositories]
+    )
+
+
+def _is_relay_owned_jarvis_builtin_repository(value: str, *, remote_home: str) -> bool:
+    """Recognize the exact legacy or content-addressed relay venv builtin path."""
+    if any(character in value for character in "\x00\r\n"):
+        return False
+    path = PurePosixPath(value)
+    home = PurePosixPath(remote_home)
+    if not path.is_absolute() or str(path) != value or not home.is_absolute():
+        return False
+    try:
+        relative = path.relative_to(home / ".local/share/clio-relay")
+    except ValueError:
+        return False
+    parts = relative.parts
+    legacy_prefix = ("jarvis-venv",)
+    generation_prefix = (
+        ("generations", parts[1], "jarvis-venv")
+        if len(parts) >= 3 and is_sha256_value(parts[1])
+        else ()
+    )
+    for prefix in (legacy_prefix, generation_prefix):
+        if not prefix or parts[: len(prefix)] != prefix:
+            continue
+        suffix = parts[len(prefix) :]
+        if (
+            len(suffix) == 4
+            and suffix[0] in {"lib", "lib64"}
+            and _is_python_library_directory_name(suffix[1])
+            and suffix[2:] == ("site-packages", "builtin")
+        ):
+            return True
+    return False
+
+
+def _is_python_library_directory_name(value: str) -> bool:
+    """Recognize one CPython virtual-environment library component."""
+    if not value.startswith("python"):
+        return False
+    major, separator, minor = value.removeprefix("python").partition(".")
+    return bool(separator and major.isdigit() and minor.isdigit())

--- a/src/clio_relay/bootstrap_recovery.py
+++ b/src/clio_relay/bootstrap_recovery.py
@@ -1,0 +1,157 @@
+"""State-aware bootstrap transaction forward-recovery (clio-relay#247).
+
+Owner module for the recovery logic that completes a transaction which
+crashed past the irreversible boundary, without re-deriving a staged
+generation identity that a given transaction mode may never have recorded.
+
+Background: forward recovery historically demanded
+``phase_identities.prepared_manifest`` unconditionally (see
+``bootstrap_recover_previous_transaction`` in ``bootstrap.py``). Only the
+``relay-only``/``component-upgrade`` reconcile path ever wrote that phase,
+before activating -- the ``full`` fresh-bootstrap path (which drives its own
+journal through ``bootstrap_journal.py``, a dependency-free sibling of this
+module) never did, so any full-mode journal that crossed the boundary
+without reaching ``committed`` was permanently wedged.
+
+The fix: once a transaction has reached ``migration_started`` or later,
+activation is durably complete for *every* mode -- the ACTIVE generation's
+own install receipt is ground truth, and recovery no longer needs a staged
+manifest at all. Only ``activating``/``activated`` (relay-only/
+component-upgrade only; ``full`` mode's own boundary excludes these two
+states, see ``BootstrapTransactionJournal.advance``) still need to redo
+activation from the recorded staged identity.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clio_relay.bootstrap_reconcile import (
+    BootstrapDesiredState,
+    BootstrapTransactionJournal,
+    BootstrapTransactionState,
+)
+from clio_relay.errors import ConfigurationError
+from clio_relay.installation import installation_info
+
+# States reachable only once activation itself is durably complete (the
+# `current` pointer and install-receipt already swapped in) -- for every
+# transaction mode. Recovery from any of these verifies the ACTIVE
+# generation instead of re-deriving a staged one.
+_POST_ACTIVATION_STATES = frozenset(
+    {
+        BootstrapTransactionState.MIGRATION_STARTED,
+        BootstrapTransactionState.MIGRATED,
+        BootstrapTransactionState.STARTING,
+        BootstrapTransactionState.SERVICE_VERIFIED,
+    }
+)
+
+_RETIRE_PROCEDURE = (
+    "back up the journal file to '<path>.stale-backup-<UTC timestamp>' next to "
+    "it, remove the original, first confirming with `clio-relay installation-info` "
+    "that the active generation is healthy and untouched, then re-run "
+    "`cluster bootstrap`"
+)
+
+
+def recovery_needs_staged_identity(journal: BootstrapTransactionJournal) -> bool:
+    """Return whether forward recovery must re-derive a staged manifest identity.
+
+    False once the generation is durably active (state past ``activated``):
+    activation itself is fully complete by then for every mode, so recovery
+    reasons from the ACTIVE generation's own receipt instead.
+    """
+    return journal.recovery_mode == "forward" and journal.state not in _POST_ACTIVATION_STATES
+
+
+def active_generation_recovery_evidence(
+    desired: BootstrapDesiredState,
+    *,
+    home: Path | None = None,
+) -> dict[str, object]:
+    """Read the ACTIVE generation's own receipt identity for state-aware recovery.
+
+    Raises ConfigurationError if the active generation pointer, or the
+    receipt it names, does not durably prove the desired deployment --
+    recovery never completes over an unproven or mismatched deployment.
+    """
+    lexical_home = Path(str(home or Path.home())).expanduser().absolute()
+    current = lexical_home / ".local/share/clio-relay/current"
+    if not current.is_symlink():
+        raise ConfigurationError(
+            "active generation recovery found no managed current generation pointer"
+        )
+    resolved = current.resolve(strict=True)
+    receipt_path = current / "install-receipt.json"
+    info = installation_info(receipt_path)
+    receipt = info.get("receipt")
+    if not isinstance(receipt, dict):
+        raise ConfigurationError("active generation omitted its install receipt")
+    generation_fingerprint = receipt.get("generation")
+    deployment_fingerprint = receipt.get("deployment_fingerprint")
+    if (
+        info.get("receipt_matches_install") is not True
+        or not isinstance(generation_fingerprint, str)
+        or generation_fingerprint != desired.fingerprint
+        or deployment_fingerprint != desired.fingerprint
+    ):
+        raise ConfigurationError(
+            "active generation receipt does not match this bootstrap transaction"
+        )
+    return {
+        "schema_version": "clio-relay.bootstrap-active-recovery.v1",
+        "generation": str(resolved),
+        "fingerprint": generation_fingerprint,
+        "install_receipt_sha256": info.get("install_receipt_sha256"),
+    }
+
+
+def complete_active_generation_recovery(
+    journal: BootstrapTransactionJournal,
+    desired: BootstrapDesiredState,
+    *,
+    home: Path | None = None,
+) -> dict[str, object]:
+    """Forward-recover a post-activation journal from the ACTIVE generation.
+
+    Never re-derives a staged manifest identity, and never silently accepts
+    a deployment whose active generation does not durably match this
+    transaction's own recorded ``prepared_generation``.
+    """
+    if recovery_needs_staged_identity(journal):
+        raise ConfigurationError(
+            "active-generation recovery is unavailable before activation completes"
+        )
+    if not journal.prepared_generation:
+        raise ConfigurationError("bootstrap transaction omitted its prepared generation")
+    evidence = active_generation_recovery_evidence(desired, home=home)
+    if evidence["fingerprint"] != journal.prepared_generation:
+        raise ConfigurationError(
+            "active generation does not match this bootstrap transaction's prepared generation"
+        )
+    return evidence
+
+
+def require_phase_identity(
+    journal: BootstrapTransactionJournal,
+    phase: str,
+    *,
+    journal_path: Path,
+) -> str:
+    """Return one recorded phase identity, or an observation-shaped refusal.
+
+    Names the exact absent key, the journal path, and the documented retire
+    procedure -- never a bare lookup failure -- so a journal that predates
+    the writer that records ``phase`` (a "prior-build journal", #247) fails
+    actionably instead of wedging the deployment.
+    """
+    identity = journal.phase_identities.get(phase)
+    if isinstance(identity, str):
+        return identity
+    raise ConfigurationError(
+        f"bootstrap transaction journal is missing phase_identities.{phase}, "
+        f"required to forward-recover a '{journal.mode}' transaction at "
+        f"'{journal.state.value}'. Journal: {journal_path}. This journal predates "
+        f"{phase} being recorded and cannot self-recover; {_RETIRE_PROCEDURE}."
+    )

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -581,7 +581,7 @@ def test_bootstrap_over_ssh_returns_the_matching_durable_invocation_receipt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from clio_relay import bootstrap
+    from clio_relay import bootstrap, bootstrap_receipt_validation
 
     calls: list[list[str]] = []
     uploaded_scripts: list[str] = []
@@ -664,7 +664,9 @@ def test_bootstrap_over_ssh_returns_the_matching_durable_invocation_receipt(
             raise RelayError("bootstrap receipt relay_install_spec changed")
 
     monkeypatch.setattr(bootstrap, "create_bootstrap_archive", fake_create_bootstrap_archive)
-    monkeypatch.setattr(bootstrap, "_validate_bootstrap_receipt", validate_receipt)
+    monkeypatch.setattr(
+        bootstrap_receipt_validation, "validate_bootstrap_receipt", validate_receipt
+    )
     monkeypatch.setattr(bootstrap, "_run", fake_run)
     monkeypatch.setattr(bootstrap, "uuid4", lambda: type("Uuid", (), {"hex": "abc"})())
 

--- a/tests/test_bootstrap_candidate_payload.py
+++ b/tests/test_bootstrap_candidate_payload.py
@@ -42,8 +42,10 @@ def test_extracted_candidate_reconciler_runs_without_provider_bounded_process(
     )
     assert set(sources) == {
         "__init__.py",
+        "bootstrap_jarvis_staging.py",
         "bootstrap_provider_build_info.py",
         "bootstrap_reconcile.py",
+        "bootstrap_recovery.py",
         "bounded_process.py",
         "errors.py",
         "process_containment.py",
@@ -63,7 +65,9 @@ def test_extracted_candidate_reconciler_runs_without_provider_bounded_process(
         legacy_root / "clio_relay",
         ignore=shutil.ignore_patterns(
             "__pycache__",
+            "bootstrap_jarvis_staging.py",
             "bootstrap_reconcile.py",
+            "bootstrap_recovery.py",
             "bounded_process.py",
             "errors.py",
             "process_containment.py",

--- a/tests/test_bootstrap_cluster_paths.py
+++ b/tests/test_bootstrap_cluster_paths.py
@@ -14,7 +14,7 @@ from typing import Any
 import pytest
 from typer.testing import CliRunner
 
-from clio_relay import bootstrap, cli
+from clio_relay import bootstrap, bootstrap_receipt_validation, cli
 from clio_relay.bootstrap import (
     DEFAULT_REMOTE_CORE_DIR,
     DEFAULT_REMOTE_SPOOL_DIR,
@@ -1217,7 +1217,9 @@ def test_bootstrap_over_ssh_forwards_configured_data_directories(
         fake_render_linux_user_bootstrap_script,
     )
     monkeypatch.setattr(bootstrap, "_run", fake_run)
-    monkeypatch.setattr(bootstrap, "_validate_bootstrap_receipt", validate_receipt)
+    monkeypatch.setattr(
+        bootstrap_receipt_validation, "validate_bootstrap_receipt", validate_receipt
+    )
     monkeypatch.setattr(
         bootstrap,
         "_verify_persistent_bootstrap_receipt",

--- a/tests/test_bootstrap_fast_path.py
+++ b/tests/test_bootstrap_fast_path.py
@@ -24,6 +24,7 @@ import pytest
 from typer.testing import CliRunner
 
 import clio_relay.bootstrap as bootstrap
+import clio_relay.bootstrap_receipt_validation as bootstrap_receipt_validation
 import clio_relay.bootstrap_reconcile as bootstrap_reconcile
 import clio_relay.bounded_process as bounded_process
 import clio_relay.cli as cli
@@ -2665,7 +2666,7 @@ def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration(
         payload_transfer_bytes=1,
     )
 
-    bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    bootstrap_receipt_validation.validate_bootstrap_receipt(
         receipt,
         bootstrap_profile="linux-user",
         relay_install_spec=desired.relay_install_spec,
@@ -2684,7 +2685,7 @@ def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration(
         "/home/operator/custom/builtin",
     ]
     with pytest.raises(RelayError, match="repository migration is invalid"):
-        bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        bootstrap_receipt_validation.validate_bootstrap_receipt(
             invalid_builtin_addition,
             bootstrap_profile="linux-user",
             relay_install_spec=desired.relay_install_spec,
@@ -2706,7 +2707,7 @@ def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration(
         cleanup_binding = cast(dict[str, object], cleanup_preservation["repositories"])
         cleanup_update = cast(dict[str, object], cleanup_binding["repositories"])
         cleanup_update["removed_previous_managed_repos"] = [relay_builtin_path]
-        bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        bootstrap_receipt_validation.validate_bootstrap_receipt(
             builtin_cleanup,
             bootstrap_profile="linux-user",
             relay_install_spec=desired.relay_install_spec,
@@ -2727,7 +2728,7 @@ def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration(
     }.items():
         evidence = cast(dict[str, object], relay_components[name])
         evidence["action"] = action
-    bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    bootstrap_receipt_validation.validate_bootstrap_receipt(
         relay_only,
         bootstrap_profile="linux-user",
         relay_install_spec=desired.relay_install_spec,
@@ -2741,7 +2742,7 @@ def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration(
     relay_binding = cast(dict[str, object], relay_preservation["repositories"])
     relay_binding["target"] = "/operator/unrelated-repository"
     with pytest.raises(RelayError, match="repository binding is invalid"):
-        bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        bootstrap_receipt_validation.validate_bootstrap_receipt(
             invalid_relay_binding,
             bootstrap_profile="linux-user",
             relay_install_spec=desired.relay_install_spec,
@@ -2757,7 +2758,7 @@ def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration(
     update = cast(dict[str, object], binding["repositories"])
     update["after_sha256"] = "0" * 64
     with pytest.raises(RelayError, match="hashes do not bind"):
-        bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        bootstrap_receipt_validation.validate_bootstrap_receipt(
             tampered,
             bootstrap_profile="linux-user",
             relay_install_spec=desired.relay_install_spec,
@@ -2773,7 +2774,7 @@ def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration(
     update = cast(dict[str, object], binding["repositories"])
     update["removed_previous_managed_repos"] = ["/operator/unrelated-repository"]
     with pytest.raises(RelayError, match="repository migration is invalid"):
-        bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        bootstrap_receipt_validation.validate_bootstrap_receipt(
             unauthorized_removal,
             bootstrap_profile="linux-user",
             relay_install_spec=desired.relay_install_spec,
@@ -2791,7 +2792,7 @@ def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration(
         "/home/operator/.local/share/clio-relay/operator-venv/lib/python3.12/site-packages/builtin"
     ]
     with pytest.raises(RelayError, match="repository migration is invalid"):
-        bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        bootstrap_receipt_validation.validate_bootstrap_receipt(
             lookalike_removal,
             bootstrap_profile="linux-user",
             relay_install_spec=desired.relay_install_spec,
@@ -2805,7 +2806,7 @@ def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration(
     preservation = cast(dict[str, object], replaced_link["jarvis_preservation"])
     binding = cast(dict[str, object], preservation["repositories"])
     binding["link_action"] = "retargeted"
-    bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    bootstrap_receipt_validation.validate_bootstrap_receipt(
         replaced_link,
         bootstrap_profile="linux-user",
         relay_install_spec=desired.relay_install_spec,
@@ -2819,7 +2820,7 @@ def test_component_upgrade_receipt_accepts_only_bound_managed_repo_registration(
     generation = cast(dict[str, object], unproven_retarget["generation"])
     generation["previous"] = "unproven"
     with pytest.raises(RelayError, match="did not preserve existing JARVIS state"):
-        bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        bootstrap_receipt_validation.validate_bootstrap_receipt(
             unproven_retarget,
             bootstrap_profile="linux-user",
             relay_install_spec=desired.relay_install_spec,
@@ -2934,7 +2935,7 @@ def test_fresh_bootstrap_receipt_allows_explicit_pending_service_install(
         payload_transfer_bytes=1,
     )
 
-    bootstrap._validate_bootstrap_receipt(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    bootstrap_receipt_validation.validate_bootstrap_receipt(
         receipt,
         bootstrap_profile="linux-user",
         relay_install_spec=desired.relay_install_spec,
@@ -3358,7 +3359,12 @@ def test_staged_upgrade_uses_journal_bound_idempotent_forward_activation() -> No
     assert 'unset "$bootstrap_environment_name"' in provider_function
     assert activation < finish < verify < activated < migration
     assert "bootstrap_candidate_action finish-activation" in recovery
-    assert "phase_identities" in recovery
+    # #247: state-aware recovery reads `phase_identities.prepared_manifest`
+    # through the new `recovery-prepared-manifest` candidate action (owned by
+    # bootstrap_recovery.require_phase_identity) rather than an inline
+    # heredoc, so it can name the exact missing key on a prior-build journal.
+    assert "bootstrap_candidate_action recovery-prepared-manifest prepared_manifest" in recovery
+    assert "recovery_needs_staged_identity" in recovery
     assert "sha256sum --check --strict -" in recovery
     assert "WORKER_LIFETIME_GUARD_FD=8" in recovery
     assert 'CLIO_RELAY_WORKER_LIFETIME_GUARD_FD="$WORKER_LIFETIME_GUARD_FD"' in recovery

--- a/tests/test_bootstrap_jarvis_staging.py
+++ b/tests/test_bootstrap_jarvis_staging.py
@@ -1,0 +1,213 @@
+"""Failing-first tests for clio_relay.bootstrap_jarvis_staging (clio-relay#254).
+
+The live defect: a full-mode `cluster bootstrap` reconcile over an
+already-bootstrapped host (`~/.local/share/clio-relay/jarvis-venv` exists,
+built by an earlier successful full bootstrap) hard-refused with "full
+component reconcile requires a staged generation" -- a precondition
+`cluster bootstrap` exposed no way to satisfy. The relay could never
+redeploy itself. The fix stages the replacement environment at a path the
+transaction owns and promotes it with one atomic pathname exchange, so the
+live environment is never absent or half-cleared at any observable point,
+including under a sabotage-shaped interrupt between stage-complete and the
+exchange.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clio_relay.bootstrap_jarvis_staging import (
+    jarvis_venv_staging_plan,
+    promote_staged_jarvis_venv,
+    retired_jarvis_venv_path,
+    staged_jarvis_venv_path,
+)
+from clio_relay.errors import ConfigurationError
+
+
+def _relay_dir(home: Path) -> Path:
+    directory = home / ".local/share/clio-relay"
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def test_virgin_host_has_no_staging_plan(tmp_path: Path) -> None:
+    """No managed jarvis-venv exists yet: the virgin path is unchanged (None)."""
+    assert jarvis_venv_staging_plan(home=tmp_path, invocation_id="inv-1") is None
+
+
+def test_existing_jarvis_venv_produces_a_staged_plan_instead_of_a_refusal(
+    tmp_path: Path,
+) -> None:
+    """The defect's exact acceptance bar: a full-mode reconcile over an
+    existing managed jarvis-venv produces the STAGED plan, not a refusal."""
+    live = _relay_dir(tmp_path) / "jarvis-venv"
+    live.mkdir()
+    (live / "bin").mkdir()
+    (live / "bin" / "python").write_bytes(b"")
+
+    plan = jarvis_venv_staging_plan(home=tmp_path, invocation_id="inv-1")
+
+    assert plan is not None
+    assert plan["schema_version"] == "clio-relay.jarvis-venv-staging-plan.v1"
+    assert plan["live"] == str(live)
+    assert plan["staged"] == str(staged_jarvis_venv_path(home=tmp_path, invocation_id="inv-1"))
+    # The plan never proposes clearing the live environment directly.
+    assert live.is_dir()
+    assert list(live.iterdir())
+
+
+def test_existing_jarvis_venv_symlink_refuses_typed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A `jarvis-venv` that is not one owned directory is a typed refusal, not
+    a silent adopt-or-clear. Simulated via monkeypatch (matching the suite's
+    `_simulate_file_symlink` idiom) rather than a real symlink, which
+    requires an elevated privilege this box does not grant."""
+    relay_dir = _relay_dir(tmp_path)
+    target = relay_dir / "elsewhere"
+    target.mkdir()
+    live = relay_dir / "jarvis-venv"
+
+    original_exists = Path.exists
+    original_is_symlink = Path.is_symlink
+
+    def simulated_exists(path: Path) -> bool:
+        if path == live:
+            return True
+        return original_exists(path)
+
+    def simulated_is_symlink(path: Path) -> bool:
+        if path == live:
+            return True
+        return original_is_symlink(path)
+
+    monkeypatch.setattr(Path, "exists", simulated_exists)
+    monkeypatch.setattr(Path, "is_symlink", simulated_is_symlink)
+
+    with pytest.raises(ConfigurationError, match="not one owned directory"):
+        jarvis_venv_staging_plan(home=tmp_path, invocation_id="inv-1")
+
+
+def _build_environment(path: Path, *, marker: str) -> None:
+    path.mkdir(parents=True)
+    (path / "bin").mkdir()
+    (path / "bin" / "python").write_text(marker, encoding="utf-8")
+
+
+def test_promote_swaps_live_and_staged_then_retires_the_old_copy(tmp_path: Path) -> None:
+    """The core mechanism: one atomic exchange promotes staged to live, then
+    the vacated pathname (holding the OLD content) is renamed to retired --
+    never deleted."""
+    invocation_id = "inv-1"
+    live = _relay_dir(tmp_path) / "jarvis-venv"
+    staged = staged_jarvis_venv_path(home=tmp_path, invocation_id=invocation_id)
+    _build_environment(live, marker="old")
+    _build_environment(staged, marker="new")
+    staged_identity = (staged.lstat().st_dev, staged.lstat().st_ino)
+
+    result = promote_staged_jarvis_venv(
+        home=tmp_path,
+        invocation_id=invocation_id,
+        retired_at="20260819T060000Z",
+        staged_identity=staged_identity,
+    )
+
+    assert live.is_dir()
+    assert (live / "bin" / "python").read_text(encoding="utf-8") == "new"
+    assert not staged.exists()
+    retired = retired_jarvis_venv_path(home=tmp_path, retired_at="20260819T060000Z")
+    assert retired.is_dir()
+    assert (retired / "bin" / "python").read_text(encoding="utf-8") == "old"
+    assert result["live"] == str(live)
+    assert result["retired"] == str(retired)
+
+
+def test_sabotage_interrupt_before_exchange_leaves_live_untouched_and_recovers(
+    tmp_path: Path,
+) -> None:
+    """Sabotage-shaped acceptance (#254): interrupt BETWEEN stage-complete and
+    the exchange -- i.e. crash before `promote_staged_jarvis_venv` ever runs.
+    The live environment must be untouched, and a later recovery call must
+    still converge (complete the promotion forward)."""
+    invocation_id = "inv-1"
+    live = _relay_dir(tmp_path) / "jarvis-venv"
+    staged = staged_jarvis_venv_path(home=tmp_path, invocation_id=invocation_id)
+    _build_environment(live, marker="old")
+    _build_environment(staged, marker="new")
+    staged_identity = (staged.lstat().st_dev, staged.lstat().st_ino)
+
+    # The "interrupt": nothing has run yet. Assert the live env is exactly
+    # what it was before staging began.
+    assert (live / "bin" / "python").read_text(encoding="utf-8") == "old"
+
+    # Recovery converges: completes the promotion forward.
+    promote_staged_jarvis_venv(
+        home=tmp_path,
+        invocation_id=invocation_id,
+        retired_at="20260819T060000Z",
+        staged_identity=staged_identity,
+    )
+    assert (live / "bin" / "python").read_text(encoding="utf-8") == "new"
+
+
+def test_sabotage_interrupt_after_exchange_before_retire_recovers_idempotently(
+    tmp_path: Path,
+) -> None:
+    """Sabotage-shaped acceptance (#254): interrupt AFTER the atomic exchange
+    but BEFORE the retire rename. A second, independent recovery call (its
+    own fresh retired_at, exactly how `bootstrap_recover_previous_transaction`
+    invokes it) must not re-exchange (which would swap live back to the
+    retired copy) -- it proves the exchange already ran via `staged_identity`
+    and is a safe no-op."""
+    invocation_id = "inv-1"
+    live = _relay_dir(tmp_path) / "jarvis-venv"
+    staged = staged_jarvis_venv_path(home=tmp_path, invocation_id=invocation_id)
+    _build_environment(live, marker="old")
+    _build_environment(staged, marker="new")
+    staged_identity = (staged.lstat().st_dev, staged.lstat().st_ino)
+
+    # First call completes fully (exchange + retire).
+    promote_staged_jarvis_venv(
+        home=tmp_path,
+        invocation_id=invocation_id,
+        retired_at="20260819T060000Z",
+        staged_identity=staged_identity,
+    )
+    assert (live / "bin" / "python").read_text(encoding="utf-8") == "new"
+
+    # Simulate the "interrupted after exchange" recovery re-run: the exchange
+    # already happened, `staged` no longer exists, so this call must be a
+    # pure no-op -- never re-exchanging live back to the retired copy.
+    second = promote_staged_jarvis_venv(
+        home=tmp_path,
+        invocation_id=invocation_id,
+        retired_at="20260819T070000Z",
+        staged_identity=staged_identity,
+    )
+    assert second["live"] == str(live)
+    # Never swapped back: live still holds the NEW content, exactly once.
+    assert (live / "bin" / "python").read_text(encoding="utf-8") == "new"
+    retired = retired_jarvis_venv_path(home=tmp_path, retired_at="20260819T060000Z")
+    assert (retired / "bin" / "python").read_text(encoding="utf-8") == "old"
+    # The second call's own retired target was never created -- nothing was
+    # left to retire a second time.
+    assert not retired_jarvis_venv_path(home=tmp_path, retired_at="20260819T070000Z").exists()
+
+
+def test_promote_refuses_when_staged_content_changed(tmp_path: Path) -> None:
+    """Promotion refuses -- typed, not silent -- if the staged directory's
+    identity no longer matches what was recorded when it was created."""
+    invocation_id = "inv-1"
+    live = _relay_dir(tmp_path) / "jarvis-venv"
+    _build_environment(live, marker="old")
+    with pytest.raises(ConfigurationError, match="unavailable for promotion"):
+        promote_staged_jarvis_venv(
+            home=tmp_path,
+            invocation_id=invocation_id,
+            retired_at="20260819T060000Z",
+            staged_identity=(0, 0),
+        )
+    assert (live / "bin" / "python").read_text(encoding="utf-8") == "old"

--- a/tests/test_bootstrap_recovery.py
+++ b/tests/test_bootstrap_recovery.py
@@ -1,0 +1,241 @@
+"""Failing-first tests for clio_relay.bootstrap_recovery (clio-relay#247).
+
+The exact live defect: a `full`-mode bootstrap transaction journal at
+`service_verified` (active generation healthy, commit record never written)
+could not forward-recover, because `bootstrap.py`'s forward recovery
+unconditionally demanded `phase_identities.prepared_manifest` -- a key ONLY
+relay-only/component-upgrade reconcile ever wrote (before activating).
+Recovery is now state-aware: past activation, the ACTIVE generation's own
+receipt is proof enough, and a journal genuinely missing a required phase
+identity for an earlier state gets a typed, observation-shaped refusal.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import clio_relay.bootstrap_recovery as bootstrap_recovery
+from clio_relay.bootstrap_reconcile import (
+    BootstrapDesiredState,
+    BootstrapTransactionJournal,
+    BootstrapTransactionState,
+)
+from clio_relay.bootstrap_recovery import (
+    complete_active_generation_recovery,
+    recovery_needs_staged_identity,
+    require_phase_identity,
+)
+from clio_relay.errors import ConfigurationError
+
+
+def _desired() -> BootstrapDesiredState:
+    return BootstrapDesiredState(
+        cluster="ares-p5run2",
+        core_dir="~/.local/share/clio-relay/core",
+        spool_dir="~/.local/share/clio-relay/spool",
+        worker_service="clio-relay-endpoint-ares-p5run2.service",
+        relay_install_spec="clio-relay==1.6.6",
+        relay_artifact_sha256="a" * 64,
+        relay_source_identity=f"wheel:sha256:{'a' * 64}",
+        frp_version="0.69.1",
+        frpc_sha256="b" * 64,
+        frps_sha256="c" * 64,
+        uv_version="0.11.28",
+        uv_sha256="d" * 64,
+        jarvis_util_commit="commit",
+        jarvis_cd_version="1.4.4",
+        jarvis_cd_wheel_url="https://example.test/jarvis.whl",
+        jarvis_cd_wheel_sha256="e" * 64,
+        clio_kit_install_spec="https://example.test/clio-kit.whl",
+        clio_kit_version="2.3.1",
+        clio_kit_artifact_sha256="f" * 64,
+        agent_adapter="exec",
+    )
+
+
+def _service_verified_journal(desired: BootstrapDesiredState) -> BootstrapTransactionJournal:
+    """A full-mode journal shaped like the live ares incident: reached
+    `service_verified` with ONLY the `locked` phase identity a prior-build
+    journal ever recorded -- `full` mode never wrote `prepared_manifest`.
+    """
+    journal = BootstrapTransactionJournal(
+        invocation_id="bootstrap-1",
+        desired_fingerprint=desired.fingerprint,
+        mode="full",
+        phase_identities={"locked": desired.fingerprint},
+    )
+    journal.prepared_generation = desired.fingerprint
+    for state in (
+        BootstrapTransactionState.INSPECTED,
+        BootstrapTransactionState.PREPARING,
+        BootstrapTransactionState.PREPARED,
+        BootstrapTransactionState.FENCING,
+        BootstrapTransactionState.FENCED,
+        BootstrapTransactionState.ACTIVATING,
+        BootstrapTransactionState.ACTIVATED,
+        BootstrapTransactionState.MIGRATION_STARTED,
+        BootstrapTransactionState.MIGRATED,
+        BootstrapTransactionState.SERVICE_VERIFIED,
+    ):
+        journal.advance(state)
+    return journal
+
+
+def _write_active_generation(
+    home: Path,
+    desired: BootstrapDesiredState,
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    generation_fingerprint: str | None = None,
+) -> None:
+    """Create the active generation and expose `current` as a symlink to it.
+
+    Simulates the symlink via monkeypatch (matching the suite's
+    `_simulate_file_symlink` idiom) rather than `Path.symlink_to`, which
+    requires an elevated privilege this box does not grant.
+    """
+    fingerprint = generation_fingerprint or desired.fingerprint
+    generation = home / ".local/share/clio-relay/generations" / fingerprint
+    generation.mkdir(parents=True)
+    current = home / ".local/share/clio-relay/current"
+    receipt = generation / "install-receipt.json"
+    receipt.write_text(
+        json.dumps({"generation": fingerprint, "deployment_fingerprint": fingerprint}),
+        encoding="utf-8",
+    )
+
+    original_is_symlink = Path.is_symlink
+    original_resolve = Path.resolve
+
+    def simulated_is_symlink(path: Path) -> bool:
+        if path == current:
+            return True
+        return original_is_symlink(path)
+
+    def simulated_resolve(path: Path, strict: bool = False) -> Path:
+        if path == current:
+            return original_resolve(generation, strict=strict)
+        return original_resolve(path, strict=strict)
+
+    monkeypatch.setattr(Path, "is_symlink", simulated_is_symlink)
+    monkeypatch.setattr(Path, "resolve", simulated_resolve)
+
+
+def _mock_installation_info(monkeypatch: pytest.MonkeyPatch, receipt: dict[str, Any]) -> None:
+    """Stand in for the real `installation_info`, which verifies live component
+    runtimes this test never installs -- only the receipt-matching CONTRACT
+    `active_generation_recovery_evidence` reads is under test here."""
+
+    def fake_installation_info(_path: Path) -> dict[str, Any]:
+        return {
+            "receipt": receipt,
+            "receipt_matches_install": True,
+            "install_receipt_sha256": "0" * 64,
+        }
+
+    monkeypatch.setattr(bootstrap_recovery, "installation_info", fake_installation_info)
+
+
+def test_service_verified_journal_only_locked_phase_needs_no_staged_identity() -> None:
+    """RED for the historical bug: the exact journal shape observed live on
+    ares (only `locked` ever recorded) must NOT need `prepared_manifest`."""
+    desired = _desired()
+    journal = _service_verified_journal(desired)
+    assert journal.phase_identities == {"locked": desired.fingerprint}
+    assert journal.irreversible_boundary is True
+    assert journal.recovery_mode == "forward"
+    assert recovery_needs_staged_identity(journal) is False
+
+
+def test_service_verified_journal_forward_recovers_to_completion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GREEN: state-aware recovery completes from the ACTIVE generation's own
+    receipt -- no `phase_identities.prepared_manifest` lookup, no ValueError,
+    the exact wedge `bootstrap.py:4654` hit live on ares (#247)."""
+    desired = _desired()
+    journal = _service_verified_journal(desired)
+    _write_active_generation(tmp_path, desired, monkeypatch=monkeypatch)
+    _mock_installation_info(
+        monkeypatch,
+        {"generation": desired.fingerprint, "deployment_fingerprint": desired.fingerprint},
+    )
+
+    evidence = complete_active_generation_recovery(journal, desired, home=tmp_path)
+    assert evidence["fingerprint"] == desired.fingerprint
+    assert evidence["generation"] == str(
+        (tmp_path / ".local/share/clio-relay/generations" / desired.fingerprint).resolve()
+    )
+
+    journal.complete_recovery()
+    assert journal.state == BootstrapTransactionState.RECOVERED
+
+
+def test_active_generation_mismatch_never_silently_recovers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A journal whose prepared_generation does not match the active receipt
+    must refuse -- never silently mark a mismatched deployment recovered."""
+    desired = _desired()
+    journal = _service_verified_journal(desired)
+    _write_active_generation(
+        tmp_path, desired, monkeypatch=monkeypatch, generation_fingerprint="b" * 64
+    )
+    _mock_installation_info(
+        monkeypatch, {"generation": "b" * 64, "deployment_fingerprint": "b" * 64}
+    )
+
+    with pytest.raises(ConfigurationError, match="does not match"):
+        complete_active_generation_recovery(journal, desired, home=tmp_path)
+
+
+def test_missing_prepared_manifest_gets_actionable_refusal(tmp_path: Path) -> None:
+    """Defect #247 part (c): a prior-build journal missing a required phase
+    identity gets a typed, observation-shaped refusal naming the key, the
+    journal path, and the retire procedure -- never a bare lookup failure."""
+    desired = _desired()
+    journal = BootstrapTransactionJournal(
+        invocation_id="bootstrap-1",
+        desired_fingerprint=desired.fingerprint,
+        mode="relay-only",
+        phase_identities={"locked": desired.fingerprint},
+    )
+    journal.prepared_generation = desired.fingerprint
+    for state in (
+        BootstrapTransactionState.INSPECTED,
+        BootstrapTransactionState.PREPARING,
+        BootstrapTransactionState.PREPARED,
+        BootstrapTransactionState.FENCING,
+        BootstrapTransactionState.FENCED,
+        BootstrapTransactionState.ACTIVATING,
+    ):
+        journal.advance(state)
+    assert journal.recovery_mode == "forward"
+    assert recovery_needs_staged_identity(journal) is True
+
+    journal_path = tmp_path / "bootstrap-transaction.json"
+    with pytest.raises(ConfigurationError) as excinfo:
+        require_phase_identity(journal, "prepared_manifest", journal_path=journal_path)
+    message = str(excinfo.value)
+    assert "phase_identities.prepared_manifest" in message
+    assert str(journal_path) in message
+    assert "stale-backup" in message
+
+
+def test_require_phase_identity_returns_recorded_value() -> None:
+    """The non-refusal path: an existing phase identity is returned as-is."""
+    desired = _desired()
+    journal = BootstrapTransactionJournal(
+        invocation_id="bootstrap-1",
+        desired_fingerprint=desired.fingerprint,
+        mode="relay-only",
+        phase_identities={"locked": desired.fingerprint, "prepared_manifest": "e" * 64},
+    )
+    assert (
+        require_phase_identity(journal, "prepared_manifest", journal_path=Path("unused"))
+        == "e" * 64
+    )


### PR DESCRIPTION
#247: forward recovery unconditionally demanded phase_identities.
prepared_manifest, a key only relay-only/component-upgrade reconcile ever
wrote before activating. Any full-mode journal that crossed the
irreversible boundary without reaching committed (e.g. left at
service_verified, as observed live on ares) was permanently wedged.
Recovery is now state-aware (bootstrap_recovery.py): past activation
(migration_started or later) the ACTIVE generation's own install receipt
is proof enough, so no staged identity is re-derived; a journal genuinely
missing a required phase identity for an earlier state gets a typed,
observation-shaped refusal naming the key, the journal path, and the
retire procedure instead of a bare ValueError.

#254: full-mode reconcile refused outright whenever a managed jarvis-venv
already existed, promising "a staged generation" precondition cluster
bootstrap never implemented -- the relay could not redeploy itself onto
an already-bootstrapped host. bootstrap_jarvis_staging.py now builds the
replacement environment at a path the transaction owns, promotes it with
one atomic pathname exchange (renameat2/RENAME_EXCHANGE) at the same
fenced boundary that activates the rest of the generation -- so the live
environment is never absent or half-cleared at any observable point --
and retires (never deletes) the pre-exchange copy. #247's recovery
completes an interrupted promotion idempotently via the owned-path
identity mkdir-owned already records.

Both new modules are added to the candidate-package overlay so recovery
runs the fixed logic even from an old installed provider. Ratchet: moved
receipt-shape/JARVIS-repository-provenance validation (631 lines, no
remote-heredoc dependency) to the new bootstrap_receipt_validation.py,
netting bootstrap.py from 8896 to 8356 lines even after both fixes' own
call sites -- bootstrap_reconcile.py and bootstrap_journal.py untouched.

Known deviation: full-mode reconcile over a host whose `current`
generation (not just jarvis-venv) already exists would still hit the
fresh-bootstrap ownership-proof's unconditional absent() assertions for
current/install_receipt/managed_repo/etc -- out of scope for these two
issues (neither names it, and the live repro never reached that code
path), flagged here for a follow-up issue.
