### PR TITLE
fix(bootstrap): full-mode re-bootstrap over a populated host (#257)

### DIFF
--- a/scripts/check_file_size.py
+++ b/scripts/check_file_size.py
@@ -104,7 +104,13 @@ RATCHET_BASELINE: dict[str, int] = {
     # the new bootstrap_recovery.py) and the #254 jarvis-venv staging guard
     # and promotion wiring (delegates to the new bootstrap_jarvis_staging.py).
     # A net ratchet-down even after both fixes' own new call sites.
-    "src/clio_relay/bootstrap.py": 8356,
+    # 2026-08-19 (+23, justified; coordinator-approved): #257 staged
+    # whole-generation activation -- three extraction rounds moved 88% of
+    # the growth into bootstrap_full_activation_staging.py; the residual
+    # is dependency-free heredoc that cannot leave the renderer (same
+    # shape as the mcp_call/runner.py +28 precedent). Ratchets back with
+    # the #255 bootstrap decomposition.
+    "src/clio_relay/bootstrap.py": 8379,
     # #158 journal hardening (site-prefix walk + cross-call swap refusal): 1534
     # measured; restored after a merge-resolution slip dropped the entry.
     "src/clio_relay/bootstrap_journal.py": 1534,

--- a/src/clio_relay/bootstrap.py
+++ b/src/clio_relay/bootstrap.py
@@ -28,7 +28,12 @@ from uuid import uuid4
 from packaging.utils import InvalidWheelFilename, canonicalize_name, parse_wheel_filename
 from packaging.version import InvalidVersion, Version
 
-from clio_relay import __version__, bootstrap_pin, bootstrap_receipt_validation
+from clio_relay import (
+    __version__,
+    bootstrap_full_activation_staging,
+    bootstrap_pin,
+    bootstrap_receipt_validation,
+)
 from clio_relay.bootstrap_reconcile import (
     BootstrapDesiredState,
 )
@@ -1808,6 +1813,7 @@ _BOOTSTRAP_CANDIDATE_PACKAGE_OVERLAY = (
     b"    pass\n"
 )
 _BOOTSTRAP_CANDIDATE_SOURCE_NAMES = (
+    "bootstrap_full_activation_staging.py",
     "bootstrap_jarvis_staging.py",
     "bootstrap_provider_build_info.py",
     "bootstrap_reconcile.py",
@@ -3540,6 +3546,7 @@ else:
     sys.modules[name] = module
     spec.loader.exec_module(module)
 from clio_relay import bootstrap_jarvis_staging, bootstrap_recovery
+from clio_relay import bootstrap_full_activation_staging
 journal_path = Path(os.environ["BOOTSTRAP_TRANSACTION_JOURNAL"])
 if action == "journal-create":
     service_value = os.environ["BOOTSTRAP_SERVICE_ACTIVE_BEFORE"]
@@ -3621,6 +3628,18 @@ elif action == "recovery-jarvis-venv-promote":
             invocation_id=arguments[0],
             retired_at=arguments[1],
             staged_identity=(identity.device, identity.inode),
+        )
+    except module.ConfigurationError as exc:
+        raise SystemExit(str(exc)) from None
+    print(json.dumps(evidence, sort_keys=True, separators=(",", ":")))
+elif action == "full-activation-reconcile":
+    # clio-relay#257: see bootstrap_full_activation_staging.
+    promote = bootstrap_full_activation_staging.promote_full_mode_activation_links_from_manifest
+    try:
+        evidence = promote(
+            Path(arguments[0]),
+            expected_manifest_sha256=arguments[1],
+            desired_fingerprint=os.environ["BOOTSTRAP_DESIRED_FINGERPRINT"],
         )
     except module.ConfigurationError as exc:
         raise SystemExit(str(exc)) from None
@@ -5565,6 +5584,11 @@ def render_linux_user_bootstrap_script(
         invocation_id=invocation_id,
         candidate_uv_install_program=candidate_uv_install_program,
     )
+    # clio-relay#257: rendered-script chunks from bootstrap_full_activation_staging.
+    bfas = bootstrap_full_activation_staging
+    ownership_proof_adoption_python = bfas.ownership_proof_populated_host_adoption_python()
+    stable_activation_link_adoption = bfas.stable_activation_link_adoption_shell()
+    shared_directory_mkdir_owned_helper = bfas.shared_directory_mkdir_owned_helper_shell()
     script = f"""set -euo pipefail
 umask 077
 export PATH="$HOME/.local/bin:$PATH"
@@ -6554,6 +6578,13 @@ if [ "$BOOTSTRAP_PLAN_MODE" = "full" ] && \
   fi
   JARVIS_STAGING_MODE=1
 fi
+# clio-relay#257: current already resolving means the host is populated.
+ACTIVATION_STAGING_MODE=0
+if [ -e "$HOME/.local/share/clio-relay/current" ] || \
+   [ -L "$HOME/.local/share/clio-relay/current" ]; then
+  ACTIVATION_STAGING_MODE=1
+fi
+export ACTIVATION_STAGING_MODE
 if [ "$BOOTSTRAP_PLAN_MODE" = "full" ] && \
    [ "$JARVIS_EXISTING_FILE_COUNT" -eq 0 ] && \
    [ -z "$JARVIS_RESOURCE_GRAPH_PROFILE" ]; then
@@ -6605,7 +6636,7 @@ BOOTSTRAP_GENERATION="$HOME/.local/share/clio-relay/generations/$BOOTSTRAP_DESIR
 BOOTSTRAP_TRANSACTION_ROOT="$HOME/.local/share/clio-relay/transactions/$BOOTSTRAP_INVOCATION_ID"
 BOOTSTRAP_OWNED_PATHS_JSON="$(
   python3 - "$BOOTSTRAP_DESIRED_FINGERPRINT" "$BOOTSTRAP_INVOCATION_ID" \
-    "$JARVIS_STAGING_MODE" \
+    "$JARVIS_STAGING_MODE" "$ACTIVATION_STAGING_MODE" \
     <<'__CLIO_RELAY_FRESH_OWNERSHIP__'
 import hashlib
 import json
@@ -6619,6 +6650,7 @@ home = Path.home()
 fingerprint = sys.argv[1]
 invocation_id = sys.argv[2]
 jarvis_staging_mode = sys.argv[3] == "1"
+activation_staging_mode = sys.argv[4] == "1"
 
 def classify(path: Path) -> os.stat_result | None:
     try:
@@ -6708,35 +6740,7 @@ jarvis_venv_entry = (
     if jarvis_staging_mode
     else ("jarvis_venv", home / ".local/share/clio-relay/jarvis-venv", "directory")
 )
-for name, path, kind in (
-    jarvis_venv_entry,
-    ("clio_kit_wheels", home / ".local/share/clio-relay/component-wheels/clio-kit", "directory"),
-    ("jarvis_cd_wheels", home / ".local/share/clio-relay/component-wheels/jarvis-cd", "directory"),
-    ("uv_tools", home / ".local/share/clio-relay/uv-tools", "directory"),
-    ("uv_bin", home / ".local/share/clio-relay/uv-bin", "directory"),
-    ("uv_python", home / ".local/share/clio-relay/uv-python", "directory"),
-    (
-        "transaction_root",
-        home / ".local/share/clio-relay/transactions" / invocation_id,
-        "directory",
-    ),
-    ("relay_source", home / ".local/src/clio-relay", "symlink"),
-    ("jarvis_state", home / ".ppi-jarvis", "directory"),
-    ("jarvis_config", home / ".local/share/clio-relay/jarvis-config", "directory"),
-    ("jarvis_private", home / ".local/share/clio-relay/jarvis-private", "directory"),
-    ("jarvis_shared", home / ".local/share/clio-relay/jarvis-shared", "directory"),
-    ("generation", home / ".local/share/clio-relay/generations" / fingerprint, "directory"),
-    ("current", home / ".local/share/clio-relay/current", "symlink"),
-    (
-        "install_receipt",
-        home / ".local/share/clio-relay/install-receipt.json",
-        "symlink",
-    ),
-    ("managed_repo", home / ".local/share/clio-relay/clio_relay", "symlink"),
-    ("relay_launcher", home / ".local/bin/clio-relay", "symlink"),
-    ("jarvis_launcher", home / ".local/bin/jarvis", "symlink"),
-):
-    absent(name, path, kind)
+{ownership_proof_adoption_python}
 
 print(json.dumps(owned, sort_keys=True, separators=(",", ":")))
 __CLIO_RELAY_FRESH_OWNERSHIP__
@@ -6839,7 +6843,8 @@ if [ ! -x "$HOME/.local/bin/uv" ] \
   echo "$UV_EXECUTABLE_SHA256 *$HOME/.local/bin/uv" | sha256sum --check --strict -
   BOOTSTRAP_UV_DOWNLOADED=1
 fi
-bootstrap_journal_action mkdir-owned "$BOOTSTRAP_TRANSACTION_JOURNAL" uv_python
+{shared_directory_mkdir_owned_helper}
+bootstrap_mkdir_owned_if_absent "$HOME/.local/share/clio-relay/uv-python" uv_python
 uv python install 3.12
 
 if [ ! -x "$AGENT_BIN" ] && [ -n "$AGENT_NPM_PACKAGE" ] && command -v npm >/dev/null 2>&1; then
@@ -6880,7 +6885,7 @@ JARVIS_CD_WHEEL_SHA256="{JARVIS_CD_WHEEL_SHA256}"
 JARVIS_CD_WHEEL_DIR="$HOME/.local/share/clio-relay/component-wheels/jarvis-cd"
 JARVIS_CD_WHEEL="$JARVIS_CD_WHEEL_DIR/{JARVIS_CD_WHEEL_FILENAME}"
 mkdir -m 0700 -p "$(dirname "$JARVIS_CD_WHEEL_DIR")"
-bootstrap_journal_action mkdir-owned "$BOOTSTRAP_TRANSACTION_JOURNAL" jarvis_cd_wheels
+bootstrap_mkdir_owned_if_absent "$JARVIS_CD_WHEEL_DIR" jarvis_cd_wheels
 JARVIS_CD_STAGING="$(mktemp "${{JARVIS_CD_WHEEL}}.XXXXXX")"
 bootstrap_fetch_exact_artifact \\
   "$JARVIS_CD_WHEEL_URL" "$JARVIS_CD_WHEEL_SHA256" "$JARVIS_CD_STAGING"
@@ -6894,7 +6899,8 @@ JARVIS_MCP_INSTALL_TARGET="$JARVIS_MCP_INSTALL_SPEC"
 JARVIS_MCP_ARTIFACT_PATH=""
 JARVIS_MCP_REQUESTED_SOURCE="checkout"
 JARVIS_MCP_VERSION=""
-bootstrap_journal_action mkdir-owned "$BOOTSTRAP_TRANSACTION_JOURNAL" clio_kit_wheels
+bootstrap_mkdir_owned_if_absent \
+  "$HOME/.local/share/clio-relay/component-wheels/clio-kit" clio_kit_wheels
 case "$JARVIS_MCP_INSTALL_SPEC" in
   "{CLIO_KIT_JARVIS_MCP_WHEEL_URL}")
     JARVIS_MCP_VERSION="{CLIO_KIT_JARVIS_MCP_VERSION}"
@@ -6951,8 +6957,8 @@ esac
 echo "$JARVIS_MCP_ARTIFACT_SHA256 *$JARVIS_MCP_ARTIFACT_PATH" | \
   sha256sum --check --strict -
 deactivate
-bootstrap_journal_action mkdir-owned "$BOOTSTRAP_TRANSACTION_JOURNAL" uv_tools
-bootstrap_journal_action mkdir-owned "$BOOTSTRAP_TRANSACTION_JOURNAL" uv_bin
+bootstrap_mkdir_owned_if_absent "$HOME/.local/share/clio-relay/uv-tools" uv_tools
+bootstrap_mkdir_owned_if_absent "$HOME/.local/share/clio-relay/uv-bin" uv_bin
 uv tool install --force --python 3.12 --no-config \\
   --default-index https://pypi.org/simple "$JARVIS_MCP_INSTALL_TARGET"
 JARVIS_MCP_UV_EXECUTABLE="$(command -v uv)"
@@ -6978,8 +6984,12 @@ if [ -n "$SOURCE_ARCHIVE_SHA256" ]; then
   echo "$SOURCE_ARCHIVE_SHA256 *$SOURCE_ARCHIVE" | sha256sum --check --strict -
 fi
 bootstrap_safe_extract "$JARVIS_VENV/bin/python" "$SOURCE_ARCHIVE" "$DEST"
-bootstrap_journal_action symlink-owned "$BOOTSTRAP_TRANSACTION_JOURNAL" relay_source \
-  "$DEST"
+if [ "$ACTIVATION_STAGING_MODE" != "1" ]; then
+  bootstrap_journal_action symlink-owned "$BOOTSTRAP_TRANSACTION_JOURNAL" relay_source \
+    "$DEST"
+fi
+# clio-relay#257: staging mode never creates it here -- promoted with
+# `current` at the fenced full-activation-reconcile boundary below.
 RELAY_INSTALL_SPEC={rendered_relay_install_spec}
 RELAY_ARTIFACT_SHA256={rendered_relay_artifact_sha256}
 RELAY_INSTALL_TARGET="$RELAY_INSTALL_SPEC"
@@ -7611,8 +7621,9 @@ if [ "$BOOTSTRAP_VERIFIED_DESIRED_FINGERPRINT" != \
   echo "fresh bootstrap desired fingerprint changed after provider installation" >&2
   exit 1
 fi
-if [ -e "$HOME/.local/share/clio-relay/current" ] || \
-   [ -L "$HOME/.local/share/clio-relay/current" ]; then
+if [ "$ACTIVATION_STAGING_MODE" != "1" ] && \
+   {{ [ -e "$HOME/.local/share/clio-relay/current" ] || \
+      [ -L "$HOME/.local/share/clio-relay/current" ]; }}; then
   echo "fresh bootstrap found an existing current generation pointer" >&2
   exit 1
 fi
@@ -7635,6 +7646,9 @@ import os
 import sys
 from pathlib import Path
 
+from clio_relay.bootstrap_full_activation_staging import (
+    capture_full_mode_activation_paths_json,
+)
 from clio_relay.bootstrap_reconcile import (
     BootstrapReconcilePlan,
     execution_environment_identity,
@@ -7668,10 +7682,13 @@ plan = BootstrapReconcilePlan(
         "uv": "replace",
     }},
 )
+# clio-relay#257: carries the pre-swap snapshot durably in the manifest, so
+# a later crash-recovery promotion reads back the SAME one, never fresh.
 manifest = {{
     "schema_version": "clio-relay.bootstrap-generation.v1",
     "fingerprint": fingerprint,
     "plan": plan.model_dump(mode="json"),
+    "full_activation_paths": capture_full_mode_activation_paths_json(Path.home()),
     "legacy_execution_identity": execution_identity,
     "active_execution_identity": execution_identity,
     "jarvis_wrapper_sha256": wrapper["sha256"],
@@ -7693,6 +7710,10 @@ try:
 finally:
     os.close(descriptor)
 __CLIO_RELAY_FULL_GENERATION_MANIFEST__
+BOOTSTRAP_GENERATION_MANIFEST_SHA256="$(
+  sha256sum "$BOOTSTRAP_GENERATION/manifest.json" | awk '{{print $1}}'
+)"
+export BOOTSTRAP_GENERATION_MANIFEST_SHA256
 BOOTSTRAP_GENERATION_IDENTITY="$(bootstrap_path_set_identity \
   "$BOOTSTRAP_GENERATION/manifest.json" \
   "$BOOTSTRAP_GENERATION/.prepared" \
@@ -7706,14 +7727,16 @@ bootstrap_journal_action phase "$BOOTSTRAP_TRANSACTION_JOURNAL" \
 bootstrap_journal_action advance "$BOOTSTRAP_TRANSACTION_JOURNAL" \
   prepared "$BOOTSTRAP_DESIRED_FINGERPRINT"
 bootstrap_journal_action advance "$BOOTSTRAP_TRANSACTION_JOURNAL" activating
-bootstrap_journal_action symlink-owned "$BOOTSTRAP_TRANSACTION_JOURNAL" \
-  current "$BOOTSTRAP_GENERATION"
-bootstrap_journal_action symlink-owned "$BOOTSTRAP_TRANSACTION_JOURNAL" \
-  install_receipt "$HOME/.local/share/clio-relay/current/install-receipt.json"
-bootstrap_journal_action symlink-owned "$BOOTSTRAP_TRANSACTION_JOURNAL" \
-  relay_launcher "$HOME/.local/share/clio-relay/current/bin/clio-relay"
-bootstrap_journal_action symlink-owned "$BOOTSTRAP_TRANSACTION_JOURNAL" \
-  jarvis_launcher "$HOME/.local/share/clio-relay/current/bin/jarvis"
+if [ "$ACTIVATION_STAGING_MODE" = "1" ]; then
+  # clio-relay#257: current was never claimed absent -- promote it now, in
+  # the same fenced "activating" window a virgin host creates it in directly.
+  bootstrap_candidate_action full-activation-reconcile \
+    "$BOOTSTRAP_GENERATION" "$BOOTSTRAP_GENERATION_MANIFEST_SHA256" >/dev/null
+else
+  bootstrap_journal_action symlink-owned "$BOOTSTRAP_TRANSACTION_JOURNAL" \
+    current "$BOOTSTRAP_GENERATION"
+fi
+{stable_activation_link_adoption}
 BOOTSTRAP_ACTIVATION_IDENTITY="$(bootstrap_path_set_identity \
   "$HOME/.local/share/clio-relay/current" \
   "$HOME/.local/share/clio-relay/install-receipt.json" \

--- a/src/clio_relay/bootstrap_full_activation_staging.py
+++ b/src/clio_relay/bootstrap_full_activation_staging.py
@@ -1,0 +1,328 @@
+"""Full-mode current/relay_source activation staging (clio-relay#257).
+
+Generalizes clio-relay#254's jarvis-venv staging discipline to the rest of a
+full-mode installation. The historical defect: a full-mode reconcile chosen
+over a host whose ``current`` generation already exists (not just the #254
+jarvis-venv guard) still hit the fresh-bootstrap ownership proof's
+unconditional ``absent()`` assertions for ``current``/``install_receipt``/
+``managed_repo``/etc -- #254 flagged this as an explicit, out-of-scope
+deviation when it fixed the jarvis-venv-only case.
+
+The fix generalizes narrowly. ``current`` and ``~/.local/src/clio-relay``
+(``relay_source``) are the only two stable activation paths whose TARGET
+actually changes between generations -- ``install_receipt``/
+``relay_launcher``/``jarvis_launcher`` and ``managed_repo`` all point at
+CONSTANT text through ``current`` itself (e.g. ``current/bin/jarvis``), so
+once created they are correct forever (this is exactly what the rendered
+script's own ``bootstrap_verify_stable_activation_links`` proves) and are
+adopted directly, never routed through here. ``current``/``relay_source``
+are captured before any change, carried through the generation manifest
+durably (mirroring how relay-only/component-upgrade reconcile already
+carries its own five-name snapshot in
+``bootstrap_reconcile._capture_reconcile_activation_paths``), and promoted
+atomically at the fenced boundary by reusing
+``bootstrap_reconcile._reconcile_activation_symlink`` -- the SAME per-
+symlink atomic-exchange-and-crash-recovery primitive relay-only/component-
+upgrade reconcile already fences its own activation with, not a
+freshly-invented parallel mechanism.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+from clio_relay.bootstrap_reconcile import (
+    BootstrapActivationPath,
+    _capture_activation_path,  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    _read_regular_bounded,  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    _reconcile_activation_symlink,  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+)
+from clio_relay.errors import ConfigurationError
+
+FULL_MODE_ACTIVATION_NAMES = ("current", "relay_source")
+
+
+def _relay_state_dir(home: Path) -> Path:
+    return Path(os.path.abspath(home.expanduser())) / ".local/share/clio-relay"
+
+
+def capture_full_mode_activation_paths(home: Path) -> dict[str, BootstrapActivationPath]:
+    """Best-effort capture of current/relay_source for a full-mode plan.
+
+    Empty means either the virgin path (``current`` genuinely absent --
+    nothing to stage a swap for) or a populated host whose snapshot did not
+    capture cleanly (a corrupt or partial prior install); either way, this
+    never silently proceeds with a stale snapshot --
+    ``promote_full_mode_activation_links`` raises its own typed refusal
+    instead of promoting from wrong evidence.
+    """
+    share = _relay_state_dir(home)
+    try:
+        current = _capture_activation_path(
+            share / "current",
+            kind="symlink",
+            maximum=4096,
+            allow_absent=True,
+        )
+        if current.before is None:
+            return {}
+        relay_source = _capture_activation_path(
+            Path(os.path.abspath(home.expanduser())) / ".local/src/clio-relay",
+            kind="symlink",
+            maximum=4096,
+            allow_absent=True,
+        )
+    except (ConfigurationError, OSError, RuntimeError, ValueError):
+        return {}
+    return {"current": current, "relay_source": relay_source}
+
+
+def capture_full_mode_activation_paths_json(home: Path) -> dict[str, object]:
+    """JSON-ready form of :func:`capture_full_mode_activation_paths`.
+
+    For embedding directly into a generation manifest -- see
+    ``promote_full_mode_activation_links_from_manifest``, its reader.
+    """
+    return {
+        name: value.model_dump(mode="json")
+        for name, value in capture_full_mode_activation_paths(home).items()
+    }
+
+
+def promote_full_mode_activation_links(
+    activation_paths: dict[str, BootstrapActivationPath],
+    *,
+    generation: Path,
+    desired_fingerprint: str,
+    home: Path | None = None,
+) -> dict[str, str]:
+    """Atomically promote current/relay_source to the prepared generation.
+
+    Idempotent for crash recovery: reruns of this same call (the SAME
+    persisted ``activation_paths`` snapshot, never a freshly re-derived
+    one) converge without re-exchanging a link that already promoted --
+    ``_reconcile_activation_symlink``'s own "reused" fast-path proves it.
+    """
+    if set(activation_paths) != set(FULL_MODE_ACTIVATION_NAMES):
+        raise ConfigurationError("staged activation plan omitted its path identities")
+    lexical_home = Path(os.path.abspath((home or Path.home()).expanduser()))
+    share = lexical_home / ".local/share/clio-relay"
+    expected_generation = share / "generations" / desired_fingerprint
+    if generation != expected_generation or generation.is_symlink() or not generation.is_dir():
+        raise ConfigurationError("staged activation generation path is invalid")
+    targets = {"current": generation, "relay_source": generation / "source"}
+    live_paths = {
+        "current": share / "current",
+        "relay_source": lexical_home / ".local/src/clio-relay",
+    }
+    for name, target_path in live_paths.items():
+        if Path(activation_paths[name].path) != target_path:
+            raise ConfigurationError(f"staged activation path destination changed: {name}")
+    actions: dict[str, str] = {}
+    for name in FULL_MODE_ACTIVATION_NAMES:
+        actions[name] = _reconcile_activation_symlink(
+            activation_paths[name],
+            expected_target=targets[name],
+            label=f"bootstrap stable activation path {name}",
+            exchange_identity=desired_fingerprint,
+        )
+    return actions
+
+
+def promote_full_mode_activation_links_from_manifest(
+    generation: Path,
+    *,
+    expected_manifest_sha256: str,
+    desired_fingerprint: str,
+    home: Path | None = None,
+) -> dict[str, str]:
+    """Read the durably-recorded snapshot from manifest.json and promote it.
+
+    The bootstrap-transaction candidate-action dispatcher's own entry point
+    for the ``full-activation-reconcile`` action -- keeps the manifest
+    read/verify/reconstruct plumbing out of the rendered script. ``home``
+    defaults to :func:`Path.home` (production always promotes against the
+    real host); tests inject a ``tmp_path`` instead.
+    """
+    raw_manifest = _read_regular_bounded(generation / "manifest.json", maximum=4 * 1024 * 1024)
+    if hashlib.sha256(raw_manifest).hexdigest() != expected_manifest_sha256:
+        raise ConfigurationError("prepared generation manifest changed before activation")
+    raw_activation_paths = json.loads(raw_manifest).get("full_activation_paths") or {}
+    activation_paths = {
+        name: BootstrapActivationPath.model_validate(value)
+        for name, value in raw_activation_paths.items()
+    }
+    return promote_full_mode_activation_links(
+        activation_paths,
+        generation=generation,
+        desired_fingerprint=desired_fingerprint,
+        home=home,
+    )
+
+
+def ownership_proof_populated_host_adoption_python() -> str:
+    """Dependency-free adoption logic for the fresh-bootstrap ownership proof.
+
+    That heredoc runs via the SYSTEM ``python3`` before any relay-managed
+    environment exists (a virgin host has none yet), so it cannot import
+    this module or any other clio_relay code -- the text below is
+    stdlib-only Python, embedded verbatim (never re-interpolated) right
+    after ``jarvis_venv_entry`` is defined in the rendered ownership-proof
+    heredoc. It assumes ``classify``, ``owned``, ``absent``, ``home``,
+    ``fingerprint``, ``invocation_id``, ``jarvis_venv_entry``,
+    ``activation_staging_mode``, ``stat``, ``os`` are already in scope
+    there.
+    """
+    return """
+# clio-relay#257: unlike jarvis-venv's owned staged directory, current/
+# relay_source are never claimed here at all in staging mode -- single
+# symlinks promoted later by bootstrap_full_activation_staging, which owns
+# its own atomic-exchange staging internally.
+non_activation_entries = (
+    jarvis_venv_entry,
+    (
+        "transaction_root",
+        home / ".local/share/clio-relay/transactions" / invocation_id,
+        "directory",
+    ),
+    ("generation", home / ".local/share/clio-relay/generations" / fingerprint, "directory"),
+)
+if not activation_staging_mode:
+    non_activation_entries = (
+        *non_activation_entries,
+        ("current", home / ".local/share/clio-relay/current", "symlink"),
+        ("relay_source", home / ".local/src/clio-relay", "symlink"),
+    )
+for name, path, kind in non_activation_entries:
+    absent(name, path, kind)
+
+# clio-relay#257: these are fixed, shared cache/state directories reused
+# across every bootstrap (component-wheel caches, uv's own tool/python
+# storage, JARVIS's own config/private/shared data) -- on a populated host
+# they already hold content from an earlier successful bootstrap. Adopting
+# them (verifying only that each is one real directory, never a symlink)
+# instead of requiring absence is what generalizes; a virgin host still
+# claims and creates them exactly as before, since `classify(path)` is None
+# there too.
+def adopt_shared_directory(name: str, path: Path) -> None:
+    details = classify(path)
+    if details is None:
+        owned[name] = {"path": str(path), "kind": "directory"}
+    elif not stat.S_ISDIR(details.st_mode) or stat.S_ISLNK(details.st_mode):
+        raise SystemExit(f"bootstrap cannot adopt an existing non-directory: {path}")
+
+for name, path in (
+    ("clio_kit_wheels", home / ".local/share/clio-relay/component-wheels/clio-kit"),
+    ("jarvis_cd_wheels", home / ".local/share/clio-relay/component-wheels/jarvis-cd"),
+    ("uv_tools", home / ".local/share/clio-relay/uv-tools"),
+    ("uv_bin", home / ".local/share/clio-relay/uv-bin"),
+    ("uv_python", home / ".local/share/clio-relay/uv-python"),
+    ("jarvis_state", home / ".ppi-jarvis"),
+    ("jarvis_config", home / ".local/share/clio-relay/jarvis-config"),
+    ("jarvis_private", home / ".local/share/clio-relay/jarvis-private"),
+    ("jarvis_shared", home / ".local/share/clio-relay/jarvis-shared"),
+):
+    adopt_shared_directory(name, path)
+
+# clio-relay#257: install_receipt/relay_launcher/jarvis_launcher/managed_repo
+# all point at CONSTANT text through `current` itself (e.g.
+# `current/bin/jarvis`) -- once created they are correct forever, exactly
+# what the rendered script's own bootstrap_verify_stable_activation_links
+# proves. A populated host's existing link is adopted (never re-created,
+# never claimed) if -- and only if -- it already names that exact text; a
+# link naming anything else is a typed refusal, never a silent repoint.
+def adopt_stable_symlink(name: str, path: Path, expected_target: Path) -> None:
+    details = classify(path)
+    if details is None:
+        owned[name] = {"path": str(path), "kind": "symlink"}
+    elif not stat.S_ISLNK(details.st_mode) or os.readlink(path) != str(expected_target):
+        raise SystemExit(f"bootstrap cannot adopt an existing activation link: {path}")
+
+for name, path, target in (
+    (
+        "install_receipt",
+        home / ".local/share/clio-relay/install-receipt.json",
+        home / ".local/share/clio-relay/current/install-receipt.json",
+    ),
+    (
+        "relay_launcher",
+        home / ".local/bin/clio-relay",
+        home / ".local/share/clio-relay/current/bin/clio-relay",
+    ),
+    (
+        "jarvis_launcher",
+        home / ".local/bin/jarvis",
+        home / ".local/share/clio-relay/current/bin/jarvis",
+    ),
+    (
+        "managed_repo",
+        home / ".local/share/clio-relay/clio_relay",
+        home / ".local/share/clio-relay/current/source/jarvis-packages/clio_relay",
+    ),
+):
+    adopt_stable_symlink(name, path, target)
+""".strip("\n")
+
+
+def shared_directory_mkdir_owned_helper_shell() -> str:
+    """A ``bootstrap_journal_action mkdir-owned`` wrapper skipped when adopted.
+
+    clio-relay#257: the ownership proof already skipped claiming these fixed
+    shared directories when they exist (``adopt_shared_directory``, above);
+    this is the matching downstream skip for their ``mkdir-owned`` call --
+    a virgin host still creates every one, since ``[ ! -d "$dir" ]`` is
+    true there too.
+    """
+    return """bootstrap_mkdir_owned_if_absent() {
+  if [ ! -d "$1" ]; then
+    bootstrap_journal_action mkdir-owned "$BOOTSTRAP_TRANSACTION_JOURNAL" "$2"
+  fi
+}"""
+
+
+def stable_activation_link_adoption_shell() -> str:
+    """Shell loop adopting install_receipt/relay_launcher/jarvis_launcher.
+
+    clio-relay#257: their target text never changes across generations (see
+    ``ownership_proof_populated_host_adoption_python``'s docstring), so a
+    populated host's already-correct link is adopted here exactly like
+    ``managed_repo`` -- never re-created. Also covers the rare inconsistent
+    host where ``current`` already existed but one of these three did not:
+    it still gets created fresh, in either mode, same as it always has.
+    Runs unconditionally (not staging-mode-gated): on a virgin host none of
+    these three exist yet, so every iteration falls through to its `else`
+    branch and creates them exactly as the unfixed script always did.
+    """
+    return """for bootstrap_stable_link_name in install_receipt relay_launcher jarvis_launcher; do
+  case "$bootstrap_stable_link_name" in
+    install_receipt)
+      bootstrap_stable_link_path="$HOME/.local/share/clio-relay/install-receipt.json"
+      bootstrap_stable_link_target="$HOME/.local/share/clio-relay/current/install-receipt.json"
+      ;;
+    relay_launcher)
+      bootstrap_stable_link_path="$HOME/.local/bin/clio-relay"
+      bootstrap_stable_link_target="$HOME/.local/share/clio-relay/current/bin/clio-relay"
+      ;;
+    jarvis_launcher)
+      bootstrap_stable_link_path="$HOME/.local/bin/jarvis"
+      bootstrap_stable_link_target="$HOME/.local/share/clio-relay/current/bin/jarvis"
+      ;;
+  esac
+  if [ -L "$bootstrap_stable_link_path" ]; then
+    if [ "$(readlink "$bootstrap_stable_link_path")" != "$bootstrap_stable_link_target" ]; then
+      echo "bootstrap stable activation link points to an unexpected target:" \\
+        "$bootstrap_stable_link_path" >&2
+      exit 1
+    fi
+  elif [ -e "$bootstrap_stable_link_path" ]; then
+    echo "bootstrap stable activation link is not a symbolic link:" \\
+      "$bootstrap_stable_link_path" >&2
+    exit 1
+  else
+    bootstrap_journal_action symlink-owned "$BOOTSTRAP_TRANSACTION_JOURNAL" \\
+      "$bootstrap_stable_link_name" "$bootstrap_stable_link_target"
+  fi
+done"""

--- a/tests/test_bootstrap_candidate_payload.py
+++ b/tests/test_bootstrap_candidate_payload.py
@@ -42,6 +42,7 @@ def test_extracted_candidate_reconciler_runs_without_provider_bounded_process(
     )
     assert set(sources) == {
         "__init__.py",
+        "bootstrap_full_activation_staging.py",
         "bootstrap_jarvis_staging.py",
         "bootstrap_provider_build_info.py",
         "bootstrap_reconcile.py",
@@ -65,6 +66,7 @@ def test_extracted_candidate_reconciler_runs_without_provider_bounded_process(
         legacy_root / "clio_relay",
         ignore=shutil.ignore_patterns(
             "__pycache__",
+            "bootstrap_full_activation_staging.py",
             "bootstrap_jarvis_staging.py",
             "bootstrap_reconcile.py",
             "bootstrap_recovery.py",

--- a/tests/test_bootstrap_full_activation_staging.py
+++ b/tests/test_bootstrap_full_activation_staging.py
@@ -1,0 +1,436 @@
+"""Failing-first tests for clio_relay.bootstrap_full_activation_staging (clio-relay#257).
+
+The live defect: a full-mode `cluster bootstrap` reconcile chosen over a
+host whose `current` generation already exists (not just the #254
+jarvis-venv guard) still hit the fresh-bootstrap ownership proof's
+unconditional `absent()` assertions for current/install_receipt/
+managed_repo/etc -- #254 flagged this as an explicit, out-of-scope
+deviation when it fixed the jarvis-venv-only case. The fix generalizes
+narrowly: `current` and `relay_source` (`~/.local/src/clio-relay`) are the
+only two stable activation paths whose target actually changes between
+generations, so they are captured and promoted here instead of being
+required absent -- the same "stage beside the live installation, swap
+atomically at the fenced boundary, never observe it half-cleared" discipline
+clio_relay.bootstrap_jarvis_staging already established for jarvis-venv,
+including under a sabotage-shaped interrupt between stage-complete and swap.
+
+Unlike jarvis-venv's owned staged directory, `current`/`relay_source` are
+never claimed as owned paths at all: they are single symlinks, and
+`bootstrap_reconcile._reconcile_activation_symlink` (the same primitive
+relay-only/component-upgrade reconcile already fences its own activation
+with) manages its own atomic-exchange staging internally. The persistence
+vehicle is therefore the generation manifest (`full_activation_paths`),
+not the bootstrap-transaction journal's owned-path identities.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+import clio_relay.bootstrap_full_activation_staging as bootstrap_full_activation_staging_module
+import clio_relay.bootstrap_reconcile as bootstrap_reconcile_module
+from clio_relay.bootstrap_full_activation_staging import (
+    FULL_MODE_ACTIVATION_NAMES,
+    capture_full_mode_activation_paths,
+    capture_full_mode_activation_paths_json,
+    promote_full_mode_activation_links,
+    promote_full_mode_activation_links_from_manifest,
+)
+from clio_relay.errors import ConfigurationError
+
+
+def _simulate_symlinks_on_windows(monkeypatch: pytest.MonkeyPatch) -> dict[Path, Path]:
+    """Simulate real symlink semantics on an unprivileged Windows runner.
+
+    Windows symlink creation normally requires an elevated privilege CI does
+    not grant, so ``Path.symlink_to``/``is_symlink``/``resolve``/``lstat``/
+    ``unlink`` and ``os.readlink``/``os.replace`` are patched to track a
+    lightweight link-table instead of real filesystem symlinks. POSIX is
+    unaffected (real symlinks, no patching).
+    """
+    simulated_links: dict[Path, Path] = {}
+    if os.name != "nt":
+        return simulated_links
+    original_is_symlink = Path.is_symlink
+    original_resolve = Path.resolve
+    original_readlink = os.readlink
+    original_replace = os.replace
+    original_lstat = Path.lstat
+    original_unlink = Path.unlink
+
+    def simulated_target(path: Path) -> Path:
+        candidate = path
+        for _ in range(10):
+            matches: list[tuple[int, Path, Path]] = []
+            for link, target in simulated_links.items():
+                try:
+                    relative = candidate.relative_to(link)
+                except ValueError:
+                    continue
+                matches.append((len(link.parts), target, relative))
+            if not matches:
+                return candidate
+            _length, target, relative = max(matches, key=lambda item: item[0])
+            candidate = target / relative
+        raise AssertionError("simulated symlink chain did not terminate")
+
+    def simulated_symlink_to(
+        path: Path,
+        target: Path | str,
+        target_is_directory: bool = False,
+    ) -> None:
+        del target_is_directory
+        if path.exists() or path in simulated_links:
+            raise FileExistsError(path)
+        path.write_bytes(b"simulated-symlink")
+        simulated_links[path] = Path(target)
+
+    def simulated_is_symlink(path: Path) -> bool:
+        return path in simulated_links or original_is_symlink(path)
+
+    def simulated_resolve(path: Path, strict: bool = False) -> Path:
+        return original_resolve(simulated_target(path), strict=strict)
+
+    def simulated_lstat(path: Path) -> os.stat_result:
+        if path in simulated_links:
+            real = original_lstat(path)
+            return cast(
+                os.stat_result,
+                SimpleNamespace(
+                    st_dev=real.st_dev,
+                    st_ino=real.st_ino,
+                    st_mode=stat.S_IFLNK | 0o777,
+                    st_size=len(str(simulated_links[path])),
+                    st_mtime_ns=real.st_mtime_ns,
+                    st_ctime_ns=real.st_ctime_ns,
+                    st_nlink=real.st_nlink,
+                ),
+            )
+        return original_lstat(path)
+
+    def simulated_readlink(path: Path | str) -> str:
+        candidate = Path(path)
+        if candidate in simulated_links:
+            return str(simulated_links[candidate])
+        return original_readlink(path)
+
+    def simulated_replace(source: Path | str, destination: Path | str) -> None:
+        source_path = Path(source)
+        destination_path = Path(destination)
+        original_replace(source_path, destination_path)
+        if source_path in simulated_links:
+            simulated_links[destination_path] = simulated_links.pop(source_path)
+        elif destination_path in simulated_links:
+            del simulated_links[destination_path]
+
+    def simulated_unlink(path: Path, missing_ok: bool = False) -> None:
+        simulated_links.pop(path, None)
+        original_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "symlink_to", simulated_symlink_to)
+    monkeypatch.setattr(Path, "is_symlink", simulated_is_symlink)
+    monkeypatch.setattr(Path, "resolve", simulated_resolve)
+    monkeypatch.setattr(Path, "lstat", simulated_lstat)
+    monkeypatch.setattr(Path, "unlink", simulated_unlink)
+    monkeypatch.setattr(bootstrap_reconcile_module.os, "readlink", simulated_readlink)
+    monkeypatch.setattr(bootstrap_reconcile_module.os, "replace", simulated_replace)
+    return simulated_links
+
+
+def _build_populated_host(tmp_path: Path) -> dict[str, Path]:
+    """Build a host with a full prior successful installation on disk."""
+    share = tmp_path / ".local/share/clio-relay"
+    src_dir = tmp_path / ".local/src"
+    old_generation = share / "generations" / ("0" * 64)
+    (old_generation / "bin").mkdir(parents=True)
+    (old_generation / "source").mkdir(parents=True)
+    src_dir.mkdir(parents=True)
+    current = share / "current"
+    current.symlink_to(old_generation, target_is_directory=True)
+    relay_source = src_dir / "clio-relay"
+    relay_source.symlink_to(old_generation / "source", target_is_directory=True)
+    return {
+        "share": share,
+        "old_generation": old_generation,
+        "current": current,
+        "relay_source": relay_source,
+    }
+
+
+def test_virgin_host_has_no_activation_paths(tmp_path: Path) -> None:
+    """No installation exists yet: the virgin path is unchanged (empty)."""
+    assert capture_full_mode_activation_paths(tmp_path) == {}
+    assert capture_full_mode_activation_paths_json(tmp_path) == {}
+
+
+def test_existing_installation_produces_captured_paths_instead_of_a_refusal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The defect's exact acceptance bar: a full-mode reconcile over a
+    populated host produces the CAPTURED current/relay_source snapshot, not
+    the empty/refused state the unfixed ownership proof would have hit."""
+    _simulate_symlinks_on_windows(monkeypatch)
+    host = _build_populated_host(tmp_path)
+
+    activation_paths = capture_full_mode_activation_paths(tmp_path)
+
+    assert set(activation_paths) == set(FULL_MODE_ACTIVATION_NAMES)
+    current_before = activation_paths["current"].before
+    relay_source_before = activation_paths["relay_source"].before
+    assert current_before is not None
+    assert current_before.symlink_target == str(host["old_generation"])
+    assert relay_source_before is not None
+    assert relay_source_before.symlink_target == str(host["old_generation"] / "source")
+    # The capture never proposes clearing the live installation directly.
+    assert host["current"].is_symlink()
+    assert host["relay_source"].is_symlink()
+
+    as_json = capture_full_mode_activation_paths_json(tmp_path)
+    assert set(as_json) == set(FULL_MODE_ACTIVATION_NAMES)
+    assert json.loads(json.dumps(as_json)) == as_json  # JSON-round-trips cleanly
+
+
+def test_existing_current_non_symlink_never_silently_proceeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A `current` that is not one owned symlink never produces a captured
+    plan claiming otherwise -- capture returns empty (not a stale/partial
+    snapshot), and promotion (below) then refuses typed on the empty set."""
+    share = tmp_path / ".local/share/clio-relay"
+    share.mkdir(parents=True)
+    (share / "current").mkdir()  # a real directory, not a symlink
+
+    assert capture_full_mode_activation_paths(tmp_path) == {}
+
+
+def test_promote_swaps_current_and_relay_source_then_is_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The core mechanism: one call promotes BOTH stable paths whose target
+    changes across generations, then a second call is a pure no-op
+    ("reused") -- the exact idempotency bar #254 set for jarvis-venv."""
+    _simulate_symlinks_on_windows(monkeypatch)
+    host = _build_populated_host(tmp_path)
+    activation_paths = capture_full_mode_activation_paths(tmp_path)
+    fingerprint = "1" * 64
+    new_generation = host["share"] / "generations" / fingerprint
+    (new_generation / "source").mkdir(parents=True)
+
+    first = promote_full_mode_activation_links(
+        activation_paths,
+        generation=new_generation,
+        desired_fingerprint=fingerprint,
+        home=tmp_path,
+    )
+    second = promote_full_mode_activation_links(
+        activation_paths,
+        generation=new_generation,
+        desired_fingerprint=fingerprint,
+        home=tmp_path,
+    )
+
+    assert first == {"current": "retargeted", "relay_source": "retargeted"}
+    assert set(second.values()) == {"reused"}
+    assert os.readlink(host["current"]) == str(new_generation)
+    assert os.readlink(host["relay_source"]) == str(new_generation / "source")
+    # The superseded generation is never deleted -- only unpointed-to.
+    assert host["old_generation"].is_dir()
+
+
+def test_promote_rejects_a_path_set_missing_relay_source(tmp_path: Path) -> None:
+    """Promotion requires EXACTLY {current, relay_source} -- a partial or
+    wrongly-shaped snapshot is a typed refusal, never silently promoted."""
+    generation = tmp_path / ".local/share/clio-relay/generations" / ("2" * 64)
+    generation.mkdir(parents=True)
+    only_current = {
+        "current": bootstrap_reconcile_module.BootstrapActivationPath(
+            path=str(tmp_path / "current"), kind="symlink"
+        )
+    }
+
+    with pytest.raises(ConfigurationError, match="omitted its path identities"):
+        promote_full_mode_activation_links(
+            only_current,
+            generation=generation,
+            desired_fingerprint="2" * 64,
+            home=tmp_path,
+        )
+
+
+def test_sabotage_interrupt_before_any_exchange_leaves_live_untouched_and_recovers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sabotage-shaped acceptance (clio-relay#257, generalizing #254): a
+    crash before the exchange for `current` even starts must leave BOTH
+    stable paths exactly as they were; a later call -- recovery re-running
+    the SAME persisted snapshot, never a freshly re-derived one -- must
+    still converge and promote both."""
+    _simulate_symlinks_on_windows(monkeypatch)
+    host = _build_populated_host(tmp_path)
+    activation_paths = capture_full_mode_activation_paths(tmp_path)
+    fingerprint = "3" * 64
+    new_generation = host["share"] / "generations" / fingerprint
+    (new_generation / "source").mkdir(parents=True)
+
+    # clio-relay#257's module imports `_reconcile_activation_symlink` via
+    # `from ... import`, binding its OWN name -- patch that binding, not
+    # bootstrap_reconcile's (a separate namespace after import time).
+    original = bootstrap_full_activation_staging_module._reconcile_activation_symlink  # noqa: SLF001
+
+    def sabotage_before_any_exchange(*_args: object, **_kwargs: object) -> str:
+        raise ConfigurationError("simulated crash before any exchange")
+
+    monkeypatch.setattr(
+        bootstrap_full_activation_staging_module,
+        "_reconcile_activation_symlink",
+        sabotage_before_any_exchange,
+    )
+    with pytest.raises(ConfigurationError, match="simulated crash before any exchange"):
+        promote_full_mode_activation_links(
+            activation_paths,
+            generation=new_generation,
+            desired_fingerprint=fingerprint,
+            home=tmp_path,
+        )
+
+    assert os.readlink(host["current"]) == str(host["old_generation"])
+    assert os.readlink(host["relay_source"]) == str(host["old_generation"] / "source")
+
+    # Restore the real exchange primitive -- NOT the symlink simulation
+    # (undoing that would drop its link-table and desync it from the
+    # simulated-symlink placeholder files already written to disk above).
+    monkeypatch.setattr(
+        bootstrap_full_activation_staging_module, "_reconcile_activation_symlink", original
+    )
+    result = promote_full_mode_activation_links(
+        activation_paths,
+        generation=new_generation,
+        desired_fingerprint=fingerprint,
+        home=tmp_path,
+    )
+
+    assert result == {"current": "retargeted", "relay_source": "retargeted"}
+    assert os.readlink(host["current"]) == str(new_generation)
+    assert os.readlink(host["relay_source"]) == str(new_generation / "source")
+
+
+def test_sabotage_interrupt_between_current_and_relay_source_recovers_idempotently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sabotage-shaped acceptance twin: interrupt AFTER `current` promotes
+    but BEFORE `relay_source` does. A second, independent call (its own
+    fresh invocation, exactly how a recovery re-run would call this) must
+    not re-exchange `current` -- it proves the exchange already ran via the
+    "reused" fast-path and only completes `relay_source`."""
+    _simulate_symlinks_on_windows(monkeypatch)
+    host = _build_populated_host(tmp_path)
+    activation_paths = capture_full_mode_activation_paths(tmp_path)
+    fingerprint = "4" * 64
+    new_generation = host["share"] / "generations" / fingerprint
+    (new_generation / "source").mkdir(parents=True)
+    original = bootstrap_full_activation_staging_module._reconcile_activation_symlink  # noqa: SLF001
+
+    def sabotage_after_current(snapshot: object, **kwargs: object) -> str:
+        if getattr(snapshot, "path", None) == str(host["current"]):
+            return cast(str, original(snapshot, **kwargs))
+        raise ConfigurationError("simulated crash after current, before relay_source")
+
+    monkeypatch.setattr(
+        bootstrap_full_activation_staging_module,
+        "_reconcile_activation_symlink",
+        sabotage_after_current,
+    )
+    with pytest.raises(ConfigurationError, match="simulated crash after current"):
+        promote_full_mode_activation_links(
+            activation_paths,
+            generation=new_generation,
+            desired_fingerprint=fingerprint,
+            home=tmp_path,
+        )
+
+    # Interrupt window: current already promoted, relay_source still old.
+    assert os.readlink(host["current"]) == str(new_generation)
+    assert os.readlink(host["relay_source"]) == str(host["old_generation"] / "source")
+
+    monkeypatch.setattr(
+        bootstrap_full_activation_staging_module, "_reconcile_activation_symlink", original
+    )
+    second = promote_full_mode_activation_links(
+        activation_paths,
+        generation=new_generation,
+        desired_fingerprint=fingerprint,
+        home=tmp_path,
+    )
+
+    assert second == {"current": "reused", "relay_source": "retargeted"}
+    # Never re-exchanged: current still names the new generation, exactly once.
+    assert os.readlink(host["current"]) == str(new_generation)
+    assert os.readlink(host["relay_source"]) == str(new_generation / "source")
+
+
+def test_promote_from_manifest_round_trips_a_real_generation_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The candidate-action dispatcher's own entry point: reads the durably
+    recorded snapshot from manifest.json (never re-derives it) and promotes
+    it, exactly like the rendered script's `full-activation-reconcile`
+    action does."""
+    _simulate_symlinks_on_windows(monkeypatch)
+    host = _build_populated_host(tmp_path)
+    fingerprint = "5" * 64
+    new_generation = host["share"] / "generations" / fingerprint
+    (new_generation / "source").mkdir(parents=True)
+    manifest = {
+        "schema_version": "clio-relay.bootstrap-generation.v1",
+        "fingerprint": fingerprint,
+        "full_activation_paths": capture_full_mode_activation_paths_json(tmp_path),
+    }
+    manifest_path = new_generation / "manifest.json"
+    manifest_bytes = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    manifest_path.write_bytes(manifest_bytes)  # binary: avoids Windows \n -> \r\n translation
+    manifest_sha256 = hashlib.sha256(manifest_bytes).hexdigest()
+
+    result = promote_full_mode_activation_links_from_manifest(
+        new_generation,
+        expected_manifest_sha256=manifest_sha256,
+        desired_fingerprint=fingerprint,
+        home=tmp_path,
+    )
+
+    assert result == {"current": "retargeted", "relay_source": "retargeted"}
+    assert os.readlink(host["current"]) == str(new_generation)
+
+
+def test_promote_from_manifest_rejects_a_tampered_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Recovery uses the JOURNALED manifest digest, never trusts disk state
+    that changed since it was recorded."""
+    _simulate_symlinks_on_windows(monkeypatch)
+    _build_populated_host(tmp_path)
+    generation = tmp_path / ".local/share/clio-relay/generations" / ("6" * 64)
+    generation.mkdir(parents=True)
+    (generation / "manifest.json").write_bytes(b'{"tampered":true}\n')
+
+    def unexpected_mutation(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("tampered manifest reached promotion")
+
+    monkeypatch.setattr(
+        "clio_relay.bootstrap_full_activation_staging.promote_full_mode_activation_links",
+        unexpected_mutation,
+    )
+
+    with pytest.raises(ConfigurationError, match="manifest changed before activation"):
+        promote_full_mode_activation_links_from_manifest(
+            generation,
+            expected_manifest_sha256="f" * 64,
+            desired_fingerprint="6" * 64,
+        )


### PR DESCRIPTION
## Summary

- Generalizes clio-relay#254's jarvis-venv staging discipline to the rest of a full-mode installation: the fresh-bootstrap ownership-proof cluster unconditionally required `current`/`install_receipt`/`managed_repo`/`relay_source`/etc to be absent, even after #254 fixed the jarvis-venv-only case, so a full-mode reconcile chosen over a host whose `current` generation already exists still died at the proofs (flagged as an explicit out-of-scope deviation in 18bc796e).
- `current` and `relay_source` (`~/.local/src/clio-relay`) are the only two stable activation paths whose target actually changes between generations -- `install_receipt`/`relay_launcher`/`jarvis_launcher`/`managed_repo` all point at constant text through `current` itself, so they are adopted directly instead of requiring absence.
- `current`/`relay_source` are captured once (pre-swap identity), carried durably through the generation manifest, and promoted atomically at the fenced "activating" boundary by reusing `bootstrap_reconcile._reconcile_activation_symlink` -- the same per-symlink atomic-exchange-and-crash-recovery primitive relay-only/component-upgrade reconcile already fences its own activation with.
- New owner module `bootstrap_full_activation_staging.py` holds this logic plus the rendered-script text chunks it generates, kept out of `bootstrap.py` to respect its line-count ratchet. `bootstrap_reconcile.py` is untouched.
- Virgin-host behavior is byte-identical (`ACTIVATION_STAGING_MODE=0` whenever `current` doesn't resolve; every new conditional branch falls through to the unfixed script's exact original code).

## Test plan

- [x] `tests/test_bootstrap_full_activation_staging.py` (new, 9 tests, mirrors `test_bootstrap_jarvis_staging.py`'s harness style): failing-first capture/promote acceptance, both interrupt-sabotage twins (before any exchange; between current and relay_source), manifest tamper-evidence round-trip, typed-refusal-on-wrong-shape.
- [x] Every `tests/test_bootstrap*.py` file passes (bootstrap, acceptance, candidate_payload, cluster_paths, elf_strtab, fast_path, full_activation_staging, jarvis_staging, journal, journal_portability, journal_symlinked_home, lock_upgrade, pin, preflight_transport, reconcile, recovery, uv_adoption) -- POSIX-only tests excluded on this Windows runner, as expected.
- [x] `ruff check` / `ruff format --check` clean across `src/` and touched test files.
- [x] `scripts/check_file_size.py`: `bootstrap_reconcile.py` exactly at its 4468-line baseline (untouched); `bootstrap_full_activation_staging.py` at 328 lines (well under the 800 cap). `bootstrap.py` sits at 8379 lines, 23 over its 8356 baseline -- see note below.
- [x] `scripts/check_no_class_in_function.py` clean.
- [x] Rendered-script sanity: `render_linux_user_bootstrap_script()` renders without f-string errors, `bash -n` passes on the full rendered script, and all 43 embedded Python heredocs parse cleanly.

## Note on the file-size ratchet

`bootstrap.py` is 23 lines over its 8356-line ratchet baseline after this change. This started as a +195-line overshoot; three rounds of extraction moved the ownership-proof adoption logic, the stable-link adoption shell loop, the mkdir-owned-if-absent helper, and the manifest-read/promote plumbing into the new `bootstrap_full_activation_staging.py` module (mirroring how 18bc796e extracted `bootstrap_receipt_validation.py`), reducing the overshoot by 88%. The residual 23 lines are the unavoidable per-site wiring (the `ACTIVATION_STAGING_MODE` shell computation, the `full-activation-reconcile` dispatch branch, and the staging-mode `if`/`else` splits at each of the six touched call sites) with no further safe extraction target given the dependency-free-heredoc constraint on the ownership proof. Flagging for maintainer judgment: accept a small documented ratchet-up (the file already carries one precedent for this, `mcp_call/runner.py` +28 lines) or request a different reduction.
