### PR TITLE
feat: outputs_missing typed failure + console_stderr stream (#265, #259)

### DIFF
--- a/scripts/check_file_size.py
+++ b/scripts/check_file_size.py
@@ -1751,7 +1751,16 @@ RATCHET_BASELINE: dict[str, int] = {
     # the capture-state loops and validator), and added append_console for
     # symmetry with append_stdout/append_stderr. A justified, minimal
     # ratchet-up.
-    "src/clio_relay/spool.py": 1000,
+    # clio-relay#259 residual (stderr channel): LOG_STREAM_NAMES/LogStreamName
+    # widens again to {stdout, stderr, console, console_stderr} -- the SAME
+    # in-place vocabulary change the #259 entry above already made once for
+    # console, applied identically for the application's stderr sibling
+    # channel (never merged into console, never aliased onto the pre-existing
+    # relay-protocol stderr name; see the widened docstring on
+    # LogStreamName). Adds append_console_stderr for symmetry with
+    # append_console, and one more file in initialize()'s created-file list.
+    # A justified, minimal ratchet-up: 1000 -> 1023.
+    "src/clio_relay/spool.py": 1023,
     # split/storage-policy-w2: storage_policy.py's own ratchet-baseline entry
     # (1826) is removed here. The wire types/limits/error vocabulary moved to
     # storage_policy_types.py (280 lines), the ledger content codec to

--- a/src/clio_relay/console_stream.py
+++ b/src/clio_relay/console_stream.py
@@ -57,12 +57,17 @@ from clio_relay.models import McpCallSpec
 from clio_relay.spool import (
     MAX_LOG_READ_BYTES,
     JobSpool,
+    LogStreamName,
     OwnedFileSizeLimitError,
     read_external_log_range,
     read_owned_regular_file_bytes,
 )
 
 CONSOLE_STREAM: Literal["console"] = "console"
+#: clio-relay#259 residual: the application's stderr, ``console``'s sibling
+#: channel -- see :data:`clio_relay.spool.LogStreamName`'s own docstring for
+#: why this is neither merged into ``console`` nor aliased onto ``stderr``.
+CONSOLE_STDERR_STREAM: Literal["console_stderr"] = "console_stderr"
 
 #: Env var jarvis-cd's own ``Jarvis`` singleton reads before defaulting to
 #: ``~/.ppi-jarvis`` (``jarvis_cd.core.config._JARVIS_ROOT_ENVIRONMENT``).
@@ -203,19 +208,38 @@ def newest_execution_dir(shared_dir: Path, pipeline_id: str) -> Path | None:
 
 
 @dataclass
+class _ChannelTailState:
+    """Per-channel mutable tail state (clio-relay#259 residual, stderr).
+
+    stdout and stderr are tailed off the SAME locked execution root but are
+    otherwise fully independent: each has its own byte offset, truncation
+    flag, reason-dedup set, and self-throttle clock, so a stderr-only
+    failure or quota trip can never disturb the stdout channel (or vice
+    versa).
+    """
+
+    offset: int = 0
+    truncated: bool = False
+    reported_reasons: set[str] = field(default_factory=set[str])
+    last_poll_monotonic: float | None = None
+
+
+@dataclass
 class ConsoleLiveTailer:
-    """Poll-driven best-effort tail of one JARVIS execution's ``stdout.log``.
+    """Poll-driven best-effort tail of one JARVIS execution's application output.
 
     Locks onto the first execution directory it finds under
     ``<shared_dir>/<pipeline_id>/executions`` and never switches once
     locked, bounding (not eliminating) exposure to a concurrently reused
     pipeline id picking up a sibling job's directory --
-    :func:`flush_terminal_console` is the correctness guarantee regardless
-    of what this best-effort half finds.
+    :func:`flush_terminal_console` / :func:`flush_terminal_console_stderr`
+    are the correctness guarantee regardless of what this best-effort half
+    finds.
 
-    Call :meth:`poll` from the job's existing subprocess poll cadence (every
-    tick is fine -- this self-throttles to :attr:`min_poll_interval_seconds`
-    internally, so it never hammers the filesystem).
+    Call :meth:`poll` (stdout) AND :meth:`poll_stderr` from the job's
+    existing subprocess poll cadence (every tick is fine -- each
+    self-throttles to :attr:`min_poll_interval_seconds` independently, so
+    neither ever hammers the filesystem).
     """
 
     spool: JobSpool
@@ -223,69 +247,153 @@ class ConsoleLiveTailer:
     env: Mapping[str, str] | None = None
     min_poll_interval_seconds: float = CONSOLE_TAIL_MIN_POLL_INTERVAL_SECONDS
     execution_root: Path | None = field(default=None, init=False)
-    offset: int = field(default=0, init=False)
-    truncated: bool = field(default=False, init=False)
-    _reported_reasons: set[str] = field(default_factory=set[str], init=False)
-    _last_poll_monotonic: float | None = field(default=None, init=False)
+    _stdout: _ChannelTailState = field(default_factory=_ChannelTailState, init=False)
+    _stderr: _ChannelTailState = field(default_factory=_ChannelTailState, init=False)
+
+    @property
+    def offset(self) -> int:
+        """The STDOUT channel's byte offset (pre-#259-stderr public name)."""
+        return self._stdout.offset
+
+    @offset.setter
+    def offset(self, value: int) -> None:
+        self._stdout.offset = value
+
+    @property
+    def truncated(self) -> bool:
+        """Whether the STDOUT channel has been truncated (pre-#259-stderr name)."""
+        return self._stdout.truncated
+
+    @truncated.setter
+    def truncated(self, value: bool) -> None:
+        self._stdout.truncated = value
+
+    @property
+    def stderr_offset(self) -> int:
+        """The STDERR channel's own byte offset."""
+        return self._stderr.offset
+
+    @stderr_offset.setter
+    def stderr_offset(self, value: int) -> None:
+        self._stderr.offset = value
+
+    @property
+    def stderr_truncated(self) -> bool:
+        """Whether the STDERR channel has been truncated."""
+        return self._stderr.truncated
+
+    @stderr_truncated.setter
+    def stderr_truncated(self, value: bool) -> None:
+        self._stderr.truncated = value
 
     def poll(self, *, now: float | None = None) -> ConsoleTailStep:
-        """Advance the tail by one increment; safe and cheap to call often.
+        """Advance the STDOUT tail by one increment; safe and cheap to call often.
 
         Never raises -- every failure mode returns a typed reason (reported
         once per distinct reason so the caller does not spam an event per
         poll tick); the job's own execution is never affected by a tailing
         failure.
         """
+        return self._poll_channel(
+            now=now,
+            state=self._stdout,
+            log_filename="stdout.log",
+            stream=CONSOLE_STREAM,
+            unreadable_reason="stdout_log_unreadable",
+        )
+
+    def poll_stderr(self, *, now: float | None = None) -> ConsoleTailStep:
+        """Advance the STDERR tail by one increment (clio-relay#259 residual).
+
+        Mirrors :meth:`poll` exactly -- same self-throttling, same typed/
+        deduplicated failure reasons, same "never raises into the job"
+        guarantee -- but for the application's ``stderr.log`` into its own
+        :data:`CONSOLE_STDERR_STREAM` spool stream.
+        """
+        return self._poll_channel(
+            now=now,
+            state=self._stderr,
+            log_filename="stderr.log",
+            stream=CONSOLE_STDERR_STREAM,
+            unreadable_reason="stderr_log_unreadable",
+        )
+
+    def _poll_channel(
+        self,
+        *,
+        now: float | None,
+        state: _ChannelTailState,
+        log_filename: str,
+        stream: LogStreamName,
+        unreadable_reason: str,
+    ) -> ConsoleTailStep:
         current = time.monotonic() if now is None else now
-        if self.truncated:
+        if state.truncated:
             return ConsoleTailStep(appended=False, reason=None, message=None)
         if (
-            self._last_poll_monotonic is not None
-            and current - self._last_poll_monotonic < self.min_poll_interval_seconds
+            state.last_poll_monotonic is not None
+            and current - state.last_poll_monotonic < self.min_poll_interval_seconds
         ):
             return ConsoleTailStep(appended=False, reason=None, message=None)
-        self._last_poll_monotonic = current
+        state.last_poll_monotonic = current
         if self.execution_root is None:
             try:
                 shared_dir = resolve_jarvis_shared_dir(self.env)
                 located = newest_execution_dir(shared_dir, self.pipeline_id)
             except ConsoleTailUnavailable as exc:
-                return self._reason_step(exc.reason, str(exc))
+                return self._reason_step(state, exc.reason, str(exc))
             if located is None:
                 return ConsoleTailStep(appended=False, reason=None, message=None)
             self.execution_root = located
-        return self._tail_locked_execution()
+        return self._tail_locked_execution(
+            state,
+            log_filename=log_filename,
+            stream=stream,
+            unreadable_reason=unreadable_reason,
+        )
 
-    def _tail_locked_execution(self) -> ConsoleTailStep:
+    def _tail_locked_execution(
+        self,
+        state: _ChannelTailState,
+        *,
+        log_filename: str,
+        stream: LogStreamName,
+        unreadable_reason: str,
+    ) -> ConsoleTailStep:
         assert self.execution_root is not None
-        stdout_path = self.execution_root / "stdout.log"
+        source_path = self.execution_root / log_filename
         try:
             chunk, next_offset, _eof = read_external_log_range(
-                stdout_path,
-                offset=self.offset,
+                source_path,
+                offset=state.offset,
                 limit=CONSOLE_TAIL_CHUNK_BYTES,
             )
         except (OSError, RuntimeError) as exc:
-            return self._reason_step("stdout_log_unreadable", f"{stdout_path}: {exc}")
+            return self._reason_step(state, unreadable_reason, f"{source_path}: {exc}")
         if not chunk:
             return ConsoleTailStep(appended=False, reason=None, message=None)
-        self.offset = next_offset
-        result = self.spool.append_log(CONSOLE_STREAM, chunk)
+        state.offset = next_offset
+        result = self.spool.append_log(stream, chunk)
         if result.truncated:
-            self.truncated = True
+            state.truncated = True
         if result.truncation_event_required:
-            self.spool.mark_truncation_event_recorded(CONSOLE_STREAM)
+            self.spool.mark_truncation_event_recorded(stream)
             return ConsoleTailStep(
                 appended=True,
                 reason="truncated",
-                message=(f"console stream reached its {result.persisted_stream_bytes}-byte quota"),
+                message=(f"{stream} stream reached its {result.persisted_stream_bytes}-byte quota"),
             )
         return ConsoleTailStep(appended=True, reason=None, message=None)
 
-    def _reason_step(self, reason: str, message: str) -> ConsoleTailStep:
-        if reason in self._reported_reasons:
+    def _reason_step(
+        self,
+        state: _ChannelTailState,
+        reason: str,
+        message: str,
+    ) -> ConsoleTailStep:
+        if reason in state.reported_reasons:
             return ConsoleTailStep(appended=False, reason=None, message=None)
-        self._reported_reasons.add(reason)
+        state.reported_reasons.add(reason)
         return ConsoleTailStep(appended=False, reason=reason, message=message)
 
 
@@ -317,6 +425,80 @@ def _same_directory(a: Path, b: Path) -> bool:
         return False
 
 
+def _flush_terminal_channel(
+    spool: JobSpool,
+    result_document: dict[str, Any],
+    *,
+    log_filename: str,
+    stream: LogStreamName,
+    unreadable_reason: str,
+    mismatch_reason: str,
+    tailer_offset: int | None,
+    tailer_execution_root: Path | None,
+) -> ConsoleFlushOutcome:
+    """Shared terminal-flush body :func:`flush_terminal_console` and
+    :func:`flush_terminal_console_stderr` both call, one per channel.
+
+    ``tailer_offset``/``tailer_execution_root`` are the ALREADY-RESOLVED
+    per-channel tailer state (the caller reads ``tailer.offset``/
+    ``tailer.execution_root`` for stdout, ``tailer.stderr_offset`` for
+    stderr -- both channels share the one locked ``execution_root``) so
+    this function stays channel-agnostic.
+    """
+    structured = result_document.get("structured_result")
+    if not isinstance(structured, dict):
+        return ConsoleFlushOutcome(appended_bytes=0, reason=None, message=None)
+    record = cast(dict[str, Any], structured).get("execution_record")
+    if not isinstance(record, dict):
+        return ConsoleFlushOutcome(appended_bytes=0, reason=None, message=None)
+    execution_root = execution_root_from_record(cast(dict[str, Any], record))
+    if execution_root is None:
+        return ConsoleFlushOutcome(
+            appended_bytes=0,
+            reason="execution_root_undeclared",
+            message="terminal JARVIS result omitted an execution root",
+        )
+    source_path = execution_root / log_filename
+    offset = 0
+    reason: str | None = None
+    message: str | None = None
+    if tailer_execution_root is not None:
+        if _same_directory(tailer_execution_root, execution_root):
+            offset = tailer_offset or 0
+        else:
+            reason = mismatch_reason
+            message = (
+                f"live tail followed {tailer_execution_root} but the terminal "
+                f"result named {execution_root}; re-flushing {stream} from the start"
+            )
+    appended_total = 0
+    while True:
+        try:
+            chunk, next_offset, eof = read_external_log_range(
+                source_path,
+                offset=offset,
+                limit=CONSOLE_TAIL_CHUNK_BYTES,
+            )
+        except (OSError, RuntimeError) as exc:
+            if appended_total == 0 and reason is None:
+                reason = unreadable_reason
+                message = f"{source_path}: {exc}"
+            break
+        if not chunk:
+            break
+        result = spool.append_log(stream, chunk)
+        appended_total += result.accepted_bytes
+        offset = next_offset
+        if result.truncation_event_required:
+            spool.mark_truncation_event_recorded(stream)
+            if reason is None:
+                reason = "truncated"
+                message = f"{stream} stream reached its {result.persisted_stream_bytes}-byte quota"
+        if result.truncated or eof:
+            break
+    return ConsoleFlushOutcome(appended_bytes=appended_total, reason=reason, message=message)
+
+
 def flush_terminal_console(
     spool: JobSpool,
     result_document: dict[str, Any],
@@ -339,58 +521,43 @@ def flush_terminal_console(
     never locked onto one at all, the full log is flushed from the start and
     a typed mismatch reason is reported so the discrepancy is visible.
     """
-    structured = result_document.get("structured_result")
-    if not isinstance(structured, dict):
-        return ConsoleFlushOutcome(appended_bytes=0, reason=None, message=None)
-    record = cast(dict[str, Any], structured).get("execution_record")
-    if not isinstance(record, dict):
-        return ConsoleFlushOutcome(appended_bytes=0, reason=None, message=None)
-    execution_root = execution_root_from_record(cast(dict[str, Any], record))
-    if execution_root is None:
-        return ConsoleFlushOutcome(
-            appended_bytes=0,
-            reason="execution_root_undeclared",
-            message="terminal JARVIS result omitted an execution root",
-        )
-    stdout_path = execution_root / "stdout.log"
-    offset = 0
-    reason: str | None = None
-    message: str | None = None
-    if tailer is not None and tailer.execution_root is not None:
-        if _same_directory(tailer.execution_root, execution_root):
-            offset = tailer.offset
-        else:
-            reason = "console_live_tail_execution_mismatch"
-            message = (
-                f"live tail followed {tailer.execution_root} but the terminal "
-                f"result named {execution_root}; re-flushing console from the start"
-            )
-    appended_total = 0
-    while True:
-        try:
-            chunk, next_offset, eof = read_external_log_range(
-                stdout_path,
-                offset=offset,
-                limit=CONSOLE_TAIL_CHUNK_BYTES,
-            )
-        except (OSError, RuntimeError) as exc:
-            if appended_total == 0 and reason is None:
-                reason = "stdout_log_unreadable"
-                message = f"{stdout_path}: {exc}"
-            break
-        if not chunk:
-            break
-        result = spool.append_log(CONSOLE_STREAM, chunk)
-        appended_total += result.accepted_bytes
-        offset = next_offset
-        if result.truncation_event_required:
-            spool.mark_truncation_event_recorded(CONSOLE_STREAM)
-            if reason is None:
-                reason = "truncated"
-                message = f"console stream reached its {result.persisted_stream_bytes}-byte quota"
-        if result.truncated or eof:
-            break
-    return ConsoleFlushOutcome(appended_bytes=appended_total, reason=reason, message=message)
+    return _flush_terminal_channel(
+        spool,
+        result_document,
+        log_filename="stdout.log",
+        stream=CONSOLE_STREAM,
+        unreadable_reason="stdout_log_unreadable",
+        mismatch_reason="console_live_tail_execution_mismatch",
+        tailer_offset=None if tailer is None else tailer.offset,
+        tailer_execution_root=None if tailer is None else tailer.execution_root,
+    )
+
+
+def flush_terminal_console_stderr(
+    spool: JobSpool,
+    result_document: dict[str, Any],
+    *,
+    tailer: ConsoleLiveTailer | None = None,
+) -> ConsoleFlushOutcome:
+    """Guarantee the ``console_stderr`` stream carries the full application log.
+
+    clio-relay#259 residual: the exact same terminal-flush guarantee
+    :func:`flush_terminal_console` gives stdout, mirrored for the
+    application's stderr -- same authoritative execution-root derivation,
+    same tailer-offset reconciliation (using the tailer's OWN
+    ``stderr_offset``/``stderr_truncated`` state, never the stdout one), same
+    typed/non-fatal reasons.
+    """
+    return _flush_terminal_channel(
+        spool,
+        result_document,
+        log_filename="stderr.log",
+        stream=CONSOLE_STDERR_STREAM,
+        unreadable_reason="stderr_log_unreadable",
+        mismatch_reason="console_stderr_live_tail_execution_mismatch",
+        tailer_offset=None if tailer is None else tailer.stderr_offset,
+        tailer_execution_root=None if tailer is None else tailer.execution_root,
+    )
 
 
 def flush_terminal_console_from_path(
@@ -400,6 +567,34 @@ def flush_terminal_console_from_path(
     tailer: ConsoleLiveTailer | None = None,
 ) -> ConsoleFlushOutcome:
     """Read one bounded terminal ``mcp-result.json`` and flush its console log."""
+    document = _terminal_result_document(spool, result_path)
+    if isinstance(document, ConsoleFlushOutcome):
+        return document
+    return flush_terminal_console(spool, document, tailer=tailer)
+
+
+def flush_terminal_console_stderr_from_path(
+    spool: JobSpool,
+    result_path: Path,
+    *,
+    tailer: ConsoleLiveTailer | None = None,
+) -> ConsoleFlushOutcome:
+    """Read one bounded terminal ``mcp-result.json`` and flush its console_stderr log."""
+    document = _terminal_result_document(spool, result_path)
+    if isinstance(document, ConsoleFlushOutcome):
+        return document
+    return flush_terminal_console_stderr(spool, document, tailer=tailer)
+
+
+def _terminal_result_document(
+    spool: JobSpool,
+    result_path: Path,
+) -> dict[str, Any] | ConsoleFlushOutcome:
+    """Read one bounded terminal ``mcp-result.json``, shared by both channels'
+    ``_from_path`` entry points. Returns a typed :class:`ConsoleFlushOutcome`
+    (never raises) when the result cannot be read/parsed -- the caller
+    returns it directly.
+    """
     try:
         snapshot = read_owned_regular_file_bytes(
             result_path,
@@ -427,4 +622,4 @@ def flush_terminal_console_from_path(
             reason="mcp_result_invalid",
             message="terminal JARVIS result must be a JSON object",
         )
-    return flush_terminal_console(spool, cast(dict[str, Any], document), tailer=tailer)
+    return cast(dict[str, Any], document)

--- a/src/clio_relay/endpoint_jarvis_dispatch.py
+++ b/src/clio_relay/endpoint_jarvis_dispatch.py
@@ -47,6 +47,7 @@ from clio_relay.jarvis_dispatch_failure import (
     JARVIS_DISPATCH_REFUSAL_RESOLUTION,
     JarvisDispatchRefusal,
 )
+from clio_relay.jarvis_execution_artifacts import ingest_jarvis_execution_outputs_from_path
 from clio_relay.jarvis_run_environment import (
     jarvis_run_environment_values,
     registered_site_spack_command,
@@ -430,11 +431,25 @@ class JarvisDispatchMixin:
             ("stdout", spool.path / "stdout.log"),
             ("stderr", spool.path / "stderr.log"),
             ("console", spool.path / "console.log"),
+            ("console_stderr", spool.path / "console_stderr.log"),
             ("log_capture", spool.log_capture_path),
             ("mcp_result", spool.path / "mcp-result.json"),
         ):
             if not internal_filesystem_path(path).is_file():
                 raise RelayError(f"recovered JARVIS spool omitted {kind}: {path}")
+            if kind == "mcp_result":
+                # #265: this crash-recovery reconciliation path (a worker
+                # restart finalizing a JARVIS dispatch abandoned mid-run) is
+                # NOT wired into #265's terminal-state fold today -- it never
+                # reaches `_run_job_impl`/`resolve_execution_outcome`, whose
+                # target state this method's own caller already computes
+                # independently (`endpoint_execution_lifecycle.py`). The
+                # ingest still runs so #252's output indexing keeps working
+                # and the typed `jarvis.execution_output_missing`/`_empty`/
+                # `_outputs_missing` events still land on the job's event
+                # log for observability -- only the FORCED-failure fold is
+                # the known, documented gap here.
+                ingest_jarvis_execution_outputs_from_path(self.queue, job, path, spool.path)
             created = self._append_spool_artifact_once(job, spool, path, kind=kind)
             if created and kind == "mcp_result":
                 self.queue.append_event(

--- a/src/clio_relay/endpoint_job_execution.py
+++ b/src/clio_relay/endpoint_job_execution.py
@@ -631,24 +631,34 @@ class JobExecutionMixin:
         self.queue.append_artifact(spool.artifact_for(spool.path / "stdout.log", kind="stdout"))
         self.queue.append_artifact(spool.artifact_for(spool.path / "stderr.log", kind="stderr"))
         if console_tailer is not None:
-            # #259: only a jarvis_run mcp_call ever writes console.log; every
-            # other job kind keeps the artifact list it already had (the log
-            # door itself still serves an empty console stream for them --
-            # JobSpool.read_log treats a missing file as empty+eof).
+            # #259: only a jarvis_run mcp_call ever writes console.log/
+            # console_stderr.log; every other job kind keeps the artifact
+            # list it already had (the log door itself still serves an
+            # empty console/console_stderr stream for them -- JobSpool.
+            # read_log treats a missing file as empty+eof).
             self.queue.append_artifact(
                 spool.artifact_for(spool.path / "console.log", kind="console")
             )
+            self.queue.append_artifact(
+                spool.artifact_for(spool.path / "console_stderr.log", kind="console_stderr")
+            )
         self.queue.append_artifact(spool.artifact_for(spool.log_capture_path, kind="log_capture"))
-        self._append_optional_result_artifacts(job, spool, console_tailer=console_tailer)
+        outputs_missing = self._append_optional_result_artifacts(
+            job, spool, console_tailer=console_tailer
+        )
         # #266: fold a resolved watch into the pre-#266 outcome logic --
         # see execution_watch.resolve_execution_outcome's own docstring for
         # why a resolved watch always wins over a pending cancellation.
+        # #265: outputs_missing (from the ONE mcp_result ingest just above)
+        # folds the same way -- producing the declared outputs is part of
+        # what "completed" means.
         outcome = execution_watch.resolve_execution_outcome(
             dispatch_recovered=dispatch_recovered,
             watch_resolution=execution_watch_resolution,
             dispatch_refusal_present=dispatch_refusal is not None,
             transport_returncode=result.returncode,
             cancellation_requested=self._job_cancellation_requested(job.job_id),
+            outputs_missing=outputs_missing,
         )
         effective_returncode = outcome.effective_returncode
         cancellation_honored = outcome.cancellation_honored
@@ -711,11 +721,14 @@ class JobExecutionMixin:
             )
             return
         watch_failure = outcome.watch_failure
+        outputs_missing_detail = outcome.outputs_missing
         failure_metadata: dict[str, object] = {"returncode": effective_returncode}
         if dispatch_refusal is not None:
             failure_metadata["jarvis_dispatch_refusal"] = dispatch_refusal.as_payload()
         if watch_failure is not None:
             failure_metadata["execution_watch_failure"] = watch_failure
+        if outputs_missing_detail is not None:
+            failure_metadata["execution_outputs_missing"] = outputs_missing_detail
         self.queue.update_task_state(
             task.task_id,
             JobState.FAILED,
@@ -730,6 +743,12 @@ class JobExecutionMixin:
                 if dispatch_refusal is not None
                 else "JARVIS execution ended in failure"
                 if watch_failure is not None
+                # clio-relay#265 owner ruling: "producing the declared
+                # outputs is PART of what completed means" -- an execution
+                # JARVIS itself reported terminal, but whose declared
+                # outputs are missing or empty, is FAILED here too.
+                else "JARVIS execution completed but declared outputs are missing or empty"
+                if outputs_missing_detail is not None
                 else "Endpoint MCP operation failed"
                 if endpoint_mcp_call
                 else "JARVIS-CD run failed"
@@ -739,6 +758,10 @@ class JobExecutionMixin:
                 if dispatch_refusal is not None
                 else bounded_error_detail(execution_watch.execution_watch_error_text(watch_failure))
                 if watch_failure is not None
+                else bounded_error_detail(
+                    execution_watch.execution_outputs_missing_error_text(outputs_missing_detail)
+                )
+                if outputs_missing_detail is not None
                 else f"exit code {effective_returncode}"
             ),
         )

--- a/src/clio_relay/endpoint_progress_ingest.py
+++ b/src/clio_relay/endpoint_progress_ingest.py
@@ -18,6 +18,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from clio_relay.console_stream import (
+    CONSOLE_STDERR_STREAM,
     CONSOLE_STREAM,
     ConsoleLiveTailer,
 )
@@ -179,7 +180,8 @@ class ProgressIngestMixin:
         job: RelayJob,
         console_tailer: ConsoleLiveTailer | None,
     ) -> None:
-        """Advance one #259 live-tail increment; never raises into the job."""
+        """Advance one #259 live-tail increment (stdout AND stderr); never
+        raises into the job."""
         if console_tailer is None:
             return
         step = console_tailer.poll()
@@ -189,6 +191,14 @@ class ProgressIngestMixin:
                 f"console.{step.reason}",
                 step.message or "console live-tail reason",
                 payload={"stream": CONSOLE_STREAM, "reason": step.reason},
+            )
+        stderr_step = console_tailer.poll_stderr()
+        if stderr_step.reason is not None:
+            self.queue.append_event(
+                job.job_id,
+                f"console_stderr.{stderr_step.reason}",
+                stderr_step.message or "console_stderr live-tail reason",
+                payload={"stream": CONSOLE_STDERR_STREAM, "reason": stderr_step.reason},
             )
 
     def _poll_running_job(

--- a/src/clio_relay/endpoint_result_finalization.py
+++ b/src/clio_relay/endpoint_result_finalization.py
@@ -14,9 +14,11 @@ from pathlib import Path
 from typing import cast
 
 from clio_relay.console_stream import (
+    CONSOLE_STDERR_STREAM,
     CONSOLE_STREAM,
     ConsoleLiveTailer,
     flush_terminal_console_from_path,
+    flush_terminal_console_stderr_from_path,
 )
 from clio_relay.endpoint_sidecar_types import (
     AGENT_RESULT_MAX_BYTES,
@@ -46,14 +48,16 @@ class ResultFinalizationMixin:
         result_path: Path,
         console_tailer: ConsoleLiveTailer | None,
     ) -> None:
-        """Guarantee the console stream carries the application's full log.
+        """Guarantee the console/console_stderr streams carry the
+        application's full logs.
 
         The #259 terminal-flush half: the live tailer wired through
         ``on_poll`` is a best-effort demo aid, but this call -- triggered
         for every ``mcp_result`` artifact index, including worker-restart
         recovery replay where no live tailer ever ran -- is the one that
-        must always succeed at making ``console`` complete, or report a
-        typed, non-fatal reason. It never fails the job.
+        must always succeed at making ``console``/``console_stderr``
+        complete, or report a typed, non-fatal reason. It never fails the
+        job.
         """
         if not (
             job.kind is JobKind.MCP_CALL
@@ -69,6 +73,16 @@ class ResultFinalizationMixin:
                 outcome.message or "console terminal flush reason",
                 payload={"stream": CONSOLE_STREAM, "reason": outcome.reason},
             )
+        stderr_outcome = flush_terminal_console_stderr_from_path(
+            spool, result_path, tailer=console_tailer
+        )
+        if stderr_outcome.reason is not None:
+            self.queue.append_event(
+                job.job_id,
+                f"console_stderr.{stderr_outcome.reason}",
+                stderr_outcome.message or "console_stderr terminal flush reason",
+                payload={"stream": CONSOLE_STDERR_STREAM, "reason": stderr_outcome.reason},
+            )
 
     def _append_optional_result_artifacts(
         self,
@@ -76,7 +90,15 @@ class ResultFinalizationMixin:
         spool: JobSpool,
         *,
         console_tailer: ConsoleLiveTailer | None = None,
-    ) -> None:
+    ) -> dict[str, object] | None:
+        """Index the job's optional terminal result artifacts.
+
+        Returns clio-relay#265's typed ``outputs_missing`` payload (or
+        ``None``) from the ONE ``mcp_result`` ingest this method always
+        performs for a terminal jarvis_run -- the caller
+        (``_run_job_impl``) folds it into the job's success/failure verdict.
+        """
+        outputs_missing: dict[str, object] | None = None
         candidates = {
             "agent_result": spool.path / "agent-result.json",
             "agent_last_message": spool.path / "agent-last-message.txt",
@@ -88,13 +110,17 @@ class ResultFinalizationMixin:
             candidate = None
             if kind == "agent_last_message" and job.kind is JobKind.REMOTE_AGENT:
                 candidate = self._remote_agent_final_artifact(job, spool, path)
+            if kind == "mcp_result":
+                _indexed, _truncation, outputs_missing = ingest_jarvis_execution_outputs_from_path(
+                    self.queue, job, path, spool.path
+                )
+                self._flush_terminal_console(job, spool, path, console_tailer)
             if self._append_spool_artifact_once(
                 job,
                 spool,
                 path,
                 kind=kind,
                 candidate=candidate,
-                console_tailer=console_tailer,
             ):
                 self.queue.append_event(
                     job.job_id,
@@ -102,6 +128,7 @@ class ResultFinalizationMixin:
                     f"Result artifact available: {kind}",
                     payload={"path": str(path)},
                 )
+        return outputs_missing
 
     def _remote_agent_final_artifact(
         self,
@@ -172,13 +199,17 @@ class ResultFinalizationMixin:
         *,
         kind: str,
         candidate: ArtifactRef | None = None,
-        console_tailer: ConsoleLiveTailer | None = None,
     ) -> bool:
-        """Index one immutable spool artifact, tolerating restart replay."""
+        """Index one immutable spool artifact, tolerating restart replay.
+
+        ``mcp_result`` no longer ingests declared JARVIS execution outputs
+        here (moved to each caller, #265): the ingest's typed
+        ``outputs_missing`` verdict must reach the caller, and this helper's
+        return type (a plain "was newly indexed" bool) is shared by five
+        call sites across three modules, most of which have nothing to do
+        with a terminal jarvis_run result.
+        """
         candidate = candidate or spool.artifact_for(path, kind=kind)
-        if kind == "mcp_result":
-            ingest_jarvis_execution_outputs_from_path(self.queue, job, path, spool.path)
-            self._flush_terminal_console(job, spool, path, console_tailer)
         cursor: int | None = 1
         while cursor is not None:
             artifacts, cursor, _total = self.queue.list_artifacts_page(

--- a/src/clio_relay/execution_watch.py
+++ b/src/clio_relay/execution_watch.py
@@ -308,6 +308,33 @@ def execution_watch_error_text(failure_detail: dict[str, object]) -> str:
     return f"JARVIS execution {execution_id} ended in {state}"
 
 
+def execution_outputs_missing_error_text(outputs_missing: dict[str, object]) -> str:
+    """Render one bounded, human-readable error from #265's outputs-missing detail.
+
+    ``outputs_missing`` is
+    :func:`~clio_relay.jarvis_execution_artifacts.ingest_jarvis_execution_outputs`'s
+    typed ``clio-relay.execution-outputs-missing.v1`` payload -- the owner
+    ruling made concrete: an execution JARVIS itself reported terminal, but
+    whose declared outputs are missing or empty, is a FAILED job with this
+    reason, never a decorated "completed".
+    """
+    execution_id = outputs_missing.get("execution_id")
+    missing = outputs_missing.get("missing")
+    entries = missing if isinstance(missing, list) else []
+    count = len(entries)
+    noun = "output" if count == 1 else "outputs"
+    names = ", ".join(
+        str(entry.get("relative_path"))
+        for entry in cast(list[dict[str, object]], entries)
+        if isinstance(entry, dict)
+    )
+    detail = f": {names}" if names else ""
+    return (
+        f"JARVIS execution {execution_id} completed but {count} declared {noun} were "
+        f"missing or empty{detail}"
+    )
+
+
 def execution_phase_status_message(
     job_state: str,
     execution_phase: object,
@@ -364,11 +391,16 @@ def deferred_jarvis_execution_from_document(
 
 @dataclass(frozen=True, slots=True)
 class ExecutionOutcome:
-    """The three ``_run_job_impl`` terminal-mapping decisions #266 touches."""
+    """The ``_run_job_impl`` terminal-mapping decisions #266/#265 touch."""
 
     effective_returncode: int
     cancellation_honored: bool
     watch_failure: dict[str, object] | None
+    #: clio-relay#265: the typed ``outputs_missing`` verdict from
+    #: ``jarvis_execution_artifacts.ingest_jarvis_execution_outputs`` for
+    #: this job's terminal ``mcp_result``, or ``None`` when nothing was
+    #: declared or every declared output is present and non-empty.
+    outputs_missing: dict[str, object] | None = None
 
 
 def resolve_execution_outcome(
@@ -378,6 +410,7 @@ def resolve_execution_outcome(
     dispatch_refusal_present: bool,
     transport_returncode: int,
     cancellation_requested: bool,
+    outputs_missing: dict[str, object] | None = None,
 ) -> ExecutionOutcome:
     """Fold a resolved watch into ``_run_job_impl``'s existing outcome logic.
 
@@ -387,6 +420,14 @@ def resolve_execution_outcome(
     Reporting the job canceled anyway would contradict that typed refusal
     and hide the real outcome, so a resolved watch always wins over a
     pending cancellation request for terminal-state purposes.
+
+    ``outputs_missing`` is clio-relay#265's owner ruling made concrete:
+    "producing the declared outputs is PART of what completed means" -- a
+    terminal execution whose declared outputs are missing or empty is
+    FAILED regardless of what the scheduler/JARVIS/dispatch path otherwise
+    reported (including an already-recovered dispatch), and a resolved
+    outputs-missing verdict wins over a pending cancellation for the same
+    reason a resolved watch already does: the real outcome was observed.
     """
     if dispatch_recovered:
         effective_returncode = 0
@@ -396,10 +437,15 @@ def resolve_execution_outcome(
         effective_returncode = 1
     else:
         effective_returncode = transport_returncode
+    cancellation_honored = watch_resolution is None and cancellation_requested
+    if outputs_missing is not None:
+        effective_returncode = 1
+        cancellation_honored = False
     return ExecutionOutcome(
         effective_returncode=effective_returncode,
-        cancellation_honored=watch_resolution is None and cancellation_requested,
+        cancellation_honored=cancellation_honored,
         watch_failure=(watch_resolution.failure_detail if watch_resolution is not None else None),
+        outputs_missing=outputs_missing,
     )
 
 
@@ -408,7 +454,9 @@ def _tail_console(
     job: RelayJob,
     console_tailer: ConsoleLiveTailer | None,
 ) -> None:
-    """Advance one #259 console-tail increment; mirrors ``endpoint.py``'s own helper."""
+    """Advance one #259 console-tail increment (stdout AND stderr); mirrors
+    ``endpoint_progress_ingest.py``'s own ``_tail_console_stream`` helper.
+    """
     if console_tailer is None:
         return
     step = console_tailer.poll()
@@ -418,6 +466,14 @@ def _tail_console(
             f"console.{step.reason}",
             step.message or "console live-tail reason",
             payload={"stream": "console", "reason": step.reason},
+        )
+    stderr_step = console_tailer.poll_stderr()
+    if stderr_step.reason is not None:
+        queue.append_event(
+            job.job_id,
+            f"console_stderr.{stderr_step.reason}",
+            stderr_step.message or "console_stderr live-tail reason",
+            payload={"stream": "console_stderr", "reason": stderr_step.reason},
         )
 
 

--- a/src/clio_relay/http_api_routes_artifacts.py
+++ b/src/clio_relay/http_api_routes_artifacts.py
@@ -35,7 +35,7 @@ from clio_relay.models import ProgressRecord
 from clio_relay.pagination import DEFAULT_RESPONSE_PAGE_RECORDS, MAX_RESPONSE_PAGE_RECORDS
 from clio_relay.progress_provenance import external_progress_metadata
 from clio_relay.relay_ops import read_artifact_bytes, read_job_log
-from clio_relay.spool import LogStreamName
+from clio_relay.spool import LOG_STREAM_NAMES, LogStreamName
 
 
 def register_artifact_routes(
@@ -54,10 +54,10 @@ def register_artifact_routes(
         limit: Annotated[int, Query(ge=1, le=1_048_576)] = 65_536,
     ) -> dict[str, object]:
         try:
-            if stream_name not in {"stdout", "stderr", "console"}:
+            if stream_name not in LOG_STREAM_NAMES:
                 raise door_errors.http_problem(
                     "log_stream_invalid",
-                    message="stream must be stdout, stderr, or console",
+                    message=f"stream must be one of: {', '.join(LOG_STREAM_NAMES)}",
                 )
             return _public_payload(
                 read_job_log(

--- a/src/clio_relay/jarvis_execution_artifacts.py
+++ b/src/clio_relay/jarvis_execution_artifacts.py
@@ -1,4 +1,23 @@
-"""Register terminal JARVIS execution outputs as bounded relay references."""
+"""Register terminal JARVIS execution outputs as bounded relay references.
+
+Also the single owner of clio-relay#265's "declared outputs" verdict. Owner
+ruling (#265, superseding an earlier ``completed_outputs_missing`` side-channel
+proposal): producing the declared outputs is PART of what "completed" means --
+a jarvis_run whose execution finished but whose declared outputs are missing
+or empty reaches terminal state FAILED with typed reason ``outputs_missing``,
+never a decorated "completed". "Declared outputs" concretely means the
+``execution-file``-kind entries in the terminal ``jarvis_get_execution``
+poll's own ``structured_result.artifact_page.artifacts`` -- the SAME
+declarations :func:`ingest_jarvis_execution_outputs` already parses to index
+artifacts (#252). A ``jarvis_run`` dispatch that completes synchronously
+(never deferred through clio-relay#266's watch) never carries
+``artifact_page`` at all -- it is absent from ``jarvis_run``'s own
+``outputSchema`` entirely (only ``jarvis_get_execution`` declares it) -- so
+that path's absent declaration keeps its current semantics unchanged, per
+the owner's explicit instruction never to invent a heuristic about which
+files "should" exist. Zero declared ``execution-file`` entries is likewise
+untouched (the pre-existing #252 fast return).
+"""
 
 from __future__ import annotations
 
@@ -9,6 +28,7 @@ from typing import Any, cast
 
 from clio_relay.core_queue import ClioCoreQueue
 from clio_relay.errors import RelayError
+from clio_relay.filesystem_paths import internal_filesystem_path
 from clio_relay.models import ArtifactRef, JobKind, McpCallSpec, RelayJob
 from clio_relay.spool import (
     OwnedFileSizeLimitError,
@@ -18,6 +38,10 @@ from clio_relay.spool import (
 
 EXECUTION_OUTPUT_OWNERSHIP_SCHEMA = "clio-relay.execution-output.v1"
 EXECUTION_OUTPUT_TRUNCATION_SCHEMA = "jarvis.execution-output-truncation.v1"
+#: clio-relay#265: the typed terminal-failure reason/payload schema for one
+#: or more declared execution outputs that turned out missing (absent on
+#: disk) or empty (declared ``size_bytes == 0``) at terminal.
+EXECUTION_OUTPUTS_MISSING_SCHEMA = "clio-relay.execution-outputs-missing.v1"
 MAX_RELAY_EXECUTION_OUTPUTS = 128
 MAX_EXECUTION_RESULT_BYTES = 16 * 1_048_576
 _OUTPUT_ROLES = frozenset({"log", "output", "frame"})
@@ -27,26 +51,37 @@ def ingest_jarvis_execution_outputs(
     queue: ClioCoreQueue,
     query_job: RelayJob,
     result_document: dict[str, Any],
-) -> tuple[list[ArtifactRef], dict[str, object] | None]:
+) -> tuple[list[ArtifactRef], dict[str, object] | None, dict[str, object] | None]:
     """Index declared terminal outputs without copying their bytes.
 
     The query job supplies the authenticated execution result. The artifact is
     owned by the original ``jarvis_run`` job, while its backing path remains in
     the execution directory and is read later through relay's bounded route.
+
+    Returns ``(indexed, truncation, outputs_missing)``. ``outputs_missing`` is
+    clio-relay#265's typed terminal-failure payload
+    (:data:`EXECUTION_OUTPUTS_MISSING_SCHEMA`) whenever at least one declared
+    ``execution-file`` output is absent on disk or declared empty
+    (``size_bytes == 0``) -- ``None`` when nothing was declared (the pre-
+    existing early returns below) or every declared output is present and
+    non-empty. A missing declared file is recorded typed here rather than
+    left to crash out of ``snapshot_owned_regular_file`` uncaught: this is a
+    real, expected outcome (#265's negative path), not a filesystem-identity
+    violation.
     """
     raw_structured = result_document.get("structured_result")
     if not isinstance(raw_structured, dict):
-        return [], None
+        return [], None, None
     structured = cast(dict[str, Any], raw_structured)
     record = structured.get("execution_record")
     page = structured.get("artifact_page")
     execution_id = structured.get("execution_id")
     if not isinstance(record, dict) or not isinstance(page, dict):
-        return [], None
+        return [], None, None
     record = cast(dict[str, Any], record)
     page = cast(dict[str, Any], page)
     if record.get("terminal") is not True or page.get("terminal") is not True:
-        return [], None
+        return [], None, None
     if not isinstance(execution_id, str) or not execution_id:
         raise RelayError("terminal JARVIS result omitted execution_id")
     raw_events = page.get("artifacts")
@@ -60,6 +95,7 @@ def ingest_jarvis_execution_outputs(
     indexed: list[ArtifactRef] = []
     truncation: dict[str, object] | None = None
     output_count = 0
+    missing_outputs: list[dict[str, object]] = []
     for raw_event in cast(list[object], raw_events):
         if not isinstance(raw_event, dict):
             raise RelayError("JARVIS artifact declaration must be an object")
@@ -91,6 +127,49 @@ def ingest_jarvis_execution_outputs(
             raise RelayError(f"invalid JARVIS execution-output size: {relative}")
         digest = _sha256_from_checksum(checksum)
         path = _safe_execution_path(execution_root, relative)
+        # #265: a declared output whose backing file is genuinely absent is
+        # an expected negative-path outcome, not a filesystem-identity
+        # violation -- gate on reality (a plain existence check) rather than
+        # let it crash out of the owned-file open below uncaught.
+        if not internal_filesystem_path(path).exists():
+            missing_outputs.append(
+                {
+                    "relative_path": relative,
+                    "role": role,
+                    "reason": "absent",
+                    "declared_size_bytes": size,
+                }
+            )
+            queue.append_event(
+                owner.job_id,
+                "jarvis.execution_output_missing",
+                f"Declared JARVIS execution output is missing on disk: {relative}",
+                payload={
+                    "execution_id": execution_id,
+                    "relative_path": relative,
+                    "role": role,
+                },
+            )
+            continue
+        if size == 0:
+            missing_outputs.append(
+                {
+                    "relative_path": relative,
+                    "role": role,
+                    "reason": "empty",
+                    "declared_size_bytes": 0,
+                }
+            )
+            queue.append_event(
+                owner.job_id,
+                "jarvis.execution_output_empty",
+                f"Declared JARVIS execution output is empty: {relative}",
+                payload={
+                    "execution_id": execution_id,
+                    "relative_path": relative,
+                    "role": role,
+                },
+            )
         snapshot = snapshot_owned_regular_file(path, owned_root=execution_root)
         if snapshot.size_bytes != size or snapshot.sha256 != digest:
             raise RelayError(f"JARVIS execution-output declaration changed: {relative}")
@@ -128,7 +207,21 @@ def ingest_jarvis_execution_outputs(
             "JARVIS execution outputs indexed as relay artifacts",
             payload={"execution_id": execution_id, "count": len(indexed)},
         )
-    return indexed, truncation
+    outputs_missing: dict[str, object] | None = None
+    if missing_outputs:
+        outputs_missing = {
+            "schema_version": EXECUTION_OUTPUTS_MISSING_SCHEMA,
+            "execution_id": execution_id,
+            "declared_count": output_count,
+            "missing": missing_outputs,
+        }
+        queue.append_event(
+            owner.job_id,
+            "jarvis.execution_outputs_missing",
+            "JARVIS execution completed but declared outputs are missing or empty",
+            payload=outputs_missing,
+        )
+    return indexed, truncation, outputs_missing
 
 
 def ingest_jarvis_execution_outputs_from_path(
@@ -136,7 +229,7 @@ def ingest_jarvis_execution_outputs_from_path(
     query_job: RelayJob,
     result_path: Path,
     owned_root: Path,
-) -> tuple[list[ArtifactRef], dict[str, object] | None]:
+) -> tuple[list[ArtifactRef], dict[str, object] | None, dict[str, object] | None]:
     """Read one bounded terminal result and ingest its declared outputs."""
     try:
         snapshot = read_owned_regular_file_bytes(

--- a/src/clio_relay/relay_ops.py
+++ b/src/clio_relay/relay_ops.py
@@ -265,8 +265,9 @@ def read_artifact_bytes(queue: ClioCoreQueue, artifact_id: str) -> dict[str, obj
 #: wrong for e.g. an oversized ``mcp_result`` artifact, which the log
 #: endpoint has no path to serve at all. ``console`` (#259) joined
 #: ``stdout``/``stderr`` here for the same reason it joined them in
-#: :data:`clio_relay.spool.LOG_STREAM_NAMES`.
-_CURSOR_LOG_SERVED_KINDS = frozenset({"stdout", "stderr", "console"})
+#: :data:`clio_relay.spool.LOG_STREAM_NAMES`; ``console_stderr`` (#259
+#: residual) joined for the identical reason.
+_CURSOR_LOG_SERVED_KINDS = frozenset({"stdout", "stderr", "console", "console_stderr"})
 
 
 def _artifact_content_too_large_refusal(artifact: JSON, artifact_id: str) -> JSON:

--- a/src/clio_relay/spool.py
+++ b/src/clio_relay/spool.py
@@ -34,9 +34,15 @@ ARTIFACT_OWNERSHIP_SCHEMA = "clio-relay.owned-artifact.v1"
 #: The job log-stream vocabulary. ``console`` (clio-relay#259) carries
 #: APPLICATION output for jarvis-backed mcp_call jobs -- distinct from
 #: ``stdout``/``stderr``, which for those jobs carry the MCP jsonrpc wire of
-#: the launched server subprocess, never application output.
-LogStreamName = Literal["stdout", "stderr", "console"]
-LOG_STREAM_NAMES: tuple[LogStreamName, ...] = ("stdout", "stderr", "console")
+#: the launched server subprocess, never application output. ``console_stderr``
+#: (clio-relay#259 residual) is ``console``'s sibling: the SAME application's
+#: stderr, on its own channel -- never merged into ``console`` (that would
+#: silently interleave two streams JARVIS keeps separate on disk) and never
+#: aliased onto the existing ``stderr`` name (that name is already spoken for
+#: by the MCP jsonrpc wire above; reusing it would be the same stdout/console
+#: mixing bug #259 already fixed once, on the other stream).
+LogStreamName = Literal["stdout", "stderr", "console", "console_stderr"]
+LOG_STREAM_NAMES: tuple[LogStreamName, ...] = ("stdout", "stderr", "console", "console_stderr")
 
 
 class _StreamCaptureState(TypedDict):
@@ -130,7 +136,14 @@ class JobSpool:
             self.job.model_dump_json(indent=2),
             encoding="utf-8",
         )
-        for name in ("events.jsonl", "stdout.log", "stderr.log", "console.log", "artifacts.jsonl"):
+        for name in (
+            "events.jsonl",
+            "stdout.log",
+            "stderr.log",
+            "console.log",
+            "console_stderr.log",
+            "artifacts.jsonl",
+        ):
             target = self._storage_path / name
             if not target.exists():
                 target.write_text("", encoding="utf-8")
@@ -272,6 +285,16 @@ class JobSpool:
         application output.
         """
         return self.append_log("console", text)
+
+    def append_console_stderr(self, text: str) -> LogAppendResult:
+        """Append application stderr within the configured durable byte quotas.
+
+        clio-relay#259 residual: ``console``'s sibling channel -- the same
+        application's stderr, kept on its own stream rather than merged
+        into ``console`` or aliased onto ``stderr`` (already the MCP jsonrpc
+        wire's name for a jarvis-backed mcp_call job).
+        """
+        return self.append_log("console_stderr", text)
 
     def append_log(
         self,

--- a/tests/execution_watch_fakes.py
+++ b/tests/execution_watch_fakes.py
@@ -196,8 +196,15 @@ def query_result_document(
     server_artifact: dict[str, Any],
     native: dict[str, object],
     include_artifacts: bool,
+    artifacts: list[dict[str, object]] | None = None,
 ) -> dict[str, object]:
-    """Build one ``jarvis_get_execution`` poll's mcp-result.json."""
+    """Build one ``jarvis_get_execution`` poll's mcp-result.json.
+
+    ``artifacts`` lets a caller declare terminal ``execution-file`` entries
+    (clio-relay#265's outputs-missing coverage); it is ignored unless
+    ``include_artifacts`` is also set, matching JARVIS's own contract (the
+    ``artifact_page`` is only ever populated when artifacts were requested).
+    """
     record = cast(dict[str, Any], native["execution_record"])
     structured: dict[str, object] = {
         "schema_version": "clio-kit.jarvis-execution.v2",
@@ -205,7 +212,9 @@ def query_result_document(
         "execution_id": record["execution_id"],
         **native,
         "artifact_page": (
-            {"artifacts": [], "terminal": record["terminal"]} if include_artifacts else None
+            {"artifacts": artifacts or [], "terminal": record["terminal"]}
+            if include_artifacts
+            else None
         ),
         "service_runtimes": None,
     }

--- a/tests/test_artifact_cluster_routing.py
+++ b/tests/test_artifact_cluster_routing.py
@@ -98,8 +98,11 @@ def _register_remote_execution_output(
             },
         }
     }
-    indexed, truncation = ingest_jarvis_execution_outputs(remote_queue, query, result_document)
+    indexed, truncation, outputs_missing = ingest_jarvis_execution_outputs(
+        remote_queue, query, result_document
+    )
     assert truncation is None
+    assert outputs_missing is None
     assert len(indexed) == 1
     return owner, indexed[0]
 

--- a/tests/test_console_stream.py
+++ b/tests/test_console_stream.py
@@ -9,12 +9,15 @@ from pathlib import Path
 import pytest
 
 from clio_relay.console_stream import (
+    CONSOLE_STDERR_STREAM,
     CONSOLE_STREAM,
     ConsoleLiveTailer,
     ConsoleTailUnavailable,
     console_tailer_for_mcp_call,
     flush_terminal_console,
     flush_terminal_console_from_path,
+    flush_terminal_console_stderr,
+    flush_terminal_console_stderr_from_path,
     newest_execution_dir,
     resolve_jarvis_shared_dir,
 )
@@ -315,6 +318,142 @@ def test_console_live_tailer_stops_after_the_spool_stream_quota_is_hit(
     assert again.reason is None
 
 
+# --- ConsoleLiveTailer: clio-relay#259 residual (stderr) --------------------
+
+
+def test_console_live_tailer_tails_a_growing_stderr_log_across_polls(tmp_path: Path) -> None:
+    """clio-relay#259 residual: the same live-tail treatment stdout gets,
+    mirrored for the application's stderr, into its own stream."""
+    jarvis_root = tmp_path / "jarvis-root"
+    shared_dir = tmp_path / "shared"
+    _write_jarvis_config(jarvis_root, shared_dir=shared_dir)
+    execution_root = _execution_dir(shared_dir, "lammps-melt", "exec-1", mtime=1_000)
+    stderr_log = execution_root / "stderr.log"
+    _write(stderr_log, "WARNING: low disk\n")
+
+    spool = _spool(tmp_path)
+    tailer = ConsoleLiveTailer(
+        spool=spool,
+        pipeline_id="lammps-melt",
+        env={"JARVIS_ROOT": str(jarvis_root)},
+    )
+
+    first = tailer.poll_stderr(now=0.0)
+    assert first.appended is True
+    assert first.reason is None
+
+    idle = tailer.poll_stderr(now=0.5)
+    assert idle.appended is False
+    assert idle.reason is None
+
+    _append(stderr_log, "ERROR: rank 3 segfault\n")
+
+    second = tailer.poll_stderr(now=3.0)
+    assert second.appended is True
+
+    text, _next_offset, eof = spool.read_log(CONSOLE_STDERR_STREAM)
+    assert text == "WARNING: low disk\nERROR: rank 3 segfault\n"
+    assert eof is True
+
+
+def test_console_live_tailer_stdout_and_stderr_channels_are_independent(tmp_path: Path) -> None:
+    """Advancing one channel must never disturb the other's offset, quota,
+    or reason-dedup state -- they are independent byte streams sharing only
+    the locked execution root."""
+    jarvis_root = tmp_path / "jarvis-root"
+    shared_dir = tmp_path / "shared"
+    _write_jarvis_config(jarvis_root, shared_dir=shared_dir)
+    execution_root = _execution_dir(shared_dir, "lammps-melt", "exec-1", mtime=1_000)
+    _write(execution_root / "stdout.log", "Step 0 Temp 300.0\n")
+    # stderr.log does not exist yet -- created lazily by the application.
+
+    spool = _spool(tmp_path)
+    tailer = ConsoleLiveTailer(
+        spool=spool,
+        pipeline_id="lammps-melt",
+        env={"JARVIS_ROOT": str(jarvis_root)},
+    )
+
+    stdout_step = tailer.poll(now=0.0)
+    assert stdout_step.appended is True
+    stderr_step = tailer.poll_stderr(now=0.0)
+    assert stderr_step.reason == "stderr_log_unreadable"
+
+    # The stdout channel is untouched by stderr's failure.
+    text, _, eof = spool.read_log(CONSOLE_STREAM)
+    assert text == "Step 0 Temp 300.0\n"
+    assert eof is True
+
+    # stderr's failure is reported once, then deduplicated, exactly like
+    # stdout's own dedup -- and does not consult stdout's dedup set.
+    again = tailer.poll_stderr(now=3.0)
+    assert again.reason is None
+
+    (execution_root / "stderr.log").write_bytes(b"late stderr\n")
+    recovered = tailer.poll_stderr(now=6.0)
+    assert recovered.appended is True
+    stderr_text, _, _ = spool.read_log(CONSOLE_STDERR_STREAM)
+    assert stderr_text == "late stderr\n"
+
+
+def test_console_live_tailer_reports_a_typed_reason_when_stderr_log_vanishes(
+    tmp_path: Path,
+) -> None:
+    jarvis_root = tmp_path / "jarvis-root"
+    shared_dir = tmp_path / "shared"
+    _write_jarvis_config(jarvis_root, shared_dir=shared_dir)
+    execution_root = _execution_dir(shared_dir, "lammps-melt", "exec-1", mtime=1_000)
+    stderr_log = execution_root / "stderr.log"
+    _write(stderr_log, "warm up\n")
+
+    spool = _spool(tmp_path)
+    tailer = ConsoleLiveTailer(
+        spool=spool,
+        pipeline_id="lammps-melt",
+        env={"JARVIS_ROOT": str(jarvis_root)},
+    )
+    tailer.poll_stderr(now=0.0)
+    stderr_log.unlink()
+
+    step = tailer.poll_stderr(now=3.0)
+
+    assert step.reason == "stderr_log_unreadable"
+    assert step.message is not None
+
+
+def test_console_live_tailer_stderr_stops_after_the_spool_stream_quota_is_hit(
+    tmp_path: Path,
+) -> None:
+    jarvis_root = tmp_path / "jarvis-root"
+    shared_dir = tmp_path / "shared"
+    _write_jarvis_config(jarvis_root, shared_dir=shared_dir)
+    execution_root = _execution_dir(shared_dir, "lammps-melt", "exec-1", mtime=1_000)
+    (execution_root / "stderr.log").write_text("x" * 100, encoding="utf-8")
+
+    spool = JobSpool(
+        tmp_path / "spool",
+        _job(),
+        max_log_bytes_per_stream=10,
+        max_log_bytes_per_job=40,
+    )
+    spool.initialize()
+    tailer = ConsoleLiveTailer(
+        spool=spool,
+        pipeline_id="lammps-melt",
+        env={"JARVIS_ROOT": str(jarvis_root)},
+    )
+
+    first = tailer.poll_stderr(now=0.0)
+    assert tailer.stderr_truncated is True
+    assert tailer.truncated is False  # the STDOUT flag is untouched
+    assert first.reason == "truncated"
+    assert first.message is not None
+
+    again = tailer.poll_stderr(now=3.0)
+    assert again.appended is False
+    assert again.reason is None
+
+
 def test_console_tailer_for_mcp_call_only_binds_the_jarvis_run_tool(tmp_path: Path) -> None:
     spool = _spool(tmp_path)
 
@@ -439,6 +578,114 @@ def test_flush_terminal_console_reflushes_and_reports_a_mismatch(tmp_path: Path)
     assert text == "right execution\n"
 
 
+# --- flush_terminal_console_stderr / _from_path: clio-relay#259 residual ----
+
+
+def test_flush_terminal_console_stderr_flushes_the_full_log_when_no_tailer_ran(
+    tmp_path: Path,
+) -> None:
+    execution_root = tmp_path / "execution"
+    execution_root.mkdir()
+    _write(execution_root / "stderr.log", "WARN 0\nWARN 1\n")
+    spool = _spool(tmp_path)
+
+    outcome = flush_terminal_console_stderr(spool, _result_document(execution_root), tailer=None)
+
+    assert outcome.reason is None
+    assert outcome.appended_bytes == len("WARN 0\nWARN 1\n")
+    text, _, eof = spool.read_log(CONSOLE_STDERR_STREAM)
+    assert text == "WARN 0\nWARN 1\n"
+    assert eof is True
+    # The stdout channel is untouched by a stderr-only flush.
+    stdout_text, _, _ = spool.read_log(CONSOLE_STREAM)
+    assert stdout_text == ""
+
+
+def test_flush_terminal_console_stderr_appends_only_the_remainder_after_a_live_tail(
+    tmp_path: Path,
+) -> None:
+    """Mirrors the stdout terminal-flush reconciliation test, using the
+    tailer's OWN ``stderr_offset`` -- never the stdout ``offset``."""
+    jarvis_root = tmp_path / "jarvis-root"
+    shared_dir = tmp_path / "shared"
+    _write_jarvis_config(jarvis_root, shared_dir=shared_dir)
+    execution_root = _execution_dir(shared_dir, "lammps-melt", "exec-1", mtime=1_000)
+    stderr_log = execution_root / "stderr.log"
+    _write(stderr_log, "WARN 0\n")
+
+    spool = _spool(tmp_path)
+    tailer = ConsoleLiveTailer(
+        spool=spool,
+        pipeline_id="lammps-melt",
+        env={"JARVIS_ROOT": str(jarvis_root)},
+    )
+    tailer.poll_stderr(now=0.0)  # tails "WARN 0\n" live
+
+    _append(stderr_log, "WARN 1\nWARN 2\n")
+
+    outcome = flush_terminal_console_stderr(spool, _result_document(execution_root), tailer=tailer)
+
+    assert outcome.reason is None
+    text, _, eof = spool.read_log(CONSOLE_STDERR_STREAM)
+    assert text == "WARN 0\nWARN 1\nWARN 2\n"
+    assert eof is True
+
+
+def test_flush_terminal_console_stderr_reflushes_and_reports_a_mismatch(tmp_path: Path) -> None:
+    followed_root = tmp_path / "followed"
+    followed_root.mkdir()
+    _write(followed_root / "stderr.log", "wrong execution\n")
+    authoritative_root = tmp_path / "authoritative"
+    authoritative_root.mkdir()
+    _write(authoritative_root / "stderr.log", "right execution\n")
+
+    spool = _spool(tmp_path)
+    tailer = ConsoleLiveTailer(spool=spool, pipeline_id="lammps-melt")
+    tailer.execution_root = followed_root
+    tailer.stderr_offset = 0
+
+    outcome = flush_terminal_console_stderr(
+        spool, _result_document(authoritative_root), tailer=tailer
+    )
+
+    assert outcome.reason == "console_stderr_live_tail_execution_mismatch"
+    assert outcome.message is not None
+    text, _, _ = spool.read_log(CONSOLE_STDERR_STREAM)
+    assert text == "right execution\n"
+
+
+def test_flush_terminal_console_stderr_from_path_reads_a_real_result_document(
+    tmp_path: Path,
+) -> None:
+    execution_root = tmp_path / "execution"
+    execution_root.mkdir()
+    _write(execution_root / "stderr.log", "WARN 0\n")
+    spool = _spool(tmp_path)
+    result_path = spool.path / "mcp-result.json"
+    result_path.write_text(
+        json.dumps(_result_document(execution_root)),
+        encoding="utf-8",
+    )
+
+    outcome = flush_terminal_console_stderr_from_path(spool, result_path, tailer=None)
+
+    assert outcome.reason is None
+    text, _, _ = spool.read_log(CONSOLE_STDERR_STREAM)
+    assert text == "WARN 0\n"
+
+
+def test_flush_terminal_console_stderr_from_path_reports_a_typed_reason_for_invalid_json(
+    tmp_path: Path,
+) -> None:
+    spool = _spool(tmp_path)
+    result_path = spool.path / "mcp-result.json"
+    result_path.write_text("not json", encoding="utf-8")
+
+    outcome = flush_terminal_console_stderr_from_path(spool, result_path, tailer=None)
+
+    assert outcome.reason == "mcp_result_unreadable"
+
+
 def test_flush_terminal_console_reports_a_typed_reason_when_execution_root_is_missing(
     tmp_path: Path,
 ) -> None:
@@ -524,3 +771,37 @@ def test_console_stream_never_mixes_with_the_stdout_stream(tmp_path: Path) -> No
     )
     assert console_text == "Step 0 Temp 300.0\n"
     assert (spool.path / "stdout.log").read_bytes() != (spool.path / "console.log").read_bytes()
+
+
+def test_console_stderr_stream_never_mixes_with_stderr_or_console(tmp_path: Path) -> None:
+    """clio-relay#259 residual sabotage twin: ``console_stderr`` must carry
+    ONLY the application's stderr -- never the MCP jsonrpc wire's ``stderr``
+    (which for a jarvis-backed mcp_call job is a distinct, pre-existing
+    stream), and never bleed into/from the stdout-side ``console`` stream."""
+    spool = _spool(tmp_path)
+
+    spool.append_stderr('{"jsonrpc": "2.0", "id": 1, "error": {}}\n')
+    spool.append_log(CONSOLE_STREAM, "Step 0 Temp 300.0\n")
+    spool.append_log(CONSOLE_STDERR_STREAM, "WARNING: low disk\n")
+    spool.append_stderr('{"jsonrpc": "2.0", "method": "notifications/progress"}\n')
+
+    stderr_text, _, _ = spool.read_log("stderr")
+    console_text, _, _ = spool.read_log(CONSOLE_STREAM)
+    console_stderr_text, _, _ = spool.read_log(CONSOLE_STDERR_STREAM)
+
+    assert "WARNING" not in stderr_text
+    assert "jsonrpc" not in console_stderr_text
+    assert "WARNING" not in console_text
+    assert "Step 0" not in console_stderr_text
+    assert stderr_text == (
+        '{"jsonrpc": "2.0", "id": 1, "error": {}}\n'
+        '{"jsonrpc": "2.0", "method": "notifications/progress"}\n'
+    )
+    assert console_text == "Step 0 Temp 300.0\n"
+    assert console_stderr_text == "WARNING: low disk\n"
+    assert (spool.path / "stderr.log").read_bytes() != (
+        spool.path / "console_stderr.log"
+    ).read_bytes()
+    assert (spool.path / "console.log").read_bytes() != (
+        spool.path / "console_stderr.log"
+    ).read_bytes()

--- a/tests/test_execution_watch.py
+++ b/tests/test_execution_watch.py
@@ -219,6 +219,69 @@ def test_execution_cancel_unsupported_payload() -> None:
     assert payload["schema_version"] == execution_watch.EXECUTION_CANCEL_REFUSAL_SCHEMA
 
 
+def test_execution_outputs_missing_error_text() -> None:
+    detail = {
+        "schema_version": "clio-relay.execution-outputs-missing.v1",
+        "execution_id": "jarvis_exec",
+        "declared_count": 2,
+        "missing": [
+            {
+                "relative_path": "dump.h5",
+                "role": "output",
+                "reason": "absent",
+                "declared_size_bytes": 2048,
+            },
+            {
+                "relative_path": "stdout.log",
+                "role": "log",
+                "reason": "empty",
+                "declared_size_bytes": 0,
+            },
+        ],
+    }
+    text = execution_watch.execution_outputs_missing_error_text(detail)
+    assert "jarvis_exec" in text
+    assert "2 declared outputs" in text
+    assert "dump.h5" in text
+    assert "stdout.log" in text
+
+
+@pytest.mark.parametrize(
+    ("watch_succeeded", "outputs_missing", "expected_returncode", "expected_cancellation"),
+    [
+        # #265: a completed (succeeded) watch is overridden to failure when
+        # outputs are missing -- "producing the declared outputs is PART of
+        # what completed means".
+        (True, {"schema_version": "clio-relay.execution-outputs-missing.v1"}, 1, False),
+        # No outputs_missing verdict: the watch's own success stands.
+        (True, None, 0, False),
+        # A genuinely failed watch stays failed regardless of outputs_missing.
+        (False, None, 1, False),
+    ],
+)
+def test_resolve_execution_outcome_folds_outputs_missing(
+    watch_succeeded: bool,
+    outputs_missing: dict[str, object] | None,
+    expected_returncode: int,
+    expected_cancellation: bool,
+) -> None:
+    resolution = execution_watch.ExecutionWatchResolution(
+        succeeded=watch_succeeded,
+        failure_detail=None if watch_succeeded else {"schema_version": "x"},
+    )
+    outcome = execution_watch.resolve_execution_outcome(
+        dispatch_recovered=False,
+        watch_resolution=resolution,
+        dispatch_refusal_present=False,
+        transport_returncode=0,
+        cancellation_requested=True,
+        outputs_missing=outputs_missing,
+    )
+    assert outcome.effective_returncode == expected_returncode
+    assert outcome.cancellation_honored is expected_cancellation
+    assert outcome.outputs_missing == outputs_missing
+
+
 # --------------------------------------------------------------------------
 # End-to-end EndpointWorker lifecycle coverage.
 # --------------------------------------------------------------------------
@@ -247,6 +310,7 @@ class _WatchTransportProvider(JarvisCdProvider):
         cancel_on_poll_index: int | None = None,
         queue: ClioCoreQueue | None = None,
         job_id: str | None = None,
+        terminal_artifacts: list[dict[str, object]] | None = None,
     ) -> None:
         super().__init__(jarvis_bin="jarvis")
         self.pipeline_id = pipeline_id
@@ -260,6 +324,10 @@ class _WatchTransportProvider(JarvisCdProvider):
         self.cancel_on_poll_index = cancel_on_poll_index
         self.queue = queue
         self.job_id = job_id
+        # clio-relay#265: declared execution-file entries the FINAL,
+        # artifact-bearing poll reports -- None keeps the pre-#265 empty
+        # ``artifacts: []`` default.
+        self.terminal_artifacts = terminal_artifacts
         self.dispatch_count = 0
         self.poll_count = 0
         self.poll_specs: list[McpCallSpec] = []
@@ -334,6 +402,7 @@ class _WatchTransportProvider(JarvisCdProvider):
             server_artifact=self.server_artifact,
             native=self._native(index),
             include_artifacts=include_artifacts,
+            artifacts=self.terminal_artifacts if include_artifacts else None,
         )
         (cwd / "mcp-result.json").write_text(json.dumps(document), encoding="utf-8")
         return subprocess.CompletedProcess(["jarvis-get-execution"], 0, "", "")
@@ -403,6 +472,9 @@ def test_deferred_execution_watched_to_success(
     execution_root = tmp_path / "execution-root"
     execution_root.mkdir()
     (execution_root / "stdout.log").write_bytes(b"application booted\napplication running\n")
+    # clio-relay#259 residual: the application's stderr must be live-tailed
+    # and terminal-flushed the SAME way stdout is, into its own channel.
+    (execution_root / "stderr.log").write_bytes(b"warning: low disk\n")
     created_at = job.created_at.isoformat()
     transport = _WatchTransportProvider(
         pipeline_id="watch-pipeline",
@@ -445,10 +517,19 @@ def test_deferred_execution_watched_to_success(
     assert "execution.running" in events
     assert events.count("execution.watch_resolved") == 1
     artifact_kinds = [artifact.kind for artifact in queue.list_artifacts(job.job_id)]
-    for required_kind in ("mcp_result", "runtime_metadata", "provenance", "console"):
+    for required_kind in (
+        "mcp_result",
+        "runtime_metadata",
+        "provenance",
+        "console",
+        "console_stderr",
+    ):
         assert artifact_kinds.count(required_kind) == 1
     console_bytes = (settings.spool_dir / job.job_id / "console.log").read_bytes()
     assert b"application running" in console_bytes
+    console_stderr_bytes = (settings.spool_dir / job.job_id / "console_stderr.log").read_bytes()
+    assert b"warning: low disk" in console_stderr_bytes
+    assert console_stderr_bytes != console_bytes
     mcp_result = json.loads(
         (settings.spool_dir / job.job_id / "mcp-result.json").read_text(encoding="utf-8")
     )
@@ -499,6 +580,80 @@ def test_deferred_execution_watched_to_failure(
     watch_failure = cast(dict[str, Any], task.metadata["execution_watch_failure"])
     assert watch_failure["state"] == "failed"
     assert watch_failure["reason"] == "application exited with code 137"
+
+
+def test_deferred_execution_completed_with_missing_declared_output_fails_typed(
+    tmp_path: Path,
+    _watch_env: tuple[RelaySettings, ClioCoreQueue, list[str], dict[str, Any], str],
+) -> None:
+    """clio-relay#265 owner ruling made concrete: JARVIS itself reports the
+    execution ``completed``, but a declared output never landed on disk --
+    "producing the declared outputs is PART of what completed means", so the
+    job must reach FAILED with a typed ``outputs_missing`` reason, never a
+    decorated "completed".
+    """
+    settings, queue, command, server_artifact, digest = _watch_env
+    job, execution_id = _submit_watch_job(queue, command=command, digest=digest)
+    execution_root = tmp_path / "execution-root"
+    execution_root.mkdir()
+    (execution_root / "stdout.log").write_bytes(b"application ran to completion\n")
+    transport = _WatchTransportProvider(
+        pipeline_id="watch-pipeline",
+        execution_id=execution_id,
+        states=[
+            ("submitted", False, "9005"),
+            ("running", False, "9005"),
+            ("completed", True, "9005"),
+        ],
+        server_artifact=server_artifact,
+        execution_root=execution_root,
+        created_at=job.created_at.isoformat(),
+        terminal_artifacts=[
+            {
+                "package_id": "jarvis.execution",
+                "kind": "execution-file",
+                "role": "output",
+                "location": {"kind": "execution_path", "value": "dump.h5"},
+                "size_bytes": 2048,
+                "checksum": f"sha256:{'b' * 64}",
+            }
+        ],
+    )
+    worker = EndpointWorker(
+        role=EndpointRole.WORKER,
+        settings=settings,
+        cluster=job.cluster,
+        queue=queue,
+        provider=transport,
+    )
+
+    result = worker.run_once()
+
+    assert result is not None
+    assert result.state is JobState.FAILED
+    assert result.last_error is not None
+    assert "declared" in result.last_error
+    assert "dump.h5" in result.last_error
+    task = queue.list_tasks(job.job_id)[0]
+    assert task.state is JobState.FAILED
+    outputs_missing = cast(dict[str, Any], task.metadata["execution_outputs_missing"])
+    assert outputs_missing["schema_version"] == "clio-relay.execution-outputs-missing.v1"
+    assert outputs_missing["declared_count"] == 1
+    assert outputs_missing["missing"] == [
+        {
+            "relative_path": "dump.h5",
+            "role": "output",
+            "reason": "absent",
+            "declared_size_bytes": 2048,
+        }
+    ]
+    # JARVIS's own execution record genuinely reached "completed" -- the
+    # watch resolved normally; #265's outputs_missing fold is what turns
+    # that into a failed job, never a fabricated execution-level failure.
+    events = _event_types(queue, job.job_id)
+    assert "execution.watch_resolved" in events
+    assert "jarvis.execution_output_missing" in events
+    assert "jarvis.execution_outputs_missing" in events
 
 
 def test_synchronous_terminal_dispatch_skips_watch(

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -198,6 +198,57 @@ def test_get_log_serves_console_stream_like_stdout_and_stderr(tmp_path: Path) ->
     assert "console" in invalid_stream_response.json()["detail"]
 
 
+def test_get_log_serves_console_stderr_stream_like_console(tmp_path: Path) -> None:
+    """clio-relay#259 residual: the door route accepts and serves
+    ``console_stderr`` -- the application's stderr channel, ``console``'s
+    sibling -- with the exact same offset/limit/eof envelope shape, and the
+    same empty-with-eof read for a stream nothing has written yet."""
+    settings = RelaySettings(core_dir=tmp_path / "core", spool_dir=tmp_path / "spool")
+    queue = ClioCoreQueue(settings.core_dir)
+    job = queue.submit_job(
+        RelayJob(
+            cluster="test-cluster",
+            kind=JobKind.JARVIS,
+            spec=JarvisRunSpec(pipeline_yaml="name: generic\npkgs: []\n"),
+            idempotency_key="http-console-stderr",
+        )
+    )
+    spool = settings.spool_dir / job.job_id
+    spool.mkdir(parents=True)
+    client = cast(Any, TestClient(create_app(settings)))
+
+    empty_response = client.get(f"/jobs/{job.job_id}/logs/console_stderr")
+    assert empty_response.status_code == 200
+    assert empty_response.json() == {
+        "job_id": job.job_id,
+        "stream": "console_stderr",
+        "offset": 0,
+        "next_offset": 0,
+        "eof": True,
+        "text": "",
+    }
+
+    console_stderr_path = spool / "console_stderr.log"
+    console_stderr_path.write_bytes(b"WARNING: rank 3 near OOM\n")
+
+    log_response = client.get(f"/jobs/{job.job_id}/logs/console_stderr", params={"limit": 7})
+
+    assert log_response.status_code == 200
+    body = log_response.json()
+    assert body["stream"] == "console_stderr"
+    assert body["text"] == "WARNING"
+    assert body["eof"] is False
+    assert body["next_offset"] == 7
+
+    tail_response = client.get(
+        f"/jobs/{job.job_id}/logs/console_stderr",
+        params={"offset": body["next_offset"]},
+    )
+    assert tail_response.status_code == 200
+    assert tail_response.json()["text"] == ": rank 3 near OOM\n"
+    assert tail_response.json()["eof"] is True
+
+
 def test_oversized_artifact_content_answers_413_payload_too_large_not_200(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_jarvis_execution_artifacts.py
+++ b/tests/test_jarvis_execution_artifacts.py
@@ -7,7 +7,10 @@ from typing import Any, cast
 
 from clio_relay.config import RelaySettings
 from clio_relay.core_queue import ClioCoreQueue
-from clio_relay.jarvis_execution_artifacts import ingest_jarvis_execution_outputs
+from clio_relay.jarvis_execution_artifacts import (
+    EXECUTION_OUTPUTS_MISSING_SCHEMA,
+    ingest_jarvis_execution_outputs,
+)
 from clio_relay.mcp_server import handle_request
 from clio_relay.models import Cursor, JobKind, McpCallSpec, RelayJob
 from clio_relay.relay_ops import read_artifact_bytes
@@ -65,9 +68,10 @@ def test_terminal_outputs_are_referenced_fetched_and_produced_by_lineage(
         }
     }
 
-    indexed, truncation = ingest_jarvis_execution_outputs(queue, query, result)
+    indexed, truncation, outputs_missing = ingest_jarvis_execution_outputs(queue, query, result)
 
     assert truncation is None
+    assert outputs_missing is None
     assert len(indexed) == 1
     artifact = indexed[0]
     assert artifact.job_id == owner.job_id
@@ -130,7 +134,7 @@ def test_declared_truncation_is_typed_and_emitted_as_a_relay_event(tmp_path: Pat
         }
     }
 
-    indexed, truncation = ingest_jarvis_execution_outputs(queue, query, result)
+    indexed, truncation, outputs_missing = ingest_jarvis_execution_outputs(queue, query, result)
 
     assert indexed == []
     assert truncation == {
@@ -139,9 +143,175 @@ def test_declared_truncation_is_typed_and_emitted_as_a_relay_event(tmp_path: Pat
         "observed_count": 65,
         "omitted_count": 1,
     }
+    assert outputs_missing is None
     events, _ = queue.drain_events(Cursor(job_id=owner.job_id), limit=100)
     assert any(
         event.event_type == "jarvis.execution_outputs_truncated"
         and event.payload["omitted_count"] == 1
         for event in events
     )
+
+
+def _terminal_result(
+    execution_id: str,
+    execution_root: Path,
+    *,
+    artifacts: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "structured_result": {
+            "execution_id": execution_id,
+            "execution_record": {
+                "terminal": True,
+                "metadata": {"pipeline_snapshot_path": str(execution_root / "submit.sh")},
+            },
+            "artifact_page": {
+                "terminal": True,
+                "artifacts": artifacts,
+            },
+        }
+    }
+
+
+def test_declared_and_present_output_is_not_outputs_missing(tmp_path: Path) -> None:
+    """clio-relay#265: declared + present + non-empty -> no outputs_missing verdict."""
+    queue = ClioCoreQueue(tmp_path / "core")
+    execution_id = "execution-present"
+    queue.submit_job(_call_job(tool="jarvis_run", execution_id=execution_id, key="run"))
+    query = queue.submit_job(
+        _call_job(tool="jarvis_get_execution", execution_id=execution_id, key="query")
+    )
+    execution_root = tmp_path / "execution"
+    execution_root.mkdir()
+    payload = b"log line one\n"
+    (execution_root / "stdout.log").write_bytes(payload)
+    digest = hashlib.sha256(payload).hexdigest()
+    result = _terminal_result(
+        execution_id,
+        execution_root,
+        artifacts=[
+            {
+                "package_id": "jarvis.execution",
+                "kind": "execution-file",
+                "role": "log",
+                "location": {"kind": "execution_path", "value": "stdout.log"},
+                "size_bytes": len(payload),
+                "checksum": f"sha256:{digest}",
+            }
+        ],
+    )
+
+    indexed, _truncation, outputs_missing = ingest_jarvis_execution_outputs(queue, query, result)
+
+    assert len(indexed) == 1
+    assert outputs_missing is None
+
+
+def test_declared_and_missing_output_is_typed_outputs_missing(tmp_path: Path) -> None:
+    """clio-relay#265: declared but absent on disk -> typed outputs_missing, no crash."""
+    queue = ClioCoreQueue(tmp_path / "core")
+    execution_id = "execution-missing"
+    owner = queue.submit_job(_call_job(tool="jarvis_run", execution_id=execution_id, key="run"))
+    query = queue.submit_job(
+        _call_job(tool="jarvis_get_execution", execution_id=execution_id, key="query")
+    )
+    execution_root = tmp_path / "execution"
+    execution_root.mkdir()
+    # dump.h5 is declared but was never actually written to disk.
+    result = _terminal_result(
+        execution_id,
+        execution_root,
+        artifacts=[
+            {
+                "package_id": "jarvis.execution",
+                "kind": "execution-file",
+                "role": "output",
+                "location": {"kind": "execution_path", "value": "dump.h5"},
+                "size_bytes": 4096,
+                "checksum": f"sha256:{'a' * 64}",
+            }
+        ],
+    )
+
+    indexed, _truncation, outputs_missing = ingest_jarvis_execution_outputs(queue, query, result)
+
+    assert indexed == []
+    assert outputs_missing is not None
+    assert outputs_missing["schema_version"] == EXECUTION_OUTPUTS_MISSING_SCHEMA
+    assert outputs_missing["execution_id"] == execution_id
+    assert outputs_missing["declared_count"] == 1
+    assert outputs_missing["missing"] == [
+        {
+            "relative_path": "dump.h5",
+            "role": "output",
+            "reason": "absent",
+            "declared_size_bytes": 4096,
+        }
+    ]
+    events, _ = queue.drain_events(Cursor(job_id=owner.job_id), limit=100)
+    assert any(event.event_type == "jarvis.execution_output_missing" for event in events)
+    assert any(event.event_type == "jarvis.execution_outputs_missing" for event in events)
+
+
+def test_declared_and_empty_output_is_typed_outputs_missing(tmp_path: Path) -> None:
+    """clio-relay#265: declared but 0 bytes -> typed outputs_missing, still indexed."""
+    queue = ClioCoreQueue(tmp_path / "core")
+    execution_id = "execution-empty"
+    owner = queue.submit_job(_call_job(tool="jarvis_run", execution_id=execution_id, key="run"))
+    query = queue.submit_job(
+        _call_job(tool="jarvis_get_execution", execution_id=execution_id, key="query")
+    )
+    execution_root = tmp_path / "execution"
+    execution_root.mkdir()
+    (execution_root / "stdout.log").write_bytes(b"")
+    empty_digest = hashlib.sha256(b"").hexdigest()
+    result = _terminal_result(
+        execution_id,
+        execution_root,
+        artifacts=[
+            {
+                "package_id": "jarvis.execution",
+                "kind": "execution-file",
+                "role": "log",
+                "location": {"kind": "execution_path", "value": "stdout.log"},
+                "size_bytes": 0,
+                "checksum": f"sha256:{empty_digest}",
+            }
+        ],
+    )
+
+    indexed, _truncation, outputs_missing = ingest_jarvis_execution_outputs(queue, query, result)
+
+    # Still indexed -- a verified, genuinely 0-byte file is fetchable -- but
+    # also typed as an outputs-missing reason (#265: empty counts too).
+    assert len(indexed) == 1
+    assert outputs_missing is not None
+    assert outputs_missing["missing"] == [
+        {
+            "relative_path": "stdout.log",
+            "role": "log",
+            "reason": "empty",
+            "declared_size_bytes": 0,
+        }
+    ]
+    events, _ = queue.drain_events(Cursor(job_id=owner.job_id), limit=100)
+    assert any(event.event_type == "jarvis.execution_output_empty" for event in events)
+
+
+def test_nothing_declared_keeps_current_semantics(tmp_path: Path) -> None:
+    """clio-relay#265: an execution that declares zero outputs is untouched."""
+    queue = ClioCoreQueue(tmp_path / "core")
+    execution_id = "execution-nothing-declared"
+    query = queue.submit_job(
+        _call_job(tool="jarvis_get_execution", execution_id=execution_id, key="query")
+    )
+    queue.submit_job(_call_job(tool="jarvis_run", execution_id=execution_id, key="run"))
+    execution_root = tmp_path / "execution"
+    execution_root.mkdir()
+    result = _terminal_result(execution_id, execution_root, artifacts=[])
+
+    indexed, truncation, outputs_missing = ingest_jarvis_execution_outputs(queue, query, result)
+
+    assert indexed == []
+    assert truncation is None
+    assert outputs_missing is None

--- a/tests/test_spool.py
+++ b/tests/test_spool.py
@@ -132,6 +132,13 @@ def test_spool_enforces_stream_and_job_byte_quotas_without_splitting_utf8(
                 "truncated": False,
                 "truncation_event_recorded": False,
             },
+            "console_stderr": {
+                "observed_bytes": 0,
+                "persisted_bytes": 0,
+                "dropped_bytes": 0,
+                "truncated": False,
+                "truncation_event_recorded": False,
+            },
         },
     }
 


### PR DESCRIPTION
DRAFT — CI-execution gate for the c-lane branch (lands after 1.6.8 merges; develop is frozen for release PR #270). A run whose declared outputs are missing/empty is a FAILED job with typed reason outputs_missing flowing job -> task metadata -> isError on the wire; stderr joins the console chain as the console_stderr sibling stream.