### PR TITLE
fix: port PR #172 survivors — cross-session idempotency identity + spack-provider agent guidance

### DIFF
--- a/scripts/check_file_size.py
+++ b/scripts/check_file_size.py
@@ -928,7 +928,15 @@ RATCHET_BASELINE: dict[str, int] = {
     # worker_runtime_verification.py), comfortably under DEFAULT_MAX_LINES
     # with no baseline entry needed.
     "src/clio_relay/jarvis_execution.py": 875,
-    "src/clio_relay/jarvis_mcp.py": 947,
+    # #172 survivors: +9 net lines -- the agent-facing jarvis_run tool
+    # description and render_virtual_jarvis_agent_context both gain the
+    # package-runtime-activation guidance (inspect jarvis_describe's
+    # provider_resolutions, call the Spack locate tool, pass its immutable
+    # load_spec via spack_specs) that a live campaign validated but that
+    # never landed on main when the rest of PR #172 was superseded. No
+    # deletion offsets it -- this is the genuinely missing guidance text
+    # itself, not a fixable regression. A justified, minimal ratchet-up.
+    "src/clio_relay/jarvis_mcp.py": 956,
     # jarvis_mcp_validation.py's own ratchet-baseline entry and history
     # comment (most recently: #231 R6-fix review, A6, the `expected_filters`
     # `content_max_bytes` fix) were removed here (split/jarvis-mcp-validation):

--- a/src/clio_relay/jarvis_input_plane.py
+++ b/src/clio_relay/jarvis_input_plane.py
@@ -207,6 +207,7 @@ def prepare_jarvis_inputs(
 def jarvis_submission_idempotency_key(
     plan: JarvisInputPlan,
     *,
+    settings: RelaySettings,
     merged_artifact_uses: list[ArtifactUse],
     requested_idempotency_key: str | None,
 ) -> str | None:
@@ -224,6 +225,8 @@ def jarvis_submission_idempotency_key(
             "cluster_route_revision": plan.route.cluster_route_revision,
             "registration_revision": plan.route.registration_revision,
             "expected_server_artifact_digest": plan.route.expected_server_artifact_digest,
+            "owner_session_id": settings.owner_session_id,
+            "owner_session_generation_id": settings.owner_session_generation_id,
             "tool": plan.route.remote_tool_name,
             "arguments": plan.arguments,
             "used_artifact_refs": [artifact_use_payload(item) for item in merged_artifact_uses],

--- a/src/clio_relay/jarvis_mcp.py
+++ b/src/clio_relay/jarvis_mcp.py
@@ -750,6 +750,11 @@ def virtual_jarvis_tool_definitions(*, clusters: list[str] | None = None) -> lis
             )
         elif remote_tool == "jarvis_run":
             tool_guidance = (
+                " Before running, inspect every selected package with jarvis_describe. If its "
+                "deployment contract reports an unavailable runtime and advertises a provider "
+                "resolution, call that provider's locate tool and pass the returned immutable "
+                "load_spec in spack_specs. Do not submit until every required runtime is usable "
+                "or explicitly activated."
                 " wait_for_terminal is a clio-relay transport control: it waits only for the "
                 "brief remote MCP dispatch to return the durable execution handle. It never "
                 "waits for workload completion. Use jarvis_get_execution with the returned "
@@ -909,6 +914,10 @@ def render_virtual_jarvis_agent_context() -> str:
         "page without adding another agent tool. Use jarvis_describe with "
         "target='package_search' for bounded package discovery, then describe the "
         "selected canonical package name. "
+        "Before jarvis_run, satisfy each selected package's deployment runtime requirements. "
+        "When an unavailable requirement advertises a Spack provider resolution, call the "
+        "Spack locate tool and pass its exact immutable load_spec in jarvis_run spack_specs; "
+        "do not assume software found in a site store is already on the execution PATH. "
         "For ordinary interactive operations, set wait_for_terminal=true so the bounded MCP "
         "result returns in the current call; leave it false only when intentionally queuing "
         "transport for a later relay_wait. "

--- a/src/clio_relay/mcp_dispatch.py
+++ b/src/clio_relay/mcp_dispatch.py
@@ -242,6 +242,7 @@ def _call_tool(
             if input_plan is None
             else jarvis_submission_idempotency_key(
                 input_plan,
+                settings=settings,
                 merged_artifact_uses=merged_input_uses,
                 requested_idempotency_key=requested_idempotency_key,
             )

--- a/src/clio_relay/mcp_submission_mcp_call.py
+++ b/src/clio_relay/mcp_submission_mcp_call.py
@@ -464,6 +464,7 @@ def _stage_builtin_jarvis_inputs(
         ]
     staged_idempotency_key = jarvis_submission_idempotency_key(
         plan,
+        settings=settings,
         merged_artifact_uses=merged_input_uses,
         requested_idempotency_key=requested_key,
     )

--- a/src/clio_relay/release_pin_sites.py
+++ b/src/clio_relay/release_pin_sites.py
@@ -471,7 +471,10 @@ PINSITES: tuple[PinSite, ...] = (
         _JC,
         _LN,
         "docstring cross-reference",
-        line=2100,
+        # #172 survivors: the new spack-provider-guidance tests inserted
+        # above it pushed this unchanged docstring reference from line
+        # 2100 to line 2125.
+        line=2125,
         pattern=_CONTRACT,
         value_group="jarvis_contract_id",
     ),
@@ -501,7 +504,9 @@ PINSITES: tuple[PinSite, ...] = (
         # from line 1406 to line 1407.
         # #231 decomposition: further test additions above it pushed this
         # unchanged reference from line 1407 to line 1421.
-        line=1421,
+        # #172 survivors: the new jarvis_run guidance test inserted above
+        # it pushed this unchanged reference from line 1421 to line 1466.
+        line=1466,
         pattern=_CONTRACT,
         value_group="jarvis_contract_id",
     ),
@@ -516,7 +521,9 @@ PINSITES: tuple[PinSite, ...] = (
         # from line 1425 to line 1426.
         # #231 decomposition: further test additions above it pushed this
         # unchanged argument from line 1426 to line 1439.
-        line=1439,
+        # #172 survivors: the new jarvis_run guidance test inserted above
+        # it pushed this unchanged argument from line 1439 to line 1484.
+        line=1484,
         pattern=_CONTRACT,
         value_group="jarvis_contract_id",
     ),

--- a/src/clio_relay/remote_mcp_catalog_models.py
+++ b/src/clio_relay/remote_mcp_catalog_models.py
@@ -166,6 +166,10 @@ class VirtualRemoteMcpTool:
             )
         elif exact_v36_routes and self.remote_tool.name == "jarvis_run":
             description += (
+                " Before running, inspect every selected package deployment contract. For each "
+                "unavailable runtime with a Spack provider resolution, locate it and pass the "
+                "returned immutable load_spec in spack_specs; presence in a site store does not "
+                "place the runtime on the execution PATH."
                 " On each genuinely new run identity, relay securely reconciles every tracked "
                 "local-file setting and pins the execution to an immutable input manifest. "
                 "Retrying the same idempotency key reuses that admitted manifest without "

--- a/tests/test_jarvis_mcp_validation.py
+++ b/tests/test_jarvis_mcp_validation.py
@@ -60,6 +60,31 @@ def test_virtual_jarvis_context_teaches_bounded_interactive_waiting() -> None:
     assert "not workload completion" in context
 
 
+def test_virtual_jarvis_context_connects_unavailable_runtimes_to_spack_activation() -> None:
+    """The agent context ties a package's deployment runtime gap to Spack activation."""
+
+    context = render_virtual_jarvis_agent_context()
+
+    assert "satisfy each selected package's deployment runtime requirements" in context
+    assert "Spack provider resolution" in context
+    assert "immutable load_spec in jarvis_run spack_specs" in context
+
+
+def test_virtual_jarvis_run_tool_explains_runtime_activation_obligation() -> None:
+    """The built-in jarvis_run tool description connects package gaps to activation."""
+
+    local_run = next(
+        tool
+        for tool in virtual_jarvis_tool_definitions(clusters=["ares"])
+        if tool["name"] == "jarvis_run"
+    )
+
+    description = cast(str, local_run["description"])
+    assert "inspect every selected package with jarvis_describe" in description
+    assert "provider resolution" in description
+    assert "immutable load_spec in spack_specs" in description
+
+
 def test_virtual_jarvis_control_queries_follow_the_pinned_annotations() -> None:
     """Only read-only, non-destructive JARVIS operations use reserved capacity."""
     assert is_virtual_jarvis_control_query("jarvis_get_execution") is True

--- a/tests/test_mcp_input_staging.py
+++ b/tests/test_mcp_input_staging.py
@@ -381,6 +381,66 @@ def test_registered_jarvis_input_flows_from_describe_through_run(
     ]
 
 
+def test_registered_jarvis_describe_idempotency_key_is_owner_session_scoped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The generated reconciliation key must not collide across owner sessions.
+
+    Two owner sessions describing the identical package previously reduced to
+    one shared "mcp:virtual:reconcile:" key, so the second session's durable
+    submission collided with the first's. The key must now also fold in
+    owner-session identity so distinct sessions never share a key, while one
+    session's repeat of the identical call keeps reusing its own key (that
+    reuse is what makes the call idempotent instead of resubmitting).
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    settings, definition, catalog, harness = _configured_flow(
+        tmp_path,
+        workspace=workspace,
+    )
+    _patch_flow(
+        monkeypatch,
+        current_catalog={"value": catalog},
+        definition=definition,
+        harness=harness,
+    )
+    queue = ClioCoreQueue(settings.core_dir)
+
+    def describe(selected_settings: RelaySettings) -> None:
+        session = McpSessionState()
+        _advertise(queue, settings=selected_settings, session=session)
+        response = _call(
+            queue,
+            settings=selected_settings,
+            session=session,
+            name=DESCRIBE_ALIAS,
+            arguments={
+                "cluster": "ares",
+                "target": "package",
+                "package_name": "lammps",
+            },
+        )
+        assert "error" not in response, response
+
+    other_session_settings = settings.model_copy(
+        update={
+            "owner_session_id": "other-desktop-session",
+            "owner_session_generation_id": "generation_fedcba9876543210fedcba9876543210",
+        }
+    )
+
+    describe(settings)
+    describe(other_session_settings)
+    describe(settings)
+
+    keys = [cast(str, payload["idempotency_key"]) for payload in harness.submitted_payloads]
+    assert len(keys) == 3
+    assert keys[0] != keys[1], "different owner sessions must not collide on one reconciliation key"
+    assert keys[0] == keys[2], "the same owner session's repeat must reuse its own key"
+
+
 def test_legacy_jarvis_contract_does_not_activate_transparent_staging(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -407,6 +407,8 @@ def test_mcp_lists_relay_tools(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
         "const": "mcp_call",
     }
     run_tool = next(tool for tool in response["result"]["tools"] if tool["name"] == "jarvis_run")
+    assert "deployment contract reports an unavailable runtime" in run_tool["description"]
+    assert "immutable load_spec in spack_specs" in run_tool["description"]
     spack_specs = run_tool["inputSchema"]["properties"]["spack_specs"]
     assert spack_specs["default"] is None
     assert spack_specs["anyOf"][0] == {
@@ -956,6 +958,7 @@ def test_mcp_remote_mcp_context_describes_virtual_tools(
     assert response is not None
     context = response["result"]["structuredContent"]["context"]
     assert "jarvis_create_pipeline" in context
+    assert "do not assume software found in a site store" in context
     assert "cluster argument" in context
 
 

--- a/tests/test_remote_mcp.py
+++ b/tests/test_remote_mcp.py
@@ -1412,6 +1412,51 @@ def test_registered_jarvis_v36_describe_advertises_terminal_reconciliation_defau
     assert "transparently reconciled" in definition["description"]
 
 
+def test_registered_jarvis_run_explains_runtime_activation_obligation() -> None:
+    """The agent-facing run tool connects package requirements to provider activation."""
+    route = remote_mcp.RemoteMcpRoute(
+        cluster="alpha",
+        server_name="jarvis",
+        command="clio-kit",
+        args=("mcp-server", "jarvis"),
+        env_from=(),
+        expected_server_artifact_digest="a" * 64,
+        remote_tool_name="jarvis_run",
+        timeout_seconds=300,
+        contract=remote_mcp.CLIO_KIT_JARVIS_USER_CONTRACT_ID,
+        cluster_route_revision="b" * 64,
+        registration_revision="c" * 64,
+    )
+    virtual = remote_mcp.VirtualRemoteMcpTool(
+        alias="remote_jarvis_jarvis_run",
+        namespace="remote_jarvis",
+        remote_tool=RemoteMcpToolSchema(
+            name="jarvis_run",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "pipeline_id": {"type": "string"},
+                    "spack_specs": {
+                        "anyOf": [
+                            {"type": "array", "items": {"type": "string"}},
+                            {"type": "null"},
+                        ]
+                    },
+                },
+                "required": ["pipeline_id"],
+                "additionalProperties": False,
+            },
+        ),
+        routes={"alpha": route},
+        arguments_wrapped=False,
+    )
+
+    description = cast(str, virtual.definition()["description"])
+
+    assert "inspect every selected package deployment contract" in description
+    assert "immutable load_spec in spack_specs" in description
+
+
 def test_registered_jarvis_get_execution_advertises_exact_runtime_handoff_schema() -> None:
     """An audited registered JARVIS route accepts relay-derived service handoffs."""
     contract_artifact = cast(


### PR DESCRIPTION
## What changed

This branch (424 commits behind main) had two genuinely-unsuperseded pieces left; the rest (title-field support, mutable-artifact catalog refusal) is superseded on `main`. This PR ports just those two survivors, rewritten against today's post-#231/#775 module shapes.

1. **Cross-session idempotency collision (real bug on main today).** `jarvis_submission_idempotency_key()` in `jarvis_input_plane.py` built its `mcp:virtual:reconcile:` digest without `owner_session_id`/`owner_session_generation_id`, so two different owner sessions submitting the identical `jarvis_describe`/`jarvis_add_step`/`jarvis_edit_step` call collided on one reconciliation key. Folds owner-session identity into the digest so distinct sessions never share a key, while a session's repeat of the identical call still reuses its own key. Ported from commit `548d439` ("fix: scope virtual reconciliation per session"); the pre-#231 callers that commit touched (`mcp_server.py`) now live in `mcp_dispatch.py` and `mcp_submission_mcp_call.py`.

2. **Spack-provider deployment-contract guidance.** `virtual_jarvis_tool_definitions`'s `jarvis_run` description + `render_virtual_jarvis_agent_context` (`jarvis_mcp.py`, the built-in door) and `VirtualRemoteMcpTool`'s `jarvis_run` description (`remote_mcp_catalog_models.py`, the registered-route door — `remote_mcp.py`'s `VirtualRemoteMcpTool` now lives there post-decomposition) never told the agent to connect an unavailable package runtime to its Spack provider resolution before calling `jarvis_run`. Ported from commit `b21b18f` ("fix: require actionable JARVIS runtime contracts"), adapted to present tense and current tool names. This exact pattern is validated by tonight's live campaign — the darshan missions succeeded by following it.

## Why superseded pieces were left out

- **Title-field support**: already present on `main`.
- **Mutable-artifact catalog refusal** (`b21b18f`'s change to `build_virtual_remote_mcp_catalog`): the underlying goal — execution recovery must never trust an unverified/mutable server-artifact route — is independently covered today by `remote_mcp_server_artifact_binding_verified`, used in `endpoint_jarvis_recovery.py` and `jarvis_service_runtime_validation.py`. Porting the old catalog-admission-time refusal on top would duplicate that protection via a different, now-redundant mechanism.

## Compatibility note (idempotency key format change)

Changing the digest inputs changes the computed key going forward. Any submission already reconciled/in-flight under an old-format key before this deploys would not be matched by a retry using the new-format key post-deploy — the retry is treated as a fresh submission rather than deduped against the pre-deploy job. This is a one-time, self-healing resubmission (the same shape as any other deploy that changes idempotency-key inputs), not data corruption or double execution of a still-running operation.

## Tests

- `tests/test_mcp_input_staging.py::test_registered_jarvis_describe_idempotency_key_is_owner_session_scoped` — two owner sessions describing the identical package get different keys; the same session's repeat reuses its key.
- `tests/test_remote_mcp.py::test_registered_jarvis_run_explains_runtime_activation_obligation` — registered-route `jarvis_run` description carries the guidance.
- `tests/test_jarvis_mcp_validation.py::test_virtual_jarvis_context_connects_unavailable_runtimes_to_spack_activation` / `test_virtual_jarvis_run_tool_explains_runtime_activation_obligation` — built-in-door context/tool description carry the guidance.
- `tests/test_mcp_server.py::test_mcp_lists_relay_tools` / `test_mcp_remote_mcp_context_describes_virtual_tools` — end-to-end MCP `tools/list`/context assertions for the guidance text.

## Validation

- `uv run ruff check` / `uv run ruff format --check` — clean
- `uv run python scripts/check_file_size.py` — clean (one justified, minimal ratchet-up on `jarvis_mcp.py`, documented inline)
- `uv run python scripts/check_no_class_in_function.py` — clean
- `uv run python scripts/check_pyright_ratchet.py` — at baseline (7663, unchanged)
- No local pytest per standing order; CI runs the suite.

Refs #172, closes #172 (comment + close to follow once this merges).
